### PR TITLE
Add GitHub Actions deploy workflow (ko + Cloud Run)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: ko-build/setup-ko@v0.7
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/320310132788/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: docstore-deployer@dlorenc-chainguard.iam.gserviceaccount.com
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure ko
+        run: |
+          gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - name: Build and push image
+        id: build
+        env:
+          KO_DOCKER_REPO: us-central1-docker.pkg.dev/dlorenc-chainguard/images/docstore
+        run: |
+          IMAGE=$(ko build --bare --tags latest,$(git rev-parse --short HEAD) ./cmd/docstore)
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy docstore \
+            --image=${{ steps.build.outputs.image }} \
+            --project=dlorenc-chainguard \
+            --region=us-central1 \
+            --service-account=docstore-server@dlorenc-chainguard.iam.gserviceaccount.com \
+            --add-cloudsql-instances=dlorenc-chainguard:us-central1:docstore-mvp \
+            --update-secrets=DATABASE_URL=docstore-db-url:latest \
+            --allow-unauthenticated \
+            --min-instances=0 \
+            --max-instances=1 \
+            --port=8080

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,7 +6,7 @@ A simplified version control system built on a versioned document store. One lon
 
 ## Data Model
 
-Six tables. All writes are appends — nothing is mutated.
+Seven tables. Documents and file_commits are append-only. Branches are mutable (head_sequence and status are updated in place).
 
 **documents** stores immutable file versions. Every save creates a new row.
 
@@ -19,18 +19,24 @@ Six tables. All writes are appends — nothing is mutated.
 | created_at | timestamp | |
 | created_by | text | author |
 
-**file_commits** is the core event log. One row per file change. A globally incrementing `sequence` provides total ordering and serves as the commit identity — all rows sharing a sequence number are one atomic commit.
+**commits** stores per-commit metadata. One row per atomic commit.
+
+| Column | Type | Notes |
+|---|---|---|
+| sequence | bigint | PK, globally monotonic |
+| message | text | commit message |
+| author | text | committer identity (from IAP) |
+| created_at | timestamp | |
+
+**file_commits** is the core event log. One row per file change. All rows sharing a `sequence` reference the same commit.
 
 | Column | Type | Notes |
 |---|---|---|
 | commit_id | uuid | PK, unique per file row |
-| sequence | bigint | globally monotonic, shared across files in one atomic commit |
+| sequence | bigint | FK → commits |
 | path | text | file that changed |
 | version_id | uuid | FK → documents, null = delete |
 | branch | text | `main` or `feature/*` |
-| message | text | same across all rows in a sequence |
-| author | text | same across all rows in a sequence |
-| created_at | timestamp | |
 
 **branches** are named pointers.
 
@@ -40,6 +46,8 @@ Six tables. All writes are appends — nothing is mutated.
 | head_sequence | bigint | latest sequence on this branch |
 | base_sequence | bigint | where it forked from main |
 | status | enum | active / merged / abandoned |
+| created_at | timestamp | |
+| created_by | text | identity that created the branch |
 
 **roles** maps identities to coarse-grained permissions.
 
@@ -57,6 +65,7 @@ Six tables. All writes are appends — nothing is mutated.
 | reviewer | text | identity of the reviewer |
 | sequence | bigint | branch head_sequence at time of review |
 | status | enum | approved / rejected / dismissed |
+| body | text | optional review comment |
 | created_at | timestamp | |
 
 **check_runs** stores external CI status reports for a branch at a specific head sequence.
@@ -79,11 +88,11 @@ On `POST /commit`, the server hashes each file's content and checks the `(conten
 
 ## Atomic Commits
 
-A single `POST /commit` with multiple files produces multiple `file_commits` rows that all share the same `sequence` number. The sequence counter increments once per commit, not once per file. This means `sequence` is the commit identity — to see everything in a commit, query `WHERE sequence = :seq`. Materialization is unaffected since `DISTINCT ON (path) ... ORDER BY path, sequence DESC` resolves ties naturally when paths are different.
+A single `POST /commit` inserts one row into `commits` (allocating the next sequence number, storing the message and author) and multiple rows into `file_commits` that all reference that sequence. The sequence counter increments once per commit, not once per file. This means `sequence` is the commit identity — to see everything in a commit, query `WHERE sequence = :seq`. Materialization is unaffected since `DISTINCT ON (path) ... ORDER BY path, sequence DESC` resolves ties naturally when paths are different.
 
 ## Concurrency
 
-All write operations (`POST /commit`, `/merge`, `/rebase`) run inside a transaction that begins with `SELECT ... FOR UPDATE` on the target branch row. This serializes writes per-branch — concurrent commits to different branches don't block each other, while concurrent commits to the same branch serialize cleanly. Merge and rebase lock both the source branch and main. The contention window is small (a few row inserts per transaction), and the design's usage pattern of short-lived single-author feature branches means lock contention is minimal in practice.
+All write operations (`POST /commit`, `/merge`, `/rebase`) run inside a transaction that begins with `SELECT ... FOR UPDATE` on the target branch row. This serializes writes per-branch — concurrent commits to different branches don't block each other, while concurrent commits to the same branch serialize cleanly. Merge and rebase lock both the source branch and main, always acquiring the main lock first to prevent deadlocks. The contention window is small (a few row inserts per transaction), and the design's usage pattern of short-lived single-author feature branches means lock contention is minimal in practice.
 
 ## Authentication
 
@@ -134,7 +143,9 @@ Fields vary by action — `reviews` and `check_runs` are only populated for `/me
 
 Policies live in `.docstore/policy/*.rego` files in the repo on `main`. They are versioned documents like any other file and go through the same branch/review/merge workflow. This means policy changes require review and approval just like code changes.
 
-The server loads policies from the materialized `main` tree. A bootstrap/fallback policy is embedded in the server config for initial setup and disaster recovery.
+The server loads policies from the materialized `main` tree and caches them in memory. Policies are reloaded whenever main's `head_sequence` advances (on commit or merge to main). This ensures policies are always fresh with no staleness window, at the cost of a small reload on each main write.
+
+The bootstrap/fallback policy (used when no `.docstore/policy/*.rego` files exist) is wide open — all authenticated users can perform all actions, subject only to role checks in Layer 2. Policies are purely additive restrictions. This allows initial setup without a chicken-and-egg problem; the first policy commit then locks things down.
 
 ### OWNERS Files
 
@@ -160,28 +171,34 @@ All endpoints are REST. Sequences are returned in every mutation response. List 
 
 `GET /branches` — List all branches. Returns `[{name, head_sequence, base_sequence, status}]`. Supports `?status=active` filter.
 
-`GET /branch/:name/status` — Evaluate all merge policies for a branch without actually merging. Returns `{mergeable: bool, policies: [{name, pass: bool, reason}]}`. Useful for UI status checks and CI gates.
+`GET /branch/:name/status` — Evaluate all merge policies for a branch without actually merging. Returns `{mergeable: bool, policies: [{name, pass, reason}]}`. Useful for UI status checks and CI gates.
+
+`GET /branch/:name/reviews` — List reviews for a branch. Returns `[{id, reviewer, sequence, status, body, created_at}]` ordered by created_at desc.
+
+`GET /branch/:name/checks` — List check runs for a branch. Returns `[{id, sequence, check_name, status, reporter, created_at}]` ordered by created_at desc.
 
 **Writes**
 
-`POST /commit` — Commit one or more file changes atomically. Body: `{branch, files: [{path, content}], message}`. Policy-evaluated: the engine checks the actor's role and the target branch (e.g., direct commits to `main` can be blocked by policy). Allocates a single sequence number, writes to documents and file_commits (one row per file, all sharing that sequence), advances the branch head.
+`POST /commit` — Commit one or more file changes atomically. Body: `{branch, files: [{path, content}], message}`. Policy-evaluated: the engine checks the actor's role and the target branch (e.g., direct commits to `main` can be blocked by policy). Allocates a single sequence number, writes one row to commits and one row per file to file_commits (all referencing that sequence), advances the branch head.
 
 `POST /branch` — Create a branch. Body: `{name}`. Policy-evaluated. Sets `base_sequence` to main's current head.
 
-`POST /merge` — Merge a branch into main. Body: `{branch}`. Policy-evaluated: the engine evaluates all merge policies (required reviews, passing checks, OWNERS approval) before proceeding. On policy failure, returns `{policies: [{name, pass, reason}]}` with a 403. The merge uses `base_sequence` from the branches table as the fork point:
+`POST /merge` — Merge a branch into main. Body: `{branch}`. Policy-evaluated: the engine evaluates all merge policies (required reviews, passing checks, OWNERS approval) before proceeding. On policy failure, returns `{policies: [{name, pass, reason}]}` with a 403. **Staleness rule**: the server only includes reviews and check_runs whose `sequence` matches the branch's current `head_sequence` in the policy input. Any new commit to the branch advances `head_sequence`, which automatically invalidates all prior reviews and checks — policies see an empty list until the branch is re-reviewed and re-checked at the new head. The merge uses `base_sequence` from the branches table as the fork point:
 
 1. **Branch changes**: find the latest version of each path changed on the branch since `base_sequence` (`WHERE branch = :branch AND sequence > :base_sequence`, `DISTINCT ON (path) ... ORDER BY path, sequence DESC`).
 2. **Main changes**: find the latest version of each path changed on main since `base_sequence` (same query shape against `branch = 'main'`).
 3. **Conflict check**: any path that appears in both sets is a conflict — return `{conflicts: [...]}` and abort.
 4. **If clean**: insert new `file_commits` rows on main for each branch-changed path (all sharing a single new sequence), advance main's head, mark the branch as merged.
 
-`POST /rebase` — Rebase a branch onto main's current head. Body: `{branch}`. Policy-evaluated. Replays the branch's file_commits grouped by their original sequence numbers, each group getting a new sequence. Updates the branch's `base_sequence` to main's current head. Fails with conflict details if any replayed path was also changed on main.
+`POST /rebase` — Rebase a branch onto main's current head. Body: `{branch}`. Policy-evaluated. The entire rebase runs in a single transaction. Replays the branch's file_commits grouped by their original sequence numbers, each group getting a new sequence. Updates the branch's `base_sequence` to main's current head. If any replayed path conflicts with a main change, the entire transaction rolls back and returns conflict details — no partial rebase state.
 
-`POST /review` — Submit a review for a branch. Body: `{branch, status}` where status is `approved` or `rejected`. Policy-evaluated. The review is recorded against the branch's current `head_sequence` — if new commits are pushed, previous approvals are scoped to the old sequence and policies can require re-review.
+`POST /review` — Submit a review for a branch. Body: `{branch, status, body}` where status is `approved` or `rejected` and body is an optional comment. Policy-evaluated. The review is recorded against the branch's current `head_sequence`. New commits invalidate prior reviews (see staleness rule on `/merge`).
 
-`POST /check` — Report CI check status. Body: `{branch, check_name, status}` where status is `passed` or `failed`. Policy-evaluated: only identities authorized for a given `check_name` can report results (prevents spoofing CI status). Recorded against the branch's current `head_sequence`.
+`POST /check` — Report CI check status. Body: `{branch, check_name, status}` where status is `passed` or `failed`. Policy-evaluated: only identities authorized for a given `check_name` can report results (prevents spoofing CI status). Recorded against the branch's current `head_sequence`. New commits invalidate prior checks (see staleness rule on `/merge`).
 
 `DELETE /branch/:name` — Mark a branch as abandoned. Policy-evaluated.
+
+`POST /purge` — Delete `file_commits` and `commits` rows for branches with status `merged` or `abandoned`. Body: `{older_than}` where `older_than` is a duration (e.g. `"90d"`) — only branches whose last activity is older than this threshold are purged. Also deletes any `documents` rows whose `version_id` is no longer referenced by any remaining `file_commits` row. Policy-evaluated (admin-only). Returns `{branches_purged: N, file_commits_deleted: N, documents_deleted: N}`.
 
 ## Client
 
@@ -196,9 +213,21 @@ ds log [path]                 # GET /file/:path/history or full branch log
 ds diff                       # GET /diff for current branch
 ds merge                      # POST /merge
 ds rebase                     # POST /rebase
+ds pull                       # fetch latest tree for current branch, update local files
 ds checkout main              # switch branch, GET /tree to update local files
 ds show <sequence> [path]     # GET /tree?at=N or GET /file/:path?at=N
 ```
+
+**`ds pull` flow**:
+
+1. Check for uncommitted local changes (`ds status`). If any exist, error with "uncommitted changes — commit or discard first".
+2. `GET /tree?branch=<current>` to fetch the latest materialized tree from the server.
+3. Compare the remote tree against the local `state.json` to find files that are new, changed, or deleted on the remote.
+4. Download content for new/changed files via `GET /file/:path?branch=<current>`.
+5. Write updated files to disk, delete locally any files removed on the remote.
+6. Update `state.json` with the new head sequence and content hashes.
+
+This covers both cases: pulling someone else's commits to your feature branch, and pulling the latest main after switching to it.
 
 **Local state**: The client keeps a `.docstore/state.json` with the current branch, the last synced sequence, and content hashes of local files. `ds status` compares local hashes to the last synced tree to detect changes without hitting the server.
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy.yml` triggered on push to `main`
- Uses `ko` to build a minimal image (no Docker daemon needed) and push to `us-central1-docker.pkg.dev/dlorenc-chainguard/images/docstore`
- Deploys to Cloud Run (`docstore`, `us-central1`) via keyless WIF auth — no stored credentials
- Tags image with both `latest` and the short git SHA

## GCP setup already done

- `docstore-server` SA — Cloud Run runtime identity, has `cloudsql.client`
- `docstore-deployer` SA — GitHub Actions identity, has AR writer + `run.developer` + SA user on `docstore-server`
- WIF binding: `dlorenc/docstore` repo → `docstore-deployer`
- Cloud SQL instance `docstore-mvp` (Postgres 15, us-central1) — still provisioning

## Before merging / first deploy

- [ ] Wait for `docstore-mvp` Cloud SQL instance to finish provisioning
- [ ] Create `docstore` database and user on the instance
- [ ] Store connection string in Secret Manager as `docstore-db-url`
- [ ] Grant `docstore-server` SA `secretmanager.secretAccessor` on that secret

## Test plan

- [ ] Merge and verify Actions run succeeds end-to-end
- [ ] `curl https://<cloud-run-url>/healthz` returns `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)