### PR TITLE
Add data model types and API structs

### DIFF
--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -1,0 +1,260 @@
+package model
+
+import "time"
+
+// ---------------------------------------------------------------------------
+// Pagination
+// ---------------------------------------------------------------------------
+
+// PaginationParams are the common query parameters for list endpoints.
+type PaginationParams struct {
+	Limit int    `json:"limit,omitempty"`
+	After string `json:"after,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// GET /tree
+// ---------------------------------------------------------------------------
+
+// TreeEntry is one file in a materialized tree.
+type TreeEntry struct {
+	Path        string `json:"path"`
+	VersionID   string `json:"version_id"`
+	ContentHash string `json:"content_hash"`
+}
+
+// TreeResponse is the response for GET /tree.
+type TreeResponse struct {
+	Entries []TreeEntry `json:"entries"`
+}
+
+// ---------------------------------------------------------------------------
+// GET /file/:path/history
+// ---------------------------------------------------------------------------
+
+// FileHistoryEntry is one row in a file's history.
+type FileHistoryEntry struct {
+	Sequence  int64     `json:"sequence"`
+	VersionID string    `json:"version_id"`
+	Message   string    `json:"message"`
+	Author    string    `json:"author"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// FileHistoryResponse is the response for GET /file/:path/history.
+type FileHistoryResponse struct {
+	Entries []FileHistoryEntry `json:"entries"`
+}
+
+// ---------------------------------------------------------------------------
+// GET /file/:path
+// ---------------------------------------------------------------------------
+
+// FileResponse is the response for GET /file/:path.
+type FileResponse struct {
+	Path        string `json:"path"`
+	VersionID   string `json:"version_id"`
+	ContentHash string `json:"content_hash"`
+	Content     []byte `json:"content"`
+}
+
+// ---------------------------------------------------------------------------
+// GET /diff
+// ---------------------------------------------------------------------------
+
+// DiffEntry represents a single file change in a diff.
+type DiffEntry struct {
+	Path      string  `json:"path"`
+	VersionID *string `json:"version_id"` // nil means deleted
+}
+
+// ConflictEntry represents a file that was changed on both main and the branch.
+type ConflictEntry struct {
+	Path            string `json:"path"`
+	MainVersionID   string `json:"main_version_id"`
+	BranchVersionID string `json:"branch_version_id"`
+}
+
+// DiffResponse is the response for GET /diff.
+type DiffResponse struct {
+	Changed   []DiffEntry     `json:"changed"`
+	Conflicts []ConflictEntry `json:"conflicts,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// GET /commit/:sequence
+// ---------------------------------------------------------------------------
+
+// CommitDetail represents one file change within a commit.
+type CommitDetail struct {
+	Path      string  `json:"path"`
+	VersionID *string `json:"version_id"` // nil means delete
+}
+
+// CommitResponse is the response for GET /commit/:sequence.
+type CommitResponse struct {
+	Sequence  int64          `json:"sequence"`
+	Message   string         `json:"message"`
+	Author    string         `json:"author"`
+	CreatedAt time.Time      `json:"created_at"`
+	Files     []CommitDetail `json:"files"`
+}
+
+// ---------------------------------------------------------------------------
+// GET /branches
+// ---------------------------------------------------------------------------
+
+// BranchesResponse is the response for GET /branches.
+type BranchesResponse struct {
+	Branches []Branch `json:"branches"`
+}
+
+// ---------------------------------------------------------------------------
+// GET /branch/:name/status
+// ---------------------------------------------------------------------------
+
+// PolicyResult is one policy evaluation outcome.
+type PolicyResult struct {
+	Name   string `json:"name"`
+	Pass   bool   `json:"pass"`
+	Reason string `json:"reason"`
+}
+
+// BranchStatusResponse is the response for GET /branch/:name/status.
+type BranchStatusResponse struct {
+	Mergeable bool           `json:"mergeable"`
+	Policies  []PolicyResult `json:"policies"`
+}
+
+// ---------------------------------------------------------------------------
+// POST /commit
+// ---------------------------------------------------------------------------
+
+// CommitFileInput is one file in a commit request.
+type CommitFileInput struct {
+	Path    string `json:"path"`
+	Content []byte `json:"content"`
+}
+
+// CommitRequest is the body for POST /commit.
+type CommitRequest struct {
+	Branch  string            `json:"branch"`
+	Files   []CommitFileInput `json:"files"`
+	Message string            `json:"message"`
+}
+
+// CommitResult is the response for POST /commit.
+type CommitResult struct {
+	Sequence int64 `json:"sequence"`
+}
+
+// ---------------------------------------------------------------------------
+// POST /branch
+// ---------------------------------------------------------------------------
+
+// CreateBranchRequest is the body for POST /branch.
+type CreateBranchRequest struct {
+	Name string `json:"name"`
+}
+
+// CreateBranchResponse is the response for POST /branch.
+type CreateBranchResponse struct {
+	Name         string `json:"name"`
+	BaseSequence int64  `json:"base_sequence"`
+}
+
+// ---------------------------------------------------------------------------
+// POST /merge
+// ---------------------------------------------------------------------------
+
+// MergeRequest is the body for POST /merge.
+type MergeRequest struct {
+	Branch string `json:"branch"`
+}
+
+// MergeResponse is the response for a successful POST /merge.
+type MergeResponse struct {
+	Sequence int64 `json:"sequence"`
+}
+
+// MergeConflictError is the error response when merge has conflicts.
+type MergeConflictError struct {
+	Conflicts []ConflictEntry `json:"conflicts"`
+}
+
+// MergePolicyError is the error response when merge policies fail.
+type MergePolicyError struct {
+	Policies []PolicyResult `json:"policies"`
+}
+
+// ---------------------------------------------------------------------------
+// POST /rebase
+// ---------------------------------------------------------------------------
+
+// RebaseRequest is the body for POST /rebase.
+type RebaseRequest struct {
+	Branch string `json:"branch"`
+}
+
+// RebaseResponse is the response for a successful POST /rebase.
+type RebaseResponse struct {
+	NewBaseSequence int64 `json:"new_base_sequence"`
+	NewHeadSequence int64 `json:"new_head_sequence"`
+}
+
+// RebaseConflictError is the error response when rebase has conflicts.
+type RebaseConflictError struct {
+	Conflicts []ConflictEntry `json:"conflicts"`
+}
+
+// ---------------------------------------------------------------------------
+// POST /review
+// ---------------------------------------------------------------------------
+
+// CreateReviewRequest is the body for POST /review.
+type CreateReviewRequest struct {
+	Branch string       `json:"branch"`
+	Status ReviewStatus `json:"status"`
+}
+
+// CreateReviewResponse is the response for POST /review.
+type CreateReviewResponse struct {
+	ID       string `json:"id"`
+	Sequence int64  `json:"sequence"`
+}
+
+// ---------------------------------------------------------------------------
+// POST /check
+// ---------------------------------------------------------------------------
+
+// CreateCheckRunRequest is the body for POST /check.
+type CreateCheckRunRequest struct {
+	Branch    string         `json:"branch"`
+	CheckName string         `json:"check_name"`
+	Status    CheckRunStatus `json:"status"`
+}
+
+// CreateCheckRunResponse is the response for POST /check.
+type CreateCheckRunResponse struct {
+	ID       string `json:"id"`
+	Sequence int64  `json:"sequence"`
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /branch/:name
+// ---------------------------------------------------------------------------
+
+// DeleteBranchResponse is the response for DELETE /branch/:name.
+type DeleteBranchResponse struct {
+	Name   string       `json:"name"`
+	Status BranchStatus `json:"status"`
+}
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+// ErrorResponse is a generic API error envelope.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1,60 +1,102 @@
+// Package model defines the data types for all six database tables
+// described in DESIGN.md.
 package model
 
 import "time"
 
-// Document stores an immutable file version.
+// BranchStatus represents the lifecycle state of a branch.
+type BranchStatus string
+
+const (
+	BranchStatusActive    BranchStatus = "active"
+	BranchStatusMerged    BranchStatus = "merged"
+	BranchStatusAbandoned BranchStatus = "abandoned"
+)
+
+// RoleType represents coarse-grained permission levels.
+type RoleType string
+
+const (
+	RoleReader     RoleType = "reader"
+	RoleWriter     RoleType = "writer"
+	RoleMaintainer RoleType = "maintainer"
+	RoleAdmin      RoleType = "admin"
+)
+
+// ReviewStatus represents the outcome of a review.
+type ReviewStatus string
+
+const (
+	ReviewApproved  ReviewStatus = "approved"
+	ReviewRejected  ReviewStatus = "rejected"
+	ReviewDismissed ReviewStatus = "dismissed"
+)
+
+// CheckRunStatus represents the state of a CI check run.
+type CheckRunStatus string
+
+const (
+	CheckRunPending CheckRunStatus = "pending"
+	CheckRunPassed  CheckRunStatus = "passed"
+	CheckRunFailed  CheckRunStatus = "failed"
+)
+
+// Document stores an immutable file version. Every save creates a new row.
 type Document struct {
 	VersionID   string    `json:"version_id"`
 	Path        string    `json:"path"`
-	Content     []byte    `json:"-"`
+	Content     []byte    `json:"content"`
 	ContentHash string    `json:"content_hash"`
 	CreatedAt   time.Time `json:"created_at"`
 	CreatedBy   string    `json:"created_by"`
 }
 
-// FileCommit is the core event log entry. One row per file change.
+// FileCommit is the core event log. One row per file change.
+// All rows sharing a sequence number form one atomic commit.
 type FileCommit struct {
 	CommitID  string    `json:"commit_id"`
 	Sequence  int64     `json:"sequence"`
 	Path      string    `json:"path"`
-	VersionID *string   `json:"version_id"` // nil = delete
+	VersionID *string   `json:"version_id"` // nil means delete
 	Branch    string    `json:"branch"`
 	Message   string    `json:"message"`
 	Author    string    `json:"author"`
 	CreatedAt time.Time `json:"created_at"`
 }
 
-// Branch is a named pointer.
+// Branch is a named pointer to a sequence.
 type Branch struct {
-	Name         string `json:"name"`
-	HeadSequence int64  `json:"head_sequence"`
-	BaseSequence int64  `json:"base_sequence"`
-	Status       string `json:"status"` // active, merged, abandoned
+	Name         string       `json:"name"`
+	HeadSequence int64        `json:"head_sequence"`
+	BaseSequence int64        `json:"base_sequence"`
+	Status       BranchStatus `json:"status"`
 }
 
-// Role maps an identity to a permission level.
+// Role maps an identity to a coarse-grained permission level.
 type Role struct {
-	Identity string `json:"identity"`
-	Role     string `json:"role"` // reader, writer, maintainer, admin
+	Identity string   `json:"identity"`
+	Role     RoleType `json:"role"`
 }
 
-// Review records an approval or rejection scoped to a branch at a sequence.
+// Review records an approval or rejection scoped to a branch at a
+// specific head sequence.
 type Review struct {
-	ID        string    `json:"id"`
-	Branch    string    `json:"branch"`
-	Reviewer  string    `json:"reviewer"`
-	Sequence  int64     `json:"sequence"`
-	Status    string    `json:"status"` // approved, rejected, dismissed
-	CreatedAt time.Time `json:"created_at"`
+	ID        string       `json:"id"`
+	Branch    string       `json:"branch"`
+	Reviewer  string       `json:"reviewer"`
+	Sequence  int64        `json:"sequence"`
+	Status    ReviewStatus `json:"status"`
+	CreatedAt time.Time    `json:"created_at"`
 }
 
-// CheckRun stores external CI status for a branch at a sequence.
+// CheckRun stores an external CI status report for a branch at a
+// specific head sequence.
 type CheckRun struct {
-	ID        string    `json:"id"`
-	Branch    string    `json:"branch"`
-	Sequence  int64     `json:"sequence"`
-	CheckName string    `json:"check_name"`
-	Status    string    `json:"status"` // pending, passed, failed
-	Reporter  string    `json:"reporter"`
-	CreatedAt time.Time `json:"created_at"`
+	ID        string         `json:"id"`
+	Branch    string         `json:"branch"`
+	Sequence  int64          `json:"sequence"`
+	CheckName string         `json:"check_name"`
+	Status    CheckRunStatus `json:"status"`
+	Reporter  string         `json:"reporter"`
+	CreatedAt time.Time      `json:"created_at"`
 }


### PR DESCRIPTION
## Summary

- Adds Go types in `internal/model/` for all six database tables from DESIGN.md: `Document`, `FileCommit`, `Branch`, `Role`, `Review`, `CheckRun`
- Defines typed string enums for all status fields (`BranchStatus`, `RoleType`, `ReviewStatus`, `CheckRunStatus`)
- Adds API request/response structs for all REST endpoints: tree, file, file history, diff, commit (read+write), branches, branch status, merge, rebase, review, check run, delete branch
- Includes conflict/policy error types for merge and rebase failures
- All structs have `json` tags matching the DESIGN.md field names
- Package compiles and passes `go vet`

## Design notes

- `VersionID` on `FileCommit` is `*string` (pointer) since null means delete
- UUIDs are `string` — no external UUID dependency needed at this layer
- Content is `[]byte` for blob fields
- `PaginationParams` struct provided for list endpoint query binding
- `ErrorResponse` provides a generic error envelope

## Opportunities (not implemented)

- Database scanning tags (`db:`) can be added when the storage layer lands
- Validation methods on request types (e.g. checking required fields)
- Custom JSON marshaling for enums if stricter parsing is desired

## Test plan

- [x] `go build ./internal/model/` passes
- [x] `go vet ./internal/model/` passes
- [ ] Downstream consumers (handlers, store) will exercise these types when implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)