### PR TITLE
Implement DELETE /branch/:name (closes #25)

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -355,6 +355,43 @@ func nullStr(s *string) string {
 	return *s
 }
 
+// DeleteBranch marks a branch as abandoned. It returns ErrBranchNotFound if
+// the branch does not exist, and ErrBranchNotActive if it is already merged
+// or abandoned (i.e. not active).
+func (s *Store) DeleteBranch(ctx context.Context, name string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	var status string
+	err = tx.QueryRowContext(ctx,
+		"SELECT status FROM branches WHERE name = $1 FOR UPDATE",
+		name,
+	).Scan(&status)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrBranchNotFound
+		}
+		return fmt.Errorf("lock branch: %w", err)
+	}
+
+	if status != "active" {
+		return ErrBranchNotActive
+	}
+
+	_, err = tx.ExecContext(ctx,
+		"UPDATE branches SET status = 'abandoned' WHERE name = $1",
+		name,
+	)
+	if err != nil {
+		return fmt.Errorf("update branch status: %w", err)
+	}
+
+	return tx.Commit()
+}
+
 // isDuplicateKeyError checks if a PostgreSQL error is a unique violation (23505).
 func isDuplicateKeyError(err error) bool {
 	var pqErr *pq.Error

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -523,6 +523,75 @@ func TestMerge_BranchNotActive(t *testing.T) {
 	}
 }
 
+// --- DeleteBranch tests ---
+
+func TestDeleteBranch_Success(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/delete-me"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+
+	if err := s.DeleteBranch(ctx, "feature/delete-me"); err != nil {
+		t.Fatalf("delete branch: %v", err)
+	}
+
+	var status string
+	err = d.QueryRow("SELECT status FROM branches WHERE name = 'feature/delete-me'").Scan(&status)
+	if err != nil {
+		t.Fatalf("query branch: %v", err)
+	}
+	if status != "abandoned" {
+		t.Errorf("expected status 'abandoned', got %q", status)
+	}
+}
+
+func TestDeleteBranch_NotFound(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	err := s.DeleteBranch(ctx, "nonexistent")
+	if err != ErrBranchNotFound {
+		t.Fatalf("expected ErrBranchNotFound, got %v", err)
+	}
+}
+
+func TestDeleteBranch_AlreadyMerged(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := d.Exec("INSERT INTO branches (name, head_sequence, base_sequence, status) VALUES ('merged-br', 0, 0, 'merged')")
+	if err != nil {
+		t.Fatalf("insert branch: %v", err)
+	}
+
+	err = s.DeleteBranch(ctx, "merged-br")
+	if err != ErrBranchNotActive {
+		t.Fatalf("expected ErrBranchNotActive, got %v", err)
+	}
+}
+
+func TestDeleteBranch_AlreadyAbandoned(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := d.Exec("INSERT INTO branches (name, head_sequence, base_sequence, status) VALUES ('abandoned-br', 0, 0, 'abandoned')")
+	if err != nil {
+		t.Fatalf("insert branch: %v", err)
+	}
+
+	err = s.DeleteBranch(ctx, "abandoned-br")
+	if err != ErrBranchNotActive {
+		t.Fatalf("expected ErrBranchNotActive, got %v", err)
+	}
+}
+
 func TestMerge_EmptyBranch(t *testing.T) {
 	d := testutil.TestDB(t, MigrationSQL)
 	s := NewStore(d)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -248,6 +248,30 @@ func (s *server) handleCreateBranch(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, resp)
 }
 
+// handleDeleteBranch implements DELETE /branch/{name}
+func (s *server) handleDeleteBranch(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "main" {
+		writeError(w, http.StatusBadRequest, "cannot delete branch 'main'")
+		return
+	}
+
+	err := s.commitStore.DeleteBranch(r.Context(), name)
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrBranchNotFound):
+			writeError(w, http.StatusNotFound, "branch not found")
+		case errors.Is(err, db.ErrBranchNotActive):
+			writeError(w, http.StatusConflict, "branch is already merged or abandoned")
+		default:
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // handleMerge implements POST /merge
 func (s *server) handleMerge(w http.ResponseWriter, r *http.Request) {
 	var req model.MergeRequest

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -347,3 +347,81 @@ func TestIntegrationCommitEndpoint(t *testing.T) {
 		}
 	})
 }
+
+func TestIntegrationDeleteBranch(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
+	seed(t, database)
+
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// Seed a branch to delete.
+	if _, err := database.Exec(
+		"INSERT INTO branches (name, head_sequence, base_sequence, status) VALUES ('feature/to-delete', 4, 4, 'active')",
+	); err != nil {
+		t.Fatalf("seed branch: %v", err)
+	}
+
+	t.Run("delete active branch returns 204", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/branch/feature/to-delete", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("DELETE /branch/feature/to-delete: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("expected 204, got %d", resp.StatusCode)
+		}
+
+		// Verify status is 'abandoned' in DB.
+		var status string
+		if err := database.QueryRow("SELECT status FROM branches WHERE name = 'feature/to-delete'").Scan(&status); err != nil {
+			t.Fatalf("query branch: %v", err)
+		}
+		if status != "abandoned" {
+			t.Errorf("expected status 'abandoned', got %q", status)
+		}
+	})
+
+	t.Run("delete main returns 400", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/branch/main", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("DELETE /branch/main: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("delete nonexistent branch returns 404", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/branch/nonexistent", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("DELETE /branch/nonexistent: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("delete abandoned branch returns 409", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/branch/feature/to-delete", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("DELETE /branch/feature/to-delete: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("expected 409, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ type WriteStore interface {
 	Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error)
 	CreateBranch(ctx context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error)
 	Merge(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error)
+	DeleteBranch(ctx context.Context, name string) error
 }
 
 // CommitStore is an alias for backward compatibility with tests.
@@ -51,7 +52,7 @@ func New(writeStore WriteStore, database *sql.DB) http.Handler {
 	mux.HandleFunc("POST /rebase", notImplemented)
 	mux.HandleFunc("POST /review", notImplemented)
 	mux.HandleFunc("POST /check", notImplemented)
-	mux.HandleFunc("DELETE /branch/{name}", notImplemented)
+	mux.HandleFunc("DELETE /branch/{name...}", s.handleDeleteBranch)
 
 	return mux
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,9 +15,10 @@ import (
 
 // mockStore implements WriteStore for testing.
 type mockStore struct {
-	commitFn       func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error)
-	createBranchFn func(ctx context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error)
-	mergeFn        func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error)
+	commitFn        func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error)
+	createBranchFn  func(ctx context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error)
+	mergeFn         func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error)
+	deleteBranchFn  func(ctx context.Context, name string) error
 }
 
 func (m *mockStore) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
@@ -36,6 +37,13 @@ func (m *mockStore) Merge(ctx context.Context, req model.MergeRequest) (*model.M
 		return m.mergeFn(ctx, req)
 	}
 	return nil, nil, errors.New("not implemented")
+}
+
+func (m *mockStore) DeleteBranch(ctx context.Context, name string) error {
+	if m.deleteBranchFn != nil {
+		return m.deleteBranchFn(ctx, name)
+	}
+	return errors.New("not implemented")
 }
 
 func TestHealthEndpoint(t *testing.T) {
@@ -68,6 +76,7 @@ func TestNotImplementedEndpoints(t *testing.T) {
 		{"POST", "/rebase"},
 		{"POST", "/review"},
 		{"POST", "/check"},
+		{"GET", "/branch/main/status"},
 	}
 
 	for _, ep := range endpoints {
@@ -497,5 +506,90 @@ func TestHandleMerge_DefaultAuthorSystem(t *testing.T) {
 	}
 	if capturedAuthor != "system" {
 		t.Errorf("expected default author 'system', got %q", capturedAuthor)
+	}
+}
+
+// --- DELETE /branch/:name tests ---
+
+func TestHandleDeleteBranch_Success(t *testing.T) {
+	store := &mockStore{
+		deleteBranchFn: func(ctx context.Context, name string) error {
+			if name != "feature/delete-me" {
+				t.Errorf("expected name feature/delete-me, got %q", name)
+			}
+			return nil
+		},
+	}
+	srv := New(store, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/branch/feature/delete-me", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleDeleteBranch_CannotDeleteMain(t *testing.T) {
+	srv := New(&mockStore{}, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/branch/main", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleDeleteBranch_NotFound(t *testing.T) {
+	store := &mockStore{
+		deleteBranchFn: func(ctx context.Context, name string) error {
+			return db.ErrBranchNotFound
+		},
+	}
+	srv := New(store, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/branch/nonexistent", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleDeleteBranch_AlreadyMerged(t *testing.T) {
+	store := &mockStore{
+		deleteBranchFn: func(ctx context.Context, name string) error {
+			return db.ErrBranchNotActive
+		},
+	}
+	srv := New(store, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/branch/merged-branch", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", rec.Code)
+	}
+}
+
+func TestHandleDeleteBranch_AlreadyAbandoned(t *testing.T) {
+	store := &mockStore{
+		deleteBranchFn: func(ctx context.Context, name string) error {
+			return db.ErrBranchNotActive
+		},
+	}
+	srv := New(store, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/branch/abandoned-branch", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", rec.Code)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `Store.DeleteBranch` in `internal/db/store.go`: locks branch row, returns `ErrBranchNotFound` / `ErrBranchNotActive`, sets `status='abandoned'`
- Adds `DeleteBranch` to the `WriteStore` interface in `server.go`
- Adds `handleDeleteBranch` handler in `handlers.go`; uses `{name...}` wildcard so branch names with slashes (e.g. `feature/foo`) work correctly
- Wires route `DELETE /branch/{name...}` (replacing `notImplemented`)

## Test plan

- [x] `TestDeleteBranch_Success` — active branch → status becomes `abandoned`
- [x] `TestDeleteBranch_NotFound` — returns `ErrBranchNotFound`
- [x] `TestDeleteBranch_AlreadyMerged` — returns `ErrBranchNotActive`
- [x] `TestDeleteBranch_AlreadyAbandoned` — returns `ErrBranchNotActive`
- [x] `TestHandleDeleteBranch_Success` — 204
- [x] `TestHandleDeleteBranch_CannotDeleteMain` — 400
- [x] `TestHandleDeleteBranch_NotFound` — 404
- [x] `TestHandleDeleteBranch_AlreadyMerged` — 409
- [x] `TestHandleDeleteBranch_AlreadyAbandoned` — 409
- [x] `TestIntegrationDeleteBranch` — 4 sub-cases with real Postgres

## Notes for future work

- The existing `GET /branch/{name}/status` route uses `{name}` (single segment); if that endpoint is implemented, it should also be updated to `{name...}` for consistency with slashed branch names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)