### PR TITLE
Fix test compilation errors after testcontainers migration

### DIFF
--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -277,7 +277,7 @@ func TestCommit_BranchNotActive(t *testing.T) {
 // --- CreateBranch tests ---
 
 func TestCreateBranch_Success(t *testing.T) {
-	d := testDB(t)
+	d := testutil.TestDB(t, MigrationSQL)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -320,7 +320,7 @@ func TestCreateBranch_Success(t *testing.T) {
 }
 
 func TestCreateBranch_Duplicate(t *testing.T) {
-	d := testDB(t)
+	d := testutil.TestDB(t, MigrationSQL)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -338,7 +338,7 @@ func TestCreateBranch_Duplicate(t *testing.T) {
 // --- Merge tests ---
 
 func TestMerge_Success(t *testing.T) {
-	d := testDB(t)
+	d := testutil.TestDB(t, MigrationSQL)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -414,7 +414,7 @@ func TestMerge_Success(t *testing.T) {
 }
 
 func TestMerge_Conflict(t *testing.T) {
-	d := testDB(t)
+	d := testutil.TestDB(t, MigrationSQL)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -480,7 +480,7 @@ func TestMerge_Conflict(t *testing.T) {
 }
 
 func TestMerge_BranchNotFound(t *testing.T) {
-	d := testDB(t)
+	d := testutil.TestDB(t, MigrationSQL)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -491,7 +491,7 @@ func TestMerge_BranchNotFound(t *testing.T) {
 }
 
 func TestMerge_BranchNotActive(t *testing.T) {
-	d := testDB(t)
+	d := testutil.TestDB(t, MigrationSQL)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -508,7 +508,7 @@ func TestMerge_BranchNotActive(t *testing.T) {
 }
 
 func TestMerge_EmptyBranch(t *testing.T) {
-	d := testDB(t)
+	d := testutil.TestDB(t, MigrationSQL)
 	s := NewStore(d)
 	ctx := context.Background()
 

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -157,7 +157,7 @@ func TestIntegrationFileEndpoint(t *testing.T) {
 }
 
 func TestIntegrationBranchesEndpoint(t *testing.T) {
-	database := testutil.TestDB(t)
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
 	seed(t, database)
 
 	// Add feature branch.
@@ -213,7 +213,7 @@ func TestIntegrationBranchesEndpoint(t *testing.T) {
 }
 
 func TestIntegrationDiffEndpoint(t *testing.T) {
-	database := testutil.TestDB(t)
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
 	seed(t, database)
 
 	// Create a branch with changes.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -324,7 +324,7 @@ func TestGetCommit(t *testing.T) {
 }
 
 func TestListBranches(t *testing.T) {
-	db := testutil.TestDB(t)
+	db := testutil.TestDB(t, dbpkg.MigrationSQL)
 	seed(t, db)
 	s := store.New(db)
 	ctx := context.Background()
@@ -379,7 +379,7 @@ func TestListBranches(t *testing.T) {
 }
 
 func TestGetDiff(t *testing.T) {
-	db := testutil.TestDB(t)
+	db := testutil.TestDB(t, dbpkg.MigrationSQL)
 	seed(t, db)
 	s := store.New(db)
 	ctx := context.Background()
@@ -443,7 +443,7 @@ func TestGetDiff(t *testing.T) {
 }
 
 func TestGetDiff_WithConflict(t *testing.T) {
-	db := testutil.TestDB(t)
+	db := testutil.TestDB(t, dbpkg.MigrationSQL)
 	s := store.New(db)
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary
- Fix `testutil.TestDB(t)` calls missing the required `migrationSQL` parameter in `internal/server/integration_test.go` (lines 160, 216) and `internal/store/store_test.go` (lines 327, 382, 446) — added `dbpkg.MigrationSQL` as second arg
- Replace undefined `testDB(t)` calls in `internal/db/store_test.go` (7 occurrences at lines 280, 323, 341, 417, 483, 494, 511) with `testutil.TestDB(t, MigrationSQL)` — the local `testDB` helper was removed by PR #9

## Context
PR #9 migrated test infrastructure to testcontainers-go and changed `testutil.TestDB` to require a `migrationSQL` parameter. Several call sites added by PR #8 (branching/merge support) were not updated, breaking CI compilation.

## Test plan
- [x] `go vet ./...` passes
- [x] `go test -run='^$' ./internal/server/ ./internal/store/ ./internal/db/` compiles all test packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)