### PR TITLE
Run migrations on startup to fix TestDockerSmoke 500 errors

### DIFF
--- a/cmd/docstore/main.go
+++ b/cmd/docstore/main.go
@@ -32,6 +32,10 @@ func main() {
 	}
 	defer database.Close()
 
+	if err := db.RunMigrations(database); err != nil {
+		log.Fatalf("run migrations: %v", err)
+	}
+
 	commitStore := db.NewStore(database)
 	srv := server.New(commitStore, database)
 

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -1,6 +1,10 @@
 package db
 
-import _ "embed"
+import (
+	"database/sql"
+	"fmt"
+	_ "embed"
+)
 
 //go:embed migrations/000001_initial_schema.up.sql
 var migration001 string
@@ -13,3 +17,11 @@ var MigrationSQL = migration001 + "\n" + migration002
 
 //go:embed migrations/000001_initial_schema.down.sql
 var MigrationDownSQL string
+
+// RunMigrations executes all migrations against the given database.
+func RunMigrations(database *sql.DB) error {
+	if _, err := database.Exec(MigrationSQL); err != nil {
+		return fmt.Errorf("run migrations: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Added `RunMigrations(*sql.DB) error` to `internal/db/migrations.go` that executes `MigrationSQL` (both migration files already embedded) against the database
- Called `db.RunMigrations(database)` in `cmd/docstore/main.go` immediately after `db.Open()` succeeds
- `go build ./...` and `go vet ./...` both pass

## Root Cause

`TestDockerSmoke` starts the server against a fresh Postgres container. Without running migrations, the `branches`/`commits` tables don't exist, so `GET /tree?branch=main` hits a DB error and returns 500.

## Test plan

- [ ] `TestDockerSmoke` should now pass: server auto-creates schema on startup
- [ ] Manual: `docker compose up` + `curl localhost:8080/tree?branch=main` should return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)