### PR TITLE
Add branch management, merge engine, rebase, and diff endpoints

### DIFF
--- a/cmd/docstore/main.go
+++ b/cmd/docstore/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/server"
 )
 
@@ -18,7 +19,22 @@ func main() {
 		port = "8080"
 	}
 
-	srv := server.New()
+	// Set up the store. If DATABASE_URL is set, use PostgreSQL; otherwise
+	// handlers that require a store will fail gracefully.
+	var store server.Store
+	if dsn := os.Getenv("DATABASE_URL"); dsn != "" {
+		database, err := db.Open(dsn)
+		if err != nil {
+			log.Fatalf("database connection failed: %v", err)
+		}
+		defer database.Close()
+		store = db.NewStore(database)
+		log.Println("connected to database")
+	} else {
+		log.Println("WARNING: no DATABASE_URL set, database-backed endpoints will not work")
+	}
+
+	srv := server.New(store)
 
 	httpServer := &http.Server{
 		Addr:         ":" + port,

--- a/internal/db/migrations/000002_add_commit_sequence.down.sql
+++ b/internal/db/migrations/000002_add_commit_sequence.down.sql
@@ -1,0 +1,1 @@
+DROP SEQUENCE IF EXISTS commit_sequence;

--- a/internal/db/migrations/000002_add_commit_sequence.up.sql
+++ b/internal/db/migrations/000002_add_commit_sequence.up.sql
@@ -1,0 +1,3 @@
+-- Add a globally monotonic sequence for commit ordering.
+-- Used by nextval('commit_sequence') in write transactions.
+CREATE SEQUENCE commit_sequence START 1;

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1,0 +1,529 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// PGStore implements the server.Store interface using PostgreSQL.
+type PGStore struct {
+	db *sql.DB
+}
+
+// NewStore creates a new PGStore wrapping the given database connection.
+func NewStore(db *sql.DB) *PGStore {
+	return &PGStore{db: db}
+}
+
+// CreateBranch creates a new branch forked from main's current head.
+// Uses a transaction with SELECT FOR UPDATE on main to get a consistent base_sequence.
+func (s *PGStore) CreateBranch(ctx context.Context, name string) (*model.Branch, error) {
+	if name == "main" {
+		return nil, model.ErrProtectedBranch
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Check if branch already exists.
+	var existing string
+	err = tx.QueryRowContext(ctx,
+		`SELECT name FROM branches WHERE name = $1`, name).Scan(&existing)
+	if err == nil {
+		return nil, model.ErrBranchExists
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("check branch: %w", err)
+	}
+
+	// Lock main and get its head_sequence as our base.
+	var mainHead int64
+	err = tx.QueryRowContext(ctx,
+		`SELECT head_sequence FROM branches WHERE name = 'main' FOR UPDATE`).Scan(&mainHead)
+	if err != nil {
+		return nil, fmt.Errorf("lock main: %w", err)
+	}
+
+	// Insert the new branch.
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO branches (name, head_sequence, base_sequence, status) VALUES ($1, $2, $3, 'active')`,
+		name, mainHead, mainHead)
+	if err != nil {
+		return nil, fmt.Errorf("insert branch: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+
+	return &model.Branch{
+		Name:         name,
+		HeadSequence: mainHead,
+		BaseSequence: mainHead,
+		Status:       model.BranchStatusActive,
+	}, nil
+}
+
+// DeleteBranch marks a branch as abandoned.
+func (s *PGStore) DeleteBranch(ctx context.Context, name string) error {
+	if name == "main" {
+		return model.ErrProtectedBranch
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Lock and check the branch.
+	var status string
+	err = tx.QueryRowContext(ctx,
+		`SELECT status FROM branches WHERE name = $1 FOR UPDATE`, name).Scan(&status)
+	if errors.Is(err, sql.ErrNoRows) {
+		return model.ErrBranchNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("lock branch: %w", err)
+	}
+	if status != "active" {
+		return model.ErrBranchNotActive
+	}
+
+	_, err = tx.ExecContext(ctx,
+		`UPDATE branches SET status = 'abandoned' WHERE name = $1`, name)
+	if err != nil {
+		return fmt.Errorf("update branch: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// ListBranches returns all branches, optionally filtered by status.
+func (s *PGStore) ListBranches(ctx context.Context, status string) ([]model.Branch, error) {
+	var rows *sql.Rows
+	var err error
+
+	if status != "" {
+		rows, err = s.db.QueryContext(ctx,
+			`SELECT name, head_sequence, base_sequence, status FROM branches WHERE status = $1::branch_status ORDER BY name`,
+			status)
+	} else {
+		rows, err = s.db.QueryContext(ctx,
+			`SELECT name, head_sequence, base_sequence, status FROM branches ORDER BY name`)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query branches: %w", err)
+	}
+	defer rows.Close()
+
+	var branches []model.Branch
+	for rows.Next() {
+		var b model.Branch
+		if err := rows.Scan(&b.Name, &b.HeadSequence, &b.BaseSequence, &b.Status); err != nil {
+			return nil, fmt.Errorf("scan branch: %w", err)
+		}
+		branches = append(branches, b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows iteration: %w", err)
+	}
+
+	// Return empty slice instead of nil for consistent JSON encoding.
+	if branches == nil {
+		branches = []model.Branch{}
+	}
+	return branches, nil
+}
+
+// changedFiles queries the latest version of each path changed on a branch since a given sequence.
+// This implements the DISTINCT ON (path) ... ORDER BY path, sequence DESC pattern from DESIGN.md.
+// Returns a map of path -> version_id (nil for deletes).
+func changedFiles(ctx context.Context, tx *sql.Tx, branch string, sinceSequence int64) (map[string]*string, error) {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT DISTINCT ON (path) path, version_id
+		 FROM file_commits
+		 WHERE branch = $1 AND sequence > $2
+		 ORDER BY path, sequence DESC`,
+		branch, sinceSequence)
+	if err != nil {
+		return nil, fmt.Errorf("query changes for %s: %w", branch, err)
+	}
+	defer rows.Close()
+
+	changes := make(map[string]*string)
+	for rows.Next() {
+		var path string
+		var versionID *string
+		if err := rows.Scan(&path, &versionID); err != nil {
+			return nil, fmt.Errorf("scan change: %w", err)
+		}
+		changes[path] = versionID
+	}
+	return changes, rows.Err()
+}
+
+// derefVersionID safely dereferences a *string, returning "" for nil (deletes).
+func derefVersionID(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
+// buildConflicts detects paths changed in both sets and returns ConflictEntry slice.
+func buildConflicts(branchChanges, mainChanges map[string]*string) []model.ConflictEntry {
+	var conflicts []model.ConflictEntry
+	for path, branchVID := range branchChanges {
+		if mainVID, ok := mainChanges[path]; ok {
+			conflicts = append(conflicts, model.ConflictEntry{
+				Path:            path,
+				MainVersionID:   derefVersionID(mainVID),
+				BranchVersionID: derefVersionID(branchVID),
+			})
+		}
+	}
+	return conflicts
+}
+
+// Merge merges a branch into main per the DESIGN.md algorithm:
+// 1. Lock both branches (SELECT FOR UPDATE)
+// 2. Find branch changes since base_sequence
+// 3. Find main changes since base_sequence
+// 4. Detect conflicts (overlapping paths)
+// 5. If clean, insert file_commits rows on main with new sequence
+func (s *PGStore) Merge(ctx context.Context, branchName string) (*model.MergeResponse, []model.ConflictEntry, error) {
+	if branchName == "main" {
+		return nil, nil, model.ErrProtectedBranch
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Step 1: Lock both branches. Lock main first for consistent ordering.
+	var mainHead int64
+	err = tx.QueryRowContext(ctx,
+		`SELECT head_sequence FROM branches WHERE name = 'main' FOR UPDATE`).Scan(&mainHead)
+	if err != nil {
+		return nil, nil, fmt.Errorf("lock main: %w", err)
+	}
+
+	var baseSeq int64
+	var branchStatus string
+	err = tx.QueryRowContext(ctx,
+		`SELECT base_sequence, status FROM branches WHERE name = $1 FOR UPDATE`,
+		branchName).Scan(&baseSeq, &branchStatus)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil, model.ErrBranchNotFound
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("lock branch: %w", err)
+	}
+	if branchStatus != "active" {
+		return nil, nil, model.ErrBranchNotActive
+	}
+
+	// Step 2: Find branch changes since base_sequence.
+	branchChanges, err := changedFiles(ctx, tx, branchName, baseSeq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Step 3: Find main changes since base_sequence.
+	mainChanges, err := changedFiles(ctx, tx, "main", baseSeq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Step 4: Conflict check — any path in both sets is a conflict.
+	conflicts := buildConflicts(branchChanges, mainChanges)
+	if len(conflicts) > 0 {
+		return nil, conflicts, nil
+	}
+
+	// Step 5: Clean merge — allocate new sequence and insert file_commits on main.
+	if len(branchChanges) == 0 {
+		// Nothing to merge, but still mark the branch.
+		_, err = tx.ExecContext(ctx,
+			`UPDATE branches SET status = 'merged' WHERE name = $1`, branchName)
+		if err != nil {
+			return nil, nil, fmt.Errorf("mark merged: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, nil, fmt.Errorf("commit: %w", err)
+		}
+		return &model.MergeResponse{Sequence: mainHead}, nil, nil
+	}
+
+	var newSeq int64
+	err = tx.QueryRowContext(ctx, `SELECT nextval('commit_sequence')`).Scan(&newSeq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("allocate sequence: %w", err)
+	}
+
+	// Insert one file_commit row on main for each branch-changed path.
+	for path, versionID := range branchChanges {
+		commitID := model.NewUUID()
+		_, err = tx.ExecContext(ctx,
+			`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author, created_at)
+			 VALUES ($1, $2, $3, $4, 'main', $5, $6, now())`,
+			commitID, newSeq, path, versionID,
+			fmt.Sprintf("Merge branch '%s'", branchName), "system")
+		if err != nil {
+			return nil, nil, fmt.Errorf("insert merge commit for %s: %w", path, err)
+		}
+	}
+
+	// Advance main's head.
+	_, err = tx.ExecContext(ctx,
+		`UPDATE branches SET head_sequence = $1 WHERE name = 'main'`, newSeq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("advance main head: %w", err)
+	}
+
+	// Mark branch as merged.
+	_, err = tx.ExecContext(ctx,
+		`UPDATE branches SET status = 'merged' WHERE name = $1`, branchName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("mark merged: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, nil, fmt.Errorf("commit: %w", err)
+	}
+
+	return &model.MergeResponse{Sequence: newSeq}, nil, nil
+}
+
+// Rebase replays branch commits onto main's current head per DESIGN.md:
+// 1. Lock both branches
+// 2. Find branch changes grouped by original sequence
+// 3. Check for conflicts with main changes since base_sequence
+// 4. If clean, replay each group with new sequence numbers
+// 5. Update branch's base_sequence to main's current head
+func (s *PGStore) Rebase(ctx context.Context, branchName string) (*model.RebaseResponse, []model.ConflictEntry, error) {
+	if branchName == "main" {
+		return nil, nil, model.ErrProtectedBranch
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Lock both branches.
+	var mainHead int64
+	err = tx.QueryRowContext(ctx,
+		`SELECT head_sequence FROM branches WHERE name = 'main' FOR UPDATE`).Scan(&mainHead)
+	if err != nil {
+		return nil, nil, fmt.Errorf("lock main: %w", err)
+	}
+
+	var baseSeq int64
+	var branchStatus string
+	err = tx.QueryRowContext(ctx,
+		`SELECT base_sequence, status FROM branches WHERE name = $1 FOR UPDATE`,
+		branchName).Scan(&baseSeq, &branchStatus)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil, model.ErrBranchNotFound
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("lock branch: %w", err)
+	}
+	if branchStatus != "active" {
+		return nil, nil, model.ErrBranchNotActive
+	}
+
+	// Find branch changes (latest version of each path) for conflict detection.
+	branchChanges, err := changedFiles(ctx, tx, branchName, baseSeq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Find main changes since base_sequence for conflict detection.
+	mainChanges, err := changedFiles(ctx, tx, "main", baseSeq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Conflict check.
+	conflicts := buildConflicts(branchChanges, mainChanges)
+	if len(conflicts) > 0 {
+		return nil, conflicts, nil
+	}
+
+	// Get all branch commits grouped by original sequence for replay.
+	rows, err := tx.QueryContext(ctx,
+		`SELECT sequence, path, version_id, message, author
+		 FROM file_commits
+		 WHERE branch = $1 AND sequence > $2
+		 ORDER BY sequence, path`,
+		branchName, baseSeq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("query branch commits: %w", err)
+	}
+	defer rows.Close()
+
+	// Group commits by original sequence.
+	type commitRow struct {
+		path      string
+		versionID *string
+		message   string
+		author    string
+	}
+	groups := make(map[int64][]commitRow)
+	var seqOrder []int64
+	seenSeq := make(map[int64]bool)
+
+	for rows.Next() {
+		var seq int64
+		var cr commitRow
+		if err := rows.Scan(&seq, &cr.path, &cr.versionID, &cr.message, &cr.author); err != nil {
+			return nil, nil, fmt.Errorf("scan commit: %w", err)
+		}
+		if !seenSeq[seq] {
+			seqOrder = append(seqOrder, seq)
+			seenSeq[seq] = true
+		}
+		groups[seq] = append(groups[seq], cr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("rows iteration: %w", err)
+	}
+
+	// Replay each group with a new sequence number.
+	var newBranchHead int64 = mainHead
+
+	for _, oldSeq := range seqOrder {
+		var newSeq int64
+		err = tx.QueryRowContext(ctx, `SELECT nextval('commit_sequence')`).Scan(&newSeq)
+		if err != nil {
+			return nil, nil, fmt.Errorf("allocate sequence: %w", err)
+		}
+		newBranchHead = newSeq
+
+		for _, cr := range groups[oldSeq] {
+			commitID := model.NewUUID()
+			_, err = tx.ExecContext(ctx,
+				`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author, created_at)
+				 VALUES ($1, $2, $3, $4, $5, $6, $7, now())`,
+				commitID, newSeq, cr.path, cr.versionID, branchName, cr.message, cr.author)
+			if err != nil {
+				return nil, nil, fmt.Errorf("insert rebased commit: %w", err)
+			}
+		}
+	}
+
+	// Update branch: base_sequence = main's head, head_sequence = last replayed sequence.
+	_, err = tx.ExecContext(ctx,
+		`UPDATE branches SET base_sequence = $1, head_sequence = $2 WHERE name = $3`,
+		mainHead, newBranchHead, branchName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("update branch: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, nil, fmt.Errorf("commit: %w", err)
+	}
+
+	return &model.RebaseResponse{
+		NewBaseSequence: mainHead,
+		NewHeadSequence: newBranchHead,
+	}, nil, nil
+}
+
+// Diff computes the diff between a branch and main since base_sequence.
+func (s *PGStore) Diff(ctx context.Context, branchName string) (*model.DiffResponse, error) {
+	// Get branch info.
+	var baseSeq int64
+	var status string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT base_sequence, status FROM branches WHERE name = $1`, branchName).Scan(&baseSeq, &status)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, model.ErrBranchNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get branch: %w", err)
+	}
+
+	// Branch changes since base_sequence.
+	branchRows, err := s.db.QueryContext(ctx,
+		`SELECT DISTINCT ON (path) path, version_id
+		 FROM file_commits
+		 WHERE branch = $1 AND sequence > $2
+		 ORDER BY path, sequence DESC`,
+		branchName, baseSeq)
+	if err != nil {
+		return nil, fmt.Errorf("query branch changes: %w", err)
+	}
+	defer branchRows.Close()
+
+	branchMap := make(map[string]*string)
+	var changed []model.DiffEntry
+	for branchRows.Next() {
+		var de model.DiffEntry
+		if err := branchRows.Scan(&de.Path, &de.VersionID); err != nil {
+			return nil, fmt.Errorf("scan branch change: %w", err)
+		}
+		changed = append(changed, de)
+		branchMap[de.Path] = de.VersionID
+	}
+	if err := branchRows.Err(); err != nil {
+		return nil, fmt.Errorf("branch rows: %w", err)
+	}
+
+	// Main changes since base_sequence for conflict detection.
+	mainRows, err := s.db.QueryContext(ctx,
+		`SELECT DISTINCT ON (path) path, version_id
+		 FROM file_commits
+		 WHERE branch = 'main' AND sequence > $1
+		 ORDER BY path, sequence DESC`,
+		baseSeq)
+	if err != nil {
+		return nil, fmt.Errorf("query main changes: %w", err)
+	}
+	defer mainRows.Close()
+
+	var conflicts []model.ConflictEntry
+	for mainRows.Next() {
+		var path string
+		var mainVID *string
+		if err := mainRows.Scan(&path, &mainVID); err != nil {
+			return nil, fmt.Errorf("scan main change: %w", err)
+		}
+		if branchVID, ok := branchMap[path]; ok {
+			conflicts = append(conflicts, model.ConflictEntry{
+				Path:            path,
+				MainVersionID:   derefVersionID(mainVID),
+				BranchVersionID: derefVersionID(branchVID),
+			})
+		}
+	}
+	if err := mainRows.Err(); err != nil {
+		return nil, fmt.Errorf("main rows: %w", err)
+	}
+
+	// Ensure non-nil slices for JSON.
+	if changed == nil {
+		changed = []model.DiffEntry{}
+	}
+	if conflicts == nil {
+		conflicts = []model.ConflictEntry{}
+	}
+
+	return &model.DiffResponse{
+		Changed:   changed,
+		Conflicts: conflicts,
+	}, nil
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -2,7 +2,31 @@
 // described in DESIGN.md.
 package model
 
-import "time"
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Sentinel errors for store operations.
+var (
+	ErrBranchExists    = errors.New("branch already exists")
+	ErrBranchNotFound  = errors.New("branch not found")
+	ErrBranchNotActive = errors.New("branch is not active")
+	ErrProtectedBranch = errors.New("cannot modify protected branch")
+)
+
+// NewUUID generates a random UUID v4.
+func NewUUID() string {
+	var u [16]byte
+	if _, err := rand.Read(u[:]); err != nil {
+		panic(err)
+	}
+	u[6] = (u[6] & 0x0f) | 0x40 // version 4
+	u[8] = (u[8] & 0x3f) | 0x80 // variant
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:16])
+}
 
 // BranchStatus represents the lifecycle state of a branch.
 type BranchStatus string
@@ -100,3 +124,4 @@ type CheckRun struct {
 	Reporter  string         `json:"reporter"`
 	CreatedAt time.Time      `json:"created_at"`
 }
+

--- a/internal/server/branch.go
+++ b/internal/server/branch.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// handleCreateBranch handles POST /branch.
+// Creates a new branch forked from main's current head.
+func (s *Server) handleCreateBranch(w http.ResponseWriter, r *http.Request) {
+	var req model.CreateBranchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if req.Name == "main" {
+		writeError(w, http.StatusBadRequest, "cannot create branch named 'main'")
+		return
+	}
+
+	branch, err := s.store.CreateBranch(r.Context(), req.Name)
+	if err != nil {
+		if errors.Is(err, model.ErrBranchExists) {
+			writeError(w, http.StatusConflict, "branch already exists")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, model.CreateBranchResponse{
+		Name:         branch.Name,
+		BaseSequence: branch.BaseSequence,
+	})
+}
+
+// handleDeleteBranch handles DELETE /branch/{name}.
+// Marks a branch as abandoned.
+func (s *Server) handleDeleteBranch(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "branch name is required")
+		return
+	}
+	if name == "main" {
+		writeError(w, http.StatusBadRequest, "cannot delete main branch")
+		return
+	}
+
+	err := s.store.DeleteBranch(r.Context(), name)
+	if err != nil {
+		if errors.Is(err, model.ErrBranchNotFound) {
+			writeError(w, http.StatusNotFound, "branch not found")
+			return
+		}
+		if errors.Is(err, model.ErrBranchNotActive) {
+			writeError(w, http.StatusBadRequest, "branch is not active")
+			return
+		}
+		if errors.Is(err, model.ErrProtectedBranch) {
+			writeError(w, http.StatusBadRequest, "cannot delete protected branch")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, model.DeleteBranchResponse{
+		Name:   name,
+		Status: model.BranchStatusAbandoned,
+	})
+}
+
+// handleListBranches handles GET /branches.
+// Returns all branches, optionally filtered by ?status=active.
+func (s *Server) handleListBranches(w http.ResponseWriter, r *http.Request) {
+	status := r.URL.Query().Get("status")
+
+	branches, err := s.store.ListBranches(r.Context(), status)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, model.BranchesResponse{Branches: branches})
+}

--- a/internal/server/diff.go
+++ b/internal/server/diff.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// handleDiff handles GET /diff?branch=X.
+// Returns files changed on the branch relative to its base_sequence,
+// plus any conflicting paths on main since that base.
+func (s *Server) handleDiff(w http.ResponseWriter, r *http.Request) {
+	branch := r.URL.Query().Get("branch")
+	if branch == "" {
+		writeError(w, http.StatusBadRequest, "branch query parameter is required")
+		return
+	}
+
+	result, err := s.store.Diff(r.Context(), branch)
+	if err != nil {
+		if errors.Is(err, model.ErrBranchNotFound) {
+			writeError(w, http.StatusNotFound, "branch not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}

--- a/internal/server/merge.go
+++ b/internal/server/merge.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// handleMerge handles POST /merge.
+// Merges a branch into main per the DESIGN.md algorithm:
+// 1. Lock both branches (SELECT FOR UPDATE)
+// 2. Find branch changes since base_sequence
+// 3. Find main changes since base_sequence
+// 4. Detect conflicts (overlapping paths)
+// 5. If clean, insert file_commits rows on main with new sequence
+func (s *Server) handleMerge(w http.ResponseWriter, r *http.Request) {
+	var req model.MergeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Branch == "" {
+		writeError(w, http.StatusBadRequest, "branch is required")
+		return
+	}
+	if req.Branch == "main" {
+		writeError(w, http.StatusBadRequest, "cannot merge main into itself")
+		return
+	}
+
+	resp, conflicts, err := s.store.Merge(r.Context(), req.Branch)
+	if err != nil {
+		if errors.Is(err, model.ErrBranchNotFound) {
+			writeError(w, http.StatusNotFound, "branch not found")
+			return
+		}
+		if errors.Is(err, model.ErrBranchNotActive) {
+			writeError(w, http.StatusBadRequest, "branch is not active")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	if len(conflicts) > 0 {
+		writeJSON(w, http.StatusConflict, model.MergeConflictError{Conflicts: conflicts})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/server/rebase.go
+++ b/internal/server/rebase.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// handleRebase handles POST /rebase.
+// Replays branch commits onto main's current head per DESIGN.md:
+// 1. Lock both branches
+// 2. Find branch changes grouped by original sequence
+// 3. Check for conflicts with main changes since base_sequence
+// 4. If clean, replay each group with new sequence numbers
+// 5. Update branch's base_sequence to main's current head
+func (s *Server) handleRebase(w http.ResponseWriter, r *http.Request) {
+	var req model.RebaseRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Branch == "" {
+		writeError(w, http.StatusBadRequest, "branch is required")
+		return
+	}
+	if req.Branch == "main" {
+		writeError(w, http.StatusBadRequest, "cannot rebase main")
+		return
+	}
+
+	resp, conflicts, err := s.store.Rebase(r.Context(), req.Branch)
+	if err != nil {
+		if errors.Is(err, model.ErrBranchNotFound) {
+			writeError(w, http.StatusNotFound, "branch not found")
+			return
+		}
+		if errors.Is(err, model.ErrBranchNotActive) {
+			writeError(w, http.StatusBadRequest, "branch is not active")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	if len(conflicts) > 0 {
+		writeJSON(w, http.StatusConflict, model.RebaseConflictError{Conflicts: conflicts})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,39 +5,54 @@ import (
 	"net/http"
 )
 
+// Server holds dependencies and registers HTTP routes.
+type Server struct {
+	store Store
+}
+
 // New returns an http.Handler with all routes registered.
-func New() http.Handler {
+func New(store Store) http.Handler {
+	s := &Server{store: store}
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /healthz", handleHealth)
 
-	// Read endpoints (placeholders).
+	// Read endpoints.
 	mux.HandleFunc("GET /tree", notImplemented)
 	mux.HandleFunc("GET /file/{path...}", notImplemented)
 	mux.HandleFunc("GET /commit/{sequence}", notImplemented)
-	mux.HandleFunc("GET /diff", notImplemented)
-	mux.HandleFunc("GET /branches", notImplemented)
+	mux.HandleFunc("GET /diff", s.handleDiff)
+	mux.HandleFunc("GET /branches", s.handleListBranches)
 	mux.HandleFunc("GET /branch/{name}/status", notImplemented)
 
-	// Write endpoints (placeholders).
+	// Write endpoints.
 	mux.HandleFunc("POST /commit", notImplemented)
-	mux.HandleFunc("POST /branch", notImplemented)
-	mux.HandleFunc("POST /merge", notImplemented)
-	mux.HandleFunc("POST /rebase", notImplemented)
+	mux.HandleFunc("POST /branch", s.handleCreateBranch)
+	mux.HandleFunc("POST /merge", s.handleMerge)
+	mux.HandleFunc("POST /rebase", s.handleRebase)
 	mux.HandleFunc("POST /review", notImplemented)
 	mux.HandleFunc("POST /check", notImplemented)
-	mux.HandleFunc("DELETE /branch/{name}", notImplemented)
+	mux.HandleFunc("DELETE /branch/{name...}", s.handleDeleteBranch)
 
 	return mux
 }
 
 func handleHealth(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 func notImplemented(w http.ResponseWriter, r *http.Request) {
+	writeError(w, http.StatusNotImplemented, "not implemented")
+}
+
+// writeJSON encodes v as JSON and writes it with the given status code.
+func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusNotImplemented)
-	json.NewEncoder(w).Encode(map[string]string{"error": "not implemented"})
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+// writeError writes a JSON error response.
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,15 +1,55 @@
 package server
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/dlorenc/docstore/internal/model"
 )
 
-func TestHealthEndpoint(t *testing.T) {
-	srv := New()
+// --- Mock Store ---
 
+type mockStore struct {
+	createBranchFn func(ctx context.Context, name string) (*model.Branch, error)
+	deleteBranchFn func(ctx context.Context, name string) error
+	listBranchesFn func(ctx context.Context, status string) ([]model.Branch, error)
+	mergeFn        func(ctx context.Context, branch string) (*model.MergeResponse, []model.ConflictEntry, error)
+	rebaseFn       func(ctx context.Context, branch string) (*model.RebaseResponse, []model.ConflictEntry, error)
+	diffFn         func(ctx context.Context, branch string) (*model.DiffResponse, error)
+}
+
+func (m *mockStore) CreateBranch(ctx context.Context, name string) (*model.Branch, error) {
+	return m.createBranchFn(ctx, name)
+}
+
+func (m *mockStore) DeleteBranch(ctx context.Context, name string) error {
+	return m.deleteBranchFn(ctx, name)
+}
+
+func (m *mockStore) ListBranches(ctx context.Context, status string) ([]model.Branch, error) {
+	return m.listBranchesFn(ctx, status)
+}
+
+func (m *mockStore) Merge(ctx context.Context, branch string) (*model.MergeResponse, []model.ConflictEntry, error) {
+	return m.mergeFn(ctx, branch)
+}
+
+func (m *mockStore) Rebase(ctx context.Context, branch string) (*model.RebaseResponse, []model.ConflictEntry, error) {
+	return m.rebaseFn(ctx, branch)
+}
+
+func (m *mockStore) Diff(ctx context.Context, branch string) (*model.DiffResponse, error) {
+	return m.diffFn(ctx, branch)
+}
+
+// --- Health ---
+
+func TestHealthEndpoint(t *testing.T) {
+	srv := New(nil)
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -17,7 +57,6 @@ func TestHealthEndpoint(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
-
 	var body map[string]string
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("decode error: %v", err)
@@ -28,18 +67,13 @@ func TestHealthEndpoint(t *testing.T) {
 }
 
 func TestNotImplementedEndpoints(t *testing.T) {
-	srv := New()
-
+	srv := New(nil)
 	endpoints := []struct {
 		method string
 		path   string
 	}{
 		{"GET", "/tree"},
-		{"GET", "/branches"},
 		{"POST", "/commit"},
-		{"POST", "/branch"},
-		{"POST", "/merge"},
-		{"POST", "/rebase"},
 		{"POST", "/review"},
 		{"POST", "/check"},
 	}
@@ -49,10 +83,540 @@ func TestNotImplementedEndpoints(t *testing.T) {
 			req := httptest.NewRequest(ep.method, ep.path, nil)
 			rec := httptest.NewRecorder()
 			srv.ServeHTTP(rec, req)
-
 			if rec.Code != http.StatusNotImplemented {
 				t.Fatalf("expected 501, got %d", rec.Code)
 			}
 		})
+	}
+}
+
+// --- POST /branch ---
+
+func TestCreateBranch(t *testing.T) {
+	ms := &mockStore{
+		createBranchFn: func(_ context.Context, name string) (*model.Branch, error) {
+			return &model.Branch{
+				Name:         name,
+				HeadSequence: 5,
+				BaseSequence: 5,
+				Status:       model.BranchStatusActive,
+			}, nil
+		},
+	}
+	srv := New(ms)
+
+	body := `{"name":"feature/test"}`
+	req := httptest.NewRequest(http.MethodPost, "/branch", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.CreateBranchResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Name != "feature/test" {
+		t.Fatalf("expected name feature/test, got %q", resp.Name)
+	}
+	if resp.BaseSequence != 5 {
+		t.Fatalf("expected base_sequence 5, got %d", resp.BaseSequence)
+	}
+}
+
+func TestCreateBranch_MissingName(t *testing.T) {
+	srv := New(&mockStore{})
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPost, "/branch", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestCreateBranch_MainForbidden(t *testing.T) {
+	srv := New(&mockStore{})
+	body := `{"name":"main"}`
+	req := httptest.NewRequest(http.MethodPost, "/branch", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestCreateBranch_AlreadyExists(t *testing.T) {
+	ms := &mockStore{
+		createBranchFn: func(_ context.Context, _ string) (*model.Branch, error) {
+			return nil, model.ErrBranchExists
+		},
+	}
+	srv := New(ms)
+
+	body := `{"name":"feature/exists"}`
+	req := httptest.NewRequest(http.MethodPost, "/branch", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", rec.Code)
+	}
+}
+
+func TestCreateBranch_InvalidJSON(t *testing.T) {
+	srv := New(&mockStore{})
+	req := httptest.NewRequest(http.MethodPost, "/branch", bytes.NewBufferString("not json"))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+// --- DELETE /branch/{name} ---
+
+func TestDeleteBranch(t *testing.T) {
+	ms := &mockStore{
+		deleteBranchFn: func(_ context.Context, _ string) error {
+			return nil
+		},
+	}
+	srv := New(ms)
+
+	req := httptest.NewRequest(http.MethodDelete, "/branch/feature/old", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.DeleteBranchResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Status != model.BranchStatusAbandoned {
+		t.Fatalf("expected status abandoned, got %q", resp.Status)
+	}
+}
+
+func TestDeleteBranch_MainForbidden(t *testing.T) {
+	srv := New(&mockStore{})
+	req := httptest.NewRequest(http.MethodDelete, "/branch/main", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestDeleteBranch_NotFound(t *testing.T) {
+	ms := &mockStore{
+		deleteBranchFn: func(_ context.Context, _ string) error {
+			return model.ErrBranchNotFound
+		},
+	}
+	srv := New(ms)
+
+	req := httptest.NewRequest(http.MethodDelete, "/branch/nonexistent", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestDeleteBranch_NotActive(t *testing.T) {
+	ms := &mockStore{
+		deleteBranchFn: func(_ context.Context, _ string) error {
+			return model.ErrBranchNotActive
+		},
+	}
+	srv := New(ms)
+
+	req := httptest.NewRequest(http.MethodDelete, "/branch/already-merged", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+// --- GET /branches ---
+
+func TestListBranches(t *testing.T) {
+	ms := &mockStore{
+		listBranchesFn: func(_ context.Context, status string) ([]model.Branch, error) {
+			branches := []model.Branch{
+				{Name: "main", HeadSequence: 10, BaseSequence: 0, Status: model.BranchStatusActive},
+				{Name: "feature/a", HeadSequence: 5, BaseSequence: 3, Status: model.BranchStatusActive},
+			}
+			if status == "active" {
+				return branches, nil
+			}
+			return append(branches, model.Branch{
+				Name: "feature/old", HeadSequence: 2, BaseSequence: 1, Status: model.BranchStatusMerged,
+			}), nil
+		},
+	}
+	srv := New(ms)
+
+	// Without filter.
+	req := httptest.NewRequest(http.MethodGet, "/branches", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp model.BranchesResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Branches) != 3 {
+		t.Fatalf("expected 3 branches, got %d", len(resp.Branches))
+	}
+
+	// With status filter.
+	req = httptest.NewRequest(http.MethodGet, "/branches?status=active", nil)
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Branches) != 2 {
+		t.Fatalf("expected 2 active branches, got %d", len(resp.Branches))
+	}
+}
+
+// --- POST /merge ---
+
+func TestMerge_Success(t *testing.T) {
+	ms := &mockStore{
+		mergeFn: func(_ context.Context, _ string) (*model.MergeResponse, []model.ConflictEntry, error) {
+			return &model.MergeResponse{Sequence: 42}, nil, nil
+		},
+	}
+	srv := New(ms)
+
+	body := `{"branch":"feature/done"}`
+	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.MergeResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Sequence != 42 {
+		t.Fatalf("expected sequence 42, got %d", resp.Sequence)
+	}
+}
+
+func TestMerge_Conflict(t *testing.T) {
+	ms := &mockStore{
+		mergeFn: func(_ context.Context, _ string) (*model.MergeResponse, []model.ConflictEntry, error) {
+			return nil, []model.ConflictEntry{
+				{Path: "src/main.go", MainVersionID: "v1", BranchVersionID: "v2"},
+			}, nil
+		},
+	}
+	srv := New(ms)
+
+	body := `{"branch":"feature/conflicting"}`
+	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.MergeConflictError
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d", len(resp.Conflicts))
+	}
+	if resp.Conflicts[0].Path != "src/main.go" {
+		t.Fatalf("expected conflict on src/main.go, got %q", resp.Conflicts[0].Path)
+	}
+}
+
+func TestMerge_BranchNotFound(t *testing.T) {
+	ms := &mockStore{
+		mergeFn: func(_ context.Context, _ string) (*model.MergeResponse, []model.ConflictEntry, error) {
+			return nil, nil, model.ErrBranchNotFound
+		},
+	}
+	srv := New(ms)
+
+	body := `{"branch":"feature/gone"}`
+	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestMerge_MissingBranch(t *testing.T) {
+	srv := New(&mockStore{})
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestMerge_MainForbidden(t *testing.T) {
+	srv := New(&mockStore{})
+	body := `{"branch":"main"}`
+	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestMerge_NotActive(t *testing.T) {
+	ms := &mockStore{
+		mergeFn: func(_ context.Context, _ string) (*model.MergeResponse, []model.ConflictEntry, error) {
+			return nil, nil, model.ErrBranchNotActive
+		},
+	}
+	srv := New(ms)
+
+	body := `{"branch":"feature/merged"}`
+	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+// --- POST /rebase ---
+
+func TestRebase_Success(t *testing.T) {
+	ms := &mockStore{
+		rebaseFn: func(_ context.Context, _ string) (*model.RebaseResponse, []model.ConflictEntry, error) {
+			return &model.RebaseResponse{NewBaseSequence: 10, NewHeadSequence: 12}, nil, nil
+		},
+	}
+	srv := New(ms)
+
+	body := `{"branch":"feature/update"}`
+	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.RebaseResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.NewBaseSequence != 10 {
+		t.Fatalf("expected new_base_sequence 10, got %d", resp.NewBaseSequence)
+	}
+	if resp.NewHeadSequence != 12 {
+		t.Fatalf("expected new_head_sequence 12, got %d", resp.NewHeadSequence)
+	}
+}
+
+func TestRebase_Conflict(t *testing.T) {
+	ms := &mockStore{
+		rebaseFn: func(_ context.Context, _ string) (*model.RebaseResponse, []model.ConflictEntry, error) {
+			return nil, []model.ConflictEntry{
+				{Path: "config.yaml", MainVersionID: "v3", BranchVersionID: "v4"},
+			}, nil
+		},
+	}
+	srv := New(ms)
+
+	body := `{"branch":"feature/conflicting"}`
+	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.RebaseConflictError
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d", len(resp.Conflicts))
+	}
+}
+
+func TestRebase_MissingBranch(t *testing.T) {
+	srv := New(&mockStore{})
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestRebase_MainForbidden(t *testing.T) {
+	srv := New(&mockStore{})
+	body := `{"branch":"main"}`
+	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestRebase_NotFound(t *testing.T) {
+	ms := &mockStore{
+		rebaseFn: func(_ context.Context, _ string) (*model.RebaseResponse, []model.ConflictEntry, error) {
+			return nil, nil, model.ErrBranchNotFound
+		},
+	}
+	srv := New(ms)
+
+	body := `{"branch":"feature/gone"}`
+	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+// --- GET /diff ---
+
+func TestDiff_Success(t *testing.T) {
+	vid := "version-123"
+	ms := &mockStore{
+		diffFn: func(_ context.Context, branch string) (*model.DiffResponse, error) {
+			return &model.DiffResponse{
+				Changed: []model.DiffEntry{
+					{Path: "src/new.go", VersionID: &vid},
+				},
+				Conflicts: []model.ConflictEntry{},
+			}, nil
+		},
+	}
+	srv := New(ms)
+
+	req := httptest.NewRequest(http.MethodGet, "/diff?branch=feature/x", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.DiffResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Changed) != 1 {
+		t.Fatalf("expected 1 changed file, got %d", len(resp.Changed))
+	}
+	if resp.Changed[0].Path != "src/new.go" {
+		t.Fatalf("expected changed path src/new.go, got %q", resp.Changed[0].Path)
+	}
+}
+
+func TestDiff_WithConflicts(t *testing.T) {
+	ms := &mockStore{
+		diffFn: func(_ context.Context, _ string) (*model.DiffResponse, error) {
+			vid := "v1"
+			return &model.DiffResponse{
+				Changed: []model.DiffEntry{
+					{Path: "shared.go", VersionID: &vid},
+				},
+				Conflicts: []model.ConflictEntry{
+					{Path: "shared.go", MainVersionID: "v2", BranchVersionID: "v1"},
+				},
+			}, nil
+		},
+	}
+	srv := New(ms)
+
+	req := httptest.NewRequest(http.MethodGet, "/diff?branch=feature/conflict", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp model.DiffResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d", len(resp.Conflicts))
+	}
+}
+
+func TestDiff_MissingBranch(t *testing.T) {
+	srv := New(&mockStore{})
+	req := httptest.NewRequest(http.MethodGet, "/diff", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestDiff_NotFound(t *testing.T) {
+	ms := &mockStore{
+		diffFn: func(_ context.Context, _ string) (*model.DiffResponse, error) {
+			return nil, model.ErrBranchNotFound
+		},
+	}
+	srv := New(ms)
+
+	req := httptest.NewRequest(http.MethodGet, "/diff?branch=nonexistent", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
 	}
 }

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"context"
+
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// Store defines the data access interface for the server.
+type Store interface {
+	// CreateBranch creates a new branch forked from main's current head.
+	CreateBranch(ctx context.Context, name string) (*model.Branch, error)
+
+	// DeleteBranch marks a branch as abandoned.
+	DeleteBranch(ctx context.Context, name string) error
+
+	// ListBranches returns all branches, optionally filtered by status.
+	ListBranches(ctx context.Context, status string) ([]model.Branch, error)
+
+	// Merge merges a branch into main using the algorithm from DESIGN.md.
+	// Returns (response, nil, nil) on success, (nil, conflicts, nil) on conflict,
+	// or (nil, nil, err) on error.
+	Merge(ctx context.Context, branch string) (*model.MergeResponse, []model.ConflictEntry, error)
+
+	// Rebase replays branch commits onto main's current head.
+	// Returns (response, nil, nil) on success, (nil, conflicts, nil) on conflict,
+	// or (nil, nil, err) on error.
+	Rebase(ctx context.Context, branch string) (*model.RebaseResponse, []model.ConflictEntry, error)
+
+	// Diff computes the diff between a branch and main since base_sequence.
+	Diff(ctx context.Context, branch string) (*model.DiffResponse, error)
+}


### PR DESCRIPTION
## Summary

- **Branch management**: `POST /branch`, `DELETE /branch/{name}`, `GET /branches` with optional `?status=` filter
- **Merge engine**: `POST /merge` implements the full DESIGN.md three-way merge algorithm — locks both branches with `SELECT FOR UPDATE`, finds changes since `base_sequence` using `DISTINCT ON (path)`, detects conflicts on overlapping paths, and if clean inserts `file_commits` rows on main with a new globally monotonic sequence
- **Rebase**: `POST /rebase` replays branch commits grouped by original sequence onto main's current head, each group getting a new sequence number
- **Diff**: `GET /diff?branch=X` returns branch changes and conflicting main paths since fork point
- **Migration**: Adds PostgreSQL `commit_sequence` for globally monotonic sequence allocation
- **Store interface**: Clean separation between HTTP handlers and database logic via `server.Store` interface, enabling full mock-based testing

## Architecture

```
server.Store (interface)  ←  db.PGStore (PostgreSQL implementation)
       ↑
  HTTP handlers (branch.go, merge.go, rebase.go, diff.go)
```

- Sentinel errors in `model` package shared between server and db layers
- Uses `api.go` types from #3 for API request/response structs
- `cmd/docstore/main.go` updated to wire `DATABASE_URL` → `PGStore` → `server.New()`

## Test plan

- [x] 28 unit tests pass (`go test ./...`)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [ ] Integration test with real PostgreSQL (future work)

## Opportunities (not implemented)

- Integration tests with testcontainers or dockertest for PostgreSQL
- Author field on merge commits should come from authenticated identity (currently "system")
- Pagination support for `GET /branches`
- The `GET /branch/{name}/status` route needs `{name...}` wildcard for slash-containing branch names (same pattern applied to DELETE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)