### PR TITLE
Fix TestDB call signatures after PR #9 migration

### DIFF
--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -277,7 +277,7 @@ func TestCommit_BranchNotActive(t *testing.T) {
 // --- CreateBranch tests ---
 
 func TestCreateBranch_Success(t *testing.T) {
-	d := testDB(t)
+	d := testutil.TestDB(t, MigrationSQL)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -320,7 +320,7 @@ func TestCreateBranch_Success(t *testing.T) {
 }
 
 func TestCreateBranch_Duplicate(t *testing.T) {
-	d := testDB(t)
+	d := testutil.TestDB(t, MigrationSQL)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -338,7 +338,7 @@ func TestCreateBranch_Duplicate(t *testing.T) {
 // --- Merge tests ---
 
 func TestMerge_Success(t *testing.T) {
-	d := testDB(t)
+	d := testutil.TestDB(t, MigrationSQL)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -414,7 +414,7 @@ func TestMerge_Success(t *testing.T) {
 }
 
 func TestMerge_Conflict(t *testing.T) {
-	d := testDB(t)
+	d := testutil.TestDB(t, MigrationSQL)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -480,7 +480,7 @@ func TestMerge_Conflict(t *testing.T) {
 }
 
 func TestMerge_BranchNotFound(t *testing.T) {
-	d := testDB(t)
+	d := testutil.TestDB(t, MigrationSQL)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -491,7 +491,7 @@ func TestMerge_BranchNotFound(t *testing.T) {
 }
 
 func TestMerge_BranchNotActive(t *testing.T) {
-	d := testDB(t)
+	d := testutil.TestDB(t, MigrationSQL)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -508,7 +508,7 @@ func TestMerge_BranchNotActive(t *testing.T) {
 }
 
 func TestMerge_EmptyBranch(t *testing.T) {
-	d := testDB(t)
+	d := testutil.TestDB(t, MigrationSQL)
 	s := NewStore(d)
 	ctx := context.Background()
 

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -157,7 +157,7 @@ func TestIntegrationFileEndpoint(t *testing.T) {
 }
 
 func TestIntegrationBranchesEndpoint(t *testing.T) {
-	database := testutil.TestDB(t)
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
 	seed(t, database)
 
 	// Add feature branch.
@@ -213,7 +213,7 @@ func TestIntegrationBranchesEndpoint(t *testing.T) {
 }
 
 func TestIntegrationDiffEndpoint(t *testing.T) {
-	database := testutil.TestDB(t)
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
 	seed(t, database)
 
 	// Create a branch with changes.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -324,7 +324,7 @@ func TestGetCommit(t *testing.T) {
 }
 
 func TestListBranches(t *testing.T) {
-	db := testutil.TestDB(t)
+	db := testutil.TestDB(t, dbpkg.MigrationSQL)
 	seed(t, db)
 	s := store.New(db)
 	ctx := context.Background()
@@ -379,7 +379,7 @@ func TestListBranches(t *testing.T) {
 }
 
 func TestGetDiff(t *testing.T) {
-	db := testutil.TestDB(t)
+	db := testutil.TestDB(t, dbpkg.MigrationSQL)
 	seed(t, db)
 	s := store.New(db)
 	ctx := context.Background()
@@ -443,7 +443,7 @@ func TestGetDiff(t *testing.T) {
 }
 
 func TestGetDiff_WithConflict(t *testing.T) {
-	db := testutil.TestDB(t)
+	db := testutil.TestDB(t, dbpkg.MigrationSQL)
 	s := store.New(db)
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary
- PR #8 added branch/merge tests using the old `testutil.TestDB(t)` signature
- PR #9 changed `TestDB` to require a `migrationSQL` parameter: `testutil.TestDB(t, migrationSQL)`
- This broke compilation for 12 test function calls across 3 files
- Fixed all callers to pass the required migration SQL parameter

## Files changed
- `internal/db/store_test.go` — 7 calls: `testDB(t)` → `testutil.TestDB(t, MigrationSQL)`
- `internal/store/store_test.go` — 3 calls: `testutil.TestDB(t)` → `testutil.TestDB(t, dbpkg.MigrationSQL)`
- `internal/server/integration_test.go` — 2 calls: `testutil.TestDB(t)` → `testutil.TestDB(t, dbpkg.MigrationSQL)`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] CI pipeline should now pass with `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)