### PR TITLE
Add TestDockerSmoke end-to-end container smoke test

### DIFF
--- a/internal/server/smoke_test.go
+++ b/internal/server/smoke_test.go
@@ -1,0 +1,142 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	tcnetwork "github.com/testcontainers/testcontainers-go/network"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// TestDockerSmoke builds the Docker image from the repo root, starts it
+// alongside a Postgres testcontainer on a shared network, and verifies that
+// GET /tree?branch=main returns 200 with an empty array.
+func TestDockerSmoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Docker smoke test in short mode")
+	}
+
+	ctx := context.Background()
+
+	// Compute repo root: two levels up from internal/server/smoke_test.go
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine source file path")
+	}
+	repoRoot := filepath.Join(filepath.Dir(filename), "..", "..")
+
+	// Create a dedicated Docker network so the app container can reach Postgres
+	// by a stable hostname rather than a dynamic IP.
+	net, err := tcnetwork.New(ctx)
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := net.Remove(ctx); err != nil {
+			t.Logf("remove network: %v", err)
+		}
+	})
+	networkName := net.Name
+
+	const pgAlias = "postgres"
+
+	// Start Postgres on the shared network.
+	pgCtr, err := postgres.Run(ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("docstore"),
+		postgres.WithUsername("docstore"),
+		postgres.WithPassword("docstore"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(30*time.Second),
+		),
+		testcontainers.CustomizeRequest(testcontainers.GenericContainerRequest{
+			ContainerRequest: testcontainers.ContainerRequest{
+				Networks: []string{networkName},
+				NetworkAliases: map[string][]string{
+					networkName: {pgAlias},
+				},
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := pgCtr.Terminate(ctx); err != nil {
+			t.Logf("terminate postgres: %v", err)
+		}
+	})
+
+	// Build and start the application container from the repo root.
+	// DATABASE_URL uses the Postgres container's network alias as the host.
+	dbURL := fmt.Sprintf("postgres://docstore:docstore@%s:5432/docstore?sslmode=disable", pgAlias)
+
+	appCtr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			FromDockerfile: testcontainers.FromDockerfile{
+				Context:    repoRoot,
+				Dockerfile: "Dockerfile",
+				KeepImage:  false,
+			},
+			Networks: []string{networkName},
+			Env: map[string]string{
+				"DATABASE_URL": dbURL,
+				"PORT":         "8080",
+			},
+			ExposedPorts: []string{"8080/tcp"},
+			WaitingFor: wait.ForHTTP("/healthz").
+				WithPort("8080/tcp").
+				WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("start app container: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := appCtr.Terminate(ctx); err != nil {
+			t.Logf("terminate app container: %v", err)
+		}
+	})
+
+	// Resolve the host-side address for the app container.
+	host, err := appCtr.Host(ctx)
+	if err != nil {
+		t.Fatalf("get host: %v", err)
+	}
+	port, err := appCtr.MappedPort(ctx, "8080/tcp")
+	if err != nil {
+		t.Fatalf("get port: %v", err)
+	}
+
+	baseURL := fmt.Sprintf("http://%s:%s", host, port.Port())
+
+	// GET /tree?branch=main must return 200 with an empty JSON array on a fresh DB.
+	resp, err := http.Get(baseURL + "/tree?branch=main")
+	if err != nil {
+		t.Fatalf("GET /tree: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var entries []json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty array, got %d entries", len(entries))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `TestDockerSmoke` in `internal/server/smoke_test.go` as specified in MVP.md Phase 6
- Builds the Docker image from the repo root using `testcontainers.GenericContainer` with `FromDockerfile`
- Starts a `postgres:16-alpine` testcontainer on a shared Docker network with alias `postgres`
- Passes `DATABASE_URL=postgres://docstore:docstore@postgres:5432/docstore?sslmode=disable` to the app container
- Waits for `GET /healthz` to return 2xx before proceeding (up to 120s)
- Hits `GET /tree?branch=main` and asserts HTTP 200 with an empty JSON array
- Skips in `-short` mode; otherwise runs as part of `go test ./...`

## Implementation notes

- Uses `tcnetwork.New(ctx)` from `testcontainers-go/network` to create an isolated bridge network per test run
- Postgres container is attached to the network via `testcontainers.CustomizeRequest` with `NetworkAliases` — same pattern as `testutil.TestDB` but extended with network membership
- `KeepImage: false` so the built image is cleaned up after the test
- All containers are terminated via `t.Cleanup` in reverse order

## Test plan

- [ ] `go test -v -run TestDockerSmoke ./internal/server/` with Docker running
- [ ] `go test -short ./internal/server/` — test should be skipped, no Docker required
- [ ] `go test -race -count=1 ./...` — full suite still passes (smoke test needs Docker)

## Opportunities noted (not implemented)

- Could add a `PrintBuildLog: true` option to `FromDockerfile` for easier CI debugging of Docker build failures
- Could also verify `GET /healthz` response body in addition to status code

🤖 Generated with [Claude Code](https://claude.com/claude-code)