### PR TITLE
Fix migrations to be idempotent on repeated startup

### DIFF
--- a/internal/db/migrations/000001_initial_schema.up.sql
+++ b/internal/db/migrations/000001_initial_schema.up.sql
@@ -1,14 +1,14 @@
 -- DocStore VCS initial schema
 -- Six tables per DESIGN.md: documents, file_commits, branches, roles, reviews, check_runs
 
--- Custom enum types
-CREATE TYPE branch_status AS ENUM ('active', 'merged', 'abandoned');
-CREATE TYPE role_type AS ENUM ('reader', 'writer', 'maintainer', 'admin');
-CREATE TYPE review_status AS ENUM ('approved', 'rejected', 'dismissed');
-CREATE TYPE check_status AS ENUM ('pending', 'passed', 'failed');
+-- Custom enum types (idempotent via DO blocks)
+DO $$ BEGIN CREATE TYPE branch_status AS ENUM ('active', 'merged', 'abandoned'); EXCEPTION WHEN duplicate_object THEN null; END $$;
+DO $$ BEGIN CREATE TYPE role_type AS ENUM ('reader', 'writer', 'maintainer', 'admin'); EXCEPTION WHEN duplicate_object THEN null; END $$;
+DO $$ BEGIN CREATE TYPE review_status AS ENUM ('approved', 'rejected', 'dismissed'); EXCEPTION WHEN duplicate_object THEN null; END $$;
+DO $$ BEGIN CREATE TYPE check_status AS ENUM ('pending', 'passed', 'failed'); EXCEPTION WHEN duplicate_object THEN null; END $$;
 
 -- documents: immutable file versions, content-addressed by content_hash
-CREATE TABLE documents (
+CREATE TABLE IF NOT EXISTS documents (
     version_id UUID PRIMARY KEY,
     path TEXT NOT NULL,
     content BYTEA NOT NULL,
@@ -17,10 +17,10 @@ CREATE TABLE documents (
     created_by TEXT NOT NULL
 );
 
-CREATE INDEX idx_documents_content_hash ON documents (content_hash);
+CREATE INDEX IF NOT EXISTS idx_documents_content_hash ON documents (content_hash);
 
 -- branches: named pointers to sequences
-CREATE TABLE branches (
+CREATE TABLE IF NOT EXISTS branches (
     name TEXT PRIMARY KEY,
     head_sequence BIGINT NOT NULL DEFAULT 0,
     base_sequence BIGINT NOT NULL DEFAULT 0,
@@ -29,7 +29,7 @@ CREATE TABLE branches (
 
 -- file_commits: core event log, one row per file change
 -- Rows sharing the same sequence number form one atomic commit
-CREATE TABLE file_commits (
+CREATE TABLE IF NOT EXISTS file_commits (
     commit_id UUID PRIMARY KEY,
     sequence BIGINT NOT NULL,
     path TEXT NOT NULL,
@@ -42,19 +42,19 @@ CREATE TABLE file_commits (
 
 -- Primary query index: tree materialization and file history
 -- Supports DISTINCT ON (path) ... ORDER BY path, sequence DESC
-CREATE INDEX idx_file_commits_branch_path_seq ON file_commits (branch, path, sequence DESC);
+CREATE INDEX IF NOT EXISTS idx_file_commits_branch_path_seq ON file_commits (branch, path, sequence DESC);
 
 -- Atomic commit lookup: all rows in a single commit
-CREATE INDEX idx_file_commits_sequence ON file_commits (sequence);
+CREATE INDEX IF NOT EXISTS idx_file_commits_sequence ON file_commits (sequence);
 
 -- roles: identity to permission mapping
-CREATE TABLE roles (
+CREATE TABLE IF NOT EXISTS roles (
     identity TEXT PRIMARY KEY,
     role role_type NOT NULL
 );
 
 -- reviews: approval/rejection records scoped to branch + sequence
-CREATE TABLE reviews (
+CREATE TABLE IF NOT EXISTS reviews (
     id UUID PRIMARY KEY,
     branch TEXT NOT NULL REFERENCES branches (name),
     reviewer TEXT NOT NULL,
@@ -63,10 +63,10 @@ CREATE TABLE reviews (
     created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX idx_reviews_branch_sequence ON reviews (branch, sequence);
+CREATE INDEX IF NOT EXISTS idx_reviews_branch_sequence ON reviews (branch, sequence);
 
 -- check_runs: external CI status reports scoped to branch + sequence
-CREATE TABLE check_runs (
+CREATE TABLE IF NOT EXISTS check_runs (
     id UUID PRIMARY KEY,
     branch TEXT NOT NULL REFERENCES branches (name),
     sequence BIGINT NOT NULL,
@@ -76,8 +76,9 @@ CREATE TABLE check_runs (
     created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX idx_check_runs_branch_seq_name ON check_runs (branch, sequence, check_name);
+CREATE INDEX IF NOT EXISTS idx_check_runs_branch_seq_name ON check_runs (branch, sequence, check_name);
 
 -- Seed the main branch
 INSERT INTO branches (name, head_sequence, base_sequence, status)
-VALUES ('main', 0, 0, 'active');
+VALUES ('main', 0, 0, 'active')
+ON CONFLICT (name) DO NOTHING;

--- a/internal/db/migrations/000002_add_commits_table.up.sql
+++ b/internal/db/migrations/000002_add_commits_table.up.sql
@@ -3,7 +3,7 @@
 -- branches, replacing the broken per-branch headSeq+1 approach.
 
 -- Global commit log: one row per atomic commit, BIGSERIAL gives global order.
-CREATE TABLE commits (
+CREATE TABLE IF NOT EXISTS commits (
     sequence   BIGSERIAL PRIMARY KEY,
     branch     TEXT NOT NULL,
     message    TEXT NOT NULL,
@@ -13,14 +13,24 @@ CREATE TABLE commits (
 
 -- Remove denormalized columns from file_commits and add FK to commits.
 -- message/author/created_at belong in commits, not duplicated per file row.
-ALTER TABLE file_commits
-    DROP COLUMN message,
-    DROP COLUMN author,
-    DROP COLUMN created_at,
-    ADD CONSTRAINT fk_file_commits_sequence
+DO $$ BEGIN
+    ALTER TABLE file_commits DROP COLUMN message;
+EXCEPTION WHEN undefined_column THEN null; END $$;
+DO $$ BEGIN
+    ALTER TABLE file_commits DROP COLUMN author;
+EXCEPTION WHEN undefined_column THEN null; END $$;
+DO $$ BEGIN
+    ALTER TABLE file_commits DROP COLUMN created_at;
+EXCEPTION WHEN undefined_column THEN null; END $$;
+DO $$ BEGIN
+    ALTER TABLE file_commits ADD CONSTRAINT fk_file_commits_sequence
         FOREIGN KEY (sequence) REFERENCES commits(sequence);
+EXCEPTION WHEN duplicate_object THEN null; END $$;
 
 -- Add created_at and created_by to branches per MVP.md spec.
-ALTER TABLE branches
-    ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    ADD COLUMN created_by TEXT NOT NULL DEFAULT 'system';
+DO $$ BEGIN
+    ALTER TABLE branches ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now();
+EXCEPTION WHEN duplicate_column THEN null; END $$;
+DO $$ BEGIN
+    ALTER TABLE branches ADD COLUMN created_by TEXT NOT NULL DEFAULT 'system';
+EXCEPTION WHEN duplicate_column THEN null; END $$;


### PR DESCRIPTION
## Problem

The server runs all migrations on every startup by concatenating and re-executing all SQL. On a live database this fails with errors like `type "branch_status" already exists`, taking down the service on every new deploy after the first.

Manifested as 503s on the deployed Cloud Run service after PRs #32 and #33 merged.

## Fix

- `CREATE TYPE` → wrapped in `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN null; END $$;` blocks
- `CREATE TABLE` → `CREATE TABLE IF NOT EXISTS`
- `CREATE INDEX` → `CREATE INDEX IF NOT EXISTS`  
- `ALTER TABLE ... DROP COLUMN` → wrapped in DO blocks with `undefined_column` exception
- `ALTER TABLE ... ADD CONSTRAINT` → wrapped in DO block with `duplicate_object` exception
- `ALTER TABLE ... ADD COLUMN` → wrapped in DO blocks with `duplicate_column` exception
- Seed `INSERT` → `ON CONFLICT (name) DO NOTHING`

## Test plan

- [ ] All DB tests pass (verified locally)
- [ ] Deploy succeeds and service comes up healthy after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)