### PR TITLE
Implement POST /rebase — replay branch commits onto main's head

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -18,7 +18,20 @@ var (
 	ErrBranchNotActive = errors.New("branch is not active")
 	ErrBranchExists    = errors.New("branch already exists")
 	ErrMergeConflict   = errors.New("merge conflict")
+	ErrRebaseConflict  = errors.New("rebase conflict")
 )
+
+// rebaseFile is one file within a replayed commit group.
+type rebaseFile struct {
+	path      string
+	versionID *string
+}
+
+// rebaseGroup is one original commit's worth of file changes to be replayed.
+type rebaseGroup struct {
+	seq   int64
+	files []rebaseFile
+}
 
 // MergeConflict holds details about a conflicting path during merge.
 type MergeConflict struct {
@@ -314,6 +327,189 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 	}
 
 	return &model.MergeResponse{Sequence: newSeq}, nil, nil
+}
+
+// Rebase replays a branch's file_commits onto main's current head.
+// It locks main first, then the source branch. All replayed groups get new global
+// sequences. On conflict, the entire transaction is rolled back.
+func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []MergeConflict, error) {
+	if req.Branch == "main" {
+		return nil, nil, ErrBranchNotActive
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Lock main first, then source branch — consistent ordering prevents deadlocks.
+	var mainHead int64
+	err = tx.QueryRowContext(ctx,
+		"SELECT head_sequence FROM branches WHERE name = 'main' FOR UPDATE",
+	).Scan(&mainHead)
+	if err != nil {
+		return nil, nil, fmt.Errorf("lock main: %w", err)
+	}
+
+	// Lock the source branch.
+	var branchHead, baseSeq int64
+	var branchStatus string
+	err = tx.QueryRowContext(ctx,
+		"SELECT head_sequence, base_sequence, status FROM branches WHERE name = $1 FOR UPDATE",
+		req.Branch,
+	).Scan(&branchHead, &baseSeq, &branchStatus)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil, ErrBranchNotFound
+		}
+		return nil, nil, fmt.Errorf("lock branch: %w", err)
+	}
+	if branchStatus != "active" {
+		return nil, nil, ErrBranchNotActive
+	}
+
+	// Get all paths changed on branch since baseSeq.
+	branchChanges, err := latestChanges(ctx, tx, req.Branch, baseSeq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("branch changes: %w", err)
+	}
+
+	// Empty branch — just update base_sequence and head_sequence (no-op rebase).
+	if len(branchChanges) == 0 {
+		_, err = tx.ExecContext(ctx,
+			"UPDATE branches SET base_sequence = $1, head_sequence = $2 WHERE name = $3",
+			mainHead, mainHead, req.Branch,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("update branch: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, nil, fmt.Errorf("commit tx: %w", err)
+		}
+		return &model.RebaseResponse{
+			NewBaseSequence: mainHead,
+			NewHeadSequence: mainHead,
+			CommitsReplayed: 0,
+		}, nil, nil
+	}
+
+	// Get all paths changed on main since baseSeq.
+	mainChanges, err := latestChanges(ctx, tx, "main", baseSeq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("main changes: %w", err)
+	}
+
+	// Conflict detection — any path changed on both is a conflict.
+	var conflicts []MergeConflict
+	for path, branchVID := range branchChanges {
+		if mainVID, ok := mainChanges[path]; ok {
+			conflicts = append(conflicts, MergeConflict{
+				Path:            path,
+				MainVersionID:   nullStr(mainVID),
+				BranchVersionID: nullStr(branchVID),
+			})
+		}
+	}
+	if len(conflicts) > 0 {
+		return nil, conflicts, ErrRebaseConflict
+	}
+
+	// Collect original commit groups ordered by sequence.
+	groups, err := branchCommitGroups(ctx, tx, req.Branch, baseSeq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("branch commit groups: %w", err)
+	}
+
+	// Replay each group as a new global sequence on the branch.
+	author := req.Author
+	if author == "" {
+		author = "system"
+	}
+	var lastSeq int64
+	for _, g := range groups {
+		var newSeq int64
+		err = tx.QueryRowContext(ctx,
+			`INSERT INTO commits (branch, message, author) VALUES ($1, $2, $3) RETURNING sequence`,
+			req.Branch, fmt.Sprintf("rebase: replay sequence %d", g.seq), author,
+		).Scan(&newSeq)
+		if err != nil {
+			return nil, nil, fmt.Errorf("insert rebase commit: %w", err)
+		}
+
+		for _, f := range g.files {
+			commitID := uuid.New().String()
+			_, err = tx.ExecContext(ctx,
+				`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
+				 VALUES ($1, $2, $3, $4, $5)`,
+				commitID, newSeq, f.path, f.versionID, req.Branch,
+			)
+			if err != nil {
+				return nil, nil, fmt.Errorf("insert file_commit: %w", err)
+			}
+		}
+		lastSeq = newSeq
+	}
+
+	// Update branch: base_sequence = mainHead, head_sequence = lastSeq.
+	_, err = tx.ExecContext(ctx,
+		"UPDATE branches SET base_sequence = $1, head_sequence = $2 WHERE name = $3",
+		mainHead, lastSeq, req.Branch,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("update branch: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, nil, fmt.Errorf("commit tx: %w", err)
+	}
+
+	return &model.RebaseResponse{
+		NewBaseSequence: mainHead,
+		NewHeadSequence: lastSeq,
+		CommitsReplayed: int64(len(groups)),
+	}, nil, nil
+}
+
+// branchCommitGroups returns the file_commits on a branch since baseSeq,
+// grouped by original sequence in ascending order.
+func branchCommitGroups(ctx context.Context, tx *sql.Tx, branch string, baseSeq int64) ([]rebaseGroup, error) {
+	const q = `
+SELECT sequence, path, version_id::text
+FROM file_commits
+WHERE branch = $1 AND sequence > $2
+ORDER BY sequence ASC, path ASC`
+
+	rows, err := tx.QueryContext(ctx, q, branch, baseSeq)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var groups []rebaseGroup
+	for rows.Next() {
+		var seq int64
+		var path string
+		var vid sql.NullString
+		if err := rows.Scan(&seq, &path, &vid); err != nil {
+			return nil, err
+		}
+
+		var versionID *string
+		if vid.Valid {
+			v := vid.String
+			versionID = &v
+		}
+
+		if len(groups) == 0 || groups[len(groups)-1].seq != seq {
+			groups = append(groups, rebaseGroup{seq: seq})
+		}
+		groups[len(groups)-1].files = append(groups[len(groups)-1].files, rebaseFile{
+			path:      path,
+			versionID: versionID,
+		})
+	}
+	return groups, rows.Err()
 }
 
 // latestChanges returns a map of path → *version_id for the latest version of

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -624,3 +624,534 @@ func TestMerge_EmptyBranch(t *testing.T) {
 		t.Errorf("expected merged, got %q", status)
 	}
 }
+
+// --- Rebase tests ---
+
+func TestRebase_CleanNoConflict(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Commit to main (seq=1).
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "base.txt", Content: []byte("base")}},
+		Message: "initial",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Create branch (base=1, head=1).
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/rebase"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+
+	// Commit to branch (seq=2, adds "branch.txt").
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Branch:  "feature/rebase",
+		Files:   []model.FileChange{{Path: "branch.txt", Content: []byte("branch work")}},
+		Message: "branch commit",
+		Author:  "bob",
+	})
+	if err != nil {
+		t.Fatalf("branch commit: %v", err)
+	}
+
+	// Advance main (seq=3, adds "main.txt").
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "main.txt", Content: []byte("main work")}},
+		Message: "main advance",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("main commit: %v", err)
+	}
+
+	// Rebase.
+	resp, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Branch: "feature/rebase", Author: "bob"})
+	if err != nil {
+		t.Fatalf("rebase: %v", err)
+	}
+	if conflicts != nil {
+		t.Fatalf("expected no conflicts, got %v", conflicts)
+	}
+
+	// base_sequence should be main's head (3).
+	if resp.NewBaseSequence != 3 {
+		t.Errorf("expected base_sequence 3, got %d", resp.NewBaseSequence)
+	}
+	// head_sequence should be the new replayed commit (4).
+	if resp.NewHeadSequence != 4 {
+		t.Errorf("expected head_sequence 4, got %d", resp.NewHeadSequence)
+	}
+	if resp.CommitsReplayed != 1 {
+		t.Errorf("expected commits_replayed 1, got %d", resp.CommitsReplayed)
+	}
+}
+
+func TestRebase_UpdatesBaseSequence(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("a")}},
+		Message: "initial",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/base"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Branch:  "feature/base",
+		Files:   []model.FileChange{{Path: "b.txt", Content: []byte("b")}},
+		Message: "branch commit",
+		Author:  "bob",
+	})
+	if err != nil {
+		t.Fatalf("branch commit: %v", err)
+	}
+
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "c.txt", Content: []byte("c")}},
+		Message: "main advance",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("main advance: %v", err)
+	}
+
+	// Verify main head is 3.
+	var mainHead int64
+	err = d.QueryRow("SELECT head_sequence FROM branches WHERE name = 'main'").Scan(&mainHead)
+	if err != nil {
+		t.Fatalf("query main: %v", err)
+	}
+	if mainHead != 3 {
+		t.Fatalf("expected main head 3, got %d", mainHead)
+	}
+
+	resp, _, err := s.Rebase(ctx, model.RebaseRequest{Branch: "feature/base"})
+	if err != nil {
+		t.Fatalf("rebase: %v", err)
+	}
+
+	// base_sequence must equal main's head at time of rebase.
+	if resp.NewBaseSequence != mainHead {
+		t.Errorf("expected base_sequence %d (mainHead), got %d", mainHead, resp.NewBaseSequence)
+	}
+
+	// Verify in DB.
+	var baseSeq int64
+	err = d.QueryRow("SELECT base_sequence FROM branches WHERE name = 'feature/base'").Scan(&baseSeq)
+	if err != nil {
+		t.Fatalf("query branch: %v", err)
+	}
+	if baseSeq != mainHead {
+		t.Errorf("expected db base_sequence %d, got %d", mainHead, baseSeq)
+	}
+}
+
+func TestRebase_ReplaysAllCommits(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Commit to main (seq=1).
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("a")}},
+		Message: "initial",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Create branch (base=1).
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/multi"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+
+	// Three commits on branch: seq=2, 3, 4.
+	for i, file := range []string{"x.txt", "y.txt", "z.txt"} {
+		_, err = s.Commit(ctx, model.CommitRequest{
+			Branch:  "feature/multi",
+			Files:   []model.FileChange{{Path: file, Content: []byte("content")}},
+			Message: "branch commit",
+			Author:  "bob",
+		})
+		if err != nil {
+			t.Fatalf("branch commit %d: %v", i, err)
+		}
+	}
+
+	// Advance main (seq=5).
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "main.txt", Content: []byte("m")}},
+		Message: "main advance",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("main advance: %v", err)
+	}
+
+	resp, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Branch: "feature/multi"})
+	if err != nil {
+		t.Fatalf("rebase: %v", err)
+	}
+	if conflicts != nil {
+		t.Fatalf("unexpected conflicts: %v", conflicts)
+	}
+	if resp.CommitsReplayed != 3 {
+		t.Errorf("expected 3 commits replayed, got %d", resp.CommitsReplayed)
+	}
+
+	// head_sequence should be base (5) + 3 = 8.
+	if resp.NewHeadSequence != 8 {
+		t.Errorf("expected head_sequence 8, got %d", resp.NewHeadSequence)
+	}
+
+	// All three files should be visible on the branch via new file_commits.
+	for _, file := range []string{"x.txt", "y.txt", "z.txt"} {
+		var count int
+		err = d.QueryRow(
+			"SELECT count(*) FROM file_commits WHERE branch = 'feature/multi' AND path = $1 AND sequence > 5",
+			file,
+		).Scan(&count)
+		if err != nil {
+			t.Fatalf("query %s: %v", file, err)
+		}
+		if count != 1 {
+			t.Errorf("expected 1 replayed file_commit for %s after base=5, got %d", file, count)
+		}
+	}
+}
+
+func TestRebase_EmptyBranch(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Commit to main (seq=1).
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("a")}},
+		Message: "initial",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Create branch (base=head=1, no commits on branch).
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/empty"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+
+	// Advance main (seq=2).
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "b.txt", Content: []byte("b")}},
+		Message: "main advance",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("main advance: %v", err)
+	}
+
+	resp, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Branch: "feature/empty"})
+	if err != nil {
+		t.Fatalf("rebase empty branch: %v", err)
+	}
+	if conflicts != nil {
+		t.Fatalf("expected no conflicts, got %v", conflicts)
+	}
+	if resp.CommitsReplayed != 0 {
+		t.Errorf("expected 0 commits replayed, got %d", resp.CommitsReplayed)
+	}
+	if resp.NewBaseSequence != 2 {
+		t.Errorf("expected base_sequence 2, got %d", resp.NewBaseSequence)
+	}
+
+	// Verify DB state.
+	var baseSeq, headSeq int64
+	err = d.QueryRow("SELECT base_sequence, head_sequence FROM branches WHERE name = 'feature/empty'").Scan(&baseSeq, &headSeq)
+	if err != nil {
+		t.Fatalf("query branch: %v", err)
+	}
+	if baseSeq != 2 {
+		t.Errorf("expected db base_sequence 2, got %d", baseSeq)
+	}
+}
+
+func TestRebase_Conflict(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Commit to main (seq=1).
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("original")}},
+		Message: "initial",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Create branch (base=1).
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/conflict"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+
+	// Branch modifies shared.txt (seq=2).
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Branch:  "feature/conflict",
+		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("branch version")}},
+		Message: "branch edit",
+		Author:  "bob",
+	})
+	if err != nil {
+		t.Fatalf("branch commit: %v", err)
+	}
+
+	// Main also modifies shared.txt (seq=3).
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("main version")}},
+		Message: "main edit",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("main commit: %v", err)
+	}
+
+	_, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Branch: "feature/conflict"})
+	if err != ErrRebaseConflict {
+		t.Fatalf("expected ErrRebaseConflict, got %v", err)
+	}
+	if len(conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d", len(conflicts))
+	}
+	if conflicts[0].Path != "shared.txt" {
+		t.Errorf("expected conflict on shared.txt, got %q", conflicts[0].Path)
+	}
+}
+
+func TestRebase_ConflictIsAtomic(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Commit to main (seq=1).
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("original")}},
+		Message: "initial",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Create branch (base=1).
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/atomic"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+
+	// Two commits on branch: shared.txt (seq=2) and other.txt (seq=3).
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Branch:  "feature/atomic",
+		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("branch shared")}},
+		Message: "edit shared",
+		Author:  "bob",
+	})
+	if err != nil {
+		t.Fatalf("branch commit 1: %v", err)
+	}
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Branch:  "feature/atomic",
+		Files:   []model.FileChange{{Path: "other.txt", Content: []byte("other")}},
+		Message: "add other",
+		Author:  "bob",
+	})
+	if err != nil {
+		t.Fatalf("branch commit 2: %v", err)
+	}
+
+	// Main modifies shared.txt (seq=4).
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("main shared")}},
+		Message: "main edit",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("main commit: %v", err)
+	}
+
+	// Rebase should fail with conflict and branch should be unchanged.
+	_, _, err = s.Rebase(ctx, model.RebaseRequest{Branch: "feature/atomic"})
+	if err != ErrRebaseConflict {
+		t.Fatalf("expected ErrRebaseConflict, got %v", err)
+	}
+
+	// Branch state must be unchanged: base=1, head=3.
+	var baseSeq, headSeq int64
+	err = d.QueryRow("SELECT base_sequence, head_sequence FROM branches WHERE name = 'feature/atomic'").Scan(&baseSeq, &headSeq)
+	if err != nil {
+		t.Fatalf("query branch: %v", err)
+	}
+	if baseSeq != 1 {
+		t.Errorf("expected base_sequence 1 (unchanged), got %d", baseSeq)
+	}
+	if headSeq != 3 {
+		t.Errorf("expected head_sequence 3 (unchanged), got %d", headSeq)
+	}
+
+	// No new file_commits should have been inserted after the rollback.
+	var count int
+	err = d.QueryRow("SELECT count(*) FROM file_commits WHERE branch = 'feature/atomic' AND sequence > 3").Scan(&count)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 new file_commits after rollback, got %d", count)
+	}
+}
+
+func TestRebase_BranchNotFound(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, _, err := s.Rebase(ctx, model.RebaseRequest{Branch: "nonexistent"})
+	if err != ErrBranchNotFound {
+		t.Fatalf("expected ErrBranchNotFound, got %v", err)
+	}
+}
+
+func TestRebase_AlreadyMerged(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := d.Exec("INSERT INTO branches (name, head_sequence, base_sequence, status) VALUES ('already-merged', 0, 0, 'merged')")
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	_, _, err = s.Rebase(ctx, model.RebaseRequest{Branch: "already-merged"})
+	if err != ErrBranchNotActive {
+		t.Fatalf("expected ErrBranchNotActive, got %v", err)
+	}
+}
+
+func TestRebase_MainBranch(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, _, err := s.Rebase(ctx, model.RebaseRequest{Branch: "main"})
+	if err != ErrBranchNotActive {
+		t.Fatalf("expected ErrBranchNotActive, got %v", err)
+	}
+}
+
+func TestRebase_ThenMerge(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Commit to main (seq=1).
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "base.txt", Content: []byte("base")}},
+		Message: "initial",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Create branch (base=1, head=1).
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/rebase-merge"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+
+	// Commit to branch (seq=2, adds "new.txt").
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Branch:  "feature/rebase-merge",
+		Files:   []model.FileChange{{Path: "new.txt", Content: []byte("new")}},
+		Message: "add new",
+		Author:  "bob",
+	})
+	if err != nil {
+		t.Fatalf("branch commit: %v", err)
+	}
+
+	// Advance main (seq=3, adds "other.txt" — no conflict with branch).
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "other.txt", Content: []byte("other")}},
+		Message: "main advance",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("main advance: %v", err)
+	}
+
+	// Rebase (seq=4 for replayed branch commit).
+	rebaseResp, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Branch: "feature/rebase-merge", Author: "bob"})
+	if err != nil {
+		t.Fatalf("rebase: %v", err)
+	}
+	if conflicts != nil {
+		t.Fatalf("unexpected conflicts: %v", conflicts)
+	}
+	if rebaseResp.NewBaseSequence != 3 {
+		t.Errorf("expected base_sequence 3, got %d", rebaseResp.NewBaseSequence)
+	}
+
+	// Merge should now succeed cleanly (seq=5).
+	mergeResp, mergeConflicts, err := s.Merge(ctx, model.MergeRequest{Branch: "feature/rebase-merge", Author: "alice"})
+	if err != nil {
+		t.Fatalf("merge after rebase: %v", err)
+	}
+	if mergeConflicts != nil {
+		t.Fatalf("unexpected merge conflicts: %v", mergeConflicts)
+	}
+	if mergeResp.Sequence != 5 {
+		t.Errorf("expected merge sequence 5, got %d", mergeResp.Sequence)
+	}
+
+	// new.txt should be visible on main.
+	var count int
+	err = d.QueryRow("SELECT count(*) FROM file_commits WHERE branch = 'main' AND path = 'new.txt'").Scan(&count)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected new.txt on main after merge, got %d file_commits", count)
+	}
+}

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -205,12 +205,14 @@ type MergePolicyError struct {
 // RebaseRequest is the body for POST /rebase.
 type RebaseRequest struct {
 	Branch string `json:"branch"`
+	Author string `json:"author,omitempty"`
 }
 
 // RebaseResponse is the response for a successful POST /rebase.
 type RebaseResponse struct {
-	NewBaseSequence int64 `json:"new_base_sequence"`
-	NewHeadSequence int64 `json:"new_head_sequence"`
+	NewBaseSequence int64 `json:"base_sequence"`
+	NewHeadSequence int64 `json:"head_sequence"`
+	CommitsReplayed int64 `json:"commits_replayed"`
 }
 
 // RebaseConflictError is the error response when rebase has conflicts.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -272,6 +272,57 @@ func (s *server) handleDeleteBranch(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// handleRebase implements POST /rebase
+func (s *server) handleRebase(w http.ResponseWriter, r *http.Request) {
+	var req model.RebaseRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Branch == "" {
+		writeError(w, http.StatusBadRequest, "branch is required")
+		return
+	}
+	if req.Branch == "main" {
+		writeError(w, http.StatusBadRequest, "cannot rebase main")
+		return
+	}
+
+	// Use X-DocStore-Identity header if Author not set in body.
+	if req.Author == "" {
+		req.Author = r.Header.Get("X-DocStore-Identity")
+	}
+	if req.Author == "" {
+		req.Author = "system"
+	}
+
+	resp, conflicts, err := s.commitStore.Rebase(r.Context(), req)
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrRebaseConflict):
+			apiConflicts := make([]model.ConflictEntry, len(conflicts))
+			for i, c := range conflicts {
+				apiConflicts[i] = model.ConflictEntry{
+					Path:            c.Path,
+					MainVersionID:   c.MainVersionID,
+					BranchVersionID: c.BranchVersionID,
+				}
+			}
+			writeJSON(w, http.StatusConflict, model.RebaseConflictError{Conflicts: apiConflicts})
+		case errors.Is(err, db.ErrBranchNotFound):
+			writeError(w, http.StatusNotFound, "branch not found")
+		case errors.Is(err, db.ErrBranchNotActive):
+			writeError(w, http.StatusBadRequest, "branch is not active")
+		default:
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // handleMerge implements POST /merge
 func (s *server) handleMerge(w http.ResponseWriter, r *http.Request) {
 	var req model.MergeRequest

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	dbpkg "github.com/dlorenc/docstore/internal/db"
@@ -424,4 +425,112 @@ func TestIntegrationDeleteBranch(t *testing.T) {
 			t.Fatalf("expected 409, got %d", resp.StatusCode)
 		}
 	})
+}
+
+func TestIntegrationRebase_FullFlow(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	post := func(path, body string) *http.Response {
+		t.Helper()
+		resp, err := http.Post(srv.URL+path, "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		return resp
+	}
+
+	// Step 1: Commit to main (creates seq=1).
+	r := post("/commit", `{"branch":"main","message":"initial","author":"alice","files":[{"path":"base.txt","content":"YmFzZQ=="}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("POST /commit to main: expected 201, got %d", r.StatusCode)
+	}
+
+	// Step 2: Create branch (base=1, head=1).
+	r = post("/branch", `{"name":"feature/rebase-flow"}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("POST /branch: expected 201, got %d", r.StatusCode)
+	}
+
+	// Step 3: Commit to branch (seq=2, adds "branch.txt").
+	r = post("/commit", `{"branch":"feature/rebase-flow","message":"branch work","author":"bob","files":[{"path":"branch.txt","content":"YnJhbmNo"}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("POST /commit to branch: expected 201, got %d", r.StatusCode)
+	}
+
+	// Step 4: Advance main (seq=3, adds "other.txt").
+	r = post("/commit", `{"branch":"main","message":"main advance","author":"alice","files":[{"path":"other.txt","content":"b3RoZXI="}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("POST /commit to advance main: expected 201, got %d", r.StatusCode)
+	}
+
+	// Step 5: GET /diff — should show main_changes before rebase.
+	diffResp, err := http.Get(srv.URL + "/diff?branch=feature/rebase-flow")
+	if err != nil {
+		t.Fatalf("GET /diff: %v", err)
+	}
+	defer diffResp.Body.Close()
+	if diffResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /diff: expected 200, got %d", diffResp.StatusCode)
+	}
+	var diffResult store.DiffResult
+	if err := json.NewDecoder(diffResp.Body).Decode(&diffResult); err != nil {
+		t.Fatalf("decode diff: %v", err)
+	}
+	if len(diffResult.MainChanges) != 1 {
+		t.Fatalf("expected 1 main_change before rebase, got %d", len(diffResult.MainChanges))
+	}
+
+	// Step 6: POST /rebase.
+	r = post("/rebase", `{"branch":"feature/rebase-flow","author":"bob"}`)
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		var errBody map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&errBody)
+		t.Fatalf("POST /rebase: expected 200, got %d; body: %v", r.StatusCode, errBody)
+	}
+	var rebaseResp struct {
+		BaseSequence    int64 `json:"base_sequence"`
+		HeadSequence    int64 `json:"head_sequence"`
+		CommitsReplayed int64 `json:"commits_replayed"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&rebaseResp); err != nil {
+		t.Fatalf("decode rebase response: %v", err)
+	}
+	if rebaseResp.CommitsReplayed != 1 {
+		t.Errorf("expected 1 commit replayed, got %d", rebaseResp.CommitsReplayed)
+	}
+
+	// Step 7: GET /diff — should show no main_changes after rebase.
+	diffResp2, err := http.Get(srv.URL + "/diff?branch=feature/rebase-flow")
+	if err != nil {
+		t.Fatalf("GET /diff after rebase: %v", err)
+	}
+	defer diffResp2.Body.Close()
+	if diffResp2.StatusCode != http.StatusOK {
+		t.Fatalf("GET /diff after rebase: expected 200, got %d", diffResp2.StatusCode)
+	}
+	var diffResult2 store.DiffResult
+	if err := json.NewDecoder(diffResp2.Body).Decode(&diffResult2); err != nil {
+		t.Fatalf("decode diff2: %v", err)
+	}
+	if len(diffResult2.MainChanges) != 0 {
+		t.Errorf("expected 0 main_changes after rebase, got %d", len(diffResult2.MainChanges))
+	}
+
+	// Step 8: POST /merge — should succeed cleanly.
+	r = post("/merge", `{"branch":"feature/rebase-flow","author":"alice"}`)
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		var errBody map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&errBody)
+		t.Fatalf("POST /merge after rebase: expected 200, got %d; body: %v", r.StatusCode, errBody)
+	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,7 @@ type WriteStore interface {
 	CreateBranch(ctx context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error)
 	Merge(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error)
 	DeleteBranch(ctx context.Context, name string) error
+	Rebase(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []db.MergeConflict, error)
 }
 
 // CommitStore is an alias for backward compatibility with tests.
@@ -49,7 +50,7 @@ func New(writeStore WriteStore, database *sql.DB) http.Handler {
 	mux.HandleFunc("POST /commit", s.handleCommit)
 	mux.HandleFunc("POST /branch", s.handleCreateBranch)
 	mux.HandleFunc("POST /merge", s.handleMerge)
-	mux.HandleFunc("POST /rebase", notImplemented)
+	mux.HandleFunc("POST /rebase", s.handleRebase)
 	mux.HandleFunc("POST /review", notImplemented)
 	mux.HandleFunc("POST /check", notImplemented)
 	mux.HandleFunc("DELETE /branch/{name...}", s.handleDeleteBranch)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,10 +15,11 @@ import (
 
 // mockStore implements WriteStore for testing.
 type mockStore struct {
-	commitFn        func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error)
-	createBranchFn  func(ctx context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error)
-	mergeFn         func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error)
-	deleteBranchFn  func(ctx context.Context, name string) error
+	commitFn       func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error)
+	createBranchFn func(ctx context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error)
+	mergeFn        func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error)
+	deleteBranchFn func(ctx context.Context, name string) error
+	rebaseFn       func(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []db.MergeConflict, error)
 }
 
 func (m *mockStore) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
@@ -44,6 +45,13 @@ func (m *mockStore) DeleteBranch(ctx context.Context, name string) error {
 		return m.deleteBranchFn(ctx, name)
 	}
 	return errors.New("not implemented")
+}
+
+func (m *mockStore) Rebase(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []db.MergeConflict, error) {
+	if m.rebaseFn != nil {
+		return m.rebaseFn(ctx, req)
+	}
+	return nil, nil, errors.New("not implemented")
 }
 
 func TestHealthEndpoint(t *testing.T) {
@@ -73,7 +81,6 @@ func TestNotImplementedEndpoints(t *testing.T) {
 		method string
 		path   string
 	}{
-		{"POST", "/rebase"},
 		{"POST", "/review"},
 		{"POST", "/check"},
 		{"GET", "/branch/main/status"},
@@ -591,5 +598,126 @@ func TestHandleDeleteBranch_AlreadyAbandoned(t *testing.T) {
 
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("expected 409, got %d", rec.Code)
+	}
+}
+
+// --- POST /rebase tests ---
+
+func TestHandleRebase_Success(t *testing.T) {
+	store := &mockStore{
+		rebaseFn: func(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []db.MergeConflict, error) {
+			if req.Branch != "feature/test" {
+				t.Errorf("expected branch feature/test, got %q", req.Branch)
+			}
+			return &model.RebaseResponse{
+				NewBaseSequence: 5,
+				NewHeadSequence: 7,
+				CommitsReplayed: 2,
+			}, nil, nil
+		},
+	}
+	srv := New(store, nil)
+
+	body, _ := json.Marshal(model.RebaseRequest{Branch: "feature/test"})
+	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.RebaseResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.NewBaseSequence != 5 {
+		t.Errorf("expected base_sequence 5, got %d", resp.NewBaseSequence)
+	}
+	if resp.NewHeadSequence != 7 {
+		t.Errorf("expected head_sequence 7, got %d", resp.NewHeadSequence)
+	}
+	if resp.CommitsReplayed != 2 {
+		t.Errorf("expected commits_replayed 2, got %d", resp.CommitsReplayed)
+	}
+}
+
+func TestHandleRebase_Conflict(t *testing.T) {
+	store := &mockStore{
+		rebaseFn: func(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []db.MergeConflict, error) {
+			return nil, []db.MergeConflict{
+				{Path: "conflict.txt", MainVersionID: "v1", BranchVersionID: "v2"},
+			}, db.ErrRebaseConflict
+		},
+	}
+	srv := New(store, nil)
+
+	body, _ := json.Marshal(model.RebaseRequest{Branch: "feature/conflict"})
+	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var errResp model.RebaseConflictError
+	if err := json.NewDecoder(rec.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(errResp.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d", len(errResp.Conflicts))
+	}
+	if errResp.Conflicts[0].Path != "conflict.txt" {
+		t.Errorf("expected conflict.txt, got %q", errResp.Conflicts[0].Path)
+	}
+}
+
+func TestHandleRebase_BranchNotFound(t *testing.T) {
+	store := &mockStore{
+		rebaseFn: func(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []db.MergeConflict, error) {
+			return nil, nil, db.ErrBranchNotFound
+		},
+	}
+	srv := New(store, nil)
+
+	body, _ := json.Marshal(model.RebaseRequest{Branch: "nonexistent"})
+	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleRebase_CannotRebaseMain(t *testing.T) {
+	srv := New(&mockStore{}, nil)
+
+	body, _ := json.Marshal(model.RebaseRequest{Branch: "main"})
+	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleRebase_BranchNotActive(t *testing.T) {
+	store := &mockStore{
+		rebaseFn: func(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []db.MergeConflict, error) {
+			return nil, nil, db.ErrBranchNotActive
+		},
+	}
+	srv := New(store, nil)
+
+	body, _ := json.Marshal(model.RebaseRequest{Branch: "merged-branch"})
+	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
 	}
 }


### PR DESCRIPTION
## Summary

Implements `POST /rebase` per issue #26. Replays a branch's file commits onto main's current head in a single atomic transaction.

- **Conflict-free rebase** → 200 with `{base_sequence, head_sequence, commits_replayed}`
- **Conflict** → 409 with `{conflicts: [{path, main_version_id, branch_version_id}]}`
- **Non-active/main branch** → 400
- **Not found** → 404

## Implementation

**Locking order**: main first, then source branch (consistent with Merge, prevents deadlocks)

**Algorithm**:
1. Lock main, lock branch
2. `latestChanges(branch, baseSeq)` — empty map → no-op rebase (just update base_sequence)
3. `latestChanges(main, baseSeq)` — check overlap for conflicts → 409 on any conflict
4. `branchCommitGroups()` — get file_commits grouped by original sequence (ascending)
5. For each group: insert new commit + file_commits, accumulate lastSeq
6. `UPDATE branches SET base_sequence = mainHead, head_sequence = lastSeq`
7. COMMIT

Old file_commits at pre-rebase sequences remain in DB but fall below new base_sequence, so `latestChanges` ignores them on future merge/diff.

## Test Coverage

**Store tests** (10): `TestRebase_{CleanNoConflict,UpdatesBaseSequence,ReplaysAllCommits,EmptyBranch,Conflict,ConflictIsAtomic,BranchNotFound,AlreadyMerged,MainBranch,ThenMerge}`

**Handler tests** (5): `TestHandleRebase_{Success,Conflict,BranchNotFound,CannotRebaseMain,BranchNotActive}`

**Integration test** (1): `TestIntegrationRebase_FullFlow` — full create→commit→advance main→diff→rebase→diff→merge flow via HTTP

All tests pass. 

## Opportunities (not implemented)
- Could delete old file_commits after rebase to reclaim space
- Could preserve original commit message/author in replayed commits instead of generic message
- Could add `GET /branch/{name}/status` to surface rebase-readiness

Closes #26