### PR TITLE
Fix 7 CLI bugs: init fetch, dirty-tree guards, sequence tracking, identity header

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -146,7 +146,30 @@ func HashBytes(data []byte) string {
 	return hex.EncodeToString(h[:])
 }
 
-// Init creates a new docstore workspace.
+// isDirty returns true if there are local uncommitted changes.
+func (a *App) isDirty() (bool, error) {
+	st, err := a.loadState()
+	if err != nil {
+		return false, err
+	}
+	localFiles, err := a.scanLocalFiles()
+	if err != nil {
+		return false, err
+	}
+	for path, hash := range localFiles {
+		if stateHash, ok := st.Files[path]; !ok || hash != stateHash {
+			return true, nil
+		}
+	}
+	for path := range st.Files {
+		if _, ok := localFiles[path]; !ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Init creates a new docstore workspace and fetches all files from the server.
 func (a *App) Init(remote, author string) error {
 	dir := filepath.Join(a.Dir, configDir)
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -171,6 +194,7 @@ func (a *App) Init(remote, author string) error {
 		return err
 	}
 
+	// Save empty initial state.
 	st := &State{
 		Branch:   "main",
 		Sequence: 0,
@@ -180,7 +204,17 @@ func (a *App) Init(remote, author string) error {
 		return err
 	}
 
-	fmt.Fprintf(a.Out, "Initialized docstore workspace\n")
+	// Fetch files from the server.
+	if err := a.syncTree(cfg, "main"); err != nil {
+		return err
+	}
+
+	// Report result using the updated state.
+	st, err := a.loadState()
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(a.Out, "Initialized docstore workspace (%d files, sequence %d)\n", len(st.Files), st.Sequence)
 	fmt.Fprintf(a.Out, "Remote: %s\n", cfg.Remote)
 	fmt.Fprintf(a.Out, "Author: %s\n", author)
 	return nil
@@ -281,8 +315,7 @@ func (a *App) Commit(message string) error {
 	}
 
 	if len(files) == 0 {
-		fmt.Fprintf(a.Out, "No changes to commit\n")
-		return nil
+		return fmt.Errorf("nothing to commit")
 	}
 
 	// Sort for deterministic ordering.
@@ -295,7 +328,7 @@ func (a *App) Commit(message string) error {
 		Author:  cfg.Author,
 	}
 
-	resp, err := a.postJSON(cfg.Remote+"/commit", req)
+	resp, err := a.postJSON(cfg, cfg.Remote+"/commit", req)
 	if err != nil {
 		return err
 	}
@@ -331,7 +364,7 @@ func (a *App) CheckoutNew(branch string) error {
 	}
 
 	req := model.CreateBranchRequest{Name: branch}
-	resp, err := a.postJSON(cfg.Remote+"/branch", req)
+	resp, err := a.postJSON(cfg, cfg.Remote+"/branch", req)
 	if err != nil {
 		return err
 	}
@@ -373,6 +406,15 @@ func (a *App) Checkout(branch string) error {
 		return err
 	}
 
+	// Refuse if there are uncommitted local changes.
+	dirty, err := a.isDirty()
+	if err != nil {
+		return err
+	}
+	if dirty {
+		return fmt.Errorf("uncommitted changes -- commit or discard first")
+	}
+
 	cfg.Branch = branch
 	if err := a.saveConfig(cfg); err != nil {
 		return err
@@ -387,6 +429,16 @@ func (a *App) Pull() error {
 	if err != nil {
 		return err
 	}
+
+	// Refuse if there are uncommitted local changes.
+	dirty, err := a.isDirty()
+	if err != nil {
+		return err
+	}
+	if dirty {
+		return fmt.Errorf("uncommitted changes -- commit or discard first")
+	}
+
 	return a.syncTree(cfg, cfg.Branch)
 }
 
@@ -407,7 +459,7 @@ func (a *App) syncTree(cfg *Config, branch string) error {
 		if after != "" {
 			q.Set("after", after)
 		}
-		resp, err := a.HTTP.Get(cfg.Remote + "/tree?" + q.Encode())
+		resp, err := a.httpGet(cfg, cfg.Remote+"/tree?"+q.Encode())
 		if err != nil {
 			return fmt.Errorf("fetching tree: %w", err)
 		}
@@ -444,7 +496,7 @@ func (a *App) syncTree(cfg *Config, branch string) error {
 
 		q := url.Values{}
 		q.Set("branch", branch)
-		resp, err := a.HTTP.Get(cfg.Remote + "/file/" + entry.Path + "?" + q.Encode())
+		resp, err := a.httpGet(cfg, cfg.Remote+"/file/"+entry.Path+"?"+q.Encode())
 		if err != nil {
 			return fmt.Errorf("fetching %s: %w", entry.Path, err)
 		}
@@ -476,6 +528,24 @@ func (a *App) syncTree(cfg *Config, branch string) error {
 		}
 	}
 
+	// Fetch the branch's current head_sequence.
+	branchesResp, err := a.httpGet(cfg, cfg.Remote+"/branches")
+	if err != nil {
+		return fmt.Errorf("fetching branches: %w", err)
+	}
+	var branches []model.Branch
+	if err := json.NewDecoder(branchesResp.Body).Decode(&branches); err != nil {
+		branchesResp.Body.Close()
+		return fmt.Errorf("decoding branches: %w", err)
+	}
+	branchesResp.Body.Close()
+	for _, b := range branches {
+		if b.Name == branch {
+			st.Sequence = b.HeadSequence
+			break
+		}
+	}
+
 	// Update state.
 	st.Branch = branch
 	st.Files = serverFiles
@@ -499,7 +569,7 @@ func (a *App) Merge() error {
 	}
 
 	req := model.MergeRequest{Branch: cfg.Branch}
-	resp, err := a.postJSON(cfg.Remote+"/merge", req)
+	resp, err := a.postJSON(cfg, cfg.Remote+"/merge", req)
 	if err != nil {
 		return err
 	}
@@ -533,7 +603,13 @@ func (a *App) Merge() error {
 	}
 
 	fmt.Fprintf(a.Out, "Merged '%s' into main at sequence %d\n", cfg.Branch, mergeResp.Sequence)
-	return nil
+
+	// Switch to main after successful merge.
+	cfg.Branch = "main"
+	if err := a.saveConfig(cfg); err != nil {
+		return err
+	}
+	return a.syncTree(cfg, "main")
 }
 
 // Diff shows the diff for the current branch relative to its base.
@@ -545,7 +621,7 @@ func (a *App) Diff() error {
 
 	q := url.Values{}
 	q.Set("branch", cfg.Branch)
-	resp, err := a.HTTP.Get(cfg.Remote + "/diff?" + q.Encode())
+	resp, err := a.httpGet(cfg, cfg.Remote+"/diff?"+q.Encode())
 	if err != nil {
 		return fmt.Errorf("fetching diff: %w", err)
 	}
@@ -597,8 +673,18 @@ func (a *App) Diff() error {
 	return nil
 }
 
-// postJSON sends a POST request with a JSON body.
-func (a *App) postJSON(urlStr string, body interface{}) (*http.Response, error) {
+// httpGet sends a GET request with the X-DocStore-Identity header set.
+func (a *App) httpGet(cfg *Config, urlStr string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", urlStr, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-DocStore-Identity", cfg.Author)
+	return a.HTTP.Do(req)
+}
+
+// postJSON sends a POST request with a JSON body and the X-DocStore-Identity header set.
+func (a *App) postJSON(cfg *Config, urlStr string, body interface{}) (*http.Response, error) {
 	data, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
@@ -608,6 +694,7 @@ func (a *App) postJSON(urlStr string, body interface{}) (*http.Response, error) 
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-DocStore-Identity", cfg.Author)
 	return a.HTTP.Do(req)
 }
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -55,14 +55,34 @@ func writeFile(t *testing.T, app *App, path, content string) {
 
 func strPtr(s string) *string { return &s }
 
+// newEmptyRepoServer returns a mock server that serves an empty tree and
+// a single "main" branch at sequence 0.  Suitable for Init tests.
+func newEmptyRepoServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/tree":
+			json.NewEncoder(w).Encode([]treeEntry{})
+		case r.Method == "GET" && r.URL.Path == "/branches":
+			json.NewEncoder(w).Encode([]model.Branch{{Name: "main", HeadSequence: 0}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
 // ---------------------------------------------------------------------------
 // Init
 // ---------------------------------------------------------------------------
 
 func TestInit(t *testing.T) {
-	app, out := newTestApp(t, nil)
+	srv := newEmptyRepoServer(t)
+	defer srv.Close()
 
-	if err := app.Init("http://localhost:8080", "alice"); err != nil {
+	app, out := newTestApp(t, srv)
+
+	if err := app.Init(srv.URL, "alice"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -70,8 +90,8 @@ func TestInit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Remote != "http://localhost:8080" {
-		t.Errorf("remote = %q, want %q", cfg.Remote, "http://localhost:8080")
+	if cfg.Remote != srv.URL {
+		t.Errorf("remote = %q, want %q", cfg.Remote, srv.URL)
 	}
 	if cfg.Branch != "main" {
 		t.Errorf("branch = %q, want %q", cfg.Branch, "main")
@@ -97,28 +117,83 @@ func TestInit(t *testing.T) {
 }
 
 func TestInitTrimsTrailingSlash(t *testing.T) {
-	app, _ := newTestApp(t, nil)
+	srv := newEmptyRepoServer(t)
+	defer srv.Close()
 
-	if err := app.Init("http://localhost:8080/", "bob"); err != nil {
+	app, _ := newTestApp(t, srv)
+
+	if err := app.Init(srv.URL+"/", "bob"); err != nil {
 		t.Fatal(err)
 	}
 
 	cfg, _ := app.loadConfig()
-	if cfg.Remote != "http://localhost:8080" {
+	if cfg.Remote != srv.URL {
 		t.Errorf("remote = %q, want trailing slash trimmed", cfg.Remote)
 	}
 }
 
 func TestInitDefaultAuthor(t *testing.T) {
-	app, _ := newTestApp(t, nil)
+	srv := newEmptyRepoServer(t)
+	defer srv.Close()
 
-	if err := app.Init("http://localhost:8080", ""); err != nil {
+	app, _ := newTestApp(t, srv)
+
+	if err := app.Init(srv.URL, ""); err != nil {
 		t.Fatal(err)
 	}
 
 	cfg, _ := app.loadConfig()
 	if cfg.Author == "" {
 		t.Error("expected non-empty default author")
+	}
+}
+
+func TestInitFetchesFiles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/tree":
+			json.NewEncoder(w).Encode([]treeEntry{
+				{Path: "README.md", VersionID: "v1", ContentHash: HashBytes([]byte("hello"))},
+				{Path: "src/main.go", VersionID: "v2", ContentHash: HashBytes([]byte("package main"))},
+			})
+		case r.Method == "GET" && r.URL.Path == "/file/README.md":
+			json.NewEncoder(w).Encode(model.FileResponse{Path: "README.md", Content: []byte("hello")})
+		case r.Method == "GET" && r.URL.Path == "/file/src/main.go":
+			json.NewEncoder(w).Encode(model.FileResponse{Path: "src/main.go", Content: []byte("package main")})
+		case r.Method == "GET" && r.URL.Path == "/branches":
+			json.NewEncoder(w).Encode([]model.Branch{{Name: "main", HeadSequence: 7}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	if err := app.Init(srv.URL, "alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Files should be written to disk.
+	content, err := os.ReadFile(filepath.Join(app.Dir, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "hello" {
+		t.Errorf("README.md content = %q, want %q", string(content), "hello")
+	}
+
+	// State should reflect the files and correct sequence.
+	st, _ := app.loadState()
+	if len(st.Files) != 2 {
+		t.Errorf("state files = %d, want 2", len(st.Files))
+	}
+	if st.Sequence != 7 {
+		t.Errorf("state sequence = %d, want 7", st.Sequence)
+	}
+
+	if !strings.Contains(out.String(), "Initialized docstore workspace (2 files, sequence 7)") {
+		t.Errorf("unexpected output: %s", out.String())
 	}
 }
 
@@ -296,15 +371,12 @@ func TestCommit(t *testing.T) {
 }
 
 func TestCommitNoChanges(t *testing.T) {
-	app, out := newTestApp(t, nil)
+	app, _ := newTestApp(t, nil)
 	initWorkspace(t, app, "http://test", "main", "alice")
 
-	if err := app.Commit("nothing"); err != nil {
-		t.Fatal(err)
-	}
-
-	if !strings.Contains(out.String(), "No changes to commit") {
-		t.Errorf("expected 'No changes' in output: %s", out.String())
+	err := app.Commit("nothing")
+	if err == nil || !strings.Contains(err.Error(), "nothing to commit") {
+		t.Errorf("expected 'nothing to commit' error, got: %v", err)
 	}
 }
 
@@ -486,28 +558,28 @@ func TestCheckoutNewServerError(t *testing.T) {
 
 func TestCheckout(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" && r.URL.Path == "/tree" {
-			w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/tree":
 			json.NewEncoder(w).Encode([]treeEntry{
 				{Path: "main.go", VersionID: "v1", ContentHash: "hash1"},
 				{Path: "README.md", VersionID: "v2", ContentHash: "hash2"},
 			})
-			return
-		}
-		if r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/file/") {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/file/"):
 			path := strings.TrimPrefix(r.URL.Path, "/file/")
 			content := map[string]string{
 				"main.go":   "package main",
 				"README.md": "# Hello",
 			}
-			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(model.FileResponse{
 				Path:    path,
 				Content: []byte(content[path]),
 			})
-			return
+		case r.Method == "GET" && r.URL.Path == "/branches":
+			json.NewEncoder(w).Encode([]model.Branch{{Name: "main", HeadSequence: 3}})
+		default:
+			http.NotFound(w, r)
 		}
-		http.NotFound(w, r)
 	}))
 	defer srv.Close()
 
@@ -541,10 +613,13 @@ func TestCheckout(t *testing.T) {
 		t.Errorf("README.md content = %q, want %q", string(content), "# Hello")
 	}
 
-	// State should have both files.
+	// State should have both files and updated sequence.
 	st, _ := app.loadState()
 	if len(st.Files) != 2 {
 		t.Errorf("state files = %d, want 2", len(st.Files))
+	}
+	if st.Sequence != 3 {
+		t.Errorf("state sequence = %d, want 3", st.Sequence)
 	}
 
 	if !strings.Contains(out.String(), "Synced branch 'main'") {
@@ -554,20 +629,23 @@ func TestCheckout(t *testing.T) {
 
 func TestCheckoutRemovesDeletedFiles(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" && r.URL.Path == "/tree" {
-			w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/tree":
 			json.NewEncoder(w).Encode([]treeEntry{})
-			return
+		case r.Method == "GET" && r.URL.Path == "/branches":
+			json.NewEncoder(w).Encode([]model.Branch{{Name: "feature/new", HeadSequence: 0}})
+		default:
+			http.NotFound(w, r)
 		}
-		http.NotFound(w, r)
 	}))
 	defer srv.Close()
 
 	app, _ := newTestApp(t, srv)
 	initWorkspace(t, app, srv.URL, "main", "alice")
 
-	// Pre-populate state with a file.
-	app.saveState(&State{Branch: "main", Files: map[string]string{"old.txt": "hash"}})
+	// Pre-populate state with a file using its actual hash so the tree is clean.
+	app.saveState(&State{Branch: "main", Files: map[string]string{"old.txt": HashBytes([]byte("old content"))}})
 	writeFile(t, app, "old.txt", "old content")
 
 	if err := app.Checkout("feature/new"); err != nil {
@@ -586,6 +664,19 @@ func TestCheckoutRemovesDeletedFiles(t *testing.T) {
 	}
 }
 
+func TestCheckoutDirtyTree(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	initWorkspace(t, app, "http://test", "main", "alice")
+
+	// Add a new untracked file — makes the tree dirty.
+	writeFile(t, app, "new.txt", "new content")
+
+	err := app.Checkout("feature/x")
+	if err == nil || !strings.Contains(err.Error(), "uncommitted changes") {
+		t.Errorf("expected 'uncommitted changes' error, got: %v", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Pull
 // ---------------------------------------------------------------------------
@@ -593,34 +684,37 @@ func TestCheckoutRemovesDeletedFiles(t *testing.T) {
 func TestPull(t *testing.T) {
 	callCount := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" && r.URL.Path == "/tree" {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/tree":
 			if r.URL.Query().Get("branch") != "feature/x" {
 				t.Errorf("expected branch=feature/x, got %q", r.URL.Query().Get("branch"))
 			}
-			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode([]treeEntry{
 				{Path: "updated.txt", VersionID: "v3", ContentHash: "newhash"},
 			})
-			return
-		}
-		if r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/file/") {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/file/"):
 			callCount++
-			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(model.FileResponse{
 				Path:    "updated.txt",
 				Content: []byte("updated content"),
 			})
-			return
+		case r.Method == "GET" && r.URL.Path == "/branches":
+			json.NewEncoder(w).Encode([]model.Branch{{Name: "feature/x", HeadSequence: 5}})
+		default:
+			http.NotFound(w, r)
 		}
-		http.NotFound(w, r)
 	}))
 	defer srv.Close()
 
 	app, out := newTestApp(t, srv)
 	initWorkspace(t, app, srv.URL, "feature/x", "alice")
 
-	// Pre-populate with old hash so the file gets downloaded.
-	app.saveState(&State{Branch: "feature/x", Files: map[string]string{"updated.txt": "oldhash"}})
+	// Pre-populate with old content on disk + matching state hash, so isDirty is clean
+	// but the server hash ("newhash") is different → file will be downloaded.
+	const oldContent = "old content"
+	writeFile(t, app, "updated.txt", oldContent)
+	app.saveState(&State{Branch: "feature/x", Files: map[string]string{"updated.txt": HashBytes([]byte(oldContent))}})
 
 	if err := app.Pull(); err != nil {
 		t.Fatal(err)
@@ -638,36 +732,45 @@ func TestPull(t *testing.T) {
 		t.Errorf("content = %q, want %q", string(content), "updated content")
 	}
 
+	// Sequence should be updated.
+	st, _ := app.loadState()
+	if st.Sequence != 5 {
+		t.Errorf("sequence = %d, want 5", st.Sequence)
+	}
+
 	if !strings.Contains(out.String(), "1 downloaded") {
 		t.Errorf("unexpected output: %s", out.String())
 	}
 }
 
 func TestPullSkipsUnchanged(t *testing.T) {
+	const sameContent = "same content"
+	sameHash := HashBytes([]byte(sameContent))
 	fileDownloads := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" && r.URL.Path == "/tree" {
-			w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/tree":
 			json.NewEncoder(w).Encode([]treeEntry{
-				{Path: "same.txt", VersionID: "v1", ContentHash: "samehash"},
+				{Path: "same.txt", VersionID: "v1", ContentHash: sameHash},
 			})
-			return
-		}
-		if r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/file/") {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/file/"):
 			fileDownloads++
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(model.FileResponse{Path: "same.txt", Content: []byte("same")})
-			return
+			json.NewEncoder(w).Encode(model.FileResponse{Path: "same.txt", Content: []byte(sameContent)})
+		case r.Method == "GET" && r.URL.Path == "/branches":
+			json.NewEncoder(w).Encode([]model.Branch{{Name: "main", HeadSequence: 1}})
+		default:
+			http.NotFound(w, r)
 		}
-		http.NotFound(w, r)
 	}))
 	defer srv.Close()
 
 	app, out := newTestApp(t, srv)
 	initWorkspace(t, app, srv.URL, "main", "alice")
 
-	// State already has the same hash.
-	app.saveState(&State{Branch: "main", Files: map[string]string{"same.txt": "samehash"}})
+	// Write the file to disk and store its real hash in state so isDirty is clean.
+	writeFile(t, app, "same.txt", sameContent)
+	app.saveState(&State{Branch: "main", Files: map[string]string{"same.txt": sameHash}})
 
 	if err := app.Pull(); err != nil {
 		t.Fatal(err)
@@ -682,24 +785,69 @@ func TestPullSkipsUnchanged(t *testing.T) {
 	}
 }
 
+func TestPullDirtyTree(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	initWorkspace(t, app, "http://test", "main", "alice")
+
+	// Add a new untracked file — makes the tree dirty.
+	writeFile(t, app, "new.txt", "new content")
+
+	err := app.Pull()
+	if err == nil || !strings.Contains(err.Error(), "uncommitted changes") {
+		t.Errorf("expected 'uncommitted changes' error, got: %v", err)
+	}
+}
+
+func TestSyncTreeUpdatesSequence(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/tree":
+			json.NewEncoder(w).Encode([]treeEntry{})
+		case r.Method == "GET" && r.URL.Path == "/branches":
+			json.NewEncoder(w).Encode([]model.Branch{{Name: "main", HeadSequence: 42}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	if err := app.Pull(); err != nil {
+		t.Fatal(err)
+	}
+
+	st, _ := app.loadState()
+	if st.Sequence != 42 {
+		t.Errorf("sequence = %d, want 42", st.Sequence)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Merge
 // ---------------------------------------------------------------------------
 
 func TestMerge(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "POST" && r.URL.Path == "/merge" {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/merge":
 			var req model.MergeRequest
 			json.NewDecoder(r.Body).Decode(&req)
 			if req.Branch != "feature/done" {
 				t.Errorf("merge branch = %q, want %q", req.Branch, "feature/done")
 			}
-			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(model.MergeResponse{Sequence: 10})
-			return
+		case r.Method == "GET" && r.URL.Path == "/tree":
+			json.NewEncoder(w).Encode([]treeEntry{})
+		case r.Method == "GET" && r.URL.Path == "/branches":
+			json.NewEncoder(w).Encode([]model.Branch{{Name: "main", HeadSequence: 10}})
+		default:
+			http.NotFound(w, r)
 		}
-		http.NotFound(w, r)
 	}))
 	defer srv.Close()
 
@@ -708,6 +856,12 @@ func TestMerge(t *testing.T) {
 
 	if err := app.Merge(); err != nil {
 		t.Fatal(err)
+	}
+
+	// Config should be switched to main.
+	cfg, _ := app.loadConfig()
+	if cfg.Branch != "main" {
+		t.Errorf("branch after merge = %q, want %q", cfg.Branch, "main")
 	}
 
 	if !strings.Contains(out.String(), "Merged 'feature/done' into main at sequence 10") {
@@ -833,6 +987,31 @@ func TestDiffWithConflicts(t *testing.T) {
 	}
 	if !strings.Contains(output, "shared.txt") {
 		t.Errorf("expected 'shared.txt' in output:\n%s", output)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Identity header
+// ---------------------------------------------------------------------------
+
+func TestIdentityHeaderSentOnCommit(t *testing.T) {
+	var gotIdentity string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotIdentity = r.Header.Get("X-DocStore-Identity")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(model.CommitResponse{Sequence: 1})
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+	writeFile(t, app, "f.txt", "content")
+
+	app.Commit("test")
+
+	if gotIdentity != "alice" {
+		t.Errorf("X-DocStore-Identity = %q, want %q", gotIdentity, "alice")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **CRITICAL: Init doesn't fetch files** — `Init()` now calls `syncTree` after writing config, downloading all files from `GET /tree?branch=main` and saving state with correct `head_sequence` and file hashes. Output changed to `Initialized docstore workspace (N files, sequence M)`.
- **CRITICAL: Checkout has no dirty-tree guard** — `Checkout()` now calls `isDirty()` before `syncTree`; returns `"uncommitted changes -- commit or discard first"` if any changes exist.
- **CRITICAL: Pull has no dirty-tree guard** — `Pull()` has the same check.
- **CRITICAL: syncTree never updates state.Sequence** — `syncTree` now fetches `GET /branches` after syncing files and sets `st.Sequence` to the branch's `head_sequence` before saving state.
- **WARNING: Merge doesn't switch to main** — `Merge()` now updates `config.Branch = "main"` and calls `syncTree("main")` after a successful merge.
- **WARNING: X-DocStore-Identity header never sent** — Added `httpGet(cfg, url)` helper and updated `postJSON(cfg, url, body)` to set `X-DocStore-Identity: cfg.Author` on all requests.
- **WARNING: Commit with no changes returns nil** — Now returns `fmt.Errorf("nothing to commit")`.

## Test plan

- Updated all existing tests to work with new behavior (Init tests now use mock servers, checkout/pull tests use real content hashes for dirty-tree safety, syncTree tests include `GET /branches` mock handler)
- Added `TestCheckoutDirtyTree` — verifies checkout refuses with uncommitted changes
- Added `TestPullDirtyTree` — verifies pull refuses with uncommitted changes
- Added `TestInitFetchesFiles` — verifies init downloads files and sets correct sequence
- Added `TestSyncTreeUpdatesSequence` — verifies state.Sequence is updated after sync
- Added `TestIdentityHeaderSentOnCommit` — verifies X-DocStore-Identity header is sent
- All 30 tests pass: `go test ./internal/cli/... -count=1`

## Opportunities noted (not implemented)

- `syncTree` could skip the `GET /branches` call by having the server embed `head_sequence` in the `GET /tree` response
- `isDirty` re-scans local files; could be refactored to share scan results with callers that already have `localFiles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)