### PR TITLE
Add commits table and fix global sequence allocation

### DIFF
--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -3,7 +3,13 @@ package db
 import _ "embed"
 
 //go:embed migrations/000001_initial_schema.up.sql
-var MigrationSQL string
+var migration001 string
+
+//go:embed migrations/000002_add_commits_table.up.sql
+var migration002 string
+
+// MigrationSQL is the combined SQL for all schema migrations, run in order.
+var MigrationSQL = migration001 + "\n" + migration002
 
 //go:embed migrations/000001_initial_schema.down.sql
 var MigrationDownSQL string

--- a/internal/db/migrations/000002_add_commits_table.up.sql
+++ b/internal/db/migrations/000002_add_commits_table.up.sql
@@ -1,0 +1,26 @@
+-- Migration 002: Add commits table for globally monotonic sequence allocation.
+-- The commits table provides a single BIGSERIAL counter shared across all
+-- branches, replacing the broken per-branch headSeq+1 approach.
+
+-- Global commit log: one row per atomic commit, BIGSERIAL gives global order.
+CREATE TABLE commits (
+    sequence   BIGSERIAL PRIMARY KEY,
+    branch     TEXT NOT NULL,
+    message    TEXT NOT NULL,
+    author     TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Remove denormalized columns from file_commits and add FK to commits.
+-- message/author/created_at belong in commits, not duplicated per file row.
+ALTER TABLE file_commits
+    DROP COLUMN message,
+    DROP COLUMN author,
+    DROP COLUMN created_at,
+    ADD CONSTRAINT fk_file_commits_sequence
+        FOREIGN KEY (sequence) REFERENCES commits(sequence);
+
+-- Add created_at and created_by to branches per MVP.md spec.
+ALTER TABLE branches
+    ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    ADD COLUMN created_by TEXT NOT NULL DEFAULT 'system';

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -66,7 +66,16 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 		return nil, ErrBranchNotActive
 	}
 
-	newSeq := headSeq + 1
+	// Allocate a globally monotonic sequence by inserting into commits.
+	var newSeq int64
+	err = tx.QueryRowContext(ctx,
+		`INSERT INTO commits (branch, message, author) VALUES ($1, $2, $3) RETURNING sequence`,
+		req.Branch, req.Message, req.Author,
+	).Scan(&newSeq)
+	if err != nil {
+		return nil, fmt.Errorf("insert commit: %w", err)
+	}
+
 	results := make([]model.CommitFileResult, 0, len(req.Files))
 
 	for _, f := range req.Files {
@@ -105,9 +114,9 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 
 		commitID := uuid.New().String()
 		_, err = tx.ExecContext(ctx,
-			`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author, created_at)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, now())`,
-			commitID, newSeq, f.Path, versionIDPtr, req.Branch, req.Message, req.Author,
+			`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+			 VALUES ($1, $2, $3, $4, $5)`,
+			commitID, newSeq, f.Path, versionIDPtr, req.Branch,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("insert file_commit: %w", err)
@@ -259,19 +268,26 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 		return nil, conflicts, ErrMergeConflict
 	}
 
-	// Step 4: No conflicts — insert new file_commits on main for each branch-changed path.
-	newSeq := mainHead + 1
+	// Step 4: No conflicts — allocate a global sequence for the merge commit,
+	// then insert file_commits rows on main for each branch-changed path.
+	var newSeq int64
+	err = tx.QueryRowContext(ctx,
+		`INSERT INTO commits (branch, message, author) VALUES ('main', $1, $2) RETURNING sequence`,
+		fmt.Sprintf("merge branch '%s'", req.Branch), req.Author,
+	).Scan(&newSeq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("insert merge commit: %w", err)
+	}
 
 	for path, versionID := range branchChanges {
 		commitID := uuid.New().String()
 		_, err = tx.ExecContext(ctx,
-			`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author, created_at)
-			 VALUES ($1, $2, $3, $4, 'main', $5, $6, now())`,
+			`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+			 VALUES ($1, $2, $3, $4, 'main')`,
 			commitID, newSeq, path, versionID,
-			fmt.Sprintf("merge branch '%s'", req.Branch), req.Author,
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("insert merge commit: %w", err)
+			return nil, nil, fmt.Errorf("insert file_commit: %w", err)
 		}
 	}
 

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -378,9 +378,9 @@ func TestMerge_Success(t *testing.T) {
 	if conflicts != nil {
 		t.Fatalf("expected no conflicts, got %v", conflicts)
 	}
-	// mainHead was 1 before merge, so merge commit is at seq 2.
-	if resp.Sequence != 2 {
-		t.Errorf("expected merge sequence 2, got %d", resp.Sequence)
+	// With global BIGSERIAL sequences: commit-to-main=1, commit-to-branch=2, merge=3.
+	if resp.Sequence != 3 {
+		t.Errorf("expected merge sequence 3, got %d", resp.Sequence)
 	}
 
 	// Verify main head advanced.
@@ -389,8 +389,8 @@ func TestMerge_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("query main: %v", err)
 	}
-	if mainHead != 2 {
-		t.Errorf("expected main head 2, got %d", mainHead)
+	if mainHead != 3 {
+		t.Errorf("expected main head 3, got %d", mainHead)
 	}
 
 	// Verify branch is marked as merged.
@@ -414,8 +414,13 @@ func TestMerge_Success(t *testing.T) {
 	}
 
 	// Verify merge commit author is the one passed in the request.
+	// After schema change, author lives in commits, not file_commits.
 	var author string
-	err = d.QueryRow("SELECT author FROM file_commits WHERE branch = 'main' AND path = 'new.txt' AND sequence = $1", resp.Sequence).Scan(&author)
+	err = d.QueryRow(`
+		SELECT c.author FROM file_commits fc
+		JOIN commits c ON c.sequence = fc.sequence
+		WHERE fc.branch = 'main' AND fc.path = 'new.txt' AND fc.sequence = $1`,
+		resp.Sequence).Scan(&author)
 	if err != nil {
 		t.Fatalf("query author: %v", err)
 	}

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -26,16 +26,23 @@ func seed(t *testing.T, db *sql.DB) {
 		 VALUES ('aaaaaaaa-0000-0000-0000-000000000003', 'world.txt', 'the world', 'hash_world_v1', 'bob')`,
 		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
 		 VALUES ('aaaaaaaa-0000-0000-0000-000000000004', 'deleted.txt', 'gone soon', 'hash_deleted_v1', 'alice')`,
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('cccccccc-0000-0000-0000-000000000001', 1, 'hello.txt', 'aaaaaaaa-0000-0000-0000-000000000001', 'main', 'initial commit', 'alice')`,
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('cccccccc-0000-0000-0000-000000000002', 1, 'world.txt', 'aaaaaaaa-0000-0000-0000-000000000003', 'main', 'initial commit', 'alice')`,
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('cccccccc-0000-0000-0000-000000000003', 2, 'hello.txt', 'aaaaaaaa-0000-0000-0000-000000000002', 'main', 'update hello', 'alice')`,
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('cccccccc-0000-0000-0000-000000000004', 3, 'deleted.txt', 'aaaaaaaa-0000-0000-0000-000000000004', 'main', 'add deleted', 'bob')`,
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('cccccccc-0000-0000-0000-000000000005', 4, 'deleted.txt', NULL, 'main', 'remove deleted', 'bob')`,
+		// Insert commits rows for global sequence allocation.
+		`INSERT INTO commits (sequence, branch, message, author) OVERRIDING SYSTEM VALUE VALUES
+		 (1, 'main', 'initial commit', 'alice'),
+		 (2, 'main', 'update hello',   'alice'),
+		 (3, 'main', 'add deleted',    'bob'),
+		 (4, 'main', 'remove deleted', 'bob')`,
+		`SELECT setval('commits_sequence_seq', 4, true)`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('cccccccc-0000-0000-0000-000000000001', 1, 'hello.txt', 'aaaaaaaa-0000-0000-0000-000000000001', 'main')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('cccccccc-0000-0000-0000-000000000002', 1, 'world.txt', 'aaaaaaaa-0000-0000-0000-000000000003', 'main')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('cccccccc-0000-0000-0000-000000000003', 2, 'hello.txt', 'aaaaaaaa-0000-0000-0000-000000000002', 'main')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('cccccccc-0000-0000-0000-000000000004', 3, 'deleted.txt', 'aaaaaaaa-0000-0000-0000-000000000004', 'main')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('cccccccc-0000-0000-0000-000000000005', 4, 'deleted.txt', NULL, 'main')`,
 		`UPDATE branches SET head_sequence = 4 WHERE name = 'main'`,
 	}
 
@@ -221,8 +228,11 @@ func TestIntegrationDiffEndpoint(t *testing.T) {
 		`INSERT INTO branches (name, head_sequence, base_sequence, status) VALUES ('feature/diff', 5, 2, 'active')`,
 		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
 		 VALUES ('aaaaaaaa-0000-0000-0000-000000000010', 'new.txt', 'new file', 'hash_new', 'carol')`,
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('cccccccc-0000-0000-0000-000000000010', 5, 'new.txt', 'aaaaaaaa-0000-0000-0000-000000000010', 'feature/diff', 'add new', 'carol')`,
+		`INSERT INTO commits (sequence, branch, message, author) OVERRIDING SYSTEM VALUE VALUES
+		 (5, 'feature/diff', 'add new', 'carol')`,
+		`SELECT setval('commits_sequence_seq', 5, true)`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('cccccccc-0000-0000-0000-000000000010', 5, 'new.txt', 'aaaaaaaa-0000-0000-0000-000000000010', 'feature/diff')`,
 	}
 	for _, stmt := range stmts {
 		if _, err := database.Exec(stmt); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -177,9 +177,10 @@ func (s *Store) GetFileHistory(ctx context.Context, branch, path string, limit i
 WITH branch_info AS (
     SELECT base_sequence FROM branches WHERE name = $1
 )
-SELECT fc.sequence, fc.version_id::text, fc.message, fc.author, fc.created_at
+SELECT fc.sequence, fc.version_id::text, c.message, c.author, c.created_at
 FROM file_commits fc
 CROSS JOIN branch_info bi
+JOIN commits c ON c.sequence = fc.sequence
 WHERE (
     fc.branch = $1
     OR (fc.branch = 'main' AND fc.sequence <= bi.base_sequence)
@@ -375,8 +376,9 @@ ORDER BY path, sequence DESC`
 // Returns nil, nil if no commit exists with that sequence.
 func (s *Store) GetCommit(ctx context.Context, sequence int64) (*CommitDetail, error) {
 	const q = `
-SELECT fc.commit_id::text, fc.path, fc.version_id::text, fc.branch, fc.message, fc.author, fc.created_at
+SELECT fc.commit_id::text, fc.path, fc.version_id::text, fc.branch, c.message, c.author, c.created_at
 FROM file_commits fc
+JOIN commits c ON c.sequence = fc.sequence
 WHERE fc.sequence = $1
 ORDER BY fc.path`
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -31,23 +31,33 @@ func seed(t *testing.T, db *sql.DB) {
 		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
 		 VALUES ('aaaaaaaa-0000-0000-0000-000000000004', 'deleted.txt', 'gone soon', 'hash_deleted_v1', 'alice')`,
 
+		// Commits rows — use OVERRIDING SYSTEM VALUE to insert specific sequence numbers.
+		`INSERT INTO commits (sequence, branch, message, author) OVERRIDING SYSTEM VALUE VALUES
+		 (1, 'main', 'initial commit', 'alice'),
+		 (2, 'main', 'update hello',   'alice'),
+		 (3, 'main', 'add deleted',    'bob'),
+		 (4, 'main', 'remove deleted', 'bob')`,
+
+		// Advance the BIGSERIAL sequence past the manually-inserted values.
+		`SELECT setval('commits_sequence_seq', 4, true)`,
+
 		// Sequence 1: initial commit of hello.txt and world.txt
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('cccccccc-0000-0000-0000-000000000001', 1, 'hello.txt', 'aaaaaaaa-0000-0000-0000-000000000001', 'main', 'initial commit', 'alice')`,
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('cccccccc-0000-0000-0000-000000000002', 1, 'world.txt', 'aaaaaaaa-0000-0000-0000-000000000003', 'main', 'initial commit', 'alice')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('cccccccc-0000-0000-0000-000000000001', 1, 'hello.txt', 'aaaaaaaa-0000-0000-0000-000000000001', 'main')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('cccccccc-0000-0000-0000-000000000002', 1, 'world.txt', 'aaaaaaaa-0000-0000-0000-000000000003', 'main')`,
 
 		// Sequence 2: update hello.txt
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('cccccccc-0000-0000-0000-000000000003', 2, 'hello.txt', 'aaaaaaaa-0000-0000-0000-000000000002', 'main', 'update hello', 'alice')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('cccccccc-0000-0000-0000-000000000003', 2, 'hello.txt', 'aaaaaaaa-0000-0000-0000-000000000002', 'main')`,
 
 		// Sequence 3: add deleted.txt
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('cccccccc-0000-0000-0000-000000000004', 3, 'deleted.txt', 'aaaaaaaa-0000-0000-0000-000000000004', 'main', 'add deleted', 'bob')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('cccccccc-0000-0000-0000-000000000004', 3, 'deleted.txt', 'aaaaaaaa-0000-0000-0000-000000000004', 'main')`,
 
 		// Sequence 4: delete deleted.txt (version_id = NULL)
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('cccccccc-0000-0000-0000-000000000005', 4, 'deleted.txt', NULL, 'main', 'remove deleted', 'bob')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('cccccccc-0000-0000-0000-000000000005', 4, 'deleted.txt', NULL, 'main')`,
 
 		// Update main head
 		`UPDATE branches SET head_sequence = 4 WHERE name = 'main'`,
@@ -392,10 +402,15 @@ func TestGetDiff(t *testing.T) {
 		 VALUES ('aaaaaaaa-0000-0000-0000-000000000020', 'new.txt', 'new file', 'hash_new', 'carol')`,
 		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
 		 VALUES ('aaaaaaaa-0000-0000-0000-000000000021', 'hello.txt', 'hello v3 branch', 'hash_hello_v3', 'carol')`,
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('cccccccc-0000-0000-0000-000000000020', 5, 'new.txt', 'aaaaaaaa-0000-0000-0000-000000000020', 'feature/diff', 'add new', 'carol')`,
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('cccccccc-0000-0000-0000-000000000021', 6, 'hello.txt', 'aaaaaaaa-0000-0000-0000-000000000021', 'feature/diff', 'update hello', 'carol')`,
+		// Insert commits rows for sequences 5 and 6.
+		`INSERT INTO commits (sequence, branch, message, author) OVERRIDING SYSTEM VALUE VALUES
+		 (5, 'feature/diff', 'add new',      'carol'),
+		 (6, 'feature/diff', 'update hello', 'carol')`,
+		`SELECT setval('commits_sequence_seq', 6, true)`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('cccccccc-0000-0000-0000-000000000020', 5, 'new.txt', 'aaaaaaaa-0000-0000-0000-000000000020', 'feature/diff')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('cccccccc-0000-0000-0000-000000000021', 6, 'hello.txt', 'aaaaaaaa-0000-0000-0000-000000000021', 'feature/diff')`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
@@ -463,11 +478,18 @@ func TestGetDiff_WithConflict(t *testing.T) {
 
 	// Minimal setup: commit to main, create branch, change same file on both.
 	stmts := []string{
+		// Commits rows for sequences 1, 2, 3.
+		`INSERT INTO commits (sequence, branch, message, author) OVERRIDING SYSTEM VALUE VALUES
+		 (1, 'main',             'init',        'alice'),
+		 (2, 'main',             'main edit',   'alice'),
+		 (3, 'feature/conflict', 'branch edit', 'bob')`,
+		`SELECT setval('commits_sequence_seq', 3, true)`,
+
 		// Initial main commit
 		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
 		 VALUES ('dddddddd-0000-0000-0000-000000000001', 'shared.txt', 'original', 'hash_orig', 'alice')`,
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('eeeeeeee-0000-0000-0000-000000000001', 1, 'shared.txt', 'dddddddd-0000-0000-0000-000000000001', 'main', 'init', 'alice')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('eeeeeeee-0000-0000-0000-000000000001', 1, 'shared.txt', 'dddddddd-0000-0000-0000-000000000001', 'main')`,
 		`UPDATE branches SET head_sequence = 1 WHERE name = 'main'`,
 
 		// Branch at base=1
@@ -476,14 +498,14 @@ func TestGetDiff_WithConflict(t *testing.T) {
 		// Main changes shared.txt after branch point
 		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
 		 VALUES ('dddddddd-0000-0000-0000-000000000002', 'shared.txt', 'main edit', 'hash_main', 'alice')`,
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('eeeeeeee-0000-0000-0000-000000000002', 2, 'shared.txt', 'dddddddd-0000-0000-0000-000000000002', 'main', 'main edit', 'alice')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('eeeeeeee-0000-0000-0000-000000000002', 2, 'shared.txt', 'dddddddd-0000-0000-0000-000000000002', 'main')`,
 
 		// Branch also changes shared.txt
 		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
 		 VALUES ('dddddddd-0000-0000-0000-000000000003', 'shared.txt', 'branch edit', 'hash_branch', 'bob')`,
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('eeeeeeee-0000-0000-0000-000000000003', 3, 'shared.txt', 'dddddddd-0000-0000-0000-000000000003', 'feature/conflict', 'branch edit', 'bob')`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('eeeeeeee-0000-0000-0000-000000000003', 3, 'shared.txt', 'dddddddd-0000-0000-0000-000000000003', 'feature/conflict')`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
@@ -518,8 +540,12 @@ func TestBranchTree(t *testing.T) {
 		// Add a new file on the branch
 		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
 		 VALUES ('aaaaaaaa-0000-0000-0000-000000000010', 'new.txt', 'new file', 'hash_new', 'carol')`,
-		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch, message, author)
-		 VALUES ('cccccccc-0000-0000-0000-000000000010', 5, 'new.txt', 'aaaaaaaa-0000-0000-0000-000000000010', 'feature/test', 'add new file', 'carol')`,
+		// Insert a commits row for sequence 5.
+		`INSERT INTO commits (sequence, branch, message, author) OVERRIDING SYSTEM VALUE VALUES
+		 (5, 'feature/test', 'add new file', 'carol')`,
+		`SELECT setval('commits_sequence_seq', 5, true)`,
+		`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+		 VALUES ('cccccccc-0000-0000-0000-000000000010', 5, 'new.txt', 'aaaaaaaa-0000-0000-0000-000000000010', 'feature/test')`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {


### PR DESCRIPTION
## Summary

- **Root cause**: No `commits` table existed. Sequences were allocated per-branch via `headSeq+1`, allowing two branches to produce the same sequence number (e.g., main at seq 2 and feature at seq 2). This broke `GET /commit/:seq` and violated the core invariant.
- **Fix**: Add a `commits` table with `BIGSERIAL PRIMARY KEY` as the single global sequence counter. Both `Commit()` and `Merge()` now `INSERT INTO commits RETURNING sequence` before inserting `file_commits` rows.
- **Schema normalization**: Remove denormalized `message`/`author`/`created_at` from `file_commits` (they belong in `commits`). Add FK `file_commits.sequence REFERENCES commits(sequence)`. Add `created_at`/`created_by` to `branches` per MVP.md spec.
- **Read query updates**: `GetFileHistory()` and `GetCommit()` now JOIN `commits` to get message/author/created_at.
- **Tests**: All seed functions updated to insert `commits` rows (using `OVERRIDING SYSTEM VALUE` for specific sequence values) before `file_commits`. `TestMerge_Success` expected sequence updated from 2→3 (global BIGSERIAL: main-commit=1, branch-commit=2, merge=3).

## Test plan

- [x] All tests pass: `go test ./... -timeout 300s`
- [x] `internal/db` tests (Commit, Merge, CreateBranch)
- [x] `internal/store` tests (MaterializeTree, GetFile, GetFileHistory, GetCommit, GetDiff, BranchTree)
- [x] `internal/server` integration tests (HTTP endpoints)

## Opportunities noted (not implemented)

- The down migration (`000001_initial_schema.down.sql`) doesn't handle the new `commits` table or the dropped columns — would need a `000002_add_commits_table.down.sql` for completeness.
- `CreateBranch` still uses `DEFAULT 'system'` for `created_by`; could thread the caller identity through `CreateBranchRequest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)