### PR TITLE
Implement POST /commit with atomic sequence allocation and content dedup

### DIFF
--- a/cmd/docstore/main.go
+++ b/cmd/docstore/main.go
@@ -9,7 +9,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/server"
+
+	_ "github.com/lib/pq"
 )
 
 func main() {
@@ -18,7 +21,19 @@ func main() {
 		port = "8080"
 	}
 
-	srv := server.New()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		log.Fatal("DATABASE_URL environment variable is required")
+	}
+
+	database, err := db.Open(dsn)
+	if err != nil {
+		log.Fatalf("database open: %v", err)
+	}
+	defer database.Close()
+
+	store := db.NewStore(database)
+	srv := server.New(store)
 
 	httpServer := &http.Server{
 		Addr:         ":" + port,

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/dlorenc/docstore
 
 go 1.25.1
+
+require (
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/lib/pq v1.12.3 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
+github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1,0 +1,129 @@
+package db
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/google/uuid"
+)
+
+var (
+	ErrBranchNotFound  = errors.New("branch not found")
+	ErrBranchNotActive = errors.New("branch is not active")
+)
+
+// Store wraps a *sql.DB and provides transactional operations.
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore returns a Store backed by the given database connection.
+func NewStore(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+// Commit atomically commits one or more file changes to a branch.
+// It locks the branch row with SELECT ... FOR UPDATE, allocates
+// a new sequence number, deduplicates document content by hash,
+// inserts file_commits rows, and advances the branch head.
+func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Lock the branch row and read current state.
+	var headSeq int64
+	var status string
+	err = tx.QueryRowContext(ctx,
+		"SELECT head_sequence, status FROM branches WHERE name = $1 FOR UPDATE",
+		req.Branch,
+	).Scan(&headSeq, &status)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrBranchNotFound
+		}
+		return nil, fmt.Errorf("lock branch: %w", err)
+	}
+
+	if status != "active" {
+		return nil, ErrBranchNotActive
+	}
+
+	newSeq := headSeq + 1
+	results := make([]model.CommitFileResult, 0, len(req.Files))
+
+	for _, f := range req.Files {
+		var versionIDPtr *string
+
+		if f.Content != nil {
+			// Hash content for dedup.
+			h := sha256.Sum256(f.Content)
+			contentHash := hex.EncodeToString(h[:])
+
+			// Check for existing document with the same hash.
+			var existingID string
+			err = tx.QueryRowContext(ctx,
+				"SELECT version_id FROM documents WHERE content_hash = $1 LIMIT 1",
+				contentHash,
+			).Scan(&existingID)
+
+			if errors.Is(err, sql.ErrNoRows) {
+				// Insert new document.
+				existingID = uuid.New().String()
+				_, err = tx.ExecContext(ctx,
+					`INSERT INTO documents (version_id, path, content, content_hash, created_at, created_by)
+					 VALUES ($1, $2, $3, $4, now(), $5)`,
+					existingID, f.Path, f.Content, contentHash, req.Author,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("insert document: %w", err)
+				}
+			} else if err != nil {
+				return nil, fmt.Errorf("check dedup: %w", err)
+			}
+
+			versionIDPtr = &existingID
+		}
+		// nil Content → delete: versionIDPtr stays nil.
+
+		commitID := uuid.New().String()
+		_, err = tx.ExecContext(ctx,
+			`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author, created_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, now())`,
+			commitID, newSeq, f.Path, versionIDPtr, req.Branch, req.Message, req.Author,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("insert file_commit: %w", err)
+		}
+
+		results = append(results, model.CommitFileResult{
+			Path:      f.Path,
+			VersionID: versionIDPtr,
+		})
+	}
+
+	// Advance branch head.
+	_, err = tx.ExecContext(ctx,
+		"UPDATE branches SET head_sequence = $1 WHERE name = $2",
+		newSeq, req.Branch,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("update branch head: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit tx: %w", err)
+	}
+
+	return &model.CommitResponse{
+		Sequence: newSeq,
+		Files:    results,
+	}, nil
+}

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -1,0 +1,324 @@
+package db
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"os"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/model"
+
+	_ "github.com/lib/pq"
+)
+
+// testDB returns a *sql.DB connected to a test PostgreSQL instance.
+// It skips the test if DOCSTORE_TEST_DSN is not set.
+// It runs the schema migration and returns a clean database.
+func testDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dsn := os.Getenv("DOCSTORE_TEST_DSN")
+	if dsn == "" {
+		t.Skip("DOCSTORE_TEST_DSN not set, skipping integration test")
+	}
+
+	d, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	// Clean up tables in dependency order, then recreate schema.
+	for _, stmt := range []string{
+		"DROP TABLE IF EXISTS check_runs CASCADE",
+		"DROP TABLE IF EXISTS reviews CASCADE",
+		"DROP TABLE IF EXISTS roles CASCADE",
+		"DROP TABLE IF EXISTS file_commits CASCADE",
+		"DROP TABLE IF EXISTS documents CASCADE",
+		"DROP TABLE IF EXISTS branches CASCADE",
+		"DROP TYPE IF EXISTS branch_status CASCADE",
+		"DROP TYPE IF EXISTS role_type CASCADE",
+		"DROP TYPE IF EXISTS review_status CASCADE",
+		"DROP TYPE IF EXISTS check_status CASCADE",
+	} {
+		if _, err := d.Exec(stmt); err != nil {
+			t.Fatalf("cleanup %q: %v", stmt, err)
+		}
+	}
+
+	// Read and apply the migration.
+	migration, err := os.ReadFile("migrations/000001_initial_schema.up.sql")
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	if _, err := d.Exec(string(migration)); err != nil {
+		t.Fatalf("apply migration: %v", err)
+	}
+
+	return d
+}
+
+func TestCommit_SingleFile(t *testing.T) {
+	d := testDB(t)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	resp, err := s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "hello.txt", Content: []byte("hello world")}},
+		Message: "first commit",
+		Author:  "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	if resp.Sequence != 1 {
+		t.Errorf("expected sequence 1, got %d", resp.Sequence)
+	}
+	if len(resp.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(resp.Files))
+	}
+	if resp.Files[0].Path != "hello.txt" {
+		t.Errorf("expected path hello.txt, got %q", resp.Files[0].Path)
+	}
+	if resp.Files[0].VersionID == nil {
+		t.Fatal("expected non-nil version_id")
+	}
+
+	// Verify branch head was advanced.
+	var headSeq int64
+	err = d.QueryRow("SELECT head_sequence FROM branches WHERE name = 'main'").Scan(&headSeq)
+	if err != nil {
+		t.Fatalf("query branch: %v", err)
+	}
+	if headSeq != 1 {
+		t.Errorf("expected branch head 1, got %d", headSeq)
+	}
+}
+
+func TestCommit_MultipleFiles(t *testing.T) {
+	d := testDB(t)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	resp, err := s.Commit(ctx, model.CommitRequest{
+		Branch: "main",
+		Files: []model.FileChange{
+			{Path: "a.txt", Content: []byte("aaa")},
+			{Path: "b.txt", Content: []byte("bbb")},
+			{Path: "c.txt", Content: []byte("ccc")},
+		},
+		Message: "add three files",
+		Author:  "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	if resp.Sequence != 1 {
+		t.Errorf("expected sequence 1, got %d", resp.Sequence)
+	}
+	if len(resp.Files) != 3 {
+		t.Fatalf("expected 3 files, got %d", len(resp.Files))
+	}
+
+	// All file_commits should share the same sequence.
+	var count int
+	err = d.QueryRow("SELECT count(*) FROM file_commits WHERE sequence = $1", resp.Sequence).Scan(&count)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 file_commits at sequence %d, got %d", resp.Sequence, count)
+	}
+}
+
+func TestCommit_ContentDedup(t *testing.T) {
+	d := testDB(t)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	content := []byte("identical content")
+
+	// Commit the same content as two different files.
+	resp, err := s.Commit(ctx, model.CommitRequest{
+		Branch: "main",
+		Files: []model.FileChange{
+			{Path: "file1.txt", Content: content},
+			{Path: "file2.txt", Content: content},
+		},
+		Message: "dedup test",
+		Author:  "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Both files should reference the same version_id.
+	if *resp.Files[0].VersionID != *resp.Files[1].VersionID {
+		t.Errorf("expected same version_id for identical content, got %q and %q",
+			*resp.Files[0].VersionID, *resp.Files[1].VersionID)
+	}
+
+	// Only one document row should exist.
+	h := sha256.Sum256(content)
+	hash := hex.EncodeToString(h[:])
+	var docCount int
+	err = d.QueryRow("SELECT count(*) FROM documents WHERE content_hash = $1", hash).Scan(&docCount)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if docCount != 1 {
+		t.Errorf("expected 1 document, got %d", docCount)
+	}
+}
+
+func TestCommit_ContentDedupAcrossCommits(t *testing.T) {
+	d := testDB(t)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	content := []byte("shared content")
+
+	resp1, err := s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "first.txt", Content: content}},
+		Message: "commit 1",
+		Author:  "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit 1: %v", err)
+	}
+
+	resp2, err := s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "second.txt", Content: content}},
+		Message: "commit 2",
+		Author:  "bob@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit 2: %v", err)
+	}
+
+	// Same version_id across commits.
+	if *resp1.Files[0].VersionID != *resp2.Files[0].VersionID {
+		t.Errorf("expected same version_id across commits, got %q and %q",
+			*resp1.Files[0].VersionID, *resp2.Files[0].VersionID)
+	}
+
+	// Sequences should increment.
+	if resp2.Sequence != 2 {
+		t.Errorf("expected sequence 2, got %d", resp2.Sequence)
+	}
+}
+
+func TestCommit_SequenceIncrementsPerCommit(t *testing.T) {
+	d := testDB(t)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	for i := 1; i <= 3; i++ {
+		resp, err := s.Commit(ctx, model.CommitRequest{
+			Branch:  "main",
+			Files:   []model.FileChange{{Path: "file.txt", Content: []byte("v" + string(rune('0'+i)))}},
+			Message: "commit",
+			Author:  "alice@example.com",
+		})
+		if err != nil {
+			t.Fatalf("commit %d: %v", i, err)
+		}
+		if resp.Sequence != int64(i) {
+			t.Errorf("commit %d: expected sequence %d, got %d", i, i, resp.Sequence)
+		}
+	}
+}
+
+func TestCommit_DeleteFile(t *testing.T) {
+	d := testDB(t)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// First, create a file.
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "doomed.txt", Content: []byte("will be deleted")}},
+		Message: "create file",
+		Author:  "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Delete the file (nil content).
+	resp, err := s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "doomed.txt", Content: nil}},
+		Message: "delete file",
+		Author:  "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	if resp.Sequence != 2 {
+		t.Errorf("expected sequence 2, got %d", resp.Sequence)
+	}
+	if resp.Files[0].VersionID != nil {
+		t.Errorf("expected nil version_id for delete, got %v", resp.Files[0].VersionID)
+	}
+
+	// The file_commit should have NULL version_id.
+	var versionID *string
+	err = d.QueryRow(
+		"SELECT version_id FROM file_commits WHERE sequence = $1 AND path = 'doomed.txt'",
+		resp.Sequence,
+	).Scan(&versionID)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if versionID != nil {
+		t.Errorf("expected NULL version_id in DB, got %v", *versionID)
+	}
+}
+
+func TestCommit_BranchNotFound(t *testing.T) {
+	d := testDB(t)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Branch:  "nonexistent",
+		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("x")}},
+		Message: "m",
+		Author:  "a",
+	})
+	if err != ErrBranchNotFound {
+		t.Fatalf("expected ErrBranchNotFound, got %v", err)
+	}
+}
+
+func TestCommit_BranchNotActive(t *testing.T) {
+	d := testDB(t)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Create a branch and mark it as merged.
+	_, err := d.Exec(
+		"INSERT INTO branches (name, head_sequence, base_sequence, status) VALUES ('merged-br', 0, 0, 'merged')",
+	)
+	if err != nil {
+		t.Fatalf("insert branch: %v", err)
+	}
+
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Branch:  "merged-br",
+		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("x")}},
+		Message: "m",
+		Author:  "a",
+	})
+	if err != ErrBranchNotActive {
+		t.Fatalf("expected ErrBranchNotActive, got %v", err)
+	}
+}

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -91,8 +91,8 @@ type CommitDetail struct {
 	VersionID *string `json:"version_id"` // nil means delete
 }
 
-// CommitResponse is the response for GET /commit/:sequence.
-type CommitResponse struct {
+// GetCommitResponse is the response for GET /commit/:sequence.
+type GetCommitResponse struct {
 	Sequence  int64          `json:"sequence"`
 	Message   string         `json:"message"`
 	Author    string         `json:"author"`
@@ -130,22 +130,31 @@ type BranchStatusResponse struct {
 // POST /commit
 // ---------------------------------------------------------------------------
 
-// CommitFileInput is one file in a commit request.
-type CommitFileInput struct {
+// FileChange is one file in a commit request.
+// A nil Content means delete.
+type FileChange struct {
 	Path    string `json:"path"`
-	Content []byte `json:"content"`
+	Content []byte `json:"content,omitempty"`
 }
 
 // CommitRequest is the body for POST /commit.
 type CommitRequest struct {
-	Branch  string            `json:"branch"`
-	Files   []CommitFileInput `json:"files"`
-	Message string            `json:"message"`
+	Branch  string       `json:"branch"`
+	Files   []FileChange `json:"files"`
+	Message string       `json:"message"`
+	Author  string       `json:"author"`
 }
 
-// CommitResult is the response for POST /commit.
-type CommitResult struct {
-	Sequence int64 `json:"sequence"`
+// CommitFileResult describes one file outcome in a commit response.
+type CommitFileResult struct {
+	Path      string  `json:"path"`
+	VersionID *string `json:"version_id"` // nil for deletes
+}
+
+// CommitResponse is the response for POST /commit.
+type CommitResponse struct {
+	Sequence int64              `json:"sequence"`
+	Files    []CommitFileResult `json:"files"`
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -100,3 +100,4 @@ type CheckRun struct {
 	Reporter  string         `json:"reporter"`
 	CreatedAt time.Time      `json:"created_at"`
 }
+

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,12 +1,25 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
+
+	"github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/model"
 )
 
+// CommitStore abstracts the database operations needed by the commit handler.
+type CommitStore interface {
+	Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error)
+}
+
 // New returns an http.Handler with all routes registered.
-func New() http.Handler {
+// The store parameter provides database operations; pass nil if only
+// health/read stubs are needed (e.g. in tests).
+func New(store CommitStore) http.Handler {
+	s := &server{store: store}
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /healthz", handleHealth)
@@ -19,8 +32,8 @@ func New() http.Handler {
 	mux.HandleFunc("GET /branches", notImplemented)
 	mux.HandleFunc("GET /branch/{name}/status", notImplemented)
 
-	// Write endpoints (placeholders).
-	mux.HandleFunc("POST /commit", notImplemented)
+	// Write endpoints.
+	mux.HandleFunc("POST /commit", s.handleCommit)
 	mux.HandleFunc("POST /branch", notImplemented)
 	mux.HandleFunc("POST /merge", notImplemented)
 	mux.HandleFunc("POST /rebase", notImplemented)
@@ -31,13 +44,66 @@ func New() http.Handler {
 	return mux
 }
 
+type server struct {
+	store CommitStore
+}
+
+func (s *server) handleCommit(w http.ResponseWriter, r *http.Request) {
+	var req model.CommitRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	if req.Branch == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "branch is required"})
+		return
+	}
+	if len(req.Files) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "at least one file is required"})
+		return
+	}
+	if req.Message == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "message is required"})
+		return
+	}
+	if req.Author == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "author is required"})
+		return
+	}
+	for _, f := range req.Files {
+		if f.Path == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "file path is required"})
+			return
+		}
+	}
+
+	resp, err := s.store.Commit(r.Context(), req)
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrBranchNotFound):
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "branch not found"})
+		case errors.Is(err, db.ErrBranchNotActive):
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "branch is not active"})
+		default:
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, resp)
+}
+
 func handleHealth(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 func notImplemented(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusNotImplemented, map[string]string{"error": "not implemented"})
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusNotImplemented)
-	json.NewEncoder(w).Encode(map[string]string{"error": "not implemented"})
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,14 +1,29 @@
 package server
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/model"
 )
 
+// mockStore implements CommitStore for testing.
+type mockStore struct {
+	commitFn func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error)
+}
+
+func (m *mockStore) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
+	return m.commitFn(ctx, req)
+}
+
 func TestHealthEndpoint(t *testing.T) {
-	srv := New()
+	srv := New(nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
@@ -28,7 +43,7 @@ func TestHealthEndpoint(t *testing.T) {
 }
 
 func TestNotImplementedEndpoints(t *testing.T) {
-	srv := New()
+	srv := New(nil)
 
 	endpoints := []struct {
 		method string
@@ -36,7 +51,6 @@ func TestNotImplementedEndpoints(t *testing.T) {
 	}{
 		{"GET", "/tree"},
 		{"GET", "/branches"},
-		{"POST", "/commit"},
 		{"POST", "/branch"},
 		{"POST", "/merge"},
 		{"POST", "/rebase"},
@@ -54,5 +68,172 @@ func TestNotImplementedEndpoints(t *testing.T) {
 				t.Fatalf("expected 501, got %d", rec.Code)
 			}
 		})
+	}
+}
+
+func TestHandleCommit_Success(t *testing.T) {
+	vid := "abc-123"
+	store := &mockStore{
+		commitFn: func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
+			if req.Branch != "main" {
+				t.Errorf("expected branch main, got %q", req.Branch)
+			}
+			if len(req.Files) != 1 {
+				t.Errorf("expected 1 file, got %d", len(req.Files))
+			}
+			return &model.CommitResponse{
+				Sequence: 1,
+				Files:    []model.CommitFileResult{{Path: "hello.txt", VersionID: &vid}},
+			}, nil
+		},
+	}
+	srv := New(store)
+
+	body, _ := json.Marshal(model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "hello.txt", Content: []byte("hello")}},
+		Message: "initial commit",
+		Author:  "alice@example.com",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.CommitResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp.Sequence != 1 {
+		t.Errorf("expected sequence 1, got %d", resp.Sequence)
+	}
+	if len(resp.Files) != 1 || resp.Files[0].Path != "hello.txt" {
+		t.Errorf("unexpected files: %+v", resp.Files)
+	}
+}
+
+func TestHandleCommit_ValidationErrors(t *testing.T) {
+	srv := New(&mockStore{
+		commitFn: func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
+			t.Fatal("store should not be called on validation error")
+			return nil, nil
+		},
+	})
+
+	tests := []struct {
+		name string
+		body model.CommitRequest
+	}{
+		{"missing branch", model.CommitRequest{Files: []model.FileChange{{Path: "a.txt", Content: []byte("x")}}, Message: "m", Author: "a"}},
+		{"missing files", model.CommitRequest{Branch: "main", Message: "m", Author: "a"}},
+		{"missing message", model.CommitRequest{Branch: "main", Files: []model.FileChange{{Path: "a.txt", Content: []byte("x")}}, Author: "a"}},
+		{"missing author", model.CommitRequest{Branch: "main", Files: []model.FileChange{{Path: "a.txt", Content: []byte("x")}}, Message: "m"}},
+		{"empty file path", model.CommitRequest{Branch: "main", Files: []model.FileChange{{Path: "", Content: []byte("x")}}, Message: "m", Author: "a"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, _ := json.Marshal(tt.body)
+			req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader(b))
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d; body: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleCommit_BranchNotFound(t *testing.T) {
+	store := &mockStore{
+		commitFn: func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
+			return nil, db.ErrBranchNotFound
+		},
+	}
+	srv := New(store)
+
+	body, _ := json.Marshal(model.CommitRequest{
+		Branch:  "nonexistent",
+		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("x")}},
+		Message: "m",
+		Author:  "a",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleCommit_BranchNotActive(t *testing.T) {
+	store := &mockStore{
+		commitFn: func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
+			return nil, db.ErrBranchNotActive
+		},
+	}
+	srv := New(store)
+
+	body, _ := json.Marshal(model.CommitRequest{
+		Branch:  "merged-branch",
+		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("x")}},
+		Message: "m",
+		Author:  "a",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", rec.Code)
+	}
+}
+
+func TestHandleCommit_InternalError(t *testing.T) {
+	store := &mockStore{
+		commitFn: func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
+			return nil, errors.New("something went wrong")
+		},
+	}
+	srv := New(store)
+
+	body, _ := json.Marshal(model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("x")}},
+		Message: "m",
+		Author:  "a",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+}
+
+func TestHandleCommit_InvalidJSON(t *testing.T) {
+	srv := New(&mockStore{
+		commitFn: func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
+			t.Fatal("store should not be called on invalid JSON")
+			return nil, nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader([]byte("not json")))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
 	}
 }


### PR DESCRIPTION
## Summary

- Implements `POST /commit` endpoint per DESIGN.md spec — the core document store write path
- Atomic sequence allocation via `SELECT ... FOR UPDATE` on the branch row, serializing concurrent writes per-branch
- Content dedup: SHA-256 hashes file content and reuses existing `documents` rows when content_hash matches
- Supports multi-file atomic commits (all files share one sequence number) and file deletes (nil content → NULL version_id)
- Wires store into HTTP server via `CommitStore` interface for testability

## Changes

| File | What |
|---|---|
| `internal/db/store.go` | New `Store` type with `Commit` transaction (lock branch → hash → dedup → insert docs → insert file_commits → advance head) |
| `internal/db/store_test.go` | 8 integration tests (single file, multi-file, dedup within/across commits, sequence increment, delete, branch-not-found, branch-not-active) — require `DOCSTORE_TEST_DSN` |
| `internal/server/server.go` | `CommitStore` interface, `handleCommit` with validation and error mapping, `writeJSON` helper |
| `internal/server/server_test.go` | 8 unit tests with mock store (success, 5 validation errors, branch-not-found, branch-not-active, internal error, invalid JSON) |
| `internal/model/model.go` | `CommitRequest`, `FileChange`, `CommitResponse`, `CommitFileResult` types |
| `cmd/docstore/main.go` | Wire up `DATABASE_URL` → `db.Open` → `db.NewStore` → `server.New(store)` |
| `go.mod` / `go.sum` | Add `github.com/lib/pq` and `github.com/google/uuid` |

## Test plan

- [x] `go test ./...` passes (15 server unit tests pass, 8 store integration tests skip without DB)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [ ] Integration tests with real PostgreSQL: `DOCSTORE_TEST_DSN="postgres://..." go test ./internal/db/ -v`

## Notes for future PRs

- `author` is currently in the request body; should be derived from IAP identity when auth middleware lands (P1)
- Policy evaluation hook point is where `s.store.Commit()` is called in the handler
- The `CommitStore` interface can be extended as more write endpoints are implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)