### PR TITLE
Add database schema migrations for all six tables

### DIFF
--- a/internal/db/migrations/000001_initial_schema.down.sql
+++ b/internal/db/migrations/000001_initial_schema.down.sql
@@ -1,0 +1,14 @@
+-- Reverse of initial schema creation
+-- Drop tables in reverse dependency order
+
+DROP TABLE IF EXISTS check_runs;
+DROP TABLE IF EXISTS reviews;
+DROP TABLE IF EXISTS roles;
+DROP TABLE IF EXISTS file_commits;
+DROP TABLE IF EXISTS branches;
+DROP TABLE IF EXISTS documents;
+
+DROP TYPE IF EXISTS check_status;
+DROP TYPE IF EXISTS review_status;
+DROP TYPE IF EXISTS role_type;
+DROP TYPE IF EXISTS branch_status;

--- a/internal/db/migrations/000001_initial_schema.up.sql
+++ b/internal/db/migrations/000001_initial_schema.up.sql
@@ -1,0 +1,83 @@
+-- DocStore VCS initial schema
+-- Six tables per DESIGN.md: documents, file_commits, branches, roles, reviews, check_runs
+
+-- Custom enum types
+CREATE TYPE branch_status AS ENUM ('active', 'merged', 'abandoned');
+CREATE TYPE role_type AS ENUM ('reader', 'writer', 'maintainer', 'admin');
+CREATE TYPE review_status AS ENUM ('approved', 'rejected', 'dismissed');
+CREATE TYPE check_status AS ENUM ('pending', 'passed', 'failed');
+
+-- documents: immutable file versions, content-addressed by content_hash
+CREATE TABLE documents (
+    version_id UUID PRIMARY KEY,
+    path TEXT NOT NULL,
+    content BYTEA NOT NULL,
+    content_hash TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by TEXT NOT NULL
+);
+
+CREATE INDEX idx_documents_content_hash ON documents (content_hash);
+
+-- branches: named pointers to sequences
+CREATE TABLE branches (
+    name TEXT PRIMARY KEY,
+    head_sequence BIGINT NOT NULL DEFAULT 0,
+    base_sequence BIGINT NOT NULL DEFAULT 0,
+    status branch_status NOT NULL DEFAULT 'active'
+);
+
+-- file_commits: core event log, one row per file change
+-- Rows sharing the same sequence number form one atomic commit
+CREATE TABLE file_commits (
+    commit_id UUID PRIMARY KEY,
+    sequence BIGINT NOT NULL,
+    path TEXT NOT NULL,
+    version_id UUID REFERENCES documents (version_id),
+    branch TEXT NOT NULL REFERENCES branches (name),
+    message TEXT NOT NULL,
+    author TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Primary query index: tree materialization and file history
+-- Supports DISTINCT ON (path) ... ORDER BY path, sequence DESC
+CREATE INDEX idx_file_commits_branch_path_seq ON file_commits (branch, path, sequence DESC);
+
+-- Atomic commit lookup: all rows in a single commit
+CREATE INDEX idx_file_commits_sequence ON file_commits (sequence);
+
+-- roles: identity to permission mapping
+CREATE TABLE roles (
+    identity TEXT PRIMARY KEY,
+    role role_type NOT NULL
+);
+
+-- reviews: approval/rejection records scoped to branch + sequence
+CREATE TABLE reviews (
+    id UUID PRIMARY KEY,
+    branch TEXT NOT NULL REFERENCES branches (name),
+    reviewer TEXT NOT NULL,
+    sequence BIGINT NOT NULL,
+    status review_status NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_reviews_branch_sequence ON reviews (branch, sequence);
+
+-- check_runs: external CI status reports scoped to branch + sequence
+CREATE TABLE check_runs (
+    id UUID PRIMARY KEY,
+    branch TEXT NOT NULL REFERENCES branches (name),
+    sequence BIGINT NOT NULL,
+    check_name TEXT NOT NULL,
+    status check_status NOT NULL,
+    reporter TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_check_runs_branch_seq_name ON check_runs (branch, sequence, check_name);
+
+-- Seed the main branch
+INSERT INTO branches (name, head_sequence, base_sequence, status)
+VALUES ('main', 0, 0, 'active');


### PR DESCRIPTION
## Summary

- Adds golang-migrate format PostgreSQL migration (`000001_initial_schema`) for all six tables from DESIGN.md: `documents`, `file_commits`, `branches`, `roles`, `reviews`, `check_runs`
- Creates four custom enum types: `branch_status`, `role_type`, `review_status`, `check_status`
- Includes all indexes from DESIGN.md: `(content_hash)` on documents, `(branch, path, sequence DESC)` on file_commits for tree materialization, `(sequence)` for atomic commit lookup, `(branch, sequence)` on reviews, `(branch, sequence, check_name)` on check_runs
- Foreign keys from `file_commits`, `reviews`, and `check_runs` referencing `branches` and `documents`
- Seeds the `main` branch row
- Includes reversible down migration that drops tables and types in correct dependency order

P0 roadmap item: "Database schema & migrations"

## Test plan

- [ ] Run `migrate -path internal/db/migrations -database $PG_URL up` against a fresh PostgreSQL database
- [ ] Verify all six tables created with correct columns and types
- [ ] Verify all indexes exist (`\di` in psql)
- [ ] Run down migration and verify clean teardown
- [ ] Run up again to confirm idempotent re-creation

## Notes for future PRs

- A sequence allocation mechanism (e.g. a PostgreSQL sequence or `SELECT ... FOR UPDATE` pattern) will be needed when implementing `POST /commit` — the schema doesn't prescribe how sequence numbers are generated, just that they exist
- The `content` column uses `BYTEA`; if large file support is needed later, consider switching to PostgreSQL large objects or external blob storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)