### PR TITLE
Add tree materialization and read endpoints

### DIFF
--- a/cmd/docstore/main.go
+++ b/cmd/docstore/main.go
@@ -9,10 +9,10 @@ import (
 	"syscall"
 	"time"
 
+	_ "github.com/lib/pq"
+
 	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/server"
-
-	_ "github.com/lib/pq"
 )
 
 func main() {
@@ -32,8 +32,8 @@ func main() {
 	}
 	defer database.Close()
 
-	store := db.NewStore(database)
-	srv := server.New(store)
+	commitStore := db.NewStore(database)
+	srv := server.New(commitStore, database)
 
 	httpServer := &http.Server{
 		Addr:         ":" + port,

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -1,0 +1,9 @@
+package db
+
+import _ "embed"
+
+//go:embed migrations/000001_initial_schema.up.sql
+var MigrationSQL string
+
+//go:embed migrations/000001_initial_schema.down.sql
+var MigrationDownSQL string

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1,0 +1,159 @@
+package server
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/dlorenc/docstore/internal/store"
+)
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+// handleTree implements GET /tree?branch=main&at=N&limit=N&after=cursor
+func (s *server) handleTree(w http.ResponseWriter, r *http.Request) {
+	branch := r.URL.Query().Get("branch")
+	if branch == "" {
+		branch = "main"
+	}
+
+	var atSequence *int64
+	if v := r.URL.Query().Get("at"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid 'at' parameter")
+			return
+		}
+		atSequence = &n
+	}
+
+	limit := 100
+	if v := r.URL.Query().Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			writeError(w, http.StatusBadRequest, "invalid 'limit' parameter")
+			return
+		}
+		limit = n
+	}
+
+	afterPath := r.URL.Query().Get("after")
+
+	entries, err := s.readStore.MaterializeTree(r.Context(), branch, atSequence, limit, afterPath)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if entries == nil {
+		entries = []store.TreeEntry{}
+	}
+	writeJSON(w, http.StatusOK, entries)
+}
+
+// handleFile implements:
+//   - GET /file/{path...}          → file content
+//   - GET /file/{path...}/history  → file change history
+//
+// Query params: branch (default "main"), at (sequence), limit, after (cursor).
+func (s *server) handleFile(w http.ResponseWriter, r *http.Request) {
+	fullPath := r.PathValue("path")
+
+	// Check for /history suffix.
+	if strings.HasSuffix(fullPath, "/history") {
+		filePath := strings.TrimSuffix(fullPath, "/history")
+		s.handleFileHistory(w, r, filePath)
+		return
+	}
+
+	s.handleFileContent(w, r, fullPath)
+}
+
+func (s *server) handleFileContent(w http.ResponseWriter, r *http.Request, path string) {
+	branch := r.URL.Query().Get("branch")
+	if branch == "" {
+		branch = "main"
+	}
+
+	var atSequence *int64
+	if v := r.URL.Query().Get("at"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid 'at' parameter")
+			return
+		}
+		atSequence = &n
+	}
+
+	fc, err := s.readStore.GetFile(r.Context(), branch, path, atSequence)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if fc == nil {
+		writeError(w, http.StatusNotFound, "file not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, fc)
+}
+
+func (s *server) handleFileHistory(w http.ResponseWriter, r *http.Request, path string) {
+	branch := r.URL.Query().Get("branch")
+	if branch == "" {
+		branch = "main"
+	}
+
+	limit := 100
+	if v := r.URL.Query().Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			writeError(w, http.StatusBadRequest, "invalid 'limit' parameter")
+			return
+		}
+		limit = n
+	}
+
+	var afterSeq *int64
+	if v := r.URL.Query().Get("after"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid 'after' parameter")
+			return
+		}
+		afterSeq = &n
+	}
+
+	entries, err := s.readStore.GetFileHistory(r.Context(), branch, path, limit, afterSeq)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if entries == nil {
+		entries = []store.FileHistoryEntry{}
+	}
+	writeJSON(w, http.StatusOK, entries)
+}
+
+// handleGetCommit implements GET /commit/{sequence}
+func (s *server) handleGetCommit(w http.ResponseWriter, r *http.Request) {
+	seqStr := r.PathValue("sequence")
+	seq, err := strconv.ParseInt(seqStr, 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid sequence number")
+		return
+	}
+
+	detail, err := s.readStore.GetCommit(r.Context(), seq)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if detail == nil {
+		writeError(w, http.StatusNotFound, "commit not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, detail)
+}

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -1,0 +1,212 @@
+package server_test
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/server"
+	"github.com/dlorenc/docstore/internal/store"
+	"github.com/dlorenc/docstore/internal/testutil"
+)
+
+// seed inserts test data for HTTP-level integration tests.
+func seed(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	stmts := []string{
+		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
+		 VALUES ('aaaaaaaa-0000-0000-0000-000000000001', 'hello.txt', 'hello world', 'hash_hello_v1', 'alice')`,
+		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
+		 VALUES ('aaaaaaaa-0000-0000-0000-000000000002', 'hello.txt', 'hello world v2', 'hash_hello_v2', 'alice')`,
+		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
+		 VALUES ('aaaaaaaa-0000-0000-0000-000000000003', 'world.txt', 'the world', 'hash_world_v1', 'bob')`,
+		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
+		 VALUES ('aaaaaaaa-0000-0000-0000-000000000004', 'deleted.txt', 'gone soon', 'hash_deleted_v1', 'alice')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
+		 VALUES ('cccccccc-0000-0000-0000-000000000001', 1, 'hello.txt', 'aaaaaaaa-0000-0000-0000-000000000001', 'main', 'initial commit', 'alice')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
+		 VALUES ('cccccccc-0000-0000-0000-000000000002', 1, 'world.txt', 'aaaaaaaa-0000-0000-0000-000000000003', 'main', 'initial commit', 'alice')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
+		 VALUES ('cccccccc-0000-0000-0000-000000000003', 2, 'hello.txt', 'aaaaaaaa-0000-0000-0000-000000000002', 'main', 'update hello', 'alice')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
+		 VALUES ('cccccccc-0000-0000-0000-000000000004', 3, 'deleted.txt', 'aaaaaaaa-0000-0000-0000-000000000004', 'main', 'add deleted', 'bob')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
+		 VALUES ('cccccccc-0000-0000-0000-000000000005', 4, 'deleted.txt', NULL, 'main', 'remove deleted', 'bob')`,
+		`UPDATE branches SET head_sequence = 4 WHERE name = 'main'`,
+	}
+
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed: %v\nstatement: %s", err, stmt)
+		}
+	}
+}
+
+func TestIntegrationTreeEndpoint(t *testing.T) {
+	db := testutil.TestDB(t)
+	seed(t, db)
+	handler := server.New(nil, db)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/tree")
+	if err != nil {
+		t.Fatalf("GET /tree: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var entries []store.TreeEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 tree entries, got %d", len(entries))
+	}
+}
+
+func TestIntegrationFileEndpoint(t *testing.T) {
+	db := testutil.TestDB(t)
+	seed(t, db)
+	handler := server.New(nil, db)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	t.Run("get file content", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/file/hello.txt")
+		if err != nil {
+			t.Fatalf("GET /file/hello.txt: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		var fc store.FileContent
+		if err := json.NewDecoder(resp.Body).Decode(&fc); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		if fc.ContentHash != "hash_hello_v2" {
+			t.Errorf("expected hash_hello_v2, got %s", fc.ContentHash)
+		}
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/file/nope.txt")
+		if err != nil {
+			t.Fatalf("GET /file/nope.txt: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("file history", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/file/hello.txt/history")
+		if err != nil {
+			t.Fatalf("GET /file/hello.txt/history: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		var entries []store.FileHistoryEntry
+		if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		if len(entries) != 2 {
+			t.Fatalf("expected 2 history entries, got %d", len(entries))
+		}
+	})
+
+	t.Run("file at sequence", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/file/hello.txt?at=1")
+		if err != nil {
+			t.Fatalf("GET /file/hello.txt?at=1: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		var fc store.FileContent
+		if err := json.NewDecoder(resp.Body).Decode(&fc); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		if fc.ContentHash != "hash_hello_v1" {
+			t.Errorf("expected hash_hello_v1, got %s", fc.ContentHash)
+		}
+	})
+}
+
+func TestIntegrationCommitEndpoint(t *testing.T) {
+	db := testutil.TestDB(t)
+	seed(t, db)
+	handler := server.New(nil, db)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	t.Run("existing commit", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/commit/1")
+		if err != nil {
+			t.Fatalf("GET /commit/1: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		var detail store.CommitDetail
+		if err := json.NewDecoder(resp.Body).Decode(&detail); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		if detail.Sequence != 1 {
+			t.Errorf("expected sequence 1, got %d", detail.Sequence)
+		}
+		if len(detail.Files) != 2 {
+			t.Fatalf("expected 2 files, got %d", len(detail.Files))
+		}
+	})
+
+	t.Run("nonexistent commit", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/commit/999")
+		if err != nil {
+			t.Fatalf("GET /commit/999: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("invalid sequence", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/commit/abc")
+		if err != nil {
+			t.Fatalf("GET /commit/abc: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,12 +2,14 @@ package server
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
 
 	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/store"
 )
 
 // CommitStore abstracts the database operations needed by the commit handler.
@@ -16,18 +18,23 @@ type CommitStore interface {
 }
 
 // New returns an http.Handler with all routes registered.
-// The store parameter provides database operations; pass nil if only
-// health/read stubs are needed (e.g. in tests).
-func New(store CommitStore) http.Handler {
-	s := &server{store: store}
+// commitStore provides write operations (POST /commit); pass nil if only
+// read/health endpoints are needed.
+// database provides read operations (GET /tree, /file, /commit); pass nil
+// if only write/health endpoints are needed (e.g. in unit tests).
+func New(commitStore CommitStore, database *sql.DB) http.Handler {
+	s := &server{commitStore: commitStore}
+	if database != nil {
+		s.readStore = store.New(database)
+	}
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /healthz", handleHealth)
 
-	// Read endpoints (placeholders).
-	mux.HandleFunc("GET /tree", notImplemented)
-	mux.HandleFunc("GET /file/{path...}", notImplemented)
-	mux.HandleFunc("GET /commit/{sequence}", notImplemented)
+	// Read endpoints.
+	mux.HandleFunc("GET /tree", s.handleTree)
+	mux.HandleFunc("GET /file/{path...}", s.handleFile)
+	mux.HandleFunc("GET /commit/{sequence}", s.handleGetCommit)
 	mux.HandleFunc("GET /diff", notImplemented)
 	mux.HandleFunc("GET /branches", notImplemented)
 	mux.HandleFunc("GET /branch/{name}/status", notImplemented)
@@ -45,7 +52,8 @@ func New(store CommitStore) http.Handler {
 }
 
 type server struct {
-	store CommitStore
+	commitStore CommitStore
+	readStore   *store.Store
 }
 
 func (s *server) handleCommit(w http.ResponseWriter, r *http.Request) {
@@ -78,7 +86,7 @@ func (s *server) handleCommit(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	resp, err := s.store.Commit(r.Context(), req)
+	resp, err := s.commitStore.Commit(r.Context(), req)
 	if err != nil {
 		switch {
 		case errors.Is(err, db.ErrBranchNotFound):

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -23,7 +23,7 @@ func (m *mockStore) Commit(ctx context.Context, req model.CommitRequest) (*model
 }
 
 func TestHealthEndpoint(t *testing.T) {
-	srv := New(nil)
+	srv := New(nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
@@ -43,13 +43,13 @@ func TestHealthEndpoint(t *testing.T) {
 }
 
 func TestNotImplementedEndpoints(t *testing.T) {
-	srv := New(nil)
+	srv := New(nil, nil)
 
 	endpoints := []struct {
 		method string
 		path   string
 	}{
-		{"GET", "/tree"},
+		{"GET", "/diff"},
 		{"GET", "/branches"},
 		{"POST", "/branch"},
 		{"POST", "/merge"},
@@ -87,7 +87,7 @@ func TestHandleCommit_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	srv := New(store)
+	srv := New(store, nil)
 
 	body, _ := json.Marshal(model.CommitRequest{
 		Branch:  "main",
@@ -122,7 +122,7 @@ func TestHandleCommit_ValidationErrors(t *testing.T) {
 			t.Fatal("store should not be called on validation error")
 			return nil, nil
 		},
-	})
+	}, nil)
 
 	tests := []struct {
 		name string
@@ -155,7 +155,7 @@ func TestHandleCommit_BranchNotFound(t *testing.T) {
 			return nil, db.ErrBranchNotFound
 		},
 	}
-	srv := New(store)
+	srv := New(store, nil)
 
 	body, _ := json.Marshal(model.CommitRequest{
 		Branch:  "nonexistent",
@@ -179,7 +179,7 @@ func TestHandleCommit_BranchNotActive(t *testing.T) {
 			return nil, db.ErrBranchNotActive
 		},
 	}
-	srv := New(store)
+	srv := New(store, nil)
 
 	body, _ := json.Marshal(model.CommitRequest{
 		Branch:  "merged-branch",
@@ -203,7 +203,7 @@ func TestHandleCommit_InternalError(t *testing.T) {
 			return nil, errors.New("something went wrong")
 		},
 	}
-	srv := New(store)
+	srv := New(store, nil)
 
 	body, _ := json.Marshal(model.CommitRequest{
 		Branch:  "main",
@@ -227,7 +227,7 @@ func TestHandleCommit_InvalidJSON(t *testing.T) {
 			t.Fatal("store should not be called on invalid JSON")
 			return nil, nil
 		},
-	})
+	}, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader([]byte("not json")))
 	rec := httptest.NewRecorder()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,0 +1,266 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+// Store provides read queries against the docstore database.
+type Store struct {
+	db *sql.DB
+}
+
+// New creates a Store backed by the given database connection.
+func New(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+// TreeEntry is a single file in a materialized tree.
+type TreeEntry struct {
+	Path        string `json:"path"`
+	VersionID   string `json:"version_id"`
+	ContentHash string `json:"content_hash"`
+}
+
+// FileContent is the content of a file at a point in time.
+type FileContent struct {
+	Path        string `json:"path"`
+	VersionID   string `json:"version_id"`
+	ContentHash string `json:"content_hash"`
+	Content     []byte `json:"content"`
+}
+
+// FileHistoryEntry is one change to a file.
+type FileHistoryEntry struct {
+	Sequence  int64     `json:"sequence"`
+	VersionID *string   `json:"version_id"`
+	Message   string    `json:"message"`
+	Author    string    `json:"author"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// CommitDetail describes a single atomic commit.
+type CommitDetail struct {
+	Sequence  int64        `json:"sequence"`
+	Branch    string       `json:"branch"`
+	Message   string       `json:"message"`
+	Author    string       `json:"author"`
+	CreatedAt time.Time    `json:"created_at"`
+	Files     []CommitFile `json:"files"`
+}
+
+// CommitFile is one file changed in a commit.
+type CommitFile struct {
+	CommitID  string  `json:"commit_id"`
+	Path      string  `json:"path"`
+	VersionID *string `json:"version_id"`
+}
+
+const defaultLimit = 100
+
+// MaterializeTree returns the current file tree for a branch, optionally at a
+// specific sequence. Pagination uses afterPath as the cursor.
+func (s *Store) MaterializeTree(ctx context.Context, branch string, atSequence *int64, limit int, afterPath string) ([]TreeEntry, error) {
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+
+	// The CTE computes the latest version of each path by combining:
+	//   - commits on the requested branch
+	//   - commits on main up to the branch's base_sequence (inherited files)
+	// For main itself, base_sequence=0 so the second arm matches nothing.
+	const q = `
+WITH branch_info AS (
+    SELECT base_sequence FROM branches WHERE name = $1
+),
+latest AS (
+    SELECT DISTINCT ON (fc.path)
+        fc.path, fc.version_id
+    FROM file_commits fc
+    CROSS JOIN branch_info bi
+    WHERE (
+        fc.branch = $1
+        OR (fc.branch = 'main' AND fc.sequence <= bi.base_sequence)
+    )
+    AND ($2::bigint IS NULL OR fc.sequence <= $2)
+    ORDER BY fc.path, fc.sequence DESC
+)
+SELECT l.path, l.version_id::text, d.content_hash
+FROM latest l
+JOIN documents d ON d.version_id = l.version_id
+WHERE l.version_id IS NOT NULL
+  AND ($3::text = '' OR l.path > $3)
+ORDER BY l.path
+LIMIT $4`
+
+	var at interface{}
+	if atSequence != nil {
+		at = *atSequence
+	}
+
+	rows, err := s.db.QueryContext(ctx, q, branch, at, afterPath, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var entries []TreeEntry
+	for rows.Next() {
+		var e TreeEntry
+		if err := rows.Scan(&e.Path, &e.VersionID, &e.ContentHash); err != nil {
+			return nil, err
+		}
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
+// GetFile returns a file's content for a branch, optionally at a specific sequence.
+// Returns nil, nil if the file does not exist or was deleted.
+func (s *Store) GetFile(ctx context.Context, branch, path string, atSequence *int64) (*FileContent, error) {
+	const q = `
+WITH branch_info AS (
+    SELECT base_sequence FROM branches WHERE name = $1
+)
+SELECT fc.version_id, d.content_hash, d.content
+FROM file_commits fc
+CROSS JOIN branch_info bi
+LEFT JOIN documents d ON d.version_id = fc.version_id
+WHERE (
+    fc.branch = $1
+    OR (fc.branch = 'main' AND fc.sequence <= bi.base_sequence)
+)
+AND fc.path = $2
+AND ($3::bigint IS NULL OR fc.sequence <= $3)
+ORDER BY fc.sequence DESC
+LIMIT 1`
+
+	var at interface{}
+	if atSequence != nil {
+		at = *atSequence
+	}
+
+	var versionID sql.NullString
+	var contentHash sql.NullString
+	var content []byte
+
+	err := s.db.QueryRowContext(ctx, q, branch, path, at).Scan(&versionID, &contentHash, &content)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// version_id NULL means the file was deleted at this point.
+	if !versionID.Valid {
+		return nil, nil
+	}
+
+	return &FileContent{
+		Path:        path,
+		VersionID:   versionID.String,
+		ContentHash: contentHash.String,
+		Content:     content,
+	}, nil
+}
+
+// GetFileHistory returns the change history for a file on a branch.
+// Pagination: afterSequence is the cursor (exclusive); pass nil for the first page.
+func (s *Store) GetFileHistory(ctx context.Context, branch, path string, limit int, afterSequence *int64) ([]FileHistoryEntry, error) {
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+
+	const q = `
+WITH branch_info AS (
+    SELECT base_sequence FROM branches WHERE name = $1
+)
+SELECT fc.sequence, fc.version_id::text, fc.message, fc.author, fc.created_at
+FROM file_commits fc
+CROSS JOIN branch_info bi
+WHERE (
+    fc.branch = $1
+    OR (fc.branch = 'main' AND fc.sequence <= bi.base_sequence)
+)
+AND fc.path = $2
+AND ($3::bigint IS NULL OR fc.sequence < $3)
+ORDER BY fc.sequence DESC
+LIMIT $4`
+
+	var after interface{}
+	if afterSequence != nil {
+		after = *afterSequence
+	}
+
+	rows, err := s.db.QueryContext(ctx, q, branch, path, after, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var entries []FileHistoryEntry
+	for rows.Next() {
+		var e FileHistoryEntry
+		var vid sql.NullString
+		if err := rows.Scan(&e.Sequence, &vid, &e.Message, &e.Author, &e.CreatedAt); err != nil {
+			return nil, err
+		}
+		if vid.Valid {
+			e.VersionID = &vid.String
+		}
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
+// GetCommit returns all file changes in a single atomic commit (by sequence).
+// Returns nil, nil if no commit exists with that sequence.
+func (s *Store) GetCommit(ctx context.Context, sequence int64) (*CommitDetail, error) {
+	const q = `
+SELECT fc.commit_id::text, fc.path, fc.version_id::text, fc.branch, fc.message, fc.author, fc.created_at
+FROM file_commits fc
+WHERE fc.sequence = $1
+ORDER BY fc.path`
+
+	rows, err := s.db.QueryContext(ctx, q, sequence)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var detail *CommitDetail
+	for rows.Next() {
+		var cid string
+		var path string
+		var vid sql.NullString
+		var branch, message, author string
+		var createdAt time.Time
+
+		if err := rows.Scan(&cid, &path, &vid, &branch, &message, &author, &createdAt); err != nil {
+			return nil, err
+		}
+
+		if detail == nil {
+			detail = &CommitDetail{
+				Sequence:  sequence,
+				Branch:    branch,
+				Message:   message,
+				Author:    author,
+				CreatedAt: createdAt,
+			}
+		}
+
+		cf := CommitFile{CommitID: cid, Path: path}
+		if vid.Valid {
+			v := vid.String
+			cf.VersionID = &v
+		}
+		detail.Files = append(detail.Files, cf)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return detail, nil
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,368 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/store"
+	"github.com/dlorenc/docstore/internal/testutil"
+)
+
+// seed inserts test data into the database. It creates:
+//   - documents: hello.txt (v1, v2), world.txt (v1), deleted.txt (v1)
+//   - file_commits on main:
+//     seq 1: hello.txt v1, world.txt v1
+//     seq 2: hello.txt v2 (update)
+//     seq 3: deleted.txt v1
+//     seq 4: deleted.txt delete
+func seed(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	stmts := []string{
+		// Documents
+		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
+		 VALUES ('aaaaaaaa-0000-0000-0000-000000000001', 'hello.txt', 'hello world', 'hash_hello_v1', 'alice')`,
+		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
+		 VALUES ('aaaaaaaa-0000-0000-0000-000000000002', 'hello.txt', 'hello world v2', 'hash_hello_v2', 'alice')`,
+		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
+		 VALUES ('aaaaaaaa-0000-0000-0000-000000000003', 'world.txt', 'the world', 'hash_world_v1', 'bob')`,
+		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
+		 VALUES ('aaaaaaaa-0000-0000-0000-000000000004', 'deleted.txt', 'gone soon', 'hash_deleted_v1', 'alice')`,
+
+		// Sequence 1: initial commit of hello.txt and world.txt
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
+		 VALUES ('cccccccc-0000-0000-0000-000000000001', 1, 'hello.txt', 'aaaaaaaa-0000-0000-0000-000000000001', 'main', 'initial commit', 'alice')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
+		 VALUES ('cccccccc-0000-0000-0000-000000000002', 1, 'world.txt', 'aaaaaaaa-0000-0000-0000-000000000003', 'main', 'initial commit', 'alice')`,
+
+		// Sequence 2: update hello.txt
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
+		 VALUES ('cccccccc-0000-0000-0000-000000000003', 2, 'hello.txt', 'aaaaaaaa-0000-0000-0000-000000000002', 'main', 'update hello', 'alice')`,
+
+		// Sequence 3: add deleted.txt
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
+		 VALUES ('cccccccc-0000-0000-0000-000000000004', 3, 'deleted.txt', 'aaaaaaaa-0000-0000-0000-000000000004', 'main', 'add deleted', 'bob')`,
+
+		// Sequence 4: delete deleted.txt (version_id = NULL)
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
+		 VALUES ('cccccccc-0000-0000-0000-000000000005', 4, 'deleted.txt', NULL, 'main', 'remove deleted', 'bob')`,
+
+		// Update main head
+		`UPDATE branches SET head_sequence = 4 WHERE name = 'main'`,
+	}
+
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed: %v\nstatement: %s", err, stmt)
+		}
+	}
+}
+
+func TestMaterializeTree(t *testing.T) {
+	db := testutil.TestDB(t)
+	seed(t, db)
+	s := store.New(db)
+	ctx := context.Background()
+
+	t.Run("head of main", func(t *testing.T) {
+		entries, err := s.MaterializeTree(ctx, "main", nil, 100, "")
+		if err != nil {
+			t.Fatalf("MaterializeTree: %v", err)
+		}
+		// Should see hello.txt (v2) and world.txt — deleted.txt is excluded.
+		if len(entries) != 2 {
+			t.Fatalf("expected 2 entries, got %d: %+v", len(entries), entries)
+		}
+		if entries[0].Path != "hello.txt" {
+			t.Errorf("expected hello.txt, got %s", entries[0].Path)
+		}
+		if entries[0].ContentHash != "hash_hello_v2" {
+			t.Errorf("expected hash_hello_v2, got %s", entries[0].ContentHash)
+		}
+		if entries[1].Path != "world.txt" {
+			t.Errorf("expected world.txt, got %s", entries[1].Path)
+		}
+	})
+
+	t.Run("at sequence 1", func(t *testing.T) {
+		seq := int64(1)
+		entries, err := s.MaterializeTree(ctx, "main", &seq, 100, "")
+		if err != nil {
+			t.Fatalf("MaterializeTree: %v", err)
+		}
+		// At seq 1: hello.txt v1 and world.txt
+		if len(entries) != 2 {
+			t.Fatalf("expected 2 entries, got %d", len(entries))
+		}
+		if entries[0].ContentHash != "hash_hello_v1" {
+			t.Errorf("expected hash_hello_v1, got %s", entries[0].ContentHash)
+		}
+	})
+
+	t.Run("at sequence 3 includes deleted file", func(t *testing.T) {
+		seq := int64(3)
+		entries, err := s.MaterializeTree(ctx, "main", &seq, 100, "")
+		if err != nil {
+			t.Fatalf("MaterializeTree: %v", err)
+		}
+		// At seq 3: hello.txt v2, world.txt, and deleted.txt (not yet deleted)
+		if len(entries) != 3 {
+			t.Fatalf("expected 3 entries, got %d: %+v", len(entries), entries)
+		}
+	})
+
+	t.Run("pagination", func(t *testing.T) {
+		entries, err := s.MaterializeTree(ctx, "main", nil, 1, "")
+		if err != nil {
+			t.Fatalf("MaterializeTree: %v", err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(entries))
+		}
+		if entries[0].Path != "hello.txt" {
+			t.Errorf("expected hello.txt first, got %s", entries[0].Path)
+		}
+
+		// Second page
+		entries2, err := s.MaterializeTree(ctx, "main", nil, 1, entries[0].Path)
+		if err != nil {
+			t.Fatalf("MaterializeTree page 2: %v", err)
+		}
+		if len(entries2) != 1 {
+			t.Fatalf("expected 1 entry on page 2, got %d", len(entries2))
+		}
+		if entries2[0].Path != "world.txt" {
+			t.Errorf("expected world.txt, got %s", entries2[0].Path)
+		}
+	})
+}
+
+func TestGetFile(t *testing.T) {
+	db := testutil.TestDB(t)
+	seed(t, db)
+	s := store.New(db)
+	ctx := context.Background()
+
+	t.Run("current version", func(t *testing.T) {
+		fc, err := s.GetFile(ctx, "main", "hello.txt", nil)
+		if err != nil {
+			t.Fatalf("GetFile: %v", err)
+		}
+		if fc == nil {
+			t.Fatal("expected file, got nil")
+		}
+		if string(fc.Content) != "hello world v2" {
+			t.Errorf("expected 'hello world v2', got %q", string(fc.Content))
+		}
+		if fc.ContentHash != "hash_hello_v2" {
+			t.Errorf("expected hash_hello_v2, got %s", fc.ContentHash)
+		}
+	})
+
+	t.Run("at sequence 1", func(t *testing.T) {
+		seq := int64(1)
+		fc, err := s.GetFile(ctx, "main", "hello.txt", &seq)
+		if err != nil {
+			t.Fatalf("GetFile: %v", err)
+		}
+		if fc == nil {
+			t.Fatal("expected file, got nil")
+		}
+		if string(fc.Content) != "hello world" {
+			t.Errorf("expected 'hello world', got %q", string(fc.Content))
+		}
+	})
+
+	t.Run("deleted file returns nil", func(t *testing.T) {
+		fc, err := s.GetFile(ctx, "main", "deleted.txt", nil)
+		if err != nil {
+			t.Fatalf("GetFile: %v", err)
+		}
+		if fc != nil {
+			t.Errorf("expected nil for deleted file, got %+v", fc)
+		}
+	})
+
+	t.Run("nonexistent file", func(t *testing.T) {
+		fc, err := s.GetFile(ctx, "main", "nope.txt", nil)
+		if err != nil {
+			t.Fatalf("GetFile: %v", err)
+		}
+		if fc != nil {
+			t.Errorf("expected nil for nonexistent file, got %+v", fc)
+		}
+	})
+}
+
+func TestGetFileHistory(t *testing.T) {
+	db := testutil.TestDB(t)
+	seed(t, db)
+	s := store.New(db)
+	ctx := context.Background()
+
+	t.Run("hello.txt history", func(t *testing.T) {
+		entries, err := s.GetFileHistory(ctx, "main", "hello.txt", 100, nil)
+		if err != nil {
+			t.Fatalf("GetFileHistory: %v", err)
+		}
+		if len(entries) != 2 {
+			t.Fatalf("expected 2 history entries, got %d", len(entries))
+		}
+		// Most recent first
+		if entries[0].Sequence != 2 {
+			t.Errorf("expected sequence 2 first, got %d", entries[0].Sequence)
+		}
+		if entries[1].Sequence != 1 {
+			t.Errorf("expected sequence 1 second, got %d", entries[1].Sequence)
+		}
+	})
+
+	t.Run("deleted.txt history includes delete", func(t *testing.T) {
+		entries, err := s.GetFileHistory(ctx, "main", "deleted.txt", 100, nil)
+		if err != nil {
+			t.Fatalf("GetFileHistory: %v", err)
+		}
+		if len(entries) != 2 {
+			t.Fatalf("expected 2 history entries, got %d", len(entries))
+		}
+		// seq 4 is the delete (version_id nil)
+		if entries[0].Sequence != 4 {
+			t.Errorf("expected sequence 4, got %d", entries[0].Sequence)
+		}
+		if entries[0].VersionID != nil {
+			t.Errorf("expected nil version_id for delete, got %v", *entries[0].VersionID)
+		}
+	})
+
+	t.Run("pagination with after cursor", func(t *testing.T) {
+		after := int64(2)
+		entries, err := s.GetFileHistory(ctx, "main", "hello.txt", 100, &after)
+		if err != nil {
+			t.Fatalf("GetFileHistory: %v", err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry after seq 2, got %d", len(entries))
+		}
+		if entries[0].Sequence != 1 {
+			t.Errorf("expected sequence 1, got %d", entries[0].Sequence)
+		}
+	})
+}
+
+func TestGetCommit(t *testing.T) {
+	db := testutil.TestDB(t)
+	seed(t, db)
+	s := store.New(db)
+	ctx := context.Background()
+
+	t.Run("multi-file commit", func(t *testing.T) {
+		detail, err := s.GetCommit(ctx, 1)
+		if err != nil {
+			t.Fatalf("GetCommit: %v", err)
+		}
+		if detail == nil {
+			t.Fatal("expected commit detail, got nil")
+		}
+		if detail.Sequence != 1 {
+			t.Errorf("expected sequence 1, got %d", detail.Sequence)
+		}
+		if detail.Message != "initial commit" {
+			t.Errorf("expected 'initial commit', got %q", detail.Message)
+		}
+		if detail.Author != "alice" {
+			t.Errorf("expected author alice, got %q", detail.Author)
+		}
+		if len(detail.Files) != 2 {
+			t.Fatalf("expected 2 files in commit, got %d", len(detail.Files))
+		}
+		// Files ordered by path
+		if detail.Files[0].Path != "hello.txt" {
+			t.Errorf("expected hello.txt first, got %s", detail.Files[0].Path)
+		}
+		if detail.Files[1].Path != "world.txt" {
+			t.Errorf("expected world.txt second, got %s", detail.Files[1].Path)
+		}
+	})
+
+	t.Run("single-file commit", func(t *testing.T) {
+		detail, err := s.GetCommit(ctx, 2)
+		if err != nil {
+			t.Fatalf("GetCommit: %v", err)
+		}
+		if detail == nil {
+			t.Fatal("expected commit detail, got nil")
+		}
+		if len(detail.Files) != 1 {
+			t.Fatalf("expected 1 file, got %d", len(detail.Files))
+		}
+	})
+
+	t.Run("delete commit has nil version_id", func(t *testing.T) {
+		detail, err := s.GetCommit(ctx, 4)
+		if err != nil {
+			t.Fatalf("GetCommit: %v", err)
+		}
+		if detail == nil {
+			t.Fatal("expected commit detail, got nil")
+		}
+		if detail.Files[0].VersionID != nil {
+			t.Errorf("expected nil version_id for delete commit")
+		}
+	})
+
+	t.Run("nonexistent sequence", func(t *testing.T) {
+		detail, err := s.GetCommit(ctx, 999)
+		if err != nil {
+			t.Fatalf("GetCommit: %v", err)
+		}
+		if detail != nil {
+			t.Errorf("expected nil for nonexistent sequence, got %+v", detail)
+		}
+	})
+}
+
+func TestBranchTree(t *testing.T) {
+	db := testutil.TestDB(t)
+	seed(t, db)
+	s := store.New(db)
+	ctx := context.Background()
+
+	// Create a feature branch forked from main at sequence 2
+	stmts := []string{
+		`INSERT INTO branches (name, head_sequence, base_sequence, status) VALUES ('feature/test', 5, 2, 'active')`,
+		// Add a new file on the branch
+		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
+		 VALUES ('aaaaaaaa-0000-0000-0000-000000000010', 'new.txt', 'new file', 'hash_new', 'carol')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
+		 VALUES ('cccccccc-0000-0000-0000-000000000010', 5, 'new.txt', 'aaaaaaaa-0000-0000-0000-000000000010', 'feature/test', 'add new file', 'carol')`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed branch: %v\n%s", err, stmt)
+		}
+	}
+
+	entries, err := s.MaterializeTree(ctx, "feature/test", nil, 100, "")
+	if err != nil {
+		t.Fatalf("MaterializeTree: %v", err)
+	}
+
+	// Branch inherits main at seq 2: hello.txt (v2), world.txt
+	// Plus branch's own: new.txt
+	// Note: deleted.txt was added at seq 3 and deleted at seq 4 on main,
+	// both after the branch point (seq 2), so it doesn't appear.
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d: %+v", len(entries), entries)
+	}
+
+	paths := make(map[string]bool)
+	for _, e := range entries {
+		paths[e.Path] = true
+	}
+	for _, want := range []string{"hello.txt", "new.txt", "world.txt"} {
+		if !paths[want] {
+			t.Errorf("expected %s in tree", want)
+		}
+	}
+}

--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -1,0 +1,80 @@
+package testutil
+
+import (
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	"github.com/dlorenc/docstore/internal/db"
+)
+
+// TestDB creates a fresh PostgreSQL database for the current test and runs
+// migrations. It returns a connected *sql.DB that is automatically cleaned up
+// when the test finishes.
+//
+// The connection string is read from DOCSTORE_TEST_DSN. If the variable is
+// not set the test is skipped. The DSN should point to a PostgreSQL server
+// (the database name in the DSN is ignored; a unique temp database is created).
+//
+// Example:
+//
+//	export DOCSTORE_TEST_DSN="postgres://localhost:5432/postgres?sslmode=disable"
+func TestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dsn := os.Getenv("DOCSTORE_TEST_DSN")
+	if dsn == "" {
+		t.Skip("DOCSTORE_TEST_DSN not set, skipping integration test")
+	}
+
+	u, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parse DOCSTORE_TEST_DSN: %v", err)
+	}
+
+	// Connect to the default "postgres" database to create the temp database.
+	adminURL := *u
+	adminURL.Path = "/postgres"
+	adminDB, err := sql.Open("postgres", adminURL.String())
+	if err != nil {
+		t.Fatalf("connect to postgres: %v", err)
+	}
+
+	dbName := fmt.Sprintf("docstore_test_%d_%d", os.Getpid(), time.Now().UnixNano())
+
+	if _, err := adminDB.Exec("CREATE DATABASE " + dbName); err != nil {
+		adminDB.Close()
+		t.Fatalf("create test database: %v", err)
+	}
+
+	// Connect to the temp database.
+	testURL := *u
+	testURL.Path = "/" + dbName
+	testDB, err := sql.Open("postgres", testURL.String())
+	if err != nil {
+		adminDB.Exec("DROP DATABASE IF EXISTS " + dbName)
+		adminDB.Close()
+		t.Fatalf("connect to test database: %v", err)
+	}
+
+	// Run schema migrations.
+	if _, err := testDB.Exec(db.MigrationSQL); err != nil {
+		testDB.Close()
+		adminDB.Exec("DROP DATABASE IF EXISTS " + dbName)
+		adminDB.Close()
+		t.Fatalf("run migrations: %v", err)
+	}
+
+	t.Cleanup(func() {
+		testDB.Close()
+		adminDB.Exec("DROP DATABASE IF EXISTS " + dbName)
+		adminDB.Close()
+	})
+
+	return testDB
+}


### PR DESCRIPTION
## Summary

- Implements 4 P0 read endpoints from DESIGN.md: `GET /tree`, `GET /file/:path`, `GET /file/:path/history`, `GET /commit/:sequence`
- Creates `internal/store` package with branch-aware query layer using `DISTINCT ON (path) ORDER BY sequence DESC` for tree materialization
- Feature branch trees correctly combine branch commits with inherited main commits via `base_sequence`
- Adds `internal/testutil/testdb.go` — test helper that provisions ephemeral PostgreSQL databases (skips gracefully when `DOCSTORE_TEST_DSN` is not set)
- Comprehensive integration tests: pagination, deleted files, point-in-time queries, branch trees, error codes

## Key design decisions

- **Branch-aware queries**: All read queries use a CTE that unions branch commits with main commits up to `base_sequence`, so feature branch trees show inherited files correctly
- **Delete handling**: Tree materialization filters out paths where the latest `version_id IS NULL` (file deleted)
- **History suffix routing**: `GET /file/{path...}` handler checks for `/history` suffix since Go's ServeMux requires `{path...}` at the end
- **Nil DB support**: `server.New(nil)` works for health check and stub endpoints, enabling unit tests without a database

## Files changed

| File | Purpose |
|------|---------|
| `internal/store/store.go` | Store type with `MaterializeTree`, `GetFile`, `GetFileHistory`, `GetCommit` |
| `internal/server/handlers.go` | HTTP handlers for all 4 read endpoints |
| `internal/server/server.go` | Updated `New()` to accept `*sql.DB`, wire read handlers |
| `internal/testutil/testdb.go` | Test DB helper with per-test database provisioning |
| `internal/db/migrations.go` | Embedded migration SQL via `//go:embed` |
| `internal/store/store_test.go` | Store-level integration tests |
| `internal/server/integration_test.go` | HTTP-level integration tests |
| `cmd/docstore/main.go` | Wire up `DATABASE_URL` → `db.Open` → `server.New` |

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (integration tests skip without `DOCSTORE_TEST_DSN`)
- [ ] With PostgreSQL: `DOCSTORE_TEST_DSN=postgres://localhost:5432/postgres?sslmode=disable go test ./...`

## Future opportunities (not in scope)

- The `POST /commit` endpoint (document store & content dedup) can reuse the `Store` pattern
- Pagination could be extracted into a shared helper if more list endpoints need it

🤖 Generated with [Claude Code](https://claude.com/claude-code)