### PR TITLE
Implement IAP authentication middleware (closes #27)

### DIFF
--- a/cmd/docstore/main.go
+++ b/cmd/docstore/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 	"net/http"
 	"os"
@@ -16,6 +17,18 @@ import (
 )
 
 func main() {
+	devIdentity := flag.String("dev-identity", "", "bypass IAP JWT validation and use this identity (local dev/testing only)")
+	flag.Parse()
+
+	// Also accept DEV_IDENTITY env var for container-based testing (e.g. smoke tests).
+	if *devIdentity == "" {
+		*devIdentity = os.Getenv("DEV_IDENTITY")
+	}
+
+	if *devIdentity != "" {
+		log.Printf("WARNING: IAP JWT validation disabled; using dev identity %q", *devIdentity)
+	}
+
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
@@ -37,7 +50,7 @@ func main() {
 	}
 
 	commitStore := db.NewStore(database)
-	srv := server.New(commitStore, database)
+	srv := server.New(commitStore, database, *devIdentity)
 
 	httpServer := &http.Server{
 		Addr:         ":" + port,

--- a/internal/cli/e2e_test.go
+++ b/internal/cli/e2e_test.go
@@ -18,7 +18,7 @@ func newRealServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	database := testutil.TestDB(t, dbpkg.MigrationSQL)
 	writeStore := dbpkg.NewStore(database)
-	handler := server.New(writeStore, database)
+	handler := server.New(writeStore, database, "test@example.com")
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 	return srv

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -289,13 +289,8 @@ func (s *server) handleRebase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Use X-DocStore-Identity header if Author not set in body.
-	if req.Author == "" {
-		req.Author = r.Header.Get("X-DocStore-Identity")
-	}
-	if req.Author == "" {
-		req.Author = "system"
-	}
+	// Author always comes from the authenticated identity; body value is ignored.
+	req.Author = IdentityFromContext(r.Context())
 
 	resp, conflicts, err := s.commitStore.Rebase(r.Context(), req)
 	if err != nil {
@@ -340,13 +335,8 @@ func (s *server) handleMerge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Use X-DocStore-Identity header if Author not set in body.
-	if req.Author == "" {
-		req.Author = r.Header.Get("X-DocStore-Identity")
-	}
-	if req.Author == "" {
-		req.Author = "system"
-	}
+	// Author always comes from the authenticated identity; body value is ignored.
+	req.Author = IdentityFromContext(r.Context())
 
 	resp, conflicts, err := s.commitStore.Merge(r.Context(), req)
 	if err != nil {

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -57,7 +57,7 @@ func seed(t *testing.T, db *sql.DB) {
 func TestIntegrationTreeEndpoint(t *testing.T) {
 	db := testutil.TestDB(t, dbpkg.MigrationSQL)
 	seed(t, db)
-	handler := server.New(nil, db)
+	handler := server.New(nil, db, "test@example.com")
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -84,7 +84,7 @@ func TestIntegrationTreeEndpoint(t *testing.T) {
 func TestIntegrationFileEndpoint(t *testing.T) {
 	db := testutil.TestDB(t, dbpkg.MigrationSQL)
 	seed(t, db)
-	handler := server.New(nil, db)
+	handler := server.New(nil, db, "test@example.com")
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -175,7 +175,7 @@ func TestIntegrationBranchesEndpoint(t *testing.T) {
 		t.Fatalf("seed branch: %v", err)
 	}
 
-	handler := server.New(nil, database)
+	handler := server.New(nil, database, "test@example.com")
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -241,7 +241,7 @@ func TestIntegrationDiffEndpoint(t *testing.T) {
 		}
 	}
 
-	handler := server.New(nil, database)
+	handler := server.New(nil, database, "test@example.com")
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -296,7 +296,7 @@ func TestIntegrationDiffEndpoint(t *testing.T) {
 func TestIntegrationCommitEndpoint(t *testing.T) {
 	db := testutil.TestDB(t, dbpkg.MigrationSQL)
 	seed(t, db)
-	handler := server.New(nil, db)
+	handler := server.New(nil, db, "test@example.com")
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -354,7 +354,7 @@ func TestIntegrationDeleteBranch(t *testing.T) {
 	seed(t, database)
 
 	writeStore := dbpkg.NewStore(database)
-	handler := server.New(writeStore, database)
+	handler := server.New(writeStore, database, "test@example.com")
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -430,7 +430,7 @@ func TestIntegrationDeleteBranch(t *testing.T) {
 func TestIntegrationRebase_FullFlow(t *testing.T) {
 	database := testutil.TestDB(t, dbpkg.MigrationSQL)
 	writeStore := dbpkg.NewStore(database)
-	handler := server.New(writeStore, database)
+	handler := server.New(writeStore, database, "test@example.com")
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -532,5 +532,74 @@ func TestIntegrationRebase_FullFlow(t *testing.T) {
 		var errBody map[string]interface{}
 		json.NewDecoder(r.Body).Decode(&errBody)
 		t.Fatalf("POST /merge after rebase: expected 200, got %d; body: %v", r.StatusCode, errBody)
+	}
+}
+
+// TestHTTP_AuthRequired verifies that write endpoints return 401 when no IAP JWT
+// is present and the server is not in dev mode.
+func TestHTTP_AuthRequired(t *testing.T) {
+	// No devIdentity → real IAP auth enforced.
+	handler := server.New(nil, nil, "")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// POST /commit without X-Goog-IAP-JWT-Assertion must return 401.
+	resp, err := http.Post(srv.URL+"/commit", "application/json",
+		strings.NewReader(`{"branch":"main","message":"m","files":[{"path":"a.txt","content":"YQ=="}]}`))
+	if err != nil {
+		t.Fatalf("POST /commit: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["error"] != "unauthenticated" {
+		t.Errorf("expected error=unauthenticated, got %q", body["error"])
+	}
+}
+
+// TestHTTP_AuthIdentityUsedAsAuthor verifies that the authenticated identity
+// (set via dev mode) is recorded as the commit author, not any value in the body.
+func TestHTTP_AuthIdentityUsedAsAuthor(t *testing.T) {
+	const identity = "alice@example.com"
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, identity)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// POST /commit with a different author in the body — it must be ignored.
+	resp, err := http.Post(srv.URL+"/commit", "application/json",
+		strings.NewReader(`{"branch":"main","message":"test commit","author":"not-alice@example.com","files":[{"path":"hello.txt","content":"aGVsbG8="}]}`))
+	if err != nil {
+		t.Fatalf("POST /commit: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("POST /commit: expected 201, got %d", resp.StatusCode)
+	}
+
+	// GET /commit/1 and verify the author is the identity, not the body value.
+	getResp, err := http.Get(srv.URL + "/commit/1")
+	if err != nil {
+		t.Fatalf("GET /commit/1: %v", err)
+	}
+	defer getResp.Body.Close()
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /commit/1: expected 200, got %d", getResp.StatusCode)
+	}
+
+	var detail store.CommitDetail
+	if err := json.NewDecoder(getResp.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if detail.Author != identity {
+		t.Errorf("expected author %q, got %q", identity, detail.Author)
 	}
 }

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -1,0 +1,235 @@
+package server
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// contextKey is the type for context keys in this package.
+type contextKey string
+
+const identityKey contextKey = "identity"
+
+// IdentityFromContext returns the authenticated identity stored in the context
+// by the IAP middleware. Returns empty string if not set.
+func IdentityFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(identityKey).(string)
+	return v
+}
+
+// IAPMiddleware returns an HTTP middleware that validates GCP IAP JWTs from the
+// X-Goog-IAP-JWT-Assertion header. If devIdentity is non-empty, JWT validation is
+// skipped and devIdentity is used directly (for local dev/testing).
+func IAPMiddleware(devIdentity string) func(http.Handler) http.Handler {
+	cache := newKeyCache()
+	return newMiddleware(devIdentity, cache.get)
+}
+
+// newMiddleware is the testable core of IAPMiddleware. fetchKey is called with a
+// key ID and returns the corresponding RSA public key.
+func newMiddleware(devIdentity string, fetchKey func(kid string) (*rsa.PublicKey, error)) func(http.Handler) http.Handler {
+	if devIdentity != "" {
+		return func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				ctx := context.WithValue(r.Context(), identityKey, devIdentity)
+				next.ServeHTTP(w, r.WithContext(ctx))
+			})
+		}
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token := r.Header.Get("X-Goog-IAP-JWT-Assertion")
+			if token == "" {
+				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthenticated"})
+				return
+			}
+			email, err := validateIAPJWT(token, fetchKey)
+			if err != nil {
+				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthenticated"})
+				return
+			}
+			ctx := context.WithValue(r.Context(), identityKey, email)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// validateIAPJWT parses and validates an IAP RS256 JWT, returning the email claim.
+func validateIAPJWT(tokenString string, fetchKey func(kid string) (*rsa.PublicKey, error)) (string, error) {
+	parts := strings.SplitN(tokenString, ".", 3)
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid JWT format")
+	}
+
+	// Parse header to get algorithm and key ID.
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return "", fmt.Errorf("decode header: %w", err)
+	}
+	var header struct {
+		Alg string `json:"alg"`
+		Kid string `json:"kid"`
+	}
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		return "", fmt.Errorf("parse header: %w", err)
+	}
+	if header.Alg != "RS256" {
+		return "", fmt.Errorf("unsupported algorithm: %s", header.Alg)
+	}
+	if header.Kid == "" {
+		return "", fmt.Errorf("missing kid")
+	}
+
+	// Fetch the public key for this key ID.
+	key, err := fetchKey(header.Kid)
+	if err != nil {
+		return "", fmt.Errorf("fetch key: %w", err)
+	}
+
+	// Verify the RS256 signature over header.payload.
+	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return "", fmt.Errorf("decode signature: %w", err)
+	}
+	signingInput := parts[0] + "." + parts[1]
+	digest := sha256.Sum256([]byte(signingInput))
+	if err := rsa.VerifyPKCS1v15(key, crypto.SHA256, digest[:], sigBytes); err != nil {
+		return "", fmt.Errorf("invalid signature: %w", err)
+	}
+
+	// Parse payload claims.
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decode payload: %w", err)
+	}
+	var claims struct {
+		Email string  `json:"email"`
+		Exp   float64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payloadJSON, &claims); err != nil {
+		return "", fmt.Errorf("parse payload: %w", err)
+	}
+
+	// Check expiry.
+	if time.Now().Unix() > int64(claims.Exp) {
+		return "", fmt.Errorf("token expired")
+	}
+
+	if claims.Email == "" {
+		return "", fmt.Errorf("missing email claim")
+	}
+	return claims.Email, nil
+}
+
+// --- JWK key cache ---
+
+const iapJWKURL = "https://www.gstatic.com/iap/verify/public_key-jwk"
+
+type keyCache struct {
+	mu        sync.RWMutex
+	keys      map[string]*rsa.PublicKey
+	fetchedAt time.Time
+	ttl       time.Duration
+}
+
+func newKeyCache() *keyCache {
+	return &keyCache{
+		ttl: time.Hour,
+	}
+}
+
+func (c *keyCache) get(kid string) (*rsa.PublicKey, error) {
+	c.mu.RLock()
+	if c.keys != nil && time.Since(c.fetchedAt) < c.ttl {
+		key, ok := c.keys[kid]
+		c.mu.RUnlock()
+		if ok {
+			return key, nil
+		}
+		return nil, fmt.Errorf("key %q not found", kid)
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Re-check under write lock.
+	if c.keys != nil && time.Since(c.fetchedAt) < c.ttl {
+		if key, ok := c.keys[kid]; ok {
+			return key, nil
+		}
+		return nil, fmt.Errorf("key %q not found", kid)
+	}
+
+	if err := c.refresh(); err != nil {
+		return nil, fmt.Errorf("refresh keys: %w", err)
+	}
+	key, ok := c.keys[kid]
+	if !ok {
+		return nil, fmt.Errorf("key %q not found", kid)
+	}
+	return key, nil
+}
+
+func (c *keyCache) refresh() error {
+	resp, err := http.Get(iapJWKURL) //nolint:noctx
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var jwks struct {
+		Keys []struct {
+			Kid string `json:"kid"`
+			Kty string `json:"kty"`
+			N   string `json:"n"`
+			E   string `json:"e"`
+		} `json:"keys"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+		return err
+	}
+
+	keys := make(map[string]*rsa.PublicKey, len(jwks.Keys))
+	for _, k := range jwks.Keys {
+		if k.Kty != "RSA" {
+			continue
+		}
+		pub, err := jwkToRSA(k.N, k.E)
+		if err != nil {
+			continue
+		}
+		keys[k.Kid] = pub
+	}
+	c.keys = keys
+	c.fetchedAt = time.Now()
+	return nil
+}
+
+// jwkToRSA converts base64url-encoded JWK n and e values to an *rsa.PublicKey.
+func jwkToRSA(nB64, eB64 string) (*rsa.PublicKey, error) {
+	nBytes, err := base64.RawURLEncoding.DecodeString(nB64)
+	if err != nil {
+		return nil, fmt.Errorf("decode n: %w", err)
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(eB64)
+	if err != nil {
+		return nil, fmt.Errorf("decode e: %w", err)
+	}
+	n := new(big.Int).SetBytes(nBytes)
+	var e int
+	for _, b := range eBytes {
+		e = e<<8 | int(b)
+	}
+	return &rsa.PublicKey{N: n, E: e}, nil
+}
+

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -1,0 +1,193 @@
+package server
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// generateTestKey generates a 2048-bit RSA key pair for tests.
+func generateTestKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return key
+}
+
+// makeTestJWT returns a signed RS256 JWT with the given claims.
+func makeTestJWT(t *testing.T, key *rsa.PrivateKey, kid, email string, exp time.Time) string {
+	t.Helper()
+
+	headerJSON, _ := json.Marshal(map[string]string{"alg": "RS256", "kid": kid, "typ": "JWT"})
+	payloadJSON, _ := json.Marshal(map[string]interface{}{
+		"email": email,
+		"exp":   exp.Unix(),
+		"iat":   time.Now().Unix(),
+		"iss":   "https://cloud.google.com/iap",
+	})
+
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	signingInput := headerB64 + "." + payloadB64
+
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+	if err != nil {
+		t.Fatalf("sign JWT: %v", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// staticKeyFetcher returns a fetcher that serves a single known key.
+func staticKeyFetcher(kid string, pub *rsa.PublicKey) func(string) (*rsa.PublicKey, error) {
+	return func(requestedKid string) (*rsa.PublicKey, error) {
+		if requestedKid != kid {
+			return nil, fmt.Errorf("key %q not found", requestedKid)
+		}
+		return pub, nil
+	}
+}
+
+// okHandler is a trivial downstream handler that records the identity it sees.
+type identityCapture struct {
+	identity string
+}
+
+func (c *identityCapture) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		c.identity = IdentityFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func TestIAPMiddleware_ValidJWT(t *testing.T) {
+	key := generateTestKey(t)
+	kid := "test-key-1"
+	mw := newMiddleware("", staticKeyFetcher(kid, &key.PublicKey))
+	cap := &identityCapture{}
+	handler := mw(cap.handler())
+
+	token := makeTestJWT(t, key, kid, "alice@example.com", time.Now().Add(time.Hour))
+	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
+	req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestIAPMiddleware_MissingHeader(t *testing.T) {
+	mw := newMiddleware("", func(kid string) (*rsa.PublicKey, error) {
+		return nil, fmt.Errorf("should not be called")
+	})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["error"] != "unauthenticated" {
+		t.Errorf("expected error=unauthenticated, got %q", body["error"])
+	}
+}
+
+func TestIAPMiddleware_InvalidSignature(t *testing.T) {
+	signingKey := generateTestKey(t)
+	verifyKey := generateTestKey(t) // different key — signature will not match
+	kid := "test-key-1"
+
+	mw := newMiddleware("", staticKeyFetcher(kid, &verifyKey.PublicKey))
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token := makeTestJWT(t, signingKey, kid, "alice@example.com", time.Now().Add(time.Hour))
+	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
+	req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+func TestIAPMiddleware_ExpiredToken(t *testing.T) {
+	key := generateTestKey(t)
+	kid := "test-key-1"
+	mw := newMiddleware("", staticKeyFetcher(kid, &key.PublicKey))
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token := makeTestJWT(t, key, kid, "alice@example.com", time.Now().Add(-time.Hour))
+	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
+	req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+func TestIAPMiddleware_DevMode(t *testing.T) {
+	// Dev mode: no key fetcher needed, no JWT header needed.
+	mw := newMiddleware("alice@example.com", nil)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestIAPMiddleware_IdentityInContext(t *testing.T) {
+	key := generateTestKey(t)
+	kid := "test-key-1"
+	const email = "alice@example.com"
+
+	mw := newMiddleware("", staticKeyFetcher(kid, &key.PublicKey))
+	cap := &identityCapture{}
+	handler := mw(cap.handler())
+
+	token := makeTestJWT(t, key, kid, email, time.Now().Add(time.Hour))
+	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
+	req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if cap.identity != email {
+		t.Errorf("expected identity %q in context, got %q", email, cap.identity)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -25,37 +25,38 @@ type WriteStore interface {
 type CommitStore = WriteStore
 
 // New returns an http.Handler with all routes registered.
-// writeStore provides write operations (POST /commit, /branch, /merge); pass nil if only
-// read/health endpoints are needed.
-// database provides read operations (GET /tree, /file, /commit, /branches, /diff); pass nil
-// if only write/health endpoints are needed (e.g. in unit tests).
-func New(writeStore WriteStore, database *sql.DB) http.Handler {
+// devIdentity, if non-empty, bypasses IAP JWT validation (for local dev/testing).
+// writeStore provides write operations; pass nil if only read/health endpoints are needed.
+// database provides read operations; pass nil if only write/health endpoints are needed.
+func New(writeStore WriteStore, database *sql.DB, devIdentity string) http.Handler {
 	s := &server{commitStore: writeStore}
 	if database != nil {
 		s.readStore = store.New(database)
 	}
-	mux := http.NewServeMux()
 
-	mux.HandleFunc("GET /healthz", handleHealth)
+	// Health check is exempt from auth — load balancers and probes call it.
+	outer := http.NewServeMux()
+	outer.HandleFunc("GET /healthz", handleHealth)
 
-	// Read endpoints.
-	mux.HandleFunc("GET /tree", s.handleTree)
-	mux.HandleFunc("GET /file/{path...}", s.handleFile)
-	mux.HandleFunc("GET /commit/{sequence}", s.handleGetCommit)
-	mux.HandleFunc("GET /diff", s.handleDiff)
-	mux.HandleFunc("GET /branches", s.handleBranches)
-	mux.HandleFunc("GET /branch/{name}/status", notImplemented)
+	// All other routes require IAP authentication.
+	inner := http.NewServeMux()
+	inner.HandleFunc("GET /tree", s.handleTree)
+	inner.HandleFunc("GET /file/{path...}", s.handleFile)
+	inner.HandleFunc("GET /commit/{sequence}", s.handleGetCommit)
+	inner.HandleFunc("GET /diff", s.handleDiff)
+	inner.HandleFunc("GET /branches", s.handleBranches)
+	inner.HandleFunc("GET /branch/{name}/status", notImplemented)
 
-	// Write endpoints.
-	mux.HandleFunc("POST /commit", s.handleCommit)
-	mux.HandleFunc("POST /branch", s.handleCreateBranch)
-	mux.HandleFunc("POST /merge", s.handleMerge)
-	mux.HandleFunc("POST /rebase", s.handleRebase)
-	mux.HandleFunc("POST /review", notImplemented)
-	mux.HandleFunc("POST /check", notImplemented)
-	mux.HandleFunc("DELETE /branch/{name...}", s.handleDeleteBranch)
+	inner.HandleFunc("POST /commit", s.handleCommit)
+	inner.HandleFunc("POST /branch", s.handleCreateBranch)
+	inner.HandleFunc("POST /merge", s.handleMerge)
+	inner.HandleFunc("POST /rebase", s.handleRebase)
+	inner.HandleFunc("POST /review", notImplemented)
+	inner.HandleFunc("POST /check", notImplemented)
+	inner.HandleFunc("DELETE /branch/{name...}", s.handleDeleteBranch)
 
-	return mux
+	outer.Handle("/", IAPMiddleware(devIdentity)(inner))
+	return outer
 }
 
 type server struct {
@@ -82,16 +83,15 @@ func (s *server) handleCommit(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "message is required"})
 		return
 	}
-	if req.Author == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "author is required"})
-		return
-	}
 	for _, f := range req.Files {
 		if f.Path == "" {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "file path is required"})
 			return
 		}
 	}
+
+	// Author always comes from the authenticated identity; clients cannot override it.
+	req.Author = IdentityFromContext(r.Context())
 
 	resp, err := s.commitStore.Commit(r.Context(), req)
 	if err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -54,8 +54,12 @@ func (m *mockStore) Rebase(ctx context.Context, req model.RebaseRequest) (*model
 	return nil, nil, errors.New("not implemented")
 }
 
+// devID is the dev identity used in handler unit tests.
+const devID = "test@example.com"
+
 func TestHealthEndpoint(t *testing.T) {
-	srv := New(nil, nil)
+	// /healthz is exempt from IAP auth, so devIdentity="" is fine here.
+	srv := New(nil, nil, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
@@ -75,7 +79,7 @@ func TestHealthEndpoint(t *testing.T) {
 }
 
 func TestNotImplementedEndpoints(t *testing.T) {
-	srv := New(nil, nil)
+	srv := New(nil, nil, devID)
 
 	endpoints := []struct {
 		method string
@@ -109,19 +113,21 @@ func TestHandleCommit_Success(t *testing.T) {
 			if len(req.Files) != 1 {
 				t.Errorf("expected 1 file, got %d", len(req.Files))
 			}
+			if req.Author != devID {
+				t.Errorf("expected author %q from context, got %q", devID, req.Author)
+			}
 			return &model.CommitResponse{
 				Sequence: 1,
 				Files:    []model.CommitFileResult{{Path: "hello.txt", VersionID: &vid}},
 			}, nil
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.CommitRequest{
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "hello.txt", Content: []byte("hello")}},
 		Message: "initial commit",
-		Author:  "alice@example.com",
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader(body))
@@ -150,17 +156,16 @@ func TestHandleCommit_ValidationErrors(t *testing.T) {
 			t.Fatal("store should not be called on validation error")
 			return nil, nil
 		},
-	}, nil)
+	}, nil, devID)
 
 	tests := []struct {
 		name string
 		body model.CommitRequest
 	}{
-		{"missing branch", model.CommitRequest{Files: []model.FileChange{{Path: "a.txt", Content: []byte("x")}}, Message: "m", Author: "a"}},
-		{"missing files", model.CommitRequest{Branch: "main", Message: "m", Author: "a"}},
-		{"missing message", model.CommitRequest{Branch: "main", Files: []model.FileChange{{Path: "a.txt", Content: []byte("x")}}, Author: "a"}},
-		{"missing author", model.CommitRequest{Branch: "main", Files: []model.FileChange{{Path: "a.txt", Content: []byte("x")}}, Message: "m"}},
-		{"empty file path", model.CommitRequest{Branch: "main", Files: []model.FileChange{{Path: "", Content: []byte("x")}}, Message: "m", Author: "a"}},
+		{"missing branch", model.CommitRequest{Files: []model.FileChange{{Path: "a.txt", Content: []byte("x")}}, Message: "m"}},
+		{"missing files", model.CommitRequest{Branch: "main", Message: "m"}},
+		{"missing message", model.CommitRequest{Branch: "main", Files: []model.FileChange{{Path: "a.txt", Content: []byte("x")}}}},
+		{"empty file path", model.CommitRequest{Branch: "main", Files: []model.FileChange{{Path: "", Content: []byte("x")}}, Message: "m"}},
 	}
 
 	for _, tt := range tests {
@@ -183,13 +188,12 @@ func TestHandleCommit_BranchNotFound(t *testing.T) {
 			return nil, db.ErrBranchNotFound
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.CommitRequest{
 		Branch:  "nonexistent",
 		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("x")}},
 		Message: "m",
-		Author:  "a",
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader(body))
@@ -207,13 +211,12 @@ func TestHandleCommit_BranchNotActive(t *testing.T) {
 			return nil, db.ErrBranchNotActive
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.CommitRequest{
 		Branch:  "merged-branch",
 		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("x")}},
 		Message: "m",
-		Author:  "a",
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader(body))
@@ -231,13 +234,12 @@ func TestHandleCommit_InternalError(t *testing.T) {
 			return nil, errors.New("something went wrong")
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.CommitRequest{
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("x")}},
 		Message: "m",
-		Author:  "a",
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader(body))
@@ -255,7 +257,7 @@ func TestHandleCommit_InvalidJSON(t *testing.T) {
 			t.Fatal("store should not be called on invalid JSON")
 			return nil, nil
 		},
-	}, nil)
+	}, nil, devID)
 
 	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader([]byte("not json")))
 	rec := httptest.NewRecorder()
@@ -274,7 +276,7 @@ func TestHandleCreateBranch_Success(t *testing.T) {
 			return &model.CreateBranchResponse{Name: req.Name, BaseSequence: 5}, nil
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.CreateBranchRequest{Name: "feature/test"})
 	req := httptest.NewRequest(http.MethodPost, "/branch", bytes.NewReader(body))
@@ -298,7 +300,7 @@ func TestHandleCreateBranch_Success(t *testing.T) {
 }
 
 func TestHandleCreateBranch_MissingName(t *testing.T) {
-	srv := New(&mockStore{}, nil)
+	srv := New(&mockStore{}, nil, devID)
 
 	body, _ := json.Marshal(model.CreateBranchRequest{Name: ""})
 	req := httptest.NewRequest(http.MethodPost, "/branch", bytes.NewReader(body))
@@ -311,7 +313,7 @@ func TestHandleCreateBranch_MissingName(t *testing.T) {
 }
 
 func TestHandleCreateBranch_CannotCreateMain(t *testing.T) {
-	srv := New(&mockStore{}, nil)
+	srv := New(&mockStore{}, nil, devID)
 
 	body, _ := json.Marshal(model.CreateBranchRequest{Name: "main"})
 	req := httptest.NewRequest(http.MethodPost, "/branch", bytes.NewReader(body))
@@ -329,7 +331,7 @@ func TestHandleCreateBranch_AlreadyExists(t *testing.T) {
 			return nil, db.ErrBranchExists
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.CreateBranchRequest{Name: "feature/exists"})
 	req := httptest.NewRequest(http.MethodPost, "/branch", bytes.NewReader(body))
@@ -349,7 +351,7 @@ func TestHandleMerge_Success(t *testing.T) {
 			return &model.MergeResponse{Sequence: 10}, nil, nil
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/test"})
 	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewReader(body))
@@ -370,7 +372,7 @@ func TestHandleMerge_Success(t *testing.T) {
 }
 
 func TestHandleMerge_MissingBranch(t *testing.T) {
-	srv := New(&mockStore{}, nil)
+	srv := New(&mockStore{}, nil, devID)
 
 	body, _ := json.Marshal(model.MergeRequest{Branch: ""})
 	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewReader(body))
@@ -390,7 +392,7 @@ func TestHandleMerge_Conflict(t *testing.T) {
 			}, db.ErrMergeConflict
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/conflict"})
 	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewReader(body))
@@ -419,7 +421,7 @@ func TestHandleMerge_BranchNotFound(t *testing.T) {
 			return nil, nil, db.ErrBranchNotFound
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.MergeRequest{Branch: "nonexistent"})
 	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewReader(body))
@@ -432,7 +434,7 @@ func TestHandleMerge_BranchNotFound(t *testing.T) {
 }
 
 func TestHandleMerge_CannotMergeMain(t *testing.T) {
-	srv := New(&mockStore{}, nil)
+	srv := New(&mockStore{}, nil, devID)
 
 	body, _ := json.Marshal(model.MergeRequest{Branch: "main"})
 	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewReader(body))
@@ -444,7 +446,10 @@ func TestHandleMerge_CannotMergeMain(t *testing.T) {
 	}
 }
 
-func TestHandleMerge_AuthorFromHeader(t *testing.T) {
+// TestHandleMerge_AuthorFromIdentity verifies that the authenticated identity
+// is always used as the merge author, regardless of what is in the request body.
+func TestHandleMerge_AuthorFromIdentity(t *testing.T) {
+	const identity = "alice@example.com"
 	var capturedAuthor string
 	store := &mockStore{
 		mergeFn: func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
@@ -452,58 +457,10 @@ func TestHandleMerge_AuthorFromHeader(t *testing.T) {
 			return &model.MergeResponse{Sequence: 1}, nil, nil
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, identity)
 
-	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/test"})
-	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewReader(body))
-	req.Header.Set("X-DocStore-Identity", "alice@example.com")
-	rec := httptest.NewRecorder()
-	srv.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
-	}
-	if capturedAuthor != "alice@example.com" {
-		t.Errorf("expected author alice@example.com, got %q", capturedAuthor)
-	}
-}
-
-func TestHandleMerge_AuthorFromBody(t *testing.T) {
-	var capturedAuthor string
-	store := &mockStore{
-		mergeFn: func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
-			capturedAuthor = req.Author
-			return &model.MergeResponse{Sequence: 1}, nil, nil
-		},
-	}
-	srv := New(store, nil)
-
-	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/test", Author: "bob@example.com"})
-	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewReader(body))
-	req.Header.Set("X-DocStore-Identity", "alice@example.com")
-	rec := httptest.NewRecorder()
-	srv.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
-	}
-	// Body author takes precedence over header.
-	if capturedAuthor != "bob@example.com" {
-		t.Errorf("expected author bob@example.com, got %q", capturedAuthor)
-	}
-}
-
-func TestHandleMerge_DefaultAuthorSystem(t *testing.T) {
-	var capturedAuthor string
-	store := &mockStore{
-		mergeFn: func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
-			capturedAuthor = req.Author
-			return &model.MergeResponse{Sequence: 1}, nil, nil
-		},
-	}
-	srv := New(store, nil)
-
-	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/test"})
+	// Send a different author in the body — it must be overridden by the identity.
+	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/test", Author: "ignored@example.com"})
 	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -511,8 +468,8 @@ func TestHandleMerge_DefaultAuthorSystem(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
 	}
-	if capturedAuthor != "system" {
-		t.Errorf("expected default author 'system', got %q", capturedAuthor)
+	if capturedAuthor != identity {
+		t.Errorf("expected author %q from identity, got %q", identity, capturedAuthor)
 	}
 }
 
@@ -527,7 +484,7 @@ func TestHandleDeleteBranch_Success(t *testing.T) {
 			return nil
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	req := httptest.NewRequest(http.MethodDelete, "/branch/feature/delete-me", nil)
 	rec := httptest.NewRecorder()
@@ -539,7 +496,7 @@ func TestHandleDeleteBranch_Success(t *testing.T) {
 }
 
 func TestHandleDeleteBranch_CannotDeleteMain(t *testing.T) {
-	srv := New(&mockStore{}, nil)
+	srv := New(&mockStore{}, nil, devID)
 
 	req := httptest.NewRequest(http.MethodDelete, "/branch/main", nil)
 	rec := httptest.NewRecorder()
@@ -556,7 +513,7 @@ func TestHandleDeleteBranch_NotFound(t *testing.T) {
 			return db.ErrBranchNotFound
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	req := httptest.NewRequest(http.MethodDelete, "/branch/nonexistent", nil)
 	rec := httptest.NewRecorder()
@@ -573,7 +530,7 @@ func TestHandleDeleteBranch_AlreadyMerged(t *testing.T) {
 			return db.ErrBranchNotActive
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	req := httptest.NewRequest(http.MethodDelete, "/branch/merged-branch", nil)
 	rec := httptest.NewRecorder()
@@ -590,7 +547,7 @@ func TestHandleDeleteBranch_AlreadyAbandoned(t *testing.T) {
 			return db.ErrBranchNotActive
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	req := httptest.NewRequest(http.MethodDelete, "/branch/abandoned-branch", nil)
 	rec := httptest.NewRecorder()
@@ -616,7 +573,7 @@ func TestHandleRebase_Success(t *testing.T) {
 			}, nil, nil
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.RebaseRequest{Branch: "feature/test"})
 	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewReader(body))
@@ -650,7 +607,7 @@ func TestHandleRebase_Conflict(t *testing.T) {
 			}, db.ErrRebaseConflict
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.RebaseRequest{Branch: "feature/conflict"})
 	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewReader(body))
@@ -679,7 +636,7 @@ func TestHandleRebase_BranchNotFound(t *testing.T) {
 			return nil, nil, db.ErrBranchNotFound
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.RebaseRequest{Branch: "nonexistent"})
 	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewReader(body))
@@ -692,7 +649,7 @@ func TestHandleRebase_BranchNotFound(t *testing.T) {
 }
 
 func TestHandleRebase_CannotRebaseMain(t *testing.T) {
-	srv := New(&mockStore{}, nil)
+	srv := New(&mockStore{}, nil, devID)
 
 	body, _ := json.Marshal(model.RebaseRequest{Branch: "main"})
 	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewReader(body))
@@ -710,7 +667,7 @@ func TestHandleRebase_BranchNotActive(t *testing.T) {
 			return nil, nil, db.ErrBranchNotActive
 		},
 	}
-	srv := New(store, nil)
+	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.RebaseRequest{Branch: "merged-branch"})
 	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewReader(body))

--- a/internal/server/smoke_test.go
+++ b/internal/server/smoke_test.go
@@ -92,6 +92,7 @@ func TestDockerSmoke(t *testing.T) {
 			Env: map[string]string{
 				"DATABASE_URL": dbURL,
 				"PORT":         "8080",
+				"DEV_IDENTITY": "smoke-test@example.com",
 			},
 			ExposedPorts: []string{"8080/tcp"},
 			WaitingFor: wait.ForHTTP("/healthz").


### PR DESCRIPTION
## Summary

- Replaces trusted `X-DocStore-Identity` header with real GCP IAP JWT validation
- `X-Goog-IAP-JWT-Assertion` required on all routes except `/healthz`; missing/invalid token → 401 `{"error":"unauthenticated"}`
- Authenticated email always used as `author` on write ops; clients cannot override via request body
- `--dev-identity=<email>` flag (and `DEV_IDENTITY` env var) bypasses JWT validation for local dev/testing

## Implementation notes

- **No new dependencies**: JWT validation implemented with standard library (`crypto/rsa`, `encoding/base64`, `encoding/json`)
- JWK keys fetched from `https://www.gstatic.com/iap/verify/public_key-jwk` with 1-hour in-memory cache
- `newMiddleware(devIdentity, keyFetcher)` is the testable internal variant; `IAPMiddleware(devIdentity)` is the public API wiring in the Google key fetcher
- `/healthz` exempt from auth (load balancer probes)

## Test coverage

All 6 middleware unit tests from spec pass:
- `TestIAPMiddleware_ValidJWT`
- `TestIAPMiddleware_MissingHeader`
- `TestIAPMiddleware_InvalidSignature`
- `TestIAPMiddleware_ExpiredToken`
- `TestIAPMiddleware_DevMode`
- `TestIAPMiddleware_IdentityInContext`

New integration tests:
- `TestHTTP_AuthRequired` — unauthenticated request → 401
- `TestHTTP_AuthIdentityUsedAsAuthor` — commit author matches IAP identity, body author ignored

All existing tests updated to pass `devIdentity` to `server.New()`.

## Potential future work

- Validate `iss` and `aud` claims (requires configuring expected audience at startup)
- Honor `Cache-Control` TTL from Google's JWK response instead of fixed 1h
- Add metrics/logging for auth failures

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)