### PR TITLE
Add CLI client (ds) with init, status, commit, checkout, pull, merge, diff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: build test lint clean
+.PHONY: build build-ds test lint clean
 
 BINARY := docstore
 BUILD_DIR := bin
 
 build:
 	go build -o $(BUILD_DIR)/$(BINARY) ./cmd/docstore
+
+build-ds:
+	go build -o $(BUILD_DIR)/ds ./cmd/ds
 
 test:
 	go test ./...

--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -1,0 +1,112 @@
+// Command ds is the docstore CLI client.
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/dlorenc/docstore/internal/cli"
+)
+
+const usage = `usage: ds <command> [args]
+
+commands:
+  init <remote-url> [--author <name>]   Initialize a docstore workspace
+  status                                 Show changed files
+  commit -m "message"                    Commit all changes
+  checkout -b <branch>                   Create and switch to a new branch
+  checkout <branch>                      Switch to an existing branch
+  pull                                   Sync files from the server
+  merge                                  Merge current branch into main
+  diff                                   Show branch diff from server`
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, usage)
+		os.Exit(1)
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+
+	app := &cli.App{
+		Dir:  dir,
+		Out:  os.Stdout,
+		HTTP: http.DefaultClient,
+	}
+
+	args := os.Args[1:]
+	cmd := args[0]
+
+	switch cmd {
+	case "init":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: ds init <remote-url> [--author <name>]")
+			os.Exit(1)
+		}
+		remote := args[1]
+		author := ""
+		for i := 2; i < len(args); i++ {
+			if args[i] == "--author" && i+1 < len(args) {
+				author = args[i+1]
+				i++
+			}
+		}
+		err = app.Init(remote, author)
+
+	case "status":
+		err = app.Status()
+
+	case "commit":
+		msg := ""
+		for i := 1; i < len(args); i++ {
+			if args[i] == "-m" && i+1 < len(args) {
+				msg = args[i+1]
+				i++
+			}
+		}
+		if msg == "" {
+			fmt.Fprintln(os.Stderr, "usage: ds commit -m \"message\"")
+			os.Exit(1)
+		}
+		err = app.Commit(msg)
+
+	case "checkout":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: ds checkout [-b] <branch>")
+			os.Exit(1)
+		}
+		if args[1] == "-b" {
+			if len(args) < 3 {
+				fmt.Fprintln(os.Stderr, "usage: ds checkout -b <branch>")
+				os.Exit(1)
+			}
+			err = app.CheckoutNew(args[2])
+		} else {
+			err = app.Checkout(args[1])
+		}
+
+	case "pull":
+		err = app.Pull()
+
+	case "merge":
+		err = app.Merge()
+
+	case "diff":
+		err = app.Diff()
+
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", cmd)
+		fmt.Fprintln(os.Stderr, usage)
+		os.Exit(1)
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1,0 +1,618 @@
+// Package cli implements the ds command-line client for docstore.
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/user"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+const configDir = ".docstore"
+const configFile = "config.json"
+const stateFile = "state.json"
+
+// Config is the persistent CLI configuration stored in .docstore/config.json.
+type Config struct {
+	Remote string `json:"remote"`
+	Branch string `json:"branch"`
+	Author string `json:"author"`
+}
+
+// State tracks the last-synced tree for offline status.
+type State struct {
+	Branch   string            `json:"branch"`
+	Sequence int64             `json:"sequence"`
+	Files    map[string]string `json:"files"` // path -> content_hash
+}
+
+// App is the CLI application. All fields are injectable for testing.
+type App struct {
+	Dir  string       // working directory
+	Out  io.Writer    // output writer
+	HTTP *http.Client // HTTP client (mockable)
+}
+
+func (a *App) configPath() string {
+	return filepath.Join(a.Dir, configDir, configFile)
+}
+
+func (a *App) statePath() string {
+	return filepath.Join(a.Dir, configDir, stateFile)
+}
+
+func (a *App) loadConfig() (*Config, error) {
+	data, err := os.ReadFile(a.configPath())
+	if err != nil {
+		return nil, fmt.Errorf("not a docstore workspace (run 'ds init' first)")
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("corrupt config: %w", err)
+	}
+	return &cfg, nil
+}
+
+func (a *App) saveConfig(cfg *Config) error {
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(a.configPath(), data, 0644)
+}
+
+func (a *App) loadState() (*State, error) {
+	data, err := os.ReadFile(a.statePath())
+	if err != nil {
+		return &State{Files: make(map[string]string)}, nil
+	}
+	var st State
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, fmt.Errorf("corrupt state: %w", err)
+	}
+	if st.Files == nil {
+		st.Files = make(map[string]string)
+	}
+	return &st, nil
+}
+
+func (a *App) saveState(st *State) error {
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(a.statePath(), data, 0644)
+}
+
+// scanLocalFiles walks the working directory and returns a map of path -> content_hash.
+// It skips the .docstore directory.
+func (a *App) scanLocalFiles() (map[string]string, error) {
+	localFiles := make(map[string]string)
+	err := filepath.Walk(a.Dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(a.Dir, path)
+		if rel == "." {
+			return nil
+		}
+		if strings.HasPrefix(rel, configDir) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		hash, err := hashFile(path)
+		if err != nil {
+			return err
+		}
+		localFiles[filepath.ToSlash(rel)] = hash
+		return nil
+	})
+	return localFiles, err
+}
+
+// hashFile returns the hex-encoded SHA256 of a file's contents.
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// HashBytes returns the hex-encoded SHA256 of the given bytes.
+func HashBytes(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+// Init creates a new docstore workspace.
+func (a *App) Init(remote, author string) error {
+	dir := filepath.Join(a.Dir, configDir)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	if author == "" {
+		u, err := user.Current()
+		if err == nil {
+			author = u.Username
+		} else {
+			author = "unknown"
+		}
+	}
+
+	cfg := &Config{
+		Remote: strings.TrimRight(remote, "/"),
+		Branch: "main",
+		Author: author,
+	}
+	if err := a.saveConfig(cfg); err != nil {
+		return err
+	}
+
+	st := &State{
+		Branch:   "main",
+		Sequence: 0,
+		Files:    make(map[string]string),
+	}
+	if err := a.saveState(st); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(a.Out, "Initialized docstore workspace\n")
+	fmt.Fprintf(a.Out, "Remote: %s\n", cfg.Remote)
+	fmt.Fprintf(a.Out, "Author: %s\n", author)
+	return nil
+}
+
+// Status shows files that differ from the last-synced state.
+func (a *App) Status() error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	st, err := a.loadState()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(a.Out, "On branch %s\n", cfg.Branch)
+
+	localFiles, err := a.scanLocalFiles()
+	if err != nil {
+		return fmt.Errorf("scanning directory: %w", err)
+	}
+
+	var newFiles, modifiedFiles, deletedFiles []string
+
+	for path, hash := range localFiles {
+		if stateHash, ok := st.Files[path]; !ok {
+			newFiles = append(newFiles, path)
+		} else if hash != stateHash {
+			modifiedFiles = append(modifiedFiles, path)
+		}
+	}
+
+	for path := range st.Files {
+		if _, ok := localFiles[path]; !ok {
+			deletedFiles = append(deletedFiles, path)
+		}
+	}
+
+	sort.Strings(newFiles)
+	sort.Strings(modifiedFiles)
+	sort.Strings(deletedFiles)
+
+	if len(newFiles) == 0 && len(modifiedFiles) == 0 && len(deletedFiles) == 0 {
+		fmt.Fprintf(a.Out, "No changes\n")
+		return nil
+	}
+
+	fmt.Fprintf(a.Out, "\nChanges:\n")
+	for _, f := range newFiles {
+		fmt.Fprintf(a.Out, "  new:      %s\n", f)
+	}
+	for _, f := range modifiedFiles {
+		fmt.Fprintf(a.Out, "  modified: %s\n", f)
+	}
+	for _, f := range deletedFiles {
+		fmt.Fprintf(a.Out, "  deleted:  %s\n", f)
+	}
+
+	return nil
+}
+
+// Commit creates a commit with all local changes.
+func (a *App) Commit(message string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	st, err := a.loadState()
+	if err != nil {
+		return err
+	}
+
+	localFiles, err := a.scanLocalFiles()
+	if err != nil {
+		return fmt.Errorf("scanning directory: %w", err)
+	}
+
+	var files []model.FileChange
+
+	// New and modified files.
+	for path, hash := range localFiles {
+		stateHash, exists := st.Files[path]
+		if !exists || hash != stateHash {
+			content, err := os.ReadFile(filepath.Join(a.Dir, filepath.FromSlash(path)))
+			if err != nil {
+				return err
+			}
+			files = append(files, model.FileChange{Path: path, Content: content})
+		}
+	}
+
+	// Deleted files (nil Content = delete).
+	for path := range st.Files {
+		if _, ok := localFiles[path]; !ok {
+			files = append(files, model.FileChange{Path: path})
+		}
+	}
+
+	if len(files) == 0 {
+		fmt.Fprintf(a.Out, "No changes to commit\n")
+		return nil
+	}
+
+	// Sort for deterministic ordering.
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+
+	req := model.CommitRequest{
+		Branch:  cfg.Branch,
+		Files:   files,
+		Message: message,
+		Author:  cfg.Author,
+	}
+
+	resp, err := a.postJSON(cfg.Remote+"/commit", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return a.readError(resp)
+	}
+
+	var commitResp model.CommitResponse
+	if err := json.NewDecoder(resp.Body).Decode(&commitResp); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	// Update state to reflect current local tree.
+	st.Files = localFiles
+	st.Sequence = commitResp.Sequence
+	st.Branch = cfg.Branch
+
+	if err := a.saveState(st); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(a.Out, "Committed sequence %d (%d files)\n", commitResp.Sequence, len(files))
+	return nil
+}
+
+// CheckoutNew creates a new branch and switches to it.
+func (a *App) CheckoutNew(branch string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+
+	req := model.CreateBranchRequest{Name: branch}
+	resp, err := a.postJSON(cfg.Remote+"/branch", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+
+	var branchResp model.CreateBranchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&branchResp); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	cfg.Branch = branch
+	if err := a.saveConfig(cfg); err != nil {
+		return err
+	}
+
+	// State carries over from current branch.
+	st, err := a.loadState()
+	if err != nil {
+		return err
+	}
+	st.Branch = branch
+	st.Sequence = branchResp.BaseSequence
+	if err := a.saveState(st); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(a.Out, "Switched to new branch '%s' (base sequence %d)\n", branch, branchResp.BaseSequence)
+	return nil
+}
+
+// Checkout switches to an existing branch and syncs files from the server.
+func (a *App) Checkout(branch string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+
+	cfg.Branch = branch
+	if err := a.saveConfig(cfg); err != nil {
+		return err
+	}
+
+	return a.syncTree(cfg, branch)
+}
+
+// Pull syncs local files from the current branch on the server.
+func (a *App) Pull() error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	return a.syncTree(cfg, cfg.Branch)
+}
+
+// syncTree fetches the full tree from the server and updates local files.
+func (a *App) syncTree(cfg *Config, branch string) error {
+	st, err := a.loadState()
+	if err != nil {
+		return err
+	}
+
+	// Fetch full tree with pagination.
+	var allEntries []treeEntry
+	after := ""
+	for {
+		q := url.Values{}
+		q.Set("branch", branch)
+		q.Set("limit", "100")
+		if after != "" {
+			q.Set("after", after)
+		}
+		resp, err := a.HTTP.Get(cfg.Remote + "/tree?" + q.Encode())
+		if err != nil {
+			return fmt.Errorf("fetching tree: %w", err)
+		}
+
+		var entries []treeEntry
+		if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+			resp.Body.Close()
+			return fmt.Errorf("decoding tree: %w", err)
+		}
+		resp.Body.Close()
+
+		if len(entries) == 0 {
+			break
+		}
+		allEntries = append(allEntries, entries...)
+		after = entries[len(entries)-1].Path
+		if len(entries) < 100 {
+			break
+		}
+	}
+
+	// Build server file map.
+	serverFiles := make(map[string]string) // path -> content_hash
+	for _, e := range allEntries {
+		serverFiles[e.Path] = e.ContentHash
+	}
+
+	// Download changed/new files.
+	downloaded := 0
+	for _, entry := range allEntries {
+		if st.Files[entry.Path] == entry.ContentHash {
+			continue // already up to date
+		}
+
+		q := url.Values{}
+		q.Set("branch", branch)
+		resp, err := a.HTTP.Get(cfg.Remote + "/file/" + entry.Path + "?" + q.Encode())
+		if err != nil {
+			return fmt.Errorf("fetching %s: %w", entry.Path, err)
+		}
+
+		var fileResp model.FileResponse
+		if err := json.NewDecoder(resp.Body).Decode(&fileResp); err != nil {
+			resp.Body.Close()
+			return fmt.Errorf("decoding %s: %w", entry.Path, err)
+		}
+		resp.Body.Close()
+
+		localPath := filepath.Join(a.Dir, filepath.FromSlash(entry.Path))
+		if err := os.MkdirAll(filepath.Dir(localPath), 0755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(localPath, fileResp.Content, 0644); err != nil {
+			return err
+		}
+		downloaded++
+	}
+
+	// Remove files that no longer exist on server.
+	removed := 0
+	for path := range st.Files {
+		if _, ok := serverFiles[path]; !ok {
+			localPath := filepath.Join(a.Dir, filepath.FromSlash(path))
+			os.Remove(localPath)
+			removed++
+		}
+	}
+
+	// Update state.
+	st.Branch = branch
+	st.Files = serverFiles
+	if err := a.saveState(st); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(a.Out, "Synced branch '%s' (%d downloaded, %d removed)\n", branch, downloaded, removed)
+	return nil
+}
+
+// Merge merges the current branch into main.
+func (a *App) Merge() error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+
+	if cfg.Branch == "main" {
+		return fmt.Errorf("cannot merge main into itself")
+	}
+
+	req := model.MergeRequest{Branch: cfg.Branch}
+	resp, err := a.postJSON(cfg.Remote+"/merge", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode == http.StatusConflict {
+		var conflictErr model.MergeConflictError
+		if err := json.Unmarshal(body, &conflictErr); err == nil && len(conflictErr.Conflicts) > 0 {
+			fmt.Fprintf(a.Out, "Merge conflicts:\n")
+			for _, c := range conflictErr.Conflicts {
+				fmt.Fprintf(a.Out, "  %s (main: %s, branch: %s)\n", c.Path, c.MainVersionID, c.BranchVersionID)
+			}
+			return fmt.Errorf("merge aborted due to conflicts")
+		}
+		return fmt.Errorf("server error (status %d)", resp.StatusCode)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		var errResp model.ErrorResponse
+		if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error != "" {
+			return fmt.Errorf("server error: %s", errResp.Error)
+		}
+		return fmt.Errorf("server error (status %d)", resp.StatusCode)
+	}
+
+	var mergeResp model.MergeResponse
+	if err := json.Unmarshal(body, &mergeResp); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	fmt.Fprintf(a.Out, "Merged '%s' into main at sequence %d\n", cfg.Branch, mergeResp.Sequence)
+	return nil
+}
+
+// Diff shows the diff for the current branch relative to its base.
+func (a *App) Diff() error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+
+	q := url.Values{}
+	q.Set("branch", cfg.Branch)
+	resp, err := a.HTTP.Get(cfg.Remote + "/diff?" + q.Encode())
+	if err != nil {
+		return fmt.Errorf("fetching diff: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+
+	var diffResp model.DiffResponse
+	if err := json.NewDecoder(resp.Body).Decode(&diffResp); err != nil {
+		return fmt.Errorf("decoding diff: %w", err)
+	}
+
+	if len(diffResp.Changed) == 0 && len(diffResp.Conflicts) == 0 {
+		fmt.Fprintf(a.Out, "No changes on branch '%s'\n", cfg.Branch)
+		return nil
+	}
+
+	if len(diffResp.Changed) > 0 {
+		fmt.Fprintf(a.Out, "Changed files on '%s':\n", cfg.Branch)
+		for _, d := range diffResp.Changed {
+			if d.VersionID == nil {
+				fmt.Fprintf(a.Out, "  deleted: %s\n", d.Path)
+			} else {
+				fmt.Fprintf(a.Out, "  changed: %s\n", d.Path)
+			}
+		}
+	}
+
+	if len(diffResp.Conflicts) > 0 {
+		fmt.Fprintf(a.Out, "\nConflicts:\n")
+		for _, c := range diffResp.Conflicts {
+			fmt.Fprintf(a.Out, "  %s (main: %s, branch: %s)\n", c.Path, c.MainVersionID, c.BranchVersionID)
+		}
+	}
+
+	return nil
+}
+
+// postJSON sends a POST request with a JSON body.
+func (a *App) postJSON(urlStr string, body interface{}) (*http.Response, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("POST", urlStr, bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return a.HTTP.Do(req)
+}
+
+// readError extracts an error message from an API error response.
+func (a *App) readError(resp *http.Response) error {
+	body, _ := io.ReadAll(resp.Body)
+	var errResp model.ErrorResponse
+	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error != "" {
+		return fmt.Errorf("server error: %s", errResp.Error)
+	}
+	return fmt.Errorf("server error (status %d)", resp.StatusCode)
+}
+
+// treeEntry matches the JSON returned by GET /tree (raw array of objects).
+type treeEntry struct {
+	Path        string `json:"path"`
+	VersionID   string `json:"version_id"`
+	ContentHash string `json:"content_hash"`
+}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1,0 +1,910 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// helper to create an App with a temp dir and optional mock server.
+func newTestApp(t *testing.T, srv *httptest.Server) (*App, *strings.Builder) {
+	t.Helper()
+	out := &strings.Builder{}
+	client := http.DefaultClient
+	if srv != nil {
+		client = srv.Client()
+	}
+	return &App{
+		Dir:  t.TempDir(),
+		Out:  out,
+		HTTP: client,
+	}, out
+}
+
+// helper to initialize a workspace in the test app.
+func initWorkspace(t *testing.T, app *App, remote, branch, author string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(app.Dir, configDir), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.saveConfig(&Config{Remote: remote, Branch: branch, Author: author}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.saveState(&State{Branch: branch, Files: make(map[string]string)}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// helper to write a file in the test workspace.
+func writeFile(t *testing.T, app *App, path, content string) {
+	t.Helper()
+	full := filepath.Join(app.Dir, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+func TestInit(t *testing.T) {
+	app, out := newTestApp(t, nil)
+
+	if err := app.Init("http://localhost:8080", "alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := app.loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Remote != "http://localhost:8080" {
+		t.Errorf("remote = %q, want %q", cfg.Remote, "http://localhost:8080")
+	}
+	if cfg.Branch != "main" {
+		t.Errorf("branch = %q, want %q", cfg.Branch, "main")
+	}
+	if cfg.Author != "alice" {
+		t.Errorf("author = %q, want %q", cfg.Author, "alice")
+	}
+
+	st, err := app.loadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Branch != "main" {
+		t.Errorf("state branch = %q, want %q", st.Branch, "main")
+	}
+	if len(st.Files) != 0 {
+		t.Errorf("state files = %d, want 0", len(st.Files))
+	}
+
+	if !strings.Contains(out.String(), "Initialized") {
+		t.Errorf("expected 'Initialized' in output: %s", out.String())
+	}
+}
+
+func TestInitTrimsTrailingSlash(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+
+	if err := app.Init("http://localhost:8080/", "bob"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _ := app.loadConfig()
+	if cfg.Remote != "http://localhost:8080" {
+		t.Errorf("remote = %q, want trailing slash trimmed", cfg.Remote)
+	}
+}
+
+func TestInitDefaultAuthor(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+
+	if err := app.Init("http://localhost:8080", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _ := app.loadConfig()
+	if cfg.Author == "" {
+		t.Error("expected non-empty default author")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Status
+// ---------------------------------------------------------------------------
+
+func TestStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		stateFiles map[string]string // path -> content_hash
+		localFiles map[string]string // path -> content (will be written to disk)
+		wantNew    []string
+		wantMod    []string
+		wantDel    []string
+		wantClean  bool
+	}{
+		{
+			name:       "no changes",
+			stateFiles: map[string]string{"a.txt": HashBytes([]byte("hello"))},
+			localFiles: map[string]string{"a.txt": "hello"},
+			wantClean:  true,
+		},
+		{
+			name:       "new file",
+			stateFiles: map[string]string{},
+			localFiles: map[string]string{"new.txt": "content"},
+			wantNew:    []string{"new.txt"},
+		},
+		{
+			name:       "modified file",
+			stateFiles: map[string]string{"mod.txt": HashBytes([]byte("old"))},
+			localFiles: map[string]string{"mod.txt": "new"},
+			wantMod:    []string{"mod.txt"},
+		},
+		{
+			name:       "deleted file",
+			stateFiles: map[string]string{"gone.txt": "somehash"},
+			localFiles: map[string]string{},
+			wantDel:    []string{"gone.txt"},
+		},
+		{
+			name:       "mixed changes",
+			stateFiles: map[string]string{"keep.txt": HashBytes([]byte("same")), "mod.txt": HashBytes([]byte("old")), "del.txt": "hash"},
+			localFiles: map[string]string{"keep.txt": "same", "mod.txt": "new", "add.txt": "fresh"},
+			wantNew:    []string{"add.txt"},
+			wantMod:    []string{"mod.txt"},
+			wantDel:    []string{"del.txt"},
+		},
+		{
+			name:       "nested new file",
+			stateFiles: map[string]string{},
+			localFiles: map[string]string{"src/pkg/file.go": "package pkg"},
+			wantNew:    []string{"src/pkg/file.go"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app, out := newTestApp(t, nil)
+			initWorkspace(t, app, "http://test", "main", "test")
+
+			// Set state.
+			st := &State{Branch: "main", Files: tt.stateFiles}
+			if err := app.saveState(st); err != nil {
+				t.Fatal(err)
+			}
+
+			// Write local files.
+			for path, content := range tt.localFiles {
+				writeFile(t, app, path, content)
+			}
+
+			if err := app.Status(); err != nil {
+				t.Fatal(err)
+			}
+
+			output := out.String()
+
+			if tt.wantClean {
+				if !strings.Contains(output, "No changes") {
+					t.Errorf("expected 'No changes' in output:\n%s", output)
+				}
+				return
+			}
+
+			for _, f := range tt.wantNew {
+				if !strings.Contains(output, "new:") || !strings.Contains(output, f) {
+					t.Errorf("expected new file %q in output:\n%s", f, output)
+				}
+			}
+			for _, f := range tt.wantMod {
+				if !strings.Contains(output, "modified:") || !strings.Contains(output, f) {
+					t.Errorf("expected modified file %q in output:\n%s", f, output)
+				}
+			}
+			for _, f := range tt.wantDel {
+				if !strings.Contains(output, "deleted:") || !strings.Contains(output, f) {
+					t.Errorf("expected deleted file %q in output:\n%s", f, output)
+				}
+			}
+		})
+	}
+}
+
+func TestStatusNoWorkspace(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	err := app.Status()
+	if err == nil || !strings.Contains(err.Error(), "not a docstore workspace") {
+		t.Errorf("expected workspace error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Commit
+// ---------------------------------------------------------------------------
+
+func TestCommit(t *testing.T) {
+	var receivedReq model.CommitRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/commit" {
+			json.NewDecoder(r.Body).Decode(&receivedReq)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(model.CommitResponse{
+				Sequence: 1,
+				Files:    []model.CommitFileResult{{Path: "hello.txt", VersionID: strPtr("v1")}},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+	writeFile(t, app, "hello.txt", "hello world")
+
+	if err := app.Commit("initial commit"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify request sent to server.
+	if receivedReq.Branch != "main" {
+		t.Errorf("branch = %q, want %q", receivedReq.Branch, "main")
+	}
+	if receivedReq.Message != "initial commit" {
+		t.Errorf("message = %q, want %q", receivedReq.Message, "initial commit")
+	}
+	if receivedReq.Author != "alice" {
+		t.Errorf("author = %q, want %q", receivedReq.Author, "alice")
+	}
+	if len(receivedReq.Files) != 1 {
+		t.Fatalf("files = %d, want 1", len(receivedReq.Files))
+	}
+	if receivedReq.Files[0].Path != "hello.txt" {
+		t.Errorf("file path = %q, want %q", receivedReq.Files[0].Path, "hello.txt")
+	}
+	if string(receivedReq.Files[0].Content) != "hello world" {
+		t.Errorf("file content = %q, want %q", string(receivedReq.Files[0].Content), "hello world")
+	}
+
+	// Verify state updated.
+	st, _ := app.loadState()
+	if st.Sequence != 1 {
+		t.Errorf("sequence = %d, want 1", st.Sequence)
+	}
+	if _, ok := st.Files["hello.txt"]; !ok {
+		t.Error("expected hello.txt in state files")
+	}
+
+	if !strings.Contains(out.String(), "Committed sequence 1") {
+		t.Errorf("expected commit confirmation in output: %s", out.String())
+	}
+}
+
+func TestCommitNoChanges(t *testing.T) {
+	app, out := newTestApp(t, nil)
+	initWorkspace(t, app, "http://test", "main", "alice")
+
+	if err := app.Commit("nothing"); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(out.String(), "No changes to commit") {
+		t.Errorf("expected 'No changes' in output: %s", out.String())
+	}
+}
+
+func TestCommitWithDelete(t *testing.T) {
+	var receivedReq model.CommitRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/commit" {
+			json.NewDecoder(r.Body).Decode(&receivedReq)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(model.CommitResponse{Sequence: 2})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	// Pre-populate state with a file that will be "deleted".
+	st := &State{Branch: "main", Files: map[string]string{"old.txt": "hash123"}}
+	app.saveState(st)
+
+	if err := app.Commit("delete old file"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have a delete entry (nil content).
+	found := false
+	for _, f := range receivedReq.Files {
+		if f.Path == "old.txt" && f.Content == nil {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected delete entry for old.txt with nil content")
+	}
+
+	// State should no longer have old.txt.
+	st, _ = app.loadState()
+	if _, ok := st.Files["old.txt"]; ok {
+		t.Error("old.txt should be removed from state after delete commit")
+	}
+}
+
+func TestCommitServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(model.ErrorResponse{Error: "branch not found"})
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "feature/x", "alice")
+	writeFile(t, app, "file.txt", "content")
+
+	err := app.Commit("test")
+	if err == nil || !strings.Contains(err.Error(), "branch not found") {
+		t.Errorf("expected 'branch not found' error, got: %v", err)
+	}
+}
+
+func TestCommitMultipleFiles(t *testing.T) {
+	var receivedReq model.CommitRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/commit" {
+			json.NewDecoder(r.Body).Decode(&receivedReq)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(model.CommitResponse{Sequence: 1})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+	writeFile(t, app, "a.txt", "aaa")
+	writeFile(t, app, "b.txt", "bbb")
+	writeFile(t, app, "src/c.go", "package c")
+
+	if err := app.Commit("add files"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(receivedReq.Files) != 3 {
+		t.Fatalf("files = %d, want 3", len(receivedReq.Files))
+	}
+
+	// Files should be sorted.
+	if receivedReq.Files[0].Path != "a.txt" {
+		t.Errorf("first file = %q, want a.txt", receivedReq.Files[0].Path)
+	}
+	if receivedReq.Files[1].Path != "b.txt" {
+		t.Errorf("second file = %q, want b.txt", receivedReq.Files[1].Path)
+	}
+	if receivedReq.Files[2].Path != "src/c.go" {
+		t.Errorf("third file = %q, want src/c.go", receivedReq.Files[2].Path)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Checkout -b (create branch)
+// ---------------------------------------------------------------------------
+
+func TestCheckoutNew(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/branch" {
+			var req model.CreateBranchRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(model.CreateBranchResponse{
+				Name:         req.Name,
+				BaseSequence: 5,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	// Pre-populate state with existing files.
+	app.saveState(&State{Branch: "main", Sequence: 5, Files: map[string]string{"f.txt": "hash1"}})
+
+	if err := app.CheckoutNew("feature/test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Config should have new branch.
+	cfg, _ := app.loadConfig()
+	if cfg.Branch != "feature/test" {
+		t.Errorf("branch = %q, want %q", cfg.Branch, "feature/test")
+	}
+
+	// State should carry over files from parent branch.
+	st, _ := app.loadState()
+	if st.Branch != "feature/test" {
+		t.Errorf("state branch = %q, want %q", st.Branch, "feature/test")
+	}
+	if st.Sequence != 5 {
+		t.Errorf("state sequence = %d, want 5", st.Sequence)
+	}
+	if _, ok := st.Files["f.txt"]; !ok {
+		t.Error("expected files to carry over from parent branch")
+	}
+
+	if !strings.Contains(out.String(), "Switched to new branch 'feature/test'") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+}
+
+func TestCheckoutNewServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(model.ErrorResponse{Error: "branch already exists"})
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	err := app.CheckoutNew("existing-branch")
+	if err == nil || !strings.Contains(err.Error(), "branch already exists") {
+		t.Errorf("expected 'branch already exists' error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Checkout (switch branch)
+// ---------------------------------------------------------------------------
+
+func TestCheckout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/tree" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]treeEntry{
+				{Path: "main.go", VersionID: "v1", ContentHash: "hash1"},
+				{Path: "README.md", VersionID: "v2", ContentHash: "hash2"},
+			})
+			return
+		}
+		if r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/file/") {
+			path := strings.TrimPrefix(r.URL.Path, "/file/")
+			content := map[string]string{
+				"main.go":   "package main",
+				"README.md": "# Hello",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(model.FileResponse{
+				Path:    path,
+				Content: []byte(content[path]),
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "feature/old", "alice")
+
+	if err := app.Checkout("main"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Config should have new branch.
+	cfg, _ := app.loadConfig()
+	if cfg.Branch != "main" {
+		t.Errorf("branch = %q, want %q", cfg.Branch, "main")
+	}
+
+	// Files should be written to disk.
+	content, err := os.ReadFile(filepath.Join(app.Dir, "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "package main" {
+		t.Errorf("main.go content = %q, want %q", string(content), "package main")
+	}
+
+	content, err = os.ReadFile(filepath.Join(app.Dir, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "# Hello" {
+		t.Errorf("README.md content = %q, want %q", string(content), "# Hello")
+	}
+
+	// State should have both files.
+	st, _ := app.loadState()
+	if len(st.Files) != 2 {
+		t.Errorf("state files = %d, want 2", len(st.Files))
+	}
+
+	if !strings.Contains(out.String(), "Synced branch 'main'") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+}
+
+func TestCheckoutRemovesDeletedFiles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/tree" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]treeEntry{})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	// Pre-populate state with a file.
+	app.saveState(&State{Branch: "main", Files: map[string]string{"old.txt": "hash"}})
+	writeFile(t, app, "old.txt", "old content")
+
+	if err := app.Checkout("feature/new"); err != nil {
+		t.Fatal(err)
+	}
+
+	// old.txt should be removed from disk.
+	if _, err := os.Stat(filepath.Join(app.Dir, "old.txt")); !os.IsNotExist(err) {
+		t.Error("expected old.txt to be removed from disk")
+	}
+
+	// State should be empty.
+	st, _ := app.loadState()
+	if len(st.Files) != 0 {
+		t.Errorf("state files = %d, want 0", len(st.Files))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pull
+// ---------------------------------------------------------------------------
+
+func TestPull(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/tree" {
+			if r.URL.Query().Get("branch") != "feature/x" {
+				t.Errorf("expected branch=feature/x, got %q", r.URL.Query().Get("branch"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]treeEntry{
+				{Path: "updated.txt", VersionID: "v3", ContentHash: "newhash"},
+			})
+			return
+		}
+		if r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/file/") {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(model.FileResponse{
+				Path:    "updated.txt",
+				Content: []byte("updated content"),
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "feature/x", "alice")
+
+	// Pre-populate with old hash so the file gets downloaded.
+	app.saveState(&State{Branch: "feature/x", Files: map[string]string{"updated.txt": "oldhash"}})
+
+	if err := app.Pull(); err != nil {
+		t.Fatal(err)
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected 1 file download, got %d", callCount)
+	}
+
+	content, err := os.ReadFile(filepath.Join(app.Dir, "updated.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "updated content" {
+		t.Errorf("content = %q, want %q", string(content), "updated content")
+	}
+
+	if !strings.Contains(out.String(), "1 downloaded") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+}
+
+func TestPullSkipsUnchanged(t *testing.T) {
+	fileDownloads := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/tree" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]treeEntry{
+				{Path: "same.txt", VersionID: "v1", ContentHash: "samehash"},
+			})
+			return
+		}
+		if r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/file/") {
+			fileDownloads++
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(model.FileResponse{Path: "same.txt", Content: []byte("same")})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	// State already has the same hash.
+	app.saveState(&State{Branch: "main", Files: map[string]string{"same.txt": "samehash"}})
+
+	if err := app.Pull(); err != nil {
+		t.Fatal(err)
+	}
+
+	if fileDownloads != 0 {
+		t.Errorf("expected 0 file downloads, got %d", fileDownloads)
+	}
+
+	if !strings.Contains(out.String(), "0 downloaded") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Merge
+// ---------------------------------------------------------------------------
+
+func TestMerge(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/merge" {
+			var req model.MergeRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Branch != "feature/done" {
+				t.Errorf("merge branch = %q, want %q", req.Branch, "feature/done")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(model.MergeResponse{Sequence: 10})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "feature/done", "alice")
+
+	if err := app.Merge(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(out.String(), "Merged 'feature/done' into main at sequence 10") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+}
+
+func TestMergeFromMain(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	initWorkspace(t, app, "http://test", "main", "alice")
+
+	err := app.Merge()
+	if err == nil || !strings.Contains(err.Error(), "cannot merge main into itself") {
+		t.Errorf("expected merge-main error, got: %v", err)
+	}
+}
+
+func TestMergeConflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(model.MergeConflictError{
+			Conflicts: []model.ConflictEntry{
+				{Path: "file.txt", MainVersionID: "v1", BranchVersionID: "v2"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "feature/conflict", "alice")
+
+	err := app.Merge()
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Errorf("expected conflict error, got: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "file.txt") {
+		t.Errorf("expected conflict path in output: %s", out.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Diff
+// ---------------------------------------------------------------------------
+
+func TestDiff(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/diff" {
+			if r.URL.Query().Get("branch") != "feature/x" {
+				t.Errorf("diff branch = %q, want %q", r.URL.Query().Get("branch"), "feature/x")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(model.DiffResponse{
+				Changed: []model.DiffEntry{
+					{Path: "new.go", VersionID: strPtr("v1")},
+					{Path: "removed.go", VersionID: nil},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "feature/x", "alice")
+
+	if err := app.Diff(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "changed: new.go") {
+		t.Errorf("expected 'changed: new.go' in output:\n%s", output)
+	}
+	if !strings.Contains(output, "deleted: removed.go") {
+		t.Errorf("expected 'deleted: removed.go' in output:\n%s", output)
+	}
+}
+
+func TestDiffNoChanges(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(model.DiffResponse{})
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "feature/x", "alice")
+
+	if err := app.Diff(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(out.String(), "No changes") {
+		t.Errorf("expected 'No changes' in output: %s", out.String())
+	}
+}
+
+func TestDiffWithConflicts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(model.DiffResponse{
+			Changed: []model.DiffEntry{{Path: "a.txt", VersionID: strPtr("v1")}},
+			Conflicts: []model.ConflictEntry{
+				{Path: "shared.txt", MainVersionID: "m1", BranchVersionID: "b1"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "feature/x", "alice")
+
+	if err := app.Diff(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "Conflicts:") {
+		t.Errorf("expected 'Conflicts:' in output:\n%s", output)
+	}
+	if !strings.Contains(output, "shared.txt") {
+		t.Errorf("expected 'shared.txt' in output:\n%s", output)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Config / State persistence
+// ---------------------------------------------------------------------------
+
+func TestConfigRoundTrip(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	os.MkdirAll(filepath.Join(app.Dir, configDir), 0755)
+
+	cfg := &Config{Remote: "http://example.com", Branch: "dev", Author: "bob"}
+	if err := app.saveConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := app.loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Remote != cfg.Remote || loaded.Branch != cfg.Branch || loaded.Author != cfg.Author {
+		t.Errorf("config mismatch: got %+v, want %+v", loaded, cfg)
+	}
+}
+
+func TestStateRoundTrip(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	os.MkdirAll(filepath.Join(app.Dir, configDir), 0755)
+
+	st := &State{
+		Branch:   "feature/test",
+		Sequence: 42,
+		Files:    map[string]string{"a.txt": "hash1", "b.txt": "hash2"},
+	}
+	if err := app.saveState(st); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := app.loadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Branch != st.Branch || loaded.Sequence != st.Sequence {
+		t.Errorf("state mismatch: got branch=%q seq=%d, want branch=%q seq=%d",
+			loaded.Branch, loaded.Sequence, st.Branch, st.Sequence)
+	}
+	if len(loaded.Files) != 2 {
+		t.Errorf("state files = %d, want 2", len(loaded.Files))
+	}
+}
+
+func TestLoadStateMissing(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+
+	st, err := app.loadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Files == nil {
+		t.Error("expected non-nil Files map for missing state")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HashBytes
+// ---------------------------------------------------------------------------
+
+func TestHashBytes(t *testing.T) {
+	h := HashBytes([]byte("hello"))
+	// SHA256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+	want := "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+	if h != want {
+		t.Errorf("hash = %q, want %q", h, want)
+	}
+}


### PR DESCRIPTION
## Summary

Implements Phase 4 (CLI: ds init, ds status, ds commit) and Phase 5 (CLI: ds checkout -b, ds checkout, ds pull, ds merge, ds diff) from the DESIGN.md roadmap.

- **`ds init <remote-url>`**: Creates `.docstore/config.json` and `state.json` in the working directory
- **`ds status`**: Offline status using local SHA256 hash comparison against last-synced state (no server round-trip)
- **`ds commit -m "msg"`**: Scans for changes, sends `POST /commit` with all modified/new/deleted files atomically, updates local state
- **`ds checkout -b <branch>`**: Creates branch via `POST /branch`, carries over file state from parent
- **`ds checkout <branch>`**: Switches branch, syncs files via `GET /tree` + `GET /file` with incremental downloads
- **`ds pull`**: Syncs local files from server, skips unchanged files (hash comparison), removes server-deleted files
- **`ds merge`**: Sends `POST /merge` with conflict detection and display
- **`ds diff`**: Shows `GET /diff` results with changed/deleted/conflict sections

### Architecture

- `cmd/ds/main.go` — CLI entry point with argument parsing
- `internal/cli/app.go` — `App` struct with injectable `Dir`, `Out`, `HTTP` for testability; all command implementations
- `internal/cli/app_test.go` — 25 tests using `httptest.Server` mocks and temp directories

### Key design decisions

- Phase 4 commands (`init`, `status`, `commit`) work against existing `POST /commit`, `GET /tree`, `GET /file` endpoints
- Phase 5 commands (`checkout -b`, `merge`, `diff`) work against `POST /branch`, `POST /merge`, `GET /diff` endpoints from PR #8
- `checkout` (switch) uses paginated `GET /tree` + individual `GET /file` per changed file
- State tracks `map[path]content_hash` for O(1) change detection in `status` and incremental `pull`

### Opportunities (not implemented, noted for future)

- `ds log` command (GET /file/:path/history)
- `ds rebase` command (POST /rebase)
- `ds resolve` for conflict resolution workflow
- Batch file download instead of per-file GET
- Progress bars for sync operations

## Test plan

- [x] `TestInit` — creates config and state, trims trailing slash, default author
- [x] `TestStatus` — table-driven: no changes, new, modified, deleted, mixed, nested dirs
- [x] `TestCommit` — sends correct request, updates state, handles no-changes, deletes, server errors, multiple files
- [x] `TestCheckoutNew` — creates branch, carries state, handles server errors
- [x] `TestCheckout` — switches branch, writes files, removes stale files
- [x] `TestPull` — downloads changed files, skips unchanged
- [x] `TestMerge` — success case, merge-from-main error, conflict handling
- [x] `TestDiff` — changes, no changes, conflicts
- [x] Config/State persistence round-trip tests
- [x] All 25 tests passing, `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)