### PR TITLE
Implement multitenancy: per-repo isolation (closes #35)

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -49,14 +49,18 @@ func main() {
 			os.Exit(1)
 		}
 		remote := args[1]
+		repo := ""
 		author := ""
 		for i := 2; i < len(args); i++ {
 			if args[i] == "--author" && i+1 < len(args) {
 				author = args[i+1]
 				i++
+			} else if args[i] == "--repo" && i+1 < len(args) {
+				repo = args[i+1]
+				i++
 			}
 		}
-		err = app.Init(remote, author)
+		err = app.Init(remote, repo, author)
 
 	case "status":
 		err = app.Status()

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -26,6 +26,7 @@ const stateFile = "state.json"
 // Config is the persistent CLI configuration stored in .docstore/config.json.
 type Config struct {
 	Remote string `json:"remote"`
+	Repo   string `json:"repo"`
 	Branch string `json:"branch"`
 	Author string `json:"author"`
 }
@@ -170,7 +171,10 @@ func (a *App) isDirty() (bool, error) {
 }
 
 // Init creates a new docstore workspace and fetches all files from the server.
-func (a *App) Init(remote, author string) error {
+// remote may include a /repos/:name suffix (e.g. https://host/repos/myrepo),
+// or repo may be provided separately via the repo parameter.
+// If repo is empty and remote doesn't contain a /repos/ segment, "default" is used.
+func (a *App) Init(remote, repo, author string) error {
 	dir := filepath.Join(a.Dir, configDir)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
@@ -185,8 +189,21 @@ func (a *App) Init(remote, author string) error {
 		}
 	}
 
+	// Extract repo from remote URL if embedded (e.g. https://host/repos/myrepo).
+	baseRemote := strings.TrimRight(remote, "/")
+	if repo == "" {
+		if idx := strings.Index(baseRemote, "/repos/"); idx >= 0 {
+			parts := strings.SplitN(baseRemote[idx+len("/repos/"):], "/", 2)
+			repo = parts[0]
+			baseRemote = baseRemote[:idx]
+		} else {
+			repo = "default"
+		}
+	}
+
 	cfg := &Config{
-		Remote: strings.TrimRight(remote, "/"),
+		Remote: baseRemote,
+		Repo:   repo,
 		Branch: "main",
 		Author: author,
 	}
@@ -328,7 +345,7 @@ func (a *App) Commit(message string) error {
 		Author:  cfg.Author,
 	}
 
-	resp, err := a.postJSON(cfg, cfg.Remote+"/commit", req)
+	resp, err := a.postJSON(cfg, repoBase(cfg)+"/commit", req)
 	if err != nil {
 		return err
 	}
@@ -364,7 +381,7 @@ func (a *App) CheckoutNew(branch string) error {
 	}
 
 	req := model.CreateBranchRequest{Name: branch}
-	resp, err := a.postJSON(cfg, cfg.Remote+"/branch", req)
+	resp, err := a.postJSON(cfg, repoBase(cfg)+"/branch", req)
 	if err != nil {
 		return err
 	}
@@ -459,7 +476,7 @@ func (a *App) syncTree(cfg *Config, branch string) error {
 		if after != "" {
 			q.Set("after", after)
 		}
-		resp, err := a.httpGet(cfg, cfg.Remote+"/tree?"+q.Encode())
+		resp, err := a.httpGet(cfg, repoBase(cfg)+"/tree?"+q.Encode())
 		if err != nil {
 			return fmt.Errorf("fetching tree: %w", err)
 		}
@@ -496,7 +513,7 @@ func (a *App) syncTree(cfg *Config, branch string) error {
 
 		q := url.Values{}
 		q.Set("branch", branch)
-		resp, err := a.httpGet(cfg, cfg.Remote+"/file/"+entry.Path+"?"+q.Encode())
+		resp, err := a.httpGet(cfg, repoBase(cfg)+"/file/"+entry.Path+"?"+q.Encode())
 		if err != nil {
 			return fmt.Errorf("fetching %s: %w", entry.Path, err)
 		}
@@ -529,7 +546,7 @@ func (a *App) syncTree(cfg *Config, branch string) error {
 	}
 
 	// Fetch the branch's current head_sequence.
-	branchesResp, err := a.httpGet(cfg, cfg.Remote+"/branches")
+	branchesResp, err := a.httpGet(cfg, repoBase(cfg)+"/branches")
 	if err != nil {
 		return fmt.Errorf("fetching branches: %w", err)
 	}
@@ -569,7 +586,7 @@ func (a *App) Merge() error {
 	}
 
 	req := model.MergeRequest{Branch: cfg.Branch}
-	resp, err := a.postJSON(cfg, cfg.Remote+"/merge", req)
+	resp, err := a.postJSON(cfg, repoBase(cfg)+"/merge", req)
 	if err != nil {
 		return err
 	}
@@ -621,7 +638,7 @@ func (a *App) Diff() error {
 
 	q := url.Values{}
 	q.Set("branch", cfg.Branch)
-	resp, err := a.httpGet(cfg, cfg.Remote+"/diff?"+q.Encode())
+	resp, err := a.httpGet(cfg, repoBase(cfg)+"/diff?"+q.Encode())
 	if err != nil {
 		return fmt.Errorf("fetching diff: %w", err)
 	}
@@ -671,6 +688,15 @@ func (a *App) Diff() error {
 	}
 
 	return nil
+}
+
+// repoBase returns the /repos/:name base URL for the configured repo.
+func repoBase(cfg *Config) string {
+	repo := cfg.Repo
+	if repo == "" {
+		repo = "default"
+	}
+	return cfg.Remote + "/repos/" + repo
 }
 
 // httpGet sends a GET request with the X-DocStore-Identity header set.

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -33,7 +33,7 @@ func initWorkspace(t *testing.T, app *App, remote, branch, author string) {
 	if err := os.MkdirAll(filepath.Join(app.Dir, configDir), 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := app.saveConfig(&Config{Remote: remote, Branch: branch, Author: author}); err != nil {
+	if err := app.saveConfig(&Config{Remote: remote, Repo: "default", Branch: branch, Author: author}); err != nil {
 		t.Fatal(err)
 	}
 	if err := app.saveState(&State{Branch: branch, Files: make(map[string]string)}); err != nil {
@@ -62,9 +62,9 @@ func newEmptyRepoServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.Method == "GET" && r.URL.Path == "/tree":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/tree":
 			json.NewEncoder(w).Encode([]treeEntry{})
-		case r.Method == "GET" && r.URL.Path == "/branches":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/branches":
 			json.NewEncoder(w).Encode([]model.Branch{{Name: "main", HeadSequence: 0}})
 		default:
 			http.NotFound(w, r)
@@ -82,7 +82,7 @@ func TestInit(t *testing.T) {
 
 	app, out := newTestApp(t, srv)
 
-	if err := app.Init(srv.URL, "alice"); err != nil {
+	if err := app.Init(srv.URL, "", "alice"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -122,7 +122,7 @@ func TestInitTrimsTrailingSlash(t *testing.T) {
 
 	app, _ := newTestApp(t, srv)
 
-	if err := app.Init(srv.URL+"/", "bob"); err != nil {
+	if err := app.Init(srv.URL+"/", "", "bob"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -138,7 +138,7 @@ func TestInitDefaultAuthor(t *testing.T) {
 
 	app, _ := newTestApp(t, srv)
 
-	if err := app.Init(srv.URL, ""); err != nil {
+	if err := app.Init(srv.URL, "", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -152,16 +152,16 @@ func TestInitFetchesFiles(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.Method == "GET" && r.URL.Path == "/tree":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/tree":
 			json.NewEncoder(w).Encode([]treeEntry{
 				{Path: "README.md", VersionID: "v1", ContentHash: HashBytes([]byte("hello"))},
 				{Path: "src/main.go", VersionID: "v2", ContentHash: HashBytes([]byte("package main"))},
 			})
-		case r.Method == "GET" && r.URL.Path == "/file/README.md":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/file/README.md":
 			json.NewEncoder(w).Encode(model.FileResponse{Path: "README.md", Content: []byte("hello")})
-		case r.Method == "GET" && r.URL.Path == "/file/src/main.go":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/file/src/main.go":
 			json.NewEncoder(w).Encode(model.FileResponse{Path: "src/main.go", Content: []byte("package main")})
-		case r.Method == "GET" && r.URL.Path == "/branches":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/branches":
 			json.NewEncoder(w).Encode([]model.Branch{{Name: "main", HeadSequence: 7}})
 		default:
 			http.NotFound(w, r)
@@ -170,7 +170,7 @@ func TestInitFetchesFiles(t *testing.T) {
 	defer srv.Close()
 
 	app, out := newTestApp(t, srv)
-	if err := app.Init(srv.URL, "alice"); err != nil {
+	if err := app.Init(srv.URL, "", "alice"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -314,7 +314,7 @@ func TestStatusNoWorkspace(t *testing.T) {
 func TestCommit(t *testing.T) {
 	var receivedReq model.CommitRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "POST" && r.URL.Path == "/commit" {
+		if r.Method == "POST" && r.URL.Path == "/repos/default/commit" {
 			json.NewDecoder(r.Body).Decode(&receivedReq)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
@@ -383,7 +383,7 @@ func TestCommitNoChanges(t *testing.T) {
 func TestCommitWithDelete(t *testing.T) {
 	var receivedReq model.CommitRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "POST" && r.URL.Path == "/commit" {
+		if r.Method == "POST" && r.URL.Path == "/repos/default/commit" {
 			json.NewDecoder(r.Body).Decode(&receivedReq)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
@@ -444,7 +444,7 @@ func TestCommitServerError(t *testing.T) {
 func TestCommitMultipleFiles(t *testing.T) {
 	var receivedReq model.CommitRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "POST" && r.URL.Path == "/commit" {
+		if r.Method == "POST" && r.URL.Path == "/repos/default/commit" {
 			json.NewDecoder(r.Body).Decode(&receivedReq)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
@@ -487,7 +487,7 @@ func TestCommitMultipleFiles(t *testing.T) {
 
 func TestCheckoutNew(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "POST" && r.URL.Path == "/branch" {
+		if r.Method == "POST" && r.URL.Path == "/repos/default/branch" {
 			var req model.CreateBranchRequest
 			json.NewDecoder(r.Body).Decode(&req)
 			w.Header().Set("Content-Type", "application/json")
@@ -560,13 +560,13 @@ func TestCheckout(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.Method == "GET" && r.URL.Path == "/tree":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/tree":
 			json.NewEncoder(w).Encode([]treeEntry{
 				{Path: "main.go", VersionID: "v1", ContentHash: "hash1"},
 				{Path: "README.md", VersionID: "v2", ContentHash: "hash2"},
 			})
-		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/file/"):
-			path := strings.TrimPrefix(r.URL.Path, "/file/")
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/repos/default/file/"):
+			path := strings.TrimPrefix(r.URL.Path, "/repos/default/file/")
 			content := map[string]string{
 				"main.go":   "package main",
 				"README.md": "# Hello",
@@ -575,7 +575,7 @@ func TestCheckout(t *testing.T) {
 				Path:    path,
 				Content: []byte(content[path]),
 			})
-		case r.Method == "GET" && r.URL.Path == "/branches":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/branches":
 			json.NewEncoder(w).Encode([]model.Branch{{Name: "main", HeadSequence: 3}})
 		default:
 			http.NotFound(w, r)
@@ -631,9 +631,9 @@ func TestCheckoutRemovesDeletedFiles(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.Method == "GET" && r.URL.Path == "/tree":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/tree":
 			json.NewEncoder(w).Encode([]treeEntry{})
-		case r.Method == "GET" && r.URL.Path == "/branches":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/branches":
 			json.NewEncoder(w).Encode([]model.Branch{{Name: "feature/new", HeadSequence: 0}})
 		default:
 			http.NotFound(w, r)
@@ -686,20 +686,20 @@ func TestPull(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.Method == "GET" && r.URL.Path == "/tree":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/tree":
 			if r.URL.Query().Get("branch") != "feature/x" {
 				t.Errorf("expected branch=feature/x, got %q", r.URL.Query().Get("branch"))
 			}
 			json.NewEncoder(w).Encode([]treeEntry{
 				{Path: "updated.txt", VersionID: "v3", ContentHash: "newhash"},
 			})
-		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/file/"):
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/repos/default/file/"):
 			callCount++
 			json.NewEncoder(w).Encode(model.FileResponse{
 				Path:    "updated.txt",
 				Content: []byte("updated content"),
 			})
-		case r.Method == "GET" && r.URL.Path == "/branches":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/branches":
 			json.NewEncoder(w).Encode([]model.Branch{{Name: "feature/x", HeadSequence: 5}})
 		default:
 			http.NotFound(w, r)
@@ -750,14 +750,14 @@ func TestPullSkipsUnchanged(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.Method == "GET" && r.URL.Path == "/tree":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/tree":
 			json.NewEncoder(w).Encode([]treeEntry{
 				{Path: "same.txt", VersionID: "v1", ContentHash: sameHash},
 			})
-		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/file/"):
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/repos/default/file/"):
 			fileDownloads++
 			json.NewEncoder(w).Encode(model.FileResponse{Path: "same.txt", Content: []byte(sameContent)})
-		case r.Method == "GET" && r.URL.Path == "/branches":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/branches":
 			json.NewEncoder(w).Encode([]model.Branch{{Name: "main", HeadSequence: 1}})
 		default:
 			http.NotFound(w, r)
@@ -802,9 +802,9 @@ func TestSyncTreeUpdatesSequence(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.Method == "GET" && r.URL.Path == "/tree":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/tree":
 			json.NewEncoder(w).Encode([]treeEntry{})
-		case r.Method == "GET" && r.URL.Path == "/branches":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/branches":
 			json.NewEncoder(w).Encode([]model.Branch{{Name: "main", HeadSequence: 42}})
 		default:
 			http.NotFound(w, r)
@@ -833,7 +833,7 @@ func TestMerge(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.Method == "POST" && r.URL.Path == "/merge":
+		case r.Method == "POST" && r.URL.Path == "/repos/default/merge":
 			var req model.MergeRequest
 			json.NewDecoder(r.Body).Decode(&req)
 			if req.Branch != "feature/done" {
@@ -841,9 +841,9 @@ func TestMerge(t *testing.T) {
 			}
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(model.MergeResponse{Sequence: 10})
-		case r.Method == "GET" && r.URL.Path == "/tree":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/tree":
 			json.NewEncoder(w).Encode([]treeEntry{})
-		case r.Method == "GET" && r.URL.Path == "/branches":
+		case r.Method == "GET" && r.URL.Path == "/repos/default/branches":
 			json.NewEncoder(w).Encode([]model.Branch{{Name: "main", HeadSequence: 10}})
 		default:
 			http.NotFound(w, r)
@@ -910,7 +910,7 @@ func TestMergeConflict(t *testing.T) {
 
 func TestDiff(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" && r.URL.Path == "/diff" {
+		if r.Method == "GET" && r.URL.Path == "/repos/default/diff" {
 			if r.URL.Query().Get("branch") != "feature/x" {
 				t.Errorf("diff branch = %q, want %q", r.URL.Query().Get("branch"), "feature/x")
 			}

--- a/internal/cli/e2e_test.go
+++ b/internal/cli/e2e_test.go
@@ -36,7 +36,7 @@ func TestFullWorkflow(t *testing.T) {
 
 	ws1, ws1Out := newTestApp(t, srv)
 
-	if err := ws1.Init(srv.URL, "alice"); err != nil {
+	if err := ws1.Init(srv.URL, "", "alice"); err != nil {
 		t.Fatalf("ws1 Init: %v", err)
 	}
 	if !strings.Contains(ws1Out.String(), "Initialized") {
@@ -67,7 +67,7 @@ func TestFullWorkflow(t *testing.T) {
 	// ── Workspace 2: init while main has README.md ────────────────────────
 
 	ws2, _ := newTestApp(t, srv)
-	if err := ws2.Init(srv.URL, "bob"); err != nil {
+	if err := ws2.Init(srv.URL, "", "bob"); err != nil {
 		t.Fatalf("ws2 Init: %v", err)
 	}
 

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -12,8 +12,11 @@ var migration001 string
 //go:embed migrations/000002_add_commits_table.up.sql
 var migration002 string
 
+//go:embed migrations/000003_multitenancy.up.sql
+var migration003 string
+
 // MigrationSQL is the combined SQL for all schema migrations, run in order.
-var MigrationSQL = migration001 + "\n" + migration002
+var MigrationSQL = migration001 + "\n" + migration002 + "\n" + migration003
 
 //go:embed migrations/000001_initial_schema.down.sql
 var MigrationDownSQL string

--- a/internal/db/migrations/000003_multitenancy.up.sql
+++ b/internal/db/migrations/000003_multitenancy.up.sql
@@ -1,0 +1,138 @@
+-- Migration 003: Multitenancy — add repos table and scope all data tables.
+-- Strategy: add repo column with DEFAULT 'default', seed 'default' repo,
+-- change branches PK to (repo, name), update indexes.
+
+-- 1. Create repos table
+CREATE TABLE IF NOT EXISTS repos (
+    name       TEXT PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by TEXT NOT NULL DEFAULT 'system'
+);
+
+-- 2. Seed the default repo
+INSERT INTO repos (name, created_by)
+VALUES ('default', 'system')
+ON CONFLICT (name) DO NOTHING;
+
+-- 3. Add repo column to branches
+DO $$ BEGIN
+    ALTER TABLE branches ADD COLUMN repo TEXT NOT NULL DEFAULT 'default';
+EXCEPTION WHEN duplicate_column THEN null; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE branches ADD CONSTRAINT branches_repo_fk
+        FOREIGN KEY (repo) REFERENCES repos(name);
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- Drop FK constraints from dependent tables before changing branches PK
+DO $$ BEGIN
+    ALTER TABLE file_commits DROP CONSTRAINT file_commits_branch_fkey;
+EXCEPTION WHEN undefined_object THEN null; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE reviews DROP CONSTRAINT reviews_branch_fkey;
+EXCEPTION WHEN undefined_object THEN null; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE check_runs DROP CONSTRAINT check_runs_branch_fkey;
+EXCEPTION WHEN undefined_object THEN null; END $$;
+
+-- Drop old PK on branches (name alone) and add composite PK
+DO $$ BEGIN
+    ALTER TABLE branches DROP CONSTRAINT branches_pkey;
+EXCEPTION WHEN undefined_object THEN null; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE branches ADD PRIMARY KEY (repo, name);
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- 4. Add repo column to documents
+DO $$ BEGIN
+    ALTER TABLE documents ADD COLUMN repo TEXT NOT NULL DEFAULT 'default';
+EXCEPTION WHEN duplicate_column THEN null; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE documents ADD CONSTRAINT documents_repo_fk
+        FOREIGN KEY (repo) REFERENCES repos(name);
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- 5. Add repo column to file_commits
+DO $$ BEGIN
+    ALTER TABLE file_commits ADD COLUMN repo TEXT NOT NULL DEFAULT 'default';
+EXCEPTION WHEN duplicate_column THEN null; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE file_commits ADD CONSTRAINT file_commits_repo_fk
+        FOREIGN KEY (repo) REFERENCES repos(name);
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- 6. Add repo column to commits
+DO $$ BEGIN
+    ALTER TABLE commits ADD COLUMN repo TEXT NOT NULL DEFAULT 'default';
+EXCEPTION WHEN duplicate_column THEN null; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE commits ADD CONSTRAINT commits_repo_fk
+        FOREIGN KEY (repo) REFERENCES repos(name);
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- 7. Add repo column to roles, change PK to (repo, identity)
+DO $$ BEGIN
+    ALTER TABLE roles ADD COLUMN repo TEXT NOT NULL DEFAULT 'default';
+EXCEPTION WHEN duplicate_column THEN null; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE roles ADD CONSTRAINT roles_repo_fk
+        FOREIGN KEY (repo) REFERENCES repos(name);
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE roles DROP CONSTRAINT roles_pkey;
+EXCEPTION WHEN undefined_object THEN null; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE roles ADD PRIMARY KEY (repo, identity);
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- 8. Add repo column to reviews
+DO $$ BEGIN
+    ALTER TABLE reviews ADD COLUMN repo TEXT NOT NULL DEFAULT 'default';
+EXCEPTION WHEN duplicate_column THEN null; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE reviews ADD CONSTRAINT reviews_repo_fk
+        FOREIGN KEY (repo) REFERENCES repos(name);
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- 9. Add repo column to check_runs
+DO $$ BEGIN
+    ALTER TABLE check_runs ADD COLUMN repo TEXT NOT NULL DEFAULT 'default';
+EXCEPTION WHEN duplicate_column THEN null; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE check_runs ADD CONSTRAINT check_runs_repo_fk
+        FOREIGN KEY (repo) REFERENCES repos(name);
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- 10. Update indexes to include repo as leading column
+DROP INDEX IF EXISTS idx_file_commits_branch_path_seq;
+DROP INDEX IF EXISTS idx_file_commits_sequence;
+DROP INDEX IF EXISTS idx_documents_content_hash;
+DROP INDEX IF EXISTS idx_reviews_branch_sequence;
+DROP INDEX IF EXISTS idx_check_runs_branch_seq_name;
+
+CREATE INDEX IF NOT EXISTS idx_file_commits_repo_branch_path_seq
+    ON file_commits (repo, branch, path, sequence DESC);
+CREATE INDEX IF NOT EXISTS idx_file_commits_repo_sequence
+    ON file_commits (repo, sequence);
+CREATE INDEX IF NOT EXISTS idx_documents_repo_content_hash
+    ON documents (repo, content_hash);
+CREATE INDEX IF NOT EXISTS idx_reviews_repo_branch_sequence
+    ON reviews (repo, branch, sequence);
+CREATE INDEX IF NOT EXISTS idx_check_runs_repo_branch_seq_name
+    ON check_runs (repo, branch, sequence, check_name);
+
+-- 11. Re-seed main branch in default repo (idempotent)
+INSERT INTO branches (repo, name, head_sequence, base_sequence, status)
+VALUES ('default', 'main', 0, 0, 'active')
+ON CONFLICT (repo, name) DO NOTHING;

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -19,6 +19,8 @@ var (
 	ErrBranchExists    = errors.New("branch already exists")
 	ErrMergeConflict   = errors.New("merge conflict")
 	ErrRebaseConflict  = errors.New("rebase conflict")
+	ErrRepoNotFound    = errors.New("repo not found")
+	ErrRepoExists      = errors.New("repo already exists")
 )
 
 // rebaseFile is one file within a replayed commit group.
@@ -50,9 +52,113 @@ func NewStore(db *sql.DB) *Store {
 	return &Store{db: db}
 }
 
+// CreateRepo creates a new repo. Returns ErrRepoExists if the name is taken.
+func (s *Store) CreateRepo(ctx context.Context, req model.CreateRepoRequest) (*model.Repo, error) {
+	createdBy := req.CreatedBy
+	if createdBy == "" {
+		createdBy = "system"
+	}
+	var r model.Repo
+	err := s.db.QueryRowContext(ctx,
+		`INSERT INTO repos (name, created_by) VALUES ($1, $2)
+		 RETURNING name, created_at, created_by`,
+		req.Name, createdBy,
+	).Scan(&r.Name, &r.CreatedAt, &r.CreatedBy)
+	if err != nil {
+		if isDuplicateKeyError(err) {
+			return nil, ErrRepoExists
+		}
+		return nil, fmt.Errorf("insert repo: %w", err)
+	}
+
+	// Seed the main branch for the new repo.
+	_, err = s.db.ExecContext(ctx,
+		"INSERT INTO branches (repo, name, head_sequence, base_sequence, status) VALUES ($1, 'main', 0, 0, 'active')",
+		req.Name,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("seed main branch: %w", err)
+	}
+
+	return &r, nil
+}
+
+// DeleteRepo hard-deletes a repo and all its data in a single transaction.
+func (s *Store) DeleteRepo(ctx context.Context, name string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Verify repo exists.
+	var exists bool
+	err = tx.QueryRowContext(ctx,
+		"SELECT EXISTS(SELECT 1 FROM repos WHERE name = $1)", name,
+	).Scan(&exists)
+	if err != nil {
+		return fmt.Errorf("check repo: %w", err)
+	}
+	if !exists {
+		return ErrRepoNotFound
+	}
+
+	// Delete all dependent data in order (child tables first).
+	for _, table := range []string{"check_runs", "reviews", "file_commits", "commits", "documents", "branches", "roles"} {
+		_, err = tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE repo = $1", table), name)
+		if err != nil {
+			return fmt.Errorf("delete %s: %w", table, err)
+		}
+	}
+
+	_, err = tx.ExecContext(ctx, "DELETE FROM repos WHERE name = $1", name)
+	if err != nil {
+		return fmt.Errorf("delete repo: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// ListRepos returns all repos ordered by name.
+func (s *Store) ListRepos(ctx context.Context) ([]model.Repo, error) {
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT name, created_at, created_by FROM repos ORDER BY name",
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var repos []model.Repo
+	for rows.Next() {
+		var r model.Repo
+		if err := rows.Scan(&r.Name, &r.CreatedAt, &r.CreatedBy); err != nil {
+			return nil, err
+		}
+		repos = append(repos, r)
+	}
+	return repos, rows.Err()
+}
+
+// GetRepo returns a single repo by name, or ErrRepoNotFound.
+func (s *Store) GetRepo(ctx context.Context, name string) (*model.Repo, error) {
+	var r model.Repo
+	err := s.db.QueryRowContext(ctx,
+		"SELECT name, created_at, created_by FROM repos WHERE name = $1",
+		name,
+	).Scan(&r.Name, &r.CreatedAt, &r.CreatedBy)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrRepoNotFound
+		}
+		return nil, err
+	}
+	return &r, nil
+}
+
 // Commit atomically commits one or more file changes to a branch.
 // It locks the branch row with SELECT ... FOR UPDATE, allocates
-// a new sequence number, deduplicates document content by hash,
+// a new sequence number, deduplicates document content by hash (per-repo),
 // inserts file_commits rows, and advances the branch head.
 func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -65,8 +171,8 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 	var headSeq int64
 	var status string
 	err = tx.QueryRowContext(ctx,
-		"SELECT head_sequence, status FROM branches WHERE name = $1 FOR UPDATE",
-		req.Branch,
+		"SELECT head_sequence, status FROM branches WHERE repo = $1 AND name = $2 FOR UPDATE",
+		req.Repo, req.Branch,
 	).Scan(&headSeq, &status)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -82,8 +188,8 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 	// Allocate a globally monotonic sequence by inserting into commits.
 	var newSeq int64
 	err = tx.QueryRowContext(ctx,
-		`INSERT INTO commits (branch, message, author) VALUES ($1, $2, $3) RETURNING sequence`,
-		req.Branch, req.Message, req.Author,
+		`INSERT INTO commits (repo, branch, message, author) VALUES ($1, $2, $3, $4) RETURNING sequence`,
+		req.Repo, req.Branch, req.Message, req.Author,
 	).Scan(&newSeq)
 	if err != nil {
 		return nil, fmt.Errorf("insert commit: %w", err)
@@ -95,24 +201,24 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 		var versionIDPtr *string
 
 		if f.Content != nil {
-			// Hash content for dedup.
+			// Hash content for per-repo dedup.
 			h := sha256.Sum256(f.Content)
 			contentHash := hex.EncodeToString(h[:])
 
-			// Check for existing document with the same hash.
+			// Check for existing document with the same hash in this repo.
 			var existingID string
 			err = tx.QueryRowContext(ctx,
-				"SELECT version_id FROM documents WHERE content_hash = $1 LIMIT 1",
-				contentHash,
+				"SELECT version_id FROM documents WHERE repo = $1 AND content_hash = $2 LIMIT 1",
+				req.Repo, contentHash,
 			).Scan(&existingID)
 
 			if errors.Is(err, sql.ErrNoRows) {
 				// Insert new document.
 				existingID = uuid.New().String()
 				_, err = tx.ExecContext(ctx,
-					`INSERT INTO documents (version_id, path, content, content_hash, created_at, created_by)
-					 VALUES ($1, $2, $3, $4, now(), $5)`,
-					existingID, f.Path, f.Content, contentHash, req.Author,
+					`INSERT INTO documents (repo, version_id, path, content, content_hash, created_at, created_by)
+					 VALUES ($1, $2, $3, $4, $5, now(), $6)`,
+					req.Repo, existingID, f.Path, f.Content, contentHash, req.Author,
 				)
 				if err != nil {
 					return nil, fmt.Errorf("insert document: %w", err)
@@ -127,9 +233,9 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 
 		commitID := uuid.New().String()
 		_, err = tx.ExecContext(ctx,
-			`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
-			 VALUES ($1, $2, $3, $4, $5)`,
-			commitID, newSeq, f.Path, versionIDPtr, req.Branch,
+			`INSERT INTO file_commits (repo, commit_id, sequence, path, version_id, branch)
+			 VALUES ($1, $2, $3, $4, $5, $6)`,
+			req.Repo, commitID, newSeq, f.Path, versionIDPtr, req.Branch,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("insert file_commit: %w", err)
@@ -143,8 +249,8 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 
 	// Advance branch head.
 	_, err = tx.ExecContext(ctx,
-		"UPDATE branches SET head_sequence = $1 WHERE name = $2",
-		newSeq, req.Branch,
+		"UPDATE branches SET head_sequence = $1 WHERE repo = $2 AND name = $3",
+		newSeq, req.Repo, req.Branch,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("update branch head: %w", err)
@@ -172,19 +278,19 @@ func (s *Store) CreateBranch(ctx context.Context, req model.CreateBranchRequest)
 	// Read main's head to set as the base_sequence.
 	var mainHead int64
 	err = tx.QueryRowContext(ctx,
-		"SELECT head_sequence FROM branches WHERE name = 'main' FOR UPDATE",
+		"SELECT head_sequence FROM branches WHERE repo = $1 AND name = 'main' FOR UPDATE",
+		req.Repo,
 	).Scan(&mainHead)
 	if err != nil {
 		return nil, fmt.Errorf("read main head: %w", err)
 	}
 
-	// Insert the new branch. Unique constraint on name prevents duplicates.
+	// Insert the new branch. Unique constraint on (repo, name) prevents duplicates.
 	_, err = tx.ExecContext(ctx,
-		"INSERT INTO branches (name, head_sequence, base_sequence, status) VALUES ($1, $2, $3, 'active')",
-		req.Name, mainHead, mainHead,
+		"INSERT INTO branches (repo, name, head_sequence, base_sequence, status) VALUES ($1, $2, $3, $4, 'active')",
+		req.Repo, req.Name, mainHead, mainHead,
 	)
 	if err != nil {
-		// Check for unique violation (branch already exists).
 		if isDuplicateKeyError(err) {
 			return nil, ErrBranchExists
 		}
@@ -216,7 +322,8 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 	// Lock main first, then source branch — consistent ordering prevents deadlocks.
 	var mainHead int64
 	err = tx.QueryRowContext(ctx,
-		"SELECT head_sequence FROM branches WHERE name = 'main' FOR UPDATE",
+		"SELECT head_sequence FROM branches WHERE repo = $1 AND name = 'main' FOR UPDATE",
+		req.Repo,
 	).Scan(&mainHead)
 	if err != nil {
 		return nil, nil, fmt.Errorf("lock main: %w", err)
@@ -226,8 +333,8 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 	var branchHead, baseSeq int64
 	var branchStatus string
 	err = tx.QueryRowContext(ctx,
-		"SELECT head_sequence, base_sequence, status FROM branches WHERE name = $1 FOR UPDATE",
-		req.Branch,
+		"SELECT head_sequence, base_sequence, status FROM branches WHERE repo = $1 AND name = $2 FOR UPDATE",
+		req.Repo, req.Branch,
 	).Scan(&branchHead, &baseSeq, &branchStatus)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -240,7 +347,7 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 	}
 
 	// Step 1: Find the latest version of each path changed on the branch since base_sequence.
-	branchChanges, err := latestChanges(ctx, tx, req.Branch, baseSeq)
+	branchChanges, err := latestChanges(ctx, tx, req.Repo, req.Branch, baseSeq)
 	if err != nil {
 		return nil, nil, fmt.Errorf("branch changes: %w", err)
 	}
@@ -248,8 +355,8 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 	if len(branchChanges) == 0 {
 		// Nothing to merge — mark branch as merged anyway.
 		_, err = tx.ExecContext(ctx,
-			"UPDATE branches SET status = 'merged' WHERE name = $1",
-			req.Branch,
+			"UPDATE branches SET status = 'merged' WHERE repo = $1 AND name = $2",
+			req.Repo, req.Branch,
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("update branch status: %w", err)
@@ -261,7 +368,7 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 	}
 
 	// Step 2: Find the latest version of each path changed on main since base_sequence.
-	mainChanges, err := latestChanges(ctx, tx, "main", baseSeq)
+	mainChanges, err := latestChanges(ctx, tx, req.Repo, "main", baseSeq)
 	if err != nil {
 		return nil, nil, fmt.Errorf("main changes: %w", err)
 	}
@@ -285,8 +392,8 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 	// then insert file_commits rows on main for each branch-changed path.
 	var newSeq int64
 	err = tx.QueryRowContext(ctx,
-		`INSERT INTO commits (branch, message, author) VALUES ('main', $1, $2) RETURNING sequence`,
-		fmt.Sprintf("merge branch '%s'", req.Branch), req.Author,
+		`INSERT INTO commits (repo, branch, message, author) VALUES ($1, 'main', $2, $3) RETURNING sequence`,
+		req.Repo, fmt.Sprintf("merge branch '%s'", req.Branch), req.Author,
 	).Scan(&newSeq)
 	if err != nil {
 		return nil, nil, fmt.Errorf("insert merge commit: %w", err)
@@ -295,9 +402,9 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 	for path, versionID := range branchChanges {
 		commitID := uuid.New().String()
 		_, err = tx.ExecContext(ctx,
-			`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
-			 VALUES ($1, $2, $3, $4, 'main')`,
-			commitID, newSeq, path, versionID,
+			`INSERT INTO file_commits (repo, commit_id, sequence, path, version_id, branch)
+			 VALUES ($1, $2, $3, $4, $5, 'main')`,
+			req.Repo, commitID, newSeq, path, versionID,
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("insert file_commit: %w", err)
@@ -306,8 +413,8 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 
 	// Advance main head.
 	_, err = tx.ExecContext(ctx,
-		"UPDATE branches SET head_sequence = $1 WHERE name = 'main'",
-		newSeq,
+		"UPDATE branches SET head_sequence = $1 WHERE repo = $2 AND name = 'main'",
+		newSeq, req.Repo,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("update main head: %w", err)
@@ -315,8 +422,8 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 
 	// Mark the branch as merged.
 	_, err = tx.ExecContext(ctx,
-		"UPDATE branches SET status = 'merged' WHERE name = $1",
-		req.Branch,
+		"UPDATE branches SET status = 'merged' WHERE repo = $1 AND name = $2",
+		req.Repo, req.Branch,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("update branch status: %w", err)
@@ -346,7 +453,8 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 	// Lock main first, then source branch — consistent ordering prevents deadlocks.
 	var mainHead int64
 	err = tx.QueryRowContext(ctx,
-		"SELECT head_sequence FROM branches WHERE name = 'main' FOR UPDATE",
+		"SELECT head_sequence FROM branches WHERE repo = $1 AND name = 'main' FOR UPDATE",
+		req.Repo,
 	).Scan(&mainHead)
 	if err != nil {
 		return nil, nil, fmt.Errorf("lock main: %w", err)
@@ -356,8 +464,8 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 	var branchHead, baseSeq int64
 	var branchStatus string
 	err = tx.QueryRowContext(ctx,
-		"SELECT head_sequence, base_sequence, status FROM branches WHERE name = $1 FOR UPDATE",
-		req.Branch,
+		"SELECT head_sequence, base_sequence, status FROM branches WHERE repo = $1 AND name = $2 FOR UPDATE",
+		req.Repo, req.Branch,
 	).Scan(&branchHead, &baseSeq, &branchStatus)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -370,7 +478,7 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 	}
 
 	// Get all paths changed on branch since baseSeq.
-	branchChanges, err := latestChanges(ctx, tx, req.Branch, baseSeq)
+	branchChanges, err := latestChanges(ctx, tx, req.Repo, req.Branch, baseSeq)
 	if err != nil {
 		return nil, nil, fmt.Errorf("branch changes: %w", err)
 	}
@@ -378,8 +486,8 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 	// Empty branch — just update base_sequence and head_sequence (no-op rebase).
 	if len(branchChanges) == 0 {
 		_, err = tx.ExecContext(ctx,
-			"UPDATE branches SET base_sequence = $1, head_sequence = $2 WHERE name = $3",
-			mainHead, mainHead, req.Branch,
+			"UPDATE branches SET base_sequence = $1, head_sequence = $2 WHERE repo = $3 AND name = $4",
+			mainHead, mainHead, req.Repo, req.Branch,
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("update branch: %w", err)
@@ -395,7 +503,7 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 	}
 
 	// Get all paths changed on main since baseSeq.
-	mainChanges, err := latestChanges(ctx, tx, "main", baseSeq)
+	mainChanges, err := latestChanges(ctx, tx, req.Repo, "main", baseSeq)
 	if err != nil {
 		return nil, nil, fmt.Errorf("main changes: %w", err)
 	}
@@ -416,7 +524,7 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 	}
 
 	// Collect original commit groups ordered by sequence.
-	groups, err := branchCommitGroups(ctx, tx, req.Branch, baseSeq)
+	groups, err := branchCommitGroups(ctx, tx, req.Repo, req.Branch, baseSeq)
 	if err != nil {
 		return nil, nil, fmt.Errorf("branch commit groups: %w", err)
 	}
@@ -430,8 +538,8 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 	for _, g := range groups {
 		var newSeq int64
 		err = tx.QueryRowContext(ctx,
-			`INSERT INTO commits (branch, message, author) VALUES ($1, $2, $3) RETURNING sequence`,
-			req.Branch, fmt.Sprintf("rebase: replay sequence %d", g.seq), author,
+			`INSERT INTO commits (repo, branch, message, author) VALUES ($1, $2, $3, $4) RETURNING sequence`,
+			req.Repo, req.Branch, fmt.Sprintf("rebase: replay sequence %d", g.seq), author,
 		).Scan(&newSeq)
 		if err != nil {
 			return nil, nil, fmt.Errorf("insert rebase commit: %w", err)
@@ -440,9 +548,9 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 		for _, f := range g.files {
 			commitID := uuid.New().String()
 			_, err = tx.ExecContext(ctx,
-				`INSERT INTO file_commits (commit_id, sequence, path, version_id, branch)
-				 VALUES ($1, $2, $3, $4, $5)`,
-				commitID, newSeq, f.path, f.versionID, req.Branch,
+				`INSERT INTO file_commits (repo, commit_id, sequence, path, version_id, branch)
+				 VALUES ($1, $2, $3, $4, $5, $6)`,
+				req.Repo, commitID, newSeq, f.path, f.versionID, req.Branch,
 			)
 			if err != nil {
 				return nil, nil, fmt.Errorf("insert file_commit: %w", err)
@@ -453,8 +561,8 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 
 	// Update branch: base_sequence = mainHead, head_sequence = lastSeq.
 	_, err = tx.ExecContext(ctx,
-		"UPDATE branches SET base_sequence = $1, head_sequence = $2 WHERE name = $3",
-		mainHead, lastSeq, req.Branch,
+		"UPDATE branches SET base_sequence = $1, head_sequence = $2 WHERE repo = $3 AND name = $4",
+		mainHead, lastSeq, req.Repo, req.Branch,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("update branch: %w", err)
@@ -473,14 +581,14 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 
 // branchCommitGroups returns the file_commits on a branch since baseSeq,
 // grouped by original sequence in ascending order.
-func branchCommitGroups(ctx context.Context, tx *sql.Tx, branch string, baseSeq int64) ([]rebaseGroup, error) {
+func branchCommitGroups(ctx context.Context, tx *sql.Tx, repo, branch string, baseSeq int64) ([]rebaseGroup, error) {
 	const q = `
 SELECT sequence, path, version_id::text
 FROM file_commits
-WHERE branch = $1 AND sequence > $2
+WHERE repo = $1 AND branch = $2 AND sequence > $3
 ORDER BY sequence ASC, path ASC`
 
-	rows, err := tx.QueryContext(ctx, q, branch, baseSeq)
+	rows, err := tx.QueryContext(ctx, q, repo, branch, baseSeq)
 	if err != nil {
 		return nil, err
 	}
@@ -514,14 +622,14 @@ ORDER BY sequence ASC, path ASC`
 
 // latestChanges returns a map of path → *version_id for the latest version of
 // each path changed on a branch since the given base sequence.
-func latestChanges(ctx context.Context, tx *sql.Tx, branch string, baseSeq int64) (map[string]*string, error) {
+func latestChanges(ctx context.Context, tx *sql.Tx, repo, branch string, baseSeq int64) (map[string]*string, error) {
 	const q = `
 SELECT DISTINCT ON (path) path, version_id::text
 FROM file_commits
-WHERE branch = $1 AND sequence > $2
+WHERE repo = $1 AND branch = $2 AND sequence > $3
 ORDER BY path, sequence DESC`
 
-	rows, err := tx.QueryContext(ctx, q, branch, baseSeq)
+	rows, err := tx.QueryContext(ctx, q, repo, branch, baseSeq)
 	if err != nil {
 		return nil, err
 	}
@@ -554,7 +662,7 @@ func nullStr(s *string) string {
 // DeleteBranch marks a branch as abandoned. It returns ErrBranchNotFound if
 // the branch does not exist, and ErrBranchNotActive if it is already merged
 // or abandoned (i.e. not active).
-func (s *Store) DeleteBranch(ctx context.Context, name string) error {
+func (s *Store) DeleteBranch(ctx context.Context, repo, name string) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
@@ -563,8 +671,8 @@ func (s *Store) DeleteBranch(ctx context.Context, name string) error {
 
 	var status string
 	err = tx.QueryRowContext(ctx,
-		"SELECT status FROM branches WHERE name = $1 FOR UPDATE",
-		name,
+		"SELECT status FROM branches WHERE repo = $1 AND name = $2 FOR UPDATE",
+		repo, name,
 	).Scan(&status)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -578,8 +686,8 @@ func (s *Store) DeleteBranch(ctx context.Context, name string) error {
 	}
 
 	_, err = tx.ExecContext(ctx,
-		"UPDATE branches SET status = 'abandoned' WHERE name = $1",
-		name,
+		"UPDATE branches SET status = 'abandoned' WHERE repo = $1 AND name = $2",
+		repo, name,
 	)
 	if err != nil {
 		return fmt.Errorf("update branch status: %w", err)

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -16,6 +16,7 @@ func TestCommit_SingleFile(t *testing.T) {
 	ctx := context.Background()
 
 	resp, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "hello.txt", Content: []byte("hello world")}},
 		Message: "first commit",
@@ -55,6 +56,7 @@ func TestCommit_MultipleFiles(t *testing.T) {
 	ctx := context.Background()
 
 	resp, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch: "main",
 		Files: []model.FileChange{
 			{Path: "a.txt", Content: []byte("aaa")},
@@ -95,6 +97,7 @@ func TestCommit_ContentDedup(t *testing.T) {
 
 	// Commit the same content as two different files.
 	resp, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch: "main",
 		Files: []model.FileChange{
 			{Path: "file1.txt", Content: content},
@@ -134,6 +137,7 @@ func TestCommit_ContentDedupAcrossCommits(t *testing.T) {
 	content := []byte("shared content")
 
 	resp1, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "first.txt", Content: content}},
 		Message: "commit 1",
@@ -144,6 +148,7 @@ func TestCommit_ContentDedupAcrossCommits(t *testing.T) {
 	}
 
 	resp2, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "second.txt", Content: content}},
 		Message: "commit 2",
@@ -172,6 +177,7 @@ func TestCommit_SequenceIncrementsPerCommit(t *testing.T) {
 
 	for i := 1; i <= 3; i++ {
 		resp, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 			Branch:  "main",
 			Files:   []model.FileChange{{Path: "file.txt", Content: []byte("v" + string(rune('0'+i)))}},
 			Message: "commit",
@@ -193,6 +199,7 @@ func TestCommit_DeleteFile(t *testing.T) {
 
 	// First, create a file.
 	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "doomed.txt", Content: []byte("will be deleted")}},
 		Message: "create file",
@@ -204,6 +211,7 @@ func TestCommit_DeleteFile(t *testing.T) {
 
 	// Delete the file (nil content).
 	resp, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "doomed.txt", Content: nil}},
 		Message: "delete file",
@@ -240,6 +248,7 @@ func TestCommit_BranchNotFound(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "nonexistent",
 		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("x")}},
 		Message: "m",
@@ -257,13 +266,14 @@ func TestCommit_BranchNotActive(t *testing.T) {
 
 	// Create a branch and mark it as merged.
 	_, err := d.Exec(
-		"INSERT INTO branches (name, head_sequence, base_sequence, status) VALUES ('merged-br', 0, 0, 'merged')",
+		"INSERT INTO branches (repo, name, head_sequence, base_sequence, status) VALUES ('default', 'merged-br', 0, 0, 'merged')",
 	)
 	if err != nil {
 		t.Fatalf("insert branch: %v", err)
 	}
 
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "merged-br",
 		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("x")}},
 		Message: "m",
@@ -283,6 +293,7 @@ func TestCreateBranch_Success(t *testing.T) {
 
 	// First commit to main to advance head.
 	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "file.txt", Content: []byte("hello")}},
 		Message: "initial",
@@ -292,7 +303,7 @@ func TestCreateBranch_Success(t *testing.T) {
 		t.Fatalf("commit: %v", err)
 	}
 
-	resp, err := s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/test"})
+	resp, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/test"})
 	if err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
@@ -324,12 +335,12 @@ func TestCreateBranch_Duplicate(t *testing.T) {
 	s := NewStore(d)
 	ctx := context.Background()
 
-	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/dup"})
+	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/dup"})
 	if err != nil {
 		t.Fatalf("first create: %v", err)
 	}
 
-	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/dup"})
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/dup"})
 	if err != ErrBranchExists {
 		t.Fatalf("expected ErrBranchExists, got %v", err)
 	}
@@ -344,6 +355,7 @@ func TestMerge_Success(t *testing.T) {
 
 	// Commit to main.
 	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "base.txt", Content: []byte("base")}},
 		Message: "initial",
@@ -354,13 +366,14 @@ func TestMerge_Success(t *testing.T) {
 	}
 
 	// Create branch.
-	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/merge"})
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/merge"})
 	if err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
 
 	// Commit to branch.
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "feature/merge",
 		Files:   []model.FileChange{{Path: "new.txt", Content: []byte("new file")}},
 		Message: "add new file",
@@ -371,7 +384,7 @@ func TestMerge_Success(t *testing.T) {
 	}
 
 	// Merge.
-	resp, conflicts, err := s.Merge(ctx, model.MergeRequest{Branch: "feature/merge", Author: "carol"})
+	resp, conflicts, err := s.Merge(ctx, model.MergeRequest{Repo: "default", Branch: "feature/merge", Author: "carol"})
 	if err != nil {
 		t.Fatalf("merge: %v", err)
 	}
@@ -436,6 +449,7 @@ func TestMerge_Conflict(t *testing.T) {
 
 	// Commit to main.
 	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("original")}},
 		Message: "initial",
@@ -446,13 +460,14 @@ func TestMerge_Conflict(t *testing.T) {
 	}
 
 	// Create branch.
-	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/conflict"})
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/conflict"})
 	if err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
 
 	// Change shared.txt on both main and branch.
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("main version")}},
 		Message: "main edit",
@@ -463,6 +478,7 @@ func TestMerge_Conflict(t *testing.T) {
 	}
 
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "feature/conflict",
 		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("branch version")}},
 		Message: "branch edit",
@@ -473,7 +489,7 @@ func TestMerge_Conflict(t *testing.T) {
 	}
 
 	// Merge should fail with conflict.
-	_, conflicts, err := s.Merge(ctx, model.MergeRequest{Branch: "feature/conflict"})
+	_, conflicts, err := s.Merge(ctx, model.MergeRequest{Repo: "default", Branch: "feature/conflict"})
 	if err != ErrMergeConflict {
 		t.Fatalf("expected ErrMergeConflict, got %v", err)
 	}
@@ -500,7 +516,7 @@ func TestMerge_BranchNotFound(t *testing.T) {
 	s := NewStore(d)
 	ctx := context.Background()
 
-	_, _, err := s.Merge(ctx, model.MergeRequest{Branch: "nonexistent"})
+	_, _, err := s.Merge(ctx, model.MergeRequest{Repo: "default", Branch: "nonexistent"})
 	if err != ErrBranchNotFound {
 		t.Fatalf("expected ErrBranchNotFound, got %v", err)
 	}
@@ -512,12 +528,12 @@ func TestMerge_BranchNotActive(t *testing.T) {
 	ctx := context.Background()
 
 	// Create and immediately mark merged.
-	_, err := d.Exec("INSERT INTO branches (name, head_sequence, base_sequence, status) VALUES ('already-merged', 0, 0, 'merged')")
+	_, err := d.Exec("INSERT INTO branches (repo, name, head_sequence, base_sequence, status) VALUES ('default', 'already-merged', 0, 0, 'merged')")
 	if err != nil {
 		t.Fatalf("insert: %v", err)
 	}
 
-	_, _, err = s.Merge(ctx, model.MergeRequest{Branch: "already-merged"})
+	_, _, err = s.Merge(ctx, model.MergeRequest{Repo: "default", Branch: "already-merged"})
 	if err != ErrBranchNotActive {
 		t.Fatalf("expected ErrBranchNotActive, got %v", err)
 	}
@@ -530,12 +546,12 @@ func TestDeleteBranch_Success(t *testing.T) {
 	s := NewStore(d)
 	ctx := context.Background()
 
-	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/delete-me"})
+	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/delete-me"})
 	if err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
 
-	if err := s.DeleteBranch(ctx, "feature/delete-me"); err != nil {
+	if err := s.DeleteBranch(ctx, "default", "feature/delete-me"); err != nil {
 		t.Fatalf("delete branch: %v", err)
 	}
 
@@ -554,7 +570,7 @@ func TestDeleteBranch_NotFound(t *testing.T) {
 	s := NewStore(d)
 	ctx := context.Background()
 
-	err := s.DeleteBranch(ctx, "nonexistent")
+	err := s.DeleteBranch(ctx, "default", "nonexistent")
 	if err != ErrBranchNotFound {
 		t.Fatalf("expected ErrBranchNotFound, got %v", err)
 	}
@@ -565,12 +581,12 @@ func TestDeleteBranch_AlreadyMerged(t *testing.T) {
 	s := NewStore(d)
 	ctx := context.Background()
 
-	_, err := d.Exec("INSERT INTO branches (name, head_sequence, base_sequence, status) VALUES ('merged-br', 0, 0, 'merged')")
+	_, err := d.Exec("INSERT INTO branches (repo, name, head_sequence, base_sequence, status) VALUES ('default', 'merged-br', 0, 0, 'merged')")
 	if err != nil {
 		t.Fatalf("insert branch: %v", err)
 	}
 
-	err = s.DeleteBranch(ctx, "merged-br")
+	err = s.DeleteBranch(ctx, "default", "merged-br")
 	if err != ErrBranchNotActive {
 		t.Fatalf("expected ErrBranchNotActive, got %v", err)
 	}
@@ -581,12 +597,12 @@ func TestDeleteBranch_AlreadyAbandoned(t *testing.T) {
 	s := NewStore(d)
 	ctx := context.Background()
 
-	_, err := d.Exec("INSERT INTO branches (name, head_sequence, base_sequence, status) VALUES ('abandoned-br', 0, 0, 'abandoned')")
+	_, err := d.Exec("INSERT INTO branches (repo, name, head_sequence, base_sequence, status) VALUES ('default', 'abandoned-br', 0, 0, 'abandoned')")
 	if err != nil {
 		t.Fatalf("insert branch: %v", err)
 	}
 
-	err = s.DeleteBranch(ctx, "abandoned-br")
+	err = s.DeleteBranch(ctx, "default", "abandoned-br")
 	if err != ErrBranchNotActive {
 		t.Fatalf("expected ErrBranchNotActive, got %v", err)
 	}
@@ -598,12 +614,12 @@ func TestMerge_EmptyBranch(t *testing.T) {
 	ctx := context.Background()
 
 	// Create branch with no commits.
-	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/empty"})
+	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/empty"})
 	if err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
 
-	resp, conflicts, err := s.Merge(ctx, model.MergeRequest{Branch: "feature/empty"})
+	resp, conflicts, err := s.Merge(ctx, model.MergeRequest{Repo: "default", Branch: "feature/empty"})
 	if err != nil {
 		t.Fatalf("merge: %v", err)
 	}
@@ -634,6 +650,7 @@ func TestRebase_CleanNoConflict(t *testing.T) {
 
 	// Commit to main (seq=1).
 	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "base.txt", Content: []byte("base")}},
 		Message: "initial",
@@ -644,13 +661,14 @@ func TestRebase_CleanNoConflict(t *testing.T) {
 	}
 
 	// Create branch (base=1, head=1).
-	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/rebase"})
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/rebase"})
 	if err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
 
 	// Commit to branch (seq=2, adds "branch.txt").
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "feature/rebase",
 		Files:   []model.FileChange{{Path: "branch.txt", Content: []byte("branch work")}},
 		Message: "branch commit",
@@ -662,6 +680,7 @@ func TestRebase_CleanNoConflict(t *testing.T) {
 
 	// Advance main (seq=3, adds "main.txt").
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "main.txt", Content: []byte("main work")}},
 		Message: "main advance",
@@ -672,7 +691,7 @@ func TestRebase_CleanNoConflict(t *testing.T) {
 	}
 
 	// Rebase.
-	resp, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Branch: "feature/rebase", Author: "bob"})
+	resp, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Repo: "default", Branch: "feature/rebase", Author: "bob"})
 	if err != nil {
 		t.Fatalf("rebase: %v", err)
 	}
@@ -699,6 +718,7 @@ func TestRebase_UpdatesBaseSequence(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("a")}},
 		Message: "initial",
@@ -708,12 +728,13 @@ func TestRebase_UpdatesBaseSequence(t *testing.T) {
 		t.Fatalf("commit: %v", err)
 	}
 
-	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/base"})
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/base"})
 	if err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
 
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "feature/base",
 		Files:   []model.FileChange{{Path: "b.txt", Content: []byte("b")}},
 		Message: "branch commit",
@@ -724,6 +745,7 @@ func TestRebase_UpdatesBaseSequence(t *testing.T) {
 	}
 
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "c.txt", Content: []byte("c")}},
 		Message: "main advance",
@@ -743,7 +765,7 @@ func TestRebase_UpdatesBaseSequence(t *testing.T) {
 		t.Fatalf("expected main head 3, got %d", mainHead)
 	}
 
-	resp, _, err := s.Rebase(ctx, model.RebaseRequest{Branch: "feature/base"})
+	resp, _, err := s.Rebase(ctx, model.RebaseRequest{Repo: "default", Branch: "feature/base"})
 	if err != nil {
 		t.Fatalf("rebase: %v", err)
 	}
@@ -771,6 +793,7 @@ func TestRebase_ReplaysAllCommits(t *testing.T) {
 
 	// Commit to main (seq=1).
 	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("a")}},
 		Message: "initial",
@@ -781,7 +804,7 @@ func TestRebase_ReplaysAllCommits(t *testing.T) {
 	}
 
 	// Create branch (base=1).
-	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/multi"})
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/multi"})
 	if err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
@@ -789,6 +812,7 @@ func TestRebase_ReplaysAllCommits(t *testing.T) {
 	// Three commits on branch: seq=2, 3, 4.
 	for i, file := range []string{"x.txt", "y.txt", "z.txt"} {
 		_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 			Branch:  "feature/multi",
 			Files:   []model.FileChange{{Path: file, Content: []byte("content")}},
 			Message: "branch commit",
@@ -801,6 +825,7 @@ func TestRebase_ReplaysAllCommits(t *testing.T) {
 
 	// Advance main (seq=5).
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "main.txt", Content: []byte("m")}},
 		Message: "main advance",
@@ -810,7 +835,7 @@ func TestRebase_ReplaysAllCommits(t *testing.T) {
 		t.Fatalf("main advance: %v", err)
 	}
 
-	resp, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Branch: "feature/multi"})
+	resp, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Repo: "default", Branch: "feature/multi"})
 	if err != nil {
 		t.Fatalf("rebase: %v", err)
 	}
@@ -849,6 +874,7 @@ func TestRebase_EmptyBranch(t *testing.T) {
 
 	// Commit to main (seq=1).
 	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("a")}},
 		Message: "initial",
@@ -859,13 +885,14 @@ func TestRebase_EmptyBranch(t *testing.T) {
 	}
 
 	// Create branch (base=head=1, no commits on branch).
-	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/empty"})
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/empty"})
 	if err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
 
 	// Advance main (seq=2).
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "b.txt", Content: []byte("b")}},
 		Message: "main advance",
@@ -875,7 +902,7 @@ func TestRebase_EmptyBranch(t *testing.T) {
 		t.Fatalf("main advance: %v", err)
 	}
 
-	resp, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Branch: "feature/empty"})
+	resp, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Repo: "default", Branch: "feature/empty"})
 	if err != nil {
 		t.Fatalf("rebase empty branch: %v", err)
 	}
@@ -907,6 +934,7 @@ func TestRebase_Conflict(t *testing.T) {
 
 	// Commit to main (seq=1).
 	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("original")}},
 		Message: "initial",
@@ -917,13 +945,14 @@ func TestRebase_Conflict(t *testing.T) {
 	}
 
 	// Create branch (base=1).
-	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/conflict"})
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/conflict"})
 	if err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
 
 	// Branch modifies shared.txt (seq=2).
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "feature/conflict",
 		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("branch version")}},
 		Message: "branch edit",
@@ -935,6 +964,7 @@ func TestRebase_Conflict(t *testing.T) {
 
 	// Main also modifies shared.txt (seq=3).
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("main version")}},
 		Message: "main edit",
@@ -944,7 +974,7 @@ func TestRebase_Conflict(t *testing.T) {
 		t.Fatalf("main commit: %v", err)
 	}
 
-	_, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Branch: "feature/conflict"})
+	_, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Repo: "default", Branch: "feature/conflict"})
 	if err != ErrRebaseConflict {
 		t.Fatalf("expected ErrRebaseConflict, got %v", err)
 	}
@@ -963,6 +993,7 @@ func TestRebase_ConflictIsAtomic(t *testing.T) {
 
 	// Commit to main (seq=1).
 	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("original")}},
 		Message: "initial",
@@ -973,13 +1004,14 @@ func TestRebase_ConflictIsAtomic(t *testing.T) {
 	}
 
 	// Create branch (base=1).
-	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/atomic"})
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/atomic"})
 	if err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
 
 	// Two commits on branch: shared.txt (seq=2) and other.txt (seq=3).
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "feature/atomic",
 		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("branch shared")}},
 		Message: "edit shared",
@@ -989,6 +1021,7 @@ func TestRebase_ConflictIsAtomic(t *testing.T) {
 		t.Fatalf("branch commit 1: %v", err)
 	}
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "feature/atomic",
 		Files:   []model.FileChange{{Path: "other.txt", Content: []byte("other")}},
 		Message: "add other",
@@ -1000,6 +1033,7 @@ func TestRebase_ConflictIsAtomic(t *testing.T) {
 
 	// Main modifies shared.txt (seq=4).
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("main shared")}},
 		Message: "main edit",
@@ -1010,7 +1044,7 @@ func TestRebase_ConflictIsAtomic(t *testing.T) {
 	}
 
 	// Rebase should fail with conflict and branch should be unchanged.
-	_, _, err = s.Rebase(ctx, model.RebaseRequest{Branch: "feature/atomic"})
+	_, _, err = s.Rebase(ctx, model.RebaseRequest{Repo: "default", Branch: "feature/atomic"})
 	if err != ErrRebaseConflict {
 		t.Fatalf("expected ErrRebaseConflict, got %v", err)
 	}
@@ -1044,7 +1078,7 @@ func TestRebase_BranchNotFound(t *testing.T) {
 	s := NewStore(d)
 	ctx := context.Background()
 
-	_, _, err := s.Rebase(ctx, model.RebaseRequest{Branch: "nonexistent"})
+	_, _, err := s.Rebase(ctx, model.RebaseRequest{Repo: "default", Branch: "nonexistent"})
 	if err != ErrBranchNotFound {
 		t.Fatalf("expected ErrBranchNotFound, got %v", err)
 	}
@@ -1055,12 +1089,12 @@ func TestRebase_AlreadyMerged(t *testing.T) {
 	s := NewStore(d)
 	ctx := context.Background()
 
-	_, err := d.Exec("INSERT INTO branches (name, head_sequence, base_sequence, status) VALUES ('already-merged', 0, 0, 'merged')")
+	_, err := d.Exec("INSERT INTO branches (repo, name, head_sequence, base_sequence, status) VALUES ('default', 'already-merged', 0, 0, 'merged')")
 	if err != nil {
 		t.Fatalf("insert: %v", err)
 	}
 
-	_, _, err = s.Rebase(ctx, model.RebaseRequest{Branch: "already-merged"})
+	_, _, err = s.Rebase(ctx, model.RebaseRequest{Repo: "default", Branch: "already-merged"})
 	if err != ErrBranchNotActive {
 		t.Fatalf("expected ErrBranchNotActive, got %v", err)
 	}
@@ -1071,7 +1105,7 @@ func TestRebase_MainBranch(t *testing.T) {
 	s := NewStore(d)
 	ctx := context.Background()
 
-	_, _, err := s.Rebase(ctx, model.RebaseRequest{Branch: "main"})
+	_, _, err := s.Rebase(ctx, model.RebaseRequest{Repo: "default", Branch: "main"})
 	if err != ErrBranchNotActive {
 		t.Fatalf("expected ErrBranchNotActive, got %v", err)
 	}
@@ -1084,6 +1118,7 @@ func TestRebase_ThenMerge(t *testing.T) {
 
 	// Commit to main (seq=1).
 	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "base.txt", Content: []byte("base")}},
 		Message: "initial",
@@ -1094,13 +1129,14 @@ func TestRebase_ThenMerge(t *testing.T) {
 	}
 
 	// Create branch (base=1, head=1).
-	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Name: "feature/rebase-merge"})
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/rebase-merge"})
 	if err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
 
 	// Commit to branch (seq=2, adds "new.txt").
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "feature/rebase-merge",
 		Files:   []model.FileChange{{Path: "new.txt", Content: []byte("new")}},
 		Message: "add new",
@@ -1112,6 +1148,7 @@ func TestRebase_ThenMerge(t *testing.T) {
 
 	// Advance main (seq=3, adds "other.txt" — no conflict with branch).
 	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
 		Branch:  "main",
 		Files:   []model.FileChange{{Path: "other.txt", Content: []byte("other")}},
 		Message: "main advance",
@@ -1122,7 +1159,7 @@ func TestRebase_ThenMerge(t *testing.T) {
 	}
 
 	// Rebase (seq=4 for replayed branch commit).
-	rebaseResp, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Branch: "feature/rebase-merge", Author: "bob"})
+	rebaseResp, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Repo: "default", Branch: "feature/rebase-merge", Author: "bob"})
 	if err != nil {
 		t.Fatalf("rebase: %v", err)
 	}
@@ -1134,7 +1171,7 @@ func TestRebase_ThenMerge(t *testing.T) {
 	}
 
 	// Merge should now succeed cleanly (seq=5).
-	mergeResp, mergeConflicts, err := s.Merge(ctx, model.MergeRequest{Branch: "feature/rebase-merge", Author: "alice"})
+	mergeResp, mergeConflicts, err := s.Merge(ctx, model.MergeRequest{Repo: "default", Branch: "feature/rebase-merge", Author: "alice"})
 	if err != nil {
 		t.Fatalf("merge after rebase: %v", err)
 	}
@@ -1154,4 +1191,306 @@ func TestRebase_ThenMerge(t *testing.T) {
 	if count != 1 {
 		t.Errorf("expected new.txt on main after merge, got %d file_commits", count)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Repo CRUD tests
+// ---------------------------------------------------------------------------
+
+func TestCreateRepo_Success(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	r, err := s.CreateRepo(ctx, model.CreateRepoRequest{Name: "myrepo", CreatedBy: "alice"})
+	if err != nil {
+		t.Fatalf("CreateRepo: %v", err)
+	}
+	if r.Name != "myrepo" {
+		t.Errorf("expected name myrepo, got %q", r.Name)
+	}
+	if r.CreatedBy != "alice" {
+		t.Errorf("expected created_by alice, got %q", r.CreatedBy)
+	}
+
+	// main branch should exist for the new repo.
+	var status string
+	err = d.QueryRow("SELECT status FROM branches WHERE repo = 'myrepo' AND name = 'main'").Scan(&status)
+	if err != nil {
+		t.Fatalf("query main branch: %v", err)
+	}
+	if status != "active" {
+		t.Errorf("expected main branch to be active, got %q", status)
+	}
+}
+
+func TestCreateRepo_Duplicate(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.CreateRepo(ctx, model.CreateRepoRequest{Name: "dup"})
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+
+	_, err = s.CreateRepo(ctx, model.CreateRepoRequest{Name: "dup"})
+	if err != ErrRepoExists {
+		t.Fatalf("expected ErrRepoExists, got %v", err)
+	}
+}
+
+func TestDeleteRepo_RemovesAllData(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Create a repo and add some data.
+	_, err := s.CreateRepo(ctx, model.CreateRepoRequest{Name: "todelete"})
+	if err != nil {
+		t.Fatalf("CreateRepo: %v", err)
+	}
+
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "todelete",
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "hello.txt", Content: []byte("hello")}},
+		Message: "initial",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// Delete the repo.
+	if err := s.DeleteRepo(ctx, "todelete"); err != nil {
+		t.Fatalf("DeleteRepo: %v", err)
+	}
+
+	// All data should be gone.
+	for _, table := range []string{"branches", "commits", "file_commits", "documents"} {
+		var count int
+		err = d.QueryRow("SELECT count(*) FROM "+table+" WHERE repo = 'todelete'").Scan(&count)
+		if err != nil {
+			t.Fatalf("query %s: %v", table, err)
+		}
+		if count != 0 {
+			t.Errorf("expected 0 rows in %s for deleted repo, got %d", table, count)
+		}
+	}
+
+	// Repo row itself gone.
+	var exists bool
+	err = d.QueryRow("SELECT EXISTS(SELECT 1 FROM repos WHERE name = 'todelete')").Scan(&exists)
+	if err != nil {
+		t.Fatalf("query repos: %v", err)
+	}
+	if exists {
+		t.Error("expected repo row to be deleted")
+	}
+}
+
+func TestDeleteRepo_DoesNotAffectOtherRepo(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Create two repos and commit data to each.
+	for _, repo := range []string{"repo-a", "repo-b"} {
+		_, err := s.CreateRepo(ctx, model.CreateRepoRequest{Name: repo})
+		if err != nil {
+			t.Fatalf("CreateRepo %s: %v", repo, err)
+		}
+		_, err = s.Commit(ctx, model.CommitRequest{
+			Repo:    repo,
+			Branch:  "main",
+			Files:   []model.FileChange{{Path: "f.txt", Content: []byte(repo)}},
+			Message: "init",
+			Author:  "alice",
+		})
+		if err != nil {
+			t.Fatalf("Commit %s: %v", repo, err)
+		}
+	}
+
+	// Delete repo-a.
+	if err := s.DeleteRepo(ctx, "repo-a"); err != nil {
+		t.Fatalf("DeleteRepo: %v", err)
+	}
+
+	// repo-b's data should be intact.
+	var count int
+	err := d.QueryRow("SELECT count(*) FROM file_commits WHERE repo = 'repo-b'").Scan(&count)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 file_commit in repo-b, got %d", count)
+	}
+}
+
+func TestDeleteRepo_NotFound(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	err := s.DeleteRepo(ctx, "nonexistent")
+	if err != ErrRepoNotFound {
+		t.Fatalf("expected ErrRepoNotFound, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Repo isolation tests
+// ---------------------------------------------------------------------------
+
+func TestRepoIsolation_Branches(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Create two repos.
+	for _, repo := range []string{"repo-x", "repo-y"} {
+		if _, err := s.CreateRepo(ctx, model.CreateRepoRequest{Name: repo}); err != nil {
+			t.Fatalf("CreateRepo %s: %v", repo, err)
+		}
+	}
+
+	// Both repos can have a branch named "feature/shared".
+	for _, repo := range []string{"repo-x", "repo-y"} {
+		_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: repo, Name: "feature/shared"})
+		if err != nil {
+			t.Fatalf("CreateBranch %s: %v", repo, err)
+		}
+	}
+
+	// Commit to one repo's branch.
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "repo-x",
+		Branch:  "feature/shared",
+		Files:   []model.FileChange{{Path: "x-only.txt", Content: []byte("x")}},
+		Message: "x commit",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("Commit repo-x: %v", err)
+	}
+
+	// The other repo's branch should have no commits.
+	var count int
+	err = d.QueryRow("SELECT count(*) FROM file_commits WHERE repo = 'repo-y' AND branch = 'feature/shared'").Scan(&count)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 file_commits in repo-y/feature/shared, got %d", count)
+	}
+}
+
+func TestRepoIsolation_Commits(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	for _, repo := range []string{"iso-a", "iso-b"} {
+		if _, err := s.CreateRepo(ctx, model.CreateRepoRequest{Name: repo}); err != nil {
+			t.Fatalf("CreateRepo %s: %v", repo, err)
+		}
+	}
+
+	// Commit unique content to each repo.
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "iso-a",
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("a only")}},
+		Message: "a init",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("Commit iso-a: %v", err)
+	}
+
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "iso-b",
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "b.txt", Content: []byte("b only")}},
+		Message: "b init",
+		Author:  "bob",
+	})
+	if err != nil {
+		t.Fatalf("Commit iso-b: %v", err)
+	}
+
+	// repo-a should only see a.txt, not b.txt.
+	var aCount, bCount int
+	if err := d.QueryRow("SELECT count(*) FROM file_commits WHERE repo = 'iso-a' AND path = 'b.txt'").Scan(&bCount); err != nil {
+		t.Fatal(err)
+	}
+	if bCount != 0 {
+		t.Errorf("expected b.txt absent in iso-a, got %d rows", bCount)
+	}
+
+	if err := d.QueryRow("SELECT count(*) FROM file_commits WHERE repo = 'iso-b' AND path = 'a.txt'").Scan(&aCount); err != nil {
+		t.Fatal(err)
+	}
+	if aCount != 0 {
+		t.Errorf("expected a.txt absent in iso-b, got %d rows", aCount)
+	}
+}
+
+func TestRepoIsolation_Merge(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	for _, repo := range []string{"merge-a", "merge-b"} {
+		if _, err := s.CreateRepo(ctx, model.CreateRepoRequest{Name: repo}); err != nil {
+			t.Fatalf("CreateRepo %s: %v", repo, err)
+		}
+	}
+
+	// Set up a branch with a change in merge-a only.
+	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "merge-a", Name: "feature/x"})
+	if err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "merge-a",
+		Branch:  "feature/x",
+		Files:   []model.FileChange{{Path: "new.txt", Content: []byte("new")}},
+		Message: "add new",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// Merge in merge-a.
+	resp, conflicts, err := s.Merge(ctx, model.MergeRequest{Repo: "merge-a", Branch: "feature/x", Author: "alice"})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if conflicts != nil {
+		t.Fatalf("unexpected conflicts: %v", conflicts)
+	}
+
+	// merge-b's main should have no file_commits from the merge.
+	var bMainCount int
+	if err := d.QueryRow("SELECT count(*) FROM file_commits WHERE repo = 'merge-b' AND branch = 'main'").Scan(&bMainCount); err != nil {
+		t.Fatal(err)
+	}
+	if bMainCount != 0 {
+		t.Errorf("expected 0 file_commits on merge-b main, got %d", bMainCount)
+	}
+
+	// merge-a's main should have the merged file.
+	var aMainCount int
+	if err := d.QueryRow("SELECT count(*) FROM file_commits WHERE repo = 'merge-a' AND branch = 'main' AND path = 'new.txt'").Scan(&aMainCount); err != nil {
+		t.Fatal(err)
+	}
+	if aMainCount != 1 {
+		t.Errorf("expected 1 file_commit for new.txt on merge-a main, got %d", aMainCount)
+	}
+
+	_ = resp
 }

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -138,8 +138,9 @@ type FileChange struct {
 	Content []byte `json:"content,omitempty"`
 }
 
-// CommitRequest is the body for POST /commit.
+// CommitRequest is the body for POST /repos/:name/commit.
 type CommitRequest struct {
+	Repo    string       `json:"repo,omitempty"`
 	Branch  string       `json:"branch"`
 	Files   []FileChange `json:"files"`
 	Message string       `json:"message"`
@@ -162,8 +163,9 @@ type CommitResponse struct {
 // POST /branch
 // ---------------------------------------------------------------------------
 
-// CreateBranchRequest is the body for POST /branch.
+// CreateBranchRequest is the body for POST /repos/:name/branch.
 type CreateBranchRequest struct {
+	Repo string `json:"repo,omitempty"`
 	Name string `json:"name"`
 }
 
@@ -177,8 +179,9 @@ type CreateBranchResponse struct {
 // POST /merge
 // ---------------------------------------------------------------------------
 
-// MergeRequest is the body for POST /merge.
+// MergeRequest is the body for POST /repos/:name/merge.
 type MergeRequest struct {
+	Repo   string `json:"repo,omitempty"`
 	Branch string `json:"branch"`
 	Author string `json:"author,omitempty"`
 }
@@ -202,8 +205,9 @@ type MergePolicyError struct {
 // POST /rebase
 // ---------------------------------------------------------------------------
 
-// RebaseRequest is the body for POST /rebase.
+// RebaseRequest is the body for POST /repos/:name/rebase.
 type RebaseRequest struct {
+	Repo   string `json:"repo,omitempty"`
 	Branch string `json:"branch"`
 	Author string `json:"author,omitempty"`
 }
@@ -261,6 +265,21 @@ type CreateCheckRunResponse struct {
 type DeleteBranchResponse struct {
 	Name   string       `json:"name"`
 	Status BranchStatus `json:"status"`
+}
+
+// ---------------------------------------------------------------------------
+// POST /repos / GET /repos / GET /repos/:name / DELETE /repos/:name
+// ---------------------------------------------------------------------------
+
+// CreateRepoRequest is the body for POST /repos.
+type CreateRepoRequest struct {
+	Name      string `json:"name"`
+	CreatedBy string `json:"created_by,omitempty"`
+}
+
+// ReposResponse is the response for GET /repos.
+type ReposResponse struct {
+	Repos []Repo `json:"repos"`
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -4,6 +4,13 @@ package model
 
 import "time"
 
+// Repo is a named tenant that owns its own isolated set of branches and commits.
+type Repo struct {
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+	CreatedBy string    `json:"created_by"`
+}
+
 // BranchStatus represents the lifecycle state of a branch.
 type BranchStatus string
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -16,8 +16,82 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, map[string]string{"error": msg})
 }
 
-// handleTree implements GET /tree?branch=main&at=N&limit=N&after=cursor
+// handleCreateRepo implements POST /repos
+func (s *server) handleCreateRepo(w http.ResponseWriter, r *http.Request) {
+	var req model.CreateRepoRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if req.CreatedBy == "" {
+		req.CreatedBy = r.Header.Get("X-DocStore-Identity")
+	}
+
+	repo, err := s.commitStore.CreateRepo(r.Context(), req)
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrRepoExists):
+			writeError(w, http.StatusConflict, "repo already exists")
+		default:
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+	writeJSON(w, http.StatusCreated, repo)
+}
+
+// handleListRepos implements GET /repos
+func (s *server) handleListRepos(w http.ResponseWriter, r *http.Request) {
+	repos, err := s.commitStore.ListRepos(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if repos == nil {
+		repos = []model.Repo{}
+	}
+	writeJSON(w, http.StatusOK, model.ReposResponse{Repos: repos})
+}
+
+// handleGetRepo implements GET /repos/:name
+func (s *server) handleGetRepo(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	repo, err := s.commitStore.GetRepo(r.Context(), name)
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrRepoNotFound):
+			writeError(w, http.StatusNotFound, "repo not found")
+		default:
+			writeError(w, http.StatusInternalServerError, "query failed")
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, repo)
+}
+
+// handleDeleteRepo implements DELETE /repos/:name (hard delete)
+func (s *server) handleDeleteRepo(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	err := s.commitStore.DeleteRepo(r.Context(), name)
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrRepoNotFound):
+			writeError(w, http.StatusNotFound, "repo not found")
+		default:
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleTree implements GET /repos/:name/tree?branch=main&at=N&limit=N&after=cursor
 func (s *server) handleTree(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
 	branch := r.URL.Query().Get("branch")
 	if branch == "" {
 		branch = "main"
@@ -45,7 +119,7 @@ func (s *server) handleTree(w http.ResponseWriter, r *http.Request) {
 
 	afterPath := r.URL.Query().Get("after")
 
-	entries, err := s.readStore.MaterializeTree(r.Context(), branch, atSequence, limit, afterPath)
+	entries, err := s.readStore.MaterializeTree(r.Context(), repo, branch, atSequence, limit, afterPath)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "query failed")
 		return
@@ -57,24 +131,25 @@ func (s *server) handleTree(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleFile implements:
-//   - GET /file/{path...}          → file content
-//   - GET /file/{path...}/history  → file change history
+//   - GET /repos/:name/file/{path...}          → file content
+//   - GET /repos/:name/file/{path...}/history  → file change history
 //
 // Query params: branch (default "main"), at (sequence), limit, after (cursor).
 func (s *server) handleFile(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
 	fullPath := r.PathValue("path")
 
 	// Check for /history suffix.
 	if strings.HasSuffix(fullPath, "/history") {
 		filePath := strings.TrimSuffix(fullPath, "/history")
-		s.handleFileHistory(w, r, filePath)
+		s.handleFileHistory(w, r, repo, filePath)
 		return
 	}
 
-	s.handleFileContent(w, r, fullPath)
+	s.handleFileContent(w, r, repo, fullPath)
 }
 
-func (s *server) handleFileContent(w http.ResponseWriter, r *http.Request, path string) {
+func (s *server) handleFileContent(w http.ResponseWriter, r *http.Request, repo, path string) {
 	branch := r.URL.Query().Get("branch")
 	if branch == "" {
 		branch = "main"
@@ -90,7 +165,7 @@ func (s *server) handleFileContent(w http.ResponseWriter, r *http.Request, path 
 		atSequence = &n
 	}
 
-	fc, err := s.readStore.GetFile(r.Context(), branch, path, atSequence)
+	fc, err := s.readStore.GetFile(r.Context(), repo, branch, path, atSequence)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "query failed")
 		return
@@ -103,7 +178,7 @@ func (s *server) handleFileContent(w http.ResponseWriter, r *http.Request, path 
 	writeJSON(w, http.StatusOK, fc)
 }
 
-func (s *server) handleFileHistory(w http.ResponseWriter, r *http.Request, path string) {
+func (s *server) handleFileHistory(w http.ResponseWriter, r *http.Request, repo, path string) {
 	branch := r.URL.Query().Get("branch")
 	if branch == "" {
 		branch = "main"
@@ -129,7 +204,7 @@ func (s *server) handleFileHistory(w http.ResponseWriter, r *http.Request, path 
 		afterSeq = &n
 	}
 
-	entries, err := s.readStore.GetFileHistory(r.Context(), branch, path, limit, afterSeq)
+	entries, err := s.readStore.GetFileHistory(r.Context(), repo, branch, path, limit, afterSeq)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "query failed")
 		return
@@ -140,8 +215,9 @@ func (s *server) handleFileHistory(w http.ResponseWriter, r *http.Request, path 
 	writeJSON(w, http.StatusOK, entries)
 }
 
-// handleGetCommit implements GET /commit/{sequence}
+// handleGetCommit implements GET /repos/:name/commit/{sequence}
 func (s *server) handleGetCommit(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
 	seqStr := r.PathValue("sequence")
 	seq, err := strconv.ParseInt(seqStr, 10, 64)
 	if err != nil {
@@ -149,7 +225,7 @@ func (s *server) handleGetCommit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	detail, err := s.readStore.GetCommit(r.Context(), seq)
+	detail, err := s.readStore.GetCommit(r.Context(), repo, seq)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "query failed")
 		return
@@ -162,11 +238,12 @@ func (s *server) handleGetCommit(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, detail)
 }
 
-// handleBranches implements GET /branches?status=active
+// handleBranches implements GET /repos/:name/branches?status=active
 func (s *server) handleBranches(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
 	statusFilter := r.URL.Query().Get("status")
 
-	branches, err := s.readStore.ListBranches(r.Context(), statusFilter)
+	branches, err := s.readStore.ListBranches(r.Context(), repo, statusFilter)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "query failed")
 		return
@@ -177,15 +254,16 @@ func (s *server) handleBranches(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, branches)
 }
 
-// handleDiff implements GET /diff?branch=X
+// handleDiff implements GET /repos/:name/diff?branch=X
 func (s *server) handleDiff(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
 	branch := r.URL.Query().Get("branch")
 	if branch == "" {
 		writeError(w, http.StatusBadRequest, "branch parameter is required")
 		return
 	}
 
-	result, err := s.readStore.GetDiff(r.Context(), branch)
+	result, err := s.readStore.GetDiff(r.Context(), repo, branch)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "query failed")
 		return
@@ -217,13 +295,16 @@ func (s *server) handleDiff(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// handleCreateBranch implements POST /branch
+// handleCreateBranch implements POST /repos/:name/branch
 func (s *server) handleCreateBranch(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+
 	var req model.CreateBranchRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
+	req.Repo = repo
 
 	if req.Name == "" {
 		writeError(w, http.StatusBadRequest, "name is required")
@@ -248,15 +329,16 @@ func (s *server) handleCreateBranch(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, resp)
 }
 
-// handleDeleteBranch implements DELETE /branch/{name}
+// handleDeleteBranch implements DELETE /repos/:name/branch/{bname}
 func (s *server) handleDeleteBranch(w http.ResponseWriter, r *http.Request) {
-	name := r.PathValue("name")
-	if name == "main" {
+	repo := r.PathValue("name")
+	bname := r.PathValue("bname")
+	if bname == "main" {
 		writeError(w, http.StatusBadRequest, "cannot delete branch 'main'")
 		return
 	}
 
-	err := s.commitStore.DeleteBranch(r.Context(), name)
+	err := s.commitStore.DeleteBranch(r.Context(), repo, bname)
 	if err != nil {
 		switch {
 		case errors.Is(err, db.ErrBranchNotFound):
@@ -272,13 +354,16 @@ func (s *server) handleDeleteBranch(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// handleRebase implements POST /rebase
+// handleRebase implements POST /repos/:name/rebase
 func (s *server) handleRebase(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+
 	var req model.RebaseRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
+	req.Repo = repo
 
 	if req.Branch == "" {
 		writeError(w, http.StatusBadRequest, "branch is required")
@@ -318,13 +403,16 @@ func (s *server) handleRebase(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// handleMerge implements POST /merge
+// handleMerge implements POST /repos/:name/merge
 func (s *server) handleMerge(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+
 	var req model.MergeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
+	req.Repo = repo
 
 	if req.Branch == "" {
 		writeError(w, http.StatusBadRequest, "branch is required")

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -61,7 +61,7 @@ func TestIntegrationTreeEndpoint(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	resp, err := http.Get(srv.URL + "/tree")
+	resp, err := http.Get(srv.URL + "/repos/default/tree")
 	if err != nil {
 		t.Fatalf("GET /tree: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestIntegrationFileEndpoint(t *testing.T) {
 	defer srv.Close()
 
 	t.Run("get file content", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/file/hello.txt")
+		resp, err := http.Get(srv.URL + "/repos/default/file/hello.txt")
 		if err != nil {
 			t.Fatalf("GET /file/hello.txt: %v", err)
 		}
@@ -110,7 +110,7 @@ func TestIntegrationFileEndpoint(t *testing.T) {
 	})
 
 	t.Run("file not found", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/file/nope.txt")
+		resp, err := http.Get(srv.URL + "/repos/default/file/nope.txt")
 		if err != nil {
 			t.Fatalf("GET /file/nope.txt: %v", err)
 		}
@@ -122,7 +122,7 @@ func TestIntegrationFileEndpoint(t *testing.T) {
 	})
 
 	t.Run("file history", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/file/hello.txt/history")
+		resp, err := http.Get(srv.URL + "/repos/default/file/hello.txt/history")
 		if err != nil {
 			t.Fatalf("GET /file/hello.txt/history: %v", err)
 		}
@@ -143,7 +143,7 @@ func TestIntegrationFileEndpoint(t *testing.T) {
 	})
 
 	t.Run("file at sequence", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/file/hello.txt?at=1")
+		resp, err := http.Get(srv.URL + "/repos/default/file/hello.txt?at=1")
 		if err != nil {
 			t.Fatalf("GET /file/hello.txt?at=1: %v", err)
 		}
@@ -180,7 +180,7 @@ func TestIntegrationBranchesEndpoint(t *testing.T) {
 	defer srv.Close()
 
 	t.Run("list all branches", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/branches")
+		resp, err := http.Get(srv.URL + "/repos/default/branches")
 		if err != nil {
 			t.Fatalf("GET /branches: %v", err)
 		}
@@ -200,7 +200,7 @@ func TestIntegrationBranchesEndpoint(t *testing.T) {
 	})
 
 	t.Run("filter active", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/branches?status=active")
+		resp, err := http.Get(srv.URL + "/repos/default/branches?status=active")
 		if err != nil {
 			t.Fatalf("GET /branches?status=active: %v", err)
 		}
@@ -246,7 +246,7 @@ func TestIntegrationDiffEndpoint(t *testing.T) {
 	defer srv.Close()
 
 	t.Run("diff with branch", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/diff?branch=feature/diff")
+		resp, err := http.Get(srv.URL + "/repos/default/diff?branch=feature/diff")
 		if err != nil {
 			t.Fatalf("GET /diff: %v", err)
 		}
@@ -269,7 +269,7 @@ func TestIntegrationDiffEndpoint(t *testing.T) {
 	})
 
 	t.Run("diff missing branch param", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/diff")
+		resp, err := http.Get(srv.URL + "/repos/default/diff")
 		if err != nil {
 			t.Fatalf("GET /diff: %v", err)
 		}
@@ -281,7 +281,7 @@ func TestIntegrationDiffEndpoint(t *testing.T) {
 	})
 
 	t.Run("diff nonexistent branch", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/diff?branch=nonexistent")
+		resp, err := http.Get(srv.URL + "/repos/default/diff?branch=nonexistent")
 		if err != nil {
 			t.Fatalf("GET /diff: %v", err)
 		}
@@ -301,7 +301,7 @@ func TestIntegrationCommitEndpoint(t *testing.T) {
 	defer srv.Close()
 
 	t.Run("existing commit", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/commit/1")
+		resp, err := http.Get(srv.URL + "/repos/default/commit/1")
 		if err != nil {
 			t.Fatalf("GET /commit/1: %v", err)
 		}
@@ -325,7 +325,7 @@ func TestIntegrationCommitEndpoint(t *testing.T) {
 	})
 
 	t.Run("nonexistent commit", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/commit/999")
+		resp, err := http.Get(srv.URL + "/repos/default/commit/999")
 		if err != nil {
 			t.Fatalf("GET /commit/999: %v", err)
 		}
@@ -337,7 +337,7 @@ func TestIntegrationCommitEndpoint(t *testing.T) {
 	})
 
 	t.Run("invalid sequence", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/commit/abc")
+		resp, err := http.Get(srv.URL + "/repos/default/commit/abc")
 		if err != nil {
 			t.Fatalf("GET /commit/abc: %v", err)
 		}
@@ -366,7 +366,7 @@ func TestIntegrationDeleteBranch(t *testing.T) {
 	}
 
 	t.Run("delete active branch returns 204", func(t *testing.T) {
-		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/branch/feature/to-delete", nil)
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/repos/default/branch/feature/to-delete", nil)
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Fatalf("DELETE /branch/feature/to-delete: %v", err)
@@ -388,7 +388,7 @@ func TestIntegrationDeleteBranch(t *testing.T) {
 	})
 
 	t.Run("delete main returns 400", func(t *testing.T) {
-		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/branch/main", nil)
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/repos/default/branch/main", nil)
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Fatalf("DELETE /branch/main: %v", err)
@@ -401,7 +401,7 @@ func TestIntegrationDeleteBranch(t *testing.T) {
 	})
 
 	t.Run("delete nonexistent branch returns 404", func(t *testing.T) {
-		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/branch/nonexistent", nil)
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/repos/default/branch/nonexistent", nil)
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Fatalf("DELETE /branch/nonexistent: %v", err)
@@ -414,7 +414,7 @@ func TestIntegrationDeleteBranch(t *testing.T) {
 	})
 
 	t.Run("delete abandoned branch returns 409", func(t *testing.T) {
-		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/branch/feature/to-delete", nil)
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/repos/default/branch/feature/to-delete", nil)
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Fatalf("DELETE /branch/feature/to-delete: %v", err)
@@ -444,35 +444,35 @@ func TestIntegrationRebase_FullFlow(t *testing.T) {
 	}
 
 	// Step 1: Commit to main (creates seq=1).
-	r := post("/commit", `{"branch":"main","message":"initial","author":"alice","files":[{"path":"base.txt","content":"YmFzZQ=="}]}`)
+	r := post("/repos/default/commit", `{"branch":"main","message":"initial","author":"alice","files":[{"path":"base.txt","content":"YmFzZQ=="}]}`)
 	r.Body.Close()
 	if r.StatusCode != http.StatusCreated {
 		t.Fatalf("POST /commit to main: expected 201, got %d", r.StatusCode)
 	}
 
 	// Step 2: Create branch (base=1, head=1).
-	r = post("/branch", `{"name":"feature/rebase-flow"}`)
+	r = post("/repos/default/branch", `{"name":"feature/rebase-flow"}`)
 	r.Body.Close()
 	if r.StatusCode != http.StatusCreated {
 		t.Fatalf("POST /branch: expected 201, got %d", r.StatusCode)
 	}
 
 	// Step 3: Commit to branch (seq=2, adds "branch.txt").
-	r = post("/commit", `{"branch":"feature/rebase-flow","message":"branch work","author":"bob","files":[{"path":"branch.txt","content":"YnJhbmNo"}]}`)
+	r = post("/repos/default/commit", `{"branch":"feature/rebase-flow","message":"branch work","author":"bob","files":[{"path":"branch.txt","content":"YnJhbmNo"}]}`)
 	r.Body.Close()
 	if r.StatusCode != http.StatusCreated {
 		t.Fatalf("POST /commit to branch: expected 201, got %d", r.StatusCode)
 	}
 
 	// Step 4: Advance main (seq=3, adds "other.txt").
-	r = post("/commit", `{"branch":"main","message":"main advance","author":"alice","files":[{"path":"other.txt","content":"b3RoZXI="}]}`)
+	r = post("/repos/default/commit", `{"branch":"main","message":"main advance","author":"alice","files":[{"path":"other.txt","content":"b3RoZXI="}]}`)
 	r.Body.Close()
 	if r.StatusCode != http.StatusCreated {
 		t.Fatalf("POST /commit to advance main: expected 201, got %d", r.StatusCode)
 	}
 
 	// Step 5: GET /diff — should show main_changes before rebase.
-	diffResp, err := http.Get(srv.URL + "/diff?branch=feature/rebase-flow")
+	diffResp, err := http.Get(srv.URL + "/repos/default/diff?branch=feature/rebase-flow")
 	if err != nil {
 		t.Fatalf("GET /diff: %v", err)
 	}
@@ -489,7 +489,7 @@ func TestIntegrationRebase_FullFlow(t *testing.T) {
 	}
 
 	// Step 6: POST /rebase.
-	r = post("/rebase", `{"branch":"feature/rebase-flow","author":"bob"}`)
+	r = post("/repos/default/rebase", `{"branch":"feature/rebase-flow","author":"bob"}`)
 	defer r.Body.Close()
 	if r.StatusCode != http.StatusOK {
 		var errBody map[string]interface{}
@@ -509,7 +509,7 @@ func TestIntegrationRebase_FullFlow(t *testing.T) {
 	}
 
 	// Step 7: GET /diff — should show no main_changes after rebase.
-	diffResp2, err := http.Get(srv.URL + "/diff?branch=feature/rebase-flow")
+	diffResp2, err := http.Get(srv.URL + "/repos/default/diff?branch=feature/rebase-flow")
 	if err != nil {
 		t.Fatalf("GET /diff after rebase: %v", err)
 	}
@@ -526,7 +526,7 @@ func TestIntegrationRebase_FullFlow(t *testing.T) {
 	}
 
 	// Step 8: POST /merge — should succeed cleanly.
-	r = post("/merge", `{"branch":"feature/rebase-flow","author":"alice"}`)
+	r = post("/repos/default/merge", `{"branch":"feature/rebase-flow","author":"alice"}`)
 	defer r.Body.Close()
 	if r.StatusCode != http.StatusOK {
 		var errBody map[string]interface{}
@@ -543,8 +543,8 @@ func TestHTTP_AuthRequired(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	// POST /commit without X-Goog-IAP-JWT-Assertion must return 401.
-	resp, err := http.Post(srv.URL+"/commit", "application/json",
+	// POST /repos/default/commit without X-Goog-IAP-JWT-Assertion must return 401.
+	resp, err := http.Post(srv.URL+"/repos/default/commit", "application/json",
 		strings.NewReader(`{"branch":"main","message":"m","files":[{"path":"a.txt","content":"YQ=="}]}`))
 	if err != nil {
 		t.Fatalf("POST /commit: %v", err)
@@ -574,8 +574,8 @@ func TestHTTP_AuthIdentityUsedAsAuthor(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	// POST /commit with a different author in the body — it must be ignored.
-	resp, err := http.Post(srv.URL+"/commit", "application/json",
+	// POST /repos/default/commit with a different author in the body — it must be ignored.
+	resp, err := http.Post(srv.URL+"/repos/default/commit", "application/json",
 		strings.NewReader(`{"branch":"main","message":"test commit","author":"not-alice@example.com","files":[{"path":"hello.txt","content":"aGVsbG8="}]}`))
 	if err != nil {
 		t.Fatalf("POST /commit: %v", err)
@@ -585,8 +585,8 @@ func TestHTTP_AuthIdentityUsedAsAuthor(t *testing.T) {
 		t.Fatalf("POST /commit: expected 201, got %d", resp.StatusCode)
 	}
 
-	// GET /commit/1 and verify the author is the identity, not the body value.
-	getResp, err := http.Get(srv.URL + "/commit/1")
+	// GET /repos/default/commit/1 and verify the author is the identity, not the body value.
+	getResp, err := http.Get(srv.URL + "/repos/default/commit/1")
 	if err != nil {
 		t.Fatalf("GET /commit/1: %v", err)
 	}
@@ -601,5 +601,259 @@ func TestHTTP_AuthIdentityUsedAsAuthor(t *testing.T) {
 	}
 	if detail.Author != identity {
 		t.Errorf("expected author %q, got %q", identity, detail.Author)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// New repo management integration tests
+// ---------------------------------------------------------------------------
+
+func TestHandleCreateRepo_Success(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, "test@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/repos", "application/json",
+		strings.NewReader(`{"name":"myrepo"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleCreateRepo_Duplicate(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, "test@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	for i, wantCode := range []int{http.StatusCreated, http.StatusConflict} {
+		resp, err := http.Post(srv.URL+"/repos", "application/json",
+			strings.NewReader(`{"name":"dup"}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != wantCode {
+			t.Errorf("attempt %d: expected %d, got %d", i+1, wantCode, resp.StatusCode)
+		}
+	}
+}
+
+func TestHandleDeleteRepo_Success(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, "test@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// Create a repo first.
+	resp, err := http.Post(srv.URL+"/repos", "application/json",
+		strings.NewReader(`{"name":"todel"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	// Delete it.
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/repos/todel", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleDeleteRepo_NotFound(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, "test@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/repos/nonexistent", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleListRepos(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, "test@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// Create a repo to add alongside the seeded 'default'.
+	resp, err := http.Post(srv.URL+"/repos", "application/json",
+		strings.NewReader(`{"name":"extra"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	resp, err = http.Get(srv.URL + "/repos")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Repos []struct{ Name string `json:"name"` } `json:"repos"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Repos) < 2 {
+		t.Fatalf("expected at least 2 repos, got %d", len(body.Repos))
+	}
+}
+
+func TestIntegrationMultiRepo_FullIsolation(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, "test@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	post := func(path, body string) *http.Response {
+		t.Helper()
+		resp, err := http.Post(srv.URL+path, "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		return resp
+	}
+
+	// Create two repos.
+	for _, name := range []string{"alpha", "beta"} {
+		r := post("/repos", `{"name":"`+name+`"}`)
+		r.Body.Close()
+		if r.StatusCode != http.StatusCreated {
+			t.Fatalf("create repo %s: expected 201, got %d", name, r.StatusCode)
+		}
+	}
+
+	// Commit unique files to each repo.
+	r := post("/repos/alpha/commit", `{"branch":"main","message":"alpha init","files":[{"path":"alpha.txt","content":"YWxwaGE="}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("commit alpha: expected 201, got %d", r.StatusCode)
+	}
+
+	r = post("/repos/beta/commit", `{"branch":"main","message":"beta init","files":[{"path":"beta.txt","content":"YmV0YQ=="}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("commit beta: expected 201, got %d", r.StatusCode)
+	}
+
+	// GET /repos/alpha/tree must NOT contain beta.txt.
+	resp, err := http.Get(srv.URL + "/repos/alpha/tree")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var alphaEntries []struct{ Path string `json:"path"` }
+	json.NewDecoder(resp.Body).Decode(&alphaEntries)
+	for _, e := range alphaEntries {
+		if e.Path == "beta.txt" {
+			t.Error("beta.txt should not appear in alpha's tree")
+		}
+	}
+	if len(alphaEntries) != 1 || alphaEntries[0].Path != "alpha.txt" {
+		t.Errorf("expected only alpha.txt in alpha tree, got %+v", alphaEntries)
+	}
+
+	// GET /repos/beta/tree must NOT contain alpha.txt.
+	resp2, err := http.Get(srv.URL + "/repos/beta/tree")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	var betaEntries []struct{ Path string `json:"path"` }
+	json.NewDecoder(resp2.Body).Decode(&betaEntries)
+	for _, e := range betaEntries {
+		if e.Path == "alpha.txt" {
+			t.Error("alpha.txt should not appear in beta's tree")
+		}
+	}
+	if len(betaEntries) != 1 || betaEntries[0].Path != "beta.txt" {
+		t.Errorf("expected only beta.txt in beta tree, got %+v", betaEntries)
+	}
+}
+
+func TestIntegrationDeleteRepo_CleansUp(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, "test@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	post := func(path, body string) *http.Response {
+		t.Helper()
+		resp, err := http.Post(srv.URL+path, "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		return resp
+	}
+
+	// Create repo, add data.
+	r := post("/repos", `{"name":"cleanup-test"}`)
+	r.Body.Close()
+	r = post("/repos/cleanup-test/commit", `{"branch":"main","message":"init","files":[{"path":"f.txt","content":"dGVzdA=="}]}`)
+	r.Body.Close()
+
+	// Verify tree is non-empty.
+	resp, err := http.Get(srv.URL + "/repos/cleanup-test/tree")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 before delete, got %d", resp.StatusCode)
+	}
+
+	// Delete the repo.
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/repos/cleanup-test", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", resp.StatusCode)
+	}
+
+	// Repo should no longer exist.
+	resp, err = http.Get(srv.URL + "/repos/cleanup-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 after delete, got %d", resp.StatusCode)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,12 +12,19 @@ import (
 	"github.com/dlorenc/docstore/internal/store"
 )
 
-// WriteStore abstracts the database write operations.
+// WriteStore abstracts the database write and repo management operations.
 type WriteStore interface {
+	// Repo management
+	CreateRepo(ctx context.Context, req model.CreateRepoRequest) (*model.Repo, error)
+	DeleteRepo(ctx context.Context, name string) error
+	ListRepos(ctx context.Context) ([]model.Repo, error)
+	GetRepo(ctx context.Context, name string) (*model.Repo, error)
+
+	// Branch and commit operations (all repo-scoped via req.Repo / explicit repo param)
 	Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error)
 	CreateBranch(ctx context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error)
 	Merge(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error)
-	DeleteBranch(ctx context.Context, name string) error
+	DeleteBranch(ctx context.Context, repo, name string) error
 	Rebase(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []db.MergeConflict, error)
 }
 
@@ -40,20 +47,29 @@ func New(writeStore WriteStore, database *sql.DB, devIdentity string) http.Handl
 
 	// All other routes require IAP authentication.
 	inner := http.NewServeMux()
-	inner.HandleFunc("GET /tree", s.handleTree)
-	inner.HandleFunc("GET /file/{path...}", s.handleFile)
-	inner.HandleFunc("GET /commit/{sequence}", s.handleGetCommit)
-	inner.HandleFunc("GET /diff", s.handleDiff)
-	inner.HandleFunc("GET /branches", s.handleBranches)
-	inner.HandleFunc("GET /branch/{name}/status", notImplemented)
 
-	inner.HandleFunc("POST /commit", s.handleCommit)
-	inner.HandleFunc("POST /branch", s.handleCreateBranch)
-	inner.HandleFunc("POST /merge", s.handleMerge)
-	inner.HandleFunc("POST /rebase", s.handleRebase)
-	inner.HandleFunc("POST /review", notImplemented)
-	inner.HandleFunc("POST /check", notImplemented)
-	inner.HandleFunc("DELETE /branch/{name...}", s.handleDeleteBranch)
+	// Repo management endpoints
+	inner.HandleFunc("POST /repos", s.handleCreateRepo)
+	inner.HandleFunc("GET /repos", s.handleListRepos)
+	inner.HandleFunc("GET /repos/{name}", s.handleGetRepo)
+	inner.HandleFunc("DELETE /repos/{name}", s.handleDeleteRepo)
+
+	// Repo-scoped read endpoints
+	inner.HandleFunc("GET /repos/{name}/tree", s.handleTree)
+	inner.HandleFunc("GET /repos/{name}/file/{path...}", s.handleFile)
+	inner.HandleFunc("GET /repos/{name}/commit/{sequence}", s.handleGetCommit)
+	inner.HandleFunc("GET /repos/{name}/diff", s.handleDiff)
+	inner.HandleFunc("GET /repos/{name}/branches", s.handleBranches)
+	inner.HandleFunc("GET /repos/{name}/branch/{bname}/status", notImplemented)
+
+	// Repo-scoped write endpoints
+	inner.HandleFunc("POST /repos/{name}/commit", s.handleCommit)
+	inner.HandleFunc("POST /repos/{name}/branch", s.handleCreateBranch)
+	inner.HandleFunc("POST /repos/{name}/merge", s.handleMerge)
+	inner.HandleFunc("POST /repos/{name}/rebase", s.handleRebase)
+	inner.HandleFunc("POST /repos/{name}/review", notImplemented)
+	inner.HandleFunc("POST /repos/{name}/check", notImplemented)
+	inner.HandleFunc("DELETE /repos/{name}/branch/{bname...}", s.handleDeleteBranch)
 
 	outer.Handle("/", IAPMiddleware(devIdentity)(inner))
 	return outer
@@ -65,11 +81,14 @@ type server struct {
 }
 
 func (s *server) handleCommit(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+
 	var req model.CommitRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 		return
 	}
+	req.Repo = repo
 
 	if req.Branch == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "branch is required"})

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -18,8 +18,12 @@ type mockStore struct {
 	commitFn       func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error)
 	createBranchFn func(ctx context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error)
 	mergeFn        func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error)
-	deleteBranchFn func(ctx context.Context, name string) error
+	deleteBranchFn func(ctx context.Context, repo, name string) error
 	rebaseFn       func(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []db.MergeConflict, error)
+	createRepoFn   func(ctx context.Context, req model.CreateRepoRequest) (*model.Repo, error)
+	deleteRepoFn   func(ctx context.Context, name string) error
+	listReposFn    func(ctx context.Context) ([]model.Repo, error)
+	getRepoFn      func(ctx context.Context, name string) (*model.Repo, error)
 }
 
 func (m *mockStore) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
@@ -40,9 +44,9 @@ func (m *mockStore) Merge(ctx context.Context, req model.MergeRequest) (*model.M
 	return nil, nil, errors.New("not implemented")
 }
 
-func (m *mockStore) DeleteBranch(ctx context.Context, name string) error {
+func (m *mockStore) DeleteBranch(ctx context.Context, repo, name string) error {
 	if m.deleteBranchFn != nil {
-		return m.deleteBranchFn(ctx, name)
+		return m.deleteBranchFn(ctx, repo, name)
 	}
 	return errors.New("not implemented")
 }
@@ -56,6 +60,34 @@ func (m *mockStore) Rebase(ctx context.Context, req model.RebaseRequest) (*model
 
 // devID is the dev identity used in handler unit tests.
 const devID = "test@example.com"
+
+func (m *mockStore) CreateRepo(ctx context.Context, req model.CreateRepoRequest) (*model.Repo, error) {
+	if m.createRepoFn != nil {
+		return m.createRepoFn(ctx, req)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockStore) DeleteRepo(ctx context.Context, name string) error {
+	if m.deleteRepoFn != nil {
+		return m.deleteRepoFn(ctx, name)
+	}
+	return errors.New("not implemented")
+}
+
+func (m *mockStore) ListRepos(ctx context.Context) ([]model.Repo, error) {
+	if m.listReposFn != nil {
+		return m.listReposFn(ctx)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockStore) GetRepo(ctx context.Context, name string) (*model.Repo, error) {
+	if m.getRepoFn != nil {
+		return m.getRepoFn(ctx, name)
+	}
+	return nil, errors.New("not implemented")
+}
 
 func TestHealthEndpoint(t *testing.T) {
 	// /healthz is exempt from IAP auth, so devIdentity="" is fine here.
@@ -85,9 +117,9 @@ func TestNotImplementedEndpoints(t *testing.T) {
 		method string
 		path   string
 	}{
-		{"POST", "/review"},
-		{"POST", "/check"},
-		{"GET", "/branch/main/status"},
+		{"POST", "/repos/default/review"},
+		{"POST", "/repos/default/check"},
+		{"GET", "/repos/default/branch/main/status"},
 	}
 
 	for _, ep := range endpoints {
@@ -130,7 +162,7 @@ func TestHandleCommit_Success(t *testing.T) {
 		Message: "initial commit",
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/commit", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -171,7 +203,7 @@ func TestHandleCommit_ValidationErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b, _ := json.Marshal(tt.body)
-			req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader(b))
+			req := httptest.NewRequest(http.MethodPost, "/repos/default/commit", bytes.NewReader(b))
 			rec := httptest.NewRecorder()
 			srv.ServeHTTP(rec, req)
 
@@ -196,7 +228,7 @@ func TestHandleCommit_BranchNotFound(t *testing.T) {
 		Message: "m",
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/commit", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -219,7 +251,7 @@ func TestHandleCommit_BranchNotActive(t *testing.T) {
 		Message: "m",
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/commit", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -242,7 +274,7 @@ func TestHandleCommit_InternalError(t *testing.T) {
 		Message: "m",
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/commit", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -259,7 +291,7 @@ func TestHandleCommit_InvalidJSON(t *testing.T) {
 		},
 	}, nil, devID)
 
-	req := httptest.NewRequest(http.MethodPost, "/commit", bytes.NewReader([]byte("not json")))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/commit", bytes.NewReader([]byte("not json")))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -268,7 +300,7 @@ func TestHandleCommit_InvalidJSON(t *testing.T) {
 	}
 }
 
-// --- POST /branch tests ---
+// --- POST /repos/default/branch tests ---
 
 func TestHandleCreateBranch_Success(t *testing.T) {
 	store := &mockStore{
@@ -279,7 +311,7 @@ func TestHandleCreateBranch_Success(t *testing.T) {
 	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.CreateBranchRequest{Name: "feature/test"})
-	req := httptest.NewRequest(http.MethodPost, "/branch", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/branch", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -303,7 +335,7 @@ func TestHandleCreateBranch_MissingName(t *testing.T) {
 	srv := New(&mockStore{}, nil, devID)
 
 	body, _ := json.Marshal(model.CreateBranchRequest{Name: ""})
-	req := httptest.NewRequest(http.MethodPost, "/branch", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/branch", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -316,7 +348,7 @@ func TestHandleCreateBranch_CannotCreateMain(t *testing.T) {
 	srv := New(&mockStore{}, nil, devID)
 
 	body, _ := json.Marshal(model.CreateBranchRequest{Name: "main"})
-	req := httptest.NewRequest(http.MethodPost, "/branch", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/branch", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -334,7 +366,7 @@ func TestHandleCreateBranch_AlreadyExists(t *testing.T) {
 	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.CreateBranchRequest{Name: "feature/exists"})
-	req := httptest.NewRequest(http.MethodPost, "/branch", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/branch", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -343,7 +375,7 @@ func TestHandleCreateBranch_AlreadyExists(t *testing.T) {
 	}
 }
 
-// --- POST /merge tests ---
+// --- POST /repos/default/merge tests ---
 
 func TestHandleMerge_Success(t *testing.T) {
 	store := &mockStore{
@@ -354,7 +386,7 @@ func TestHandleMerge_Success(t *testing.T) {
 	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/test"})
-	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/merge", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -375,7 +407,7 @@ func TestHandleMerge_MissingBranch(t *testing.T) {
 	srv := New(&mockStore{}, nil, devID)
 
 	body, _ := json.Marshal(model.MergeRequest{Branch: ""})
-	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/merge", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -395,7 +427,7 @@ func TestHandleMerge_Conflict(t *testing.T) {
 	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/conflict"})
-	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/merge", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -424,7 +456,7 @@ func TestHandleMerge_BranchNotFound(t *testing.T) {
 	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.MergeRequest{Branch: "nonexistent"})
-	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/merge", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -437,7 +469,7 @@ func TestHandleMerge_CannotMergeMain(t *testing.T) {
 	srv := New(&mockStore{}, nil, devID)
 
 	body, _ := json.Marshal(model.MergeRequest{Branch: "main"})
-	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/merge", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -461,7 +493,7 @@ func TestHandleMerge_AuthorFromIdentity(t *testing.T) {
 
 	// Send a different author in the body — it must be overridden by the identity.
 	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/test", Author: "ignored@example.com"})
-	req := httptest.NewRequest(http.MethodPost, "/merge", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/merge", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -473,11 +505,11 @@ func TestHandleMerge_AuthorFromIdentity(t *testing.T) {
 	}
 }
 
-// --- DELETE /branch/:name tests ---
+// --- DELETE /repos/default/branch/:name tests ---
 
 func TestHandleDeleteBranch_Success(t *testing.T) {
 	store := &mockStore{
-		deleteBranchFn: func(ctx context.Context, name string) error {
+		deleteBranchFn: func(ctx context.Context, repo, name string) error {
 			if name != "feature/delete-me" {
 				t.Errorf("expected name feature/delete-me, got %q", name)
 			}
@@ -486,7 +518,7 @@ func TestHandleDeleteBranch_Success(t *testing.T) {
 	}
 	srv := New(store, nil, devID)
 
-	req := httptest.NewRequest(http.MethodDelete, "/branch/feature/delete-me", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/repos/default/branch/feature/delete-me", nil)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -498,7 +530,7 @@ func TestHandleDeleteBranch_Success(t *testing.T) {
 func TestHandleDeleteBranch_CannotDeleteMain(t *testing.T) {
 	srv := New(&mockStore{}, nil, devID)
 
-	req := httptest.NewRequest(http.MethodDelete, "/branch/main", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/repos/default/branch/main", nil)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -509,13 +541,13 @@ func TestHandleDeleteBranch_CannotDeleteMain(t *testing.T) {
 
 func TestHandleDeleteBranch_NotFound(t *testing.T) {
 	store := &mockStore{
-		deleteBranchFn: func(ctx context.Context, name string) error {
+		deleteBranchFn: func(ctx context.Context, repo, name string) error {
 			return db.ErrBranchNotFound
 		},
 	}
 	srv := New(store, nil, devID)
 
-	req := httptest.NewRequest(http.MethodDelete, "/branch/nonexistent", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/repos/default/branch/nonexistent", nil)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -526,13 +558,13 @@ func TestHandleDeleteBranch_NotFound(t *testing.T) {
 
 func TestHandleDeleteBranch_AlreadyMerged(t *testing.T) {
 	store := &mockStore{
-		deleteBranchFn: func(ctx context.Context, name string) error {
+		deleteBranchFn: func(ctx context.Context, repo, name string) error {
 			return db.ErrBranchNotActive
 		},
 	}
 	srv := New(store, nil, devID)
 
-	req := httptest.NewRequest(http.MethodDelete, "/branch/merged-branch", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/repos/default/branch/merged-branch", nil)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -543,13 +575,13 @@ func TestHandleDeleteBranch_AlreadyMerged(t *testing.T) {
 
 func TestHandleDeleteBranch_AlreadyAbandoned(t *testing.T) {
 	store := &mockStore{
-		deleteBranchFn: func(ctx context.Context, name string) error {
+		deleteBranchFn: func(ctx context.Context, repo, name string) error {
 			return db.ErrBranchNotActive
 		},
 	}
 	srv := New(store, nil, devID)
 
-	req := httptest.NewRequest(http.MethodDelete, "/branch/abandoned-branch", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/repos/default/branch/abandoned-branch", nil)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -558,7 +590,7 @@ func TestHandleDeleteBranch_AlreadyAbandoned(t *testing.T) {
 	}
 }
 
-// --- POST /rebase tests ---
+// --- POST /repos/default/rebase tests ---
 
 func TestHandleRebase_Success(t *testing.T) {
 	store := &mockStore{
@@ -576,7 +608,7 @@ func TestHandleRebase_Success(t *testing.T) {
 	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.RebaseRequest{Branch: "feature/test"})
-	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/rebase", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -610,7 +642,7 @@ func TestHandleRebase_Conflict(t *testing.T) {
 	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.RebaseRequest{Branch: "feature/conflict"})
-	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/rebase", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -639,7 +671,7 @@ func TestHandleRebase_BranchNotFound(t *testing.T) {
 	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.RebaseRequest{Branch: "nonexistent"})
-	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/rebase", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -652,7 +684,7 @@ func TestHandleRebase_CannotRebaseMain(t *testing.T) {
 	srv := New(&mockStore{}, nil, devID)
 
 	body, _ := json.Marshal(model.RebaseRequest{Branch: "main"})
-	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/rebase", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -670,7 +702,7 @@ func TestHandleRebase_BranchNotActive(t *testing.T) {
 	srv := New(store, nil, devID)
 
 	body, _ := json.Marshal(model.RebaseRequest{Branch: "merged-branch"})
-	req := httptest.NewRequest(http.MethodPost, "/rebase", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/rebase", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 

--- a/internal/server/smoke_test.go
+++ b/internal/server/smoke_test.go
@@ -123,7 +123,7 @@ func TestDockerSmoke(t *testing.T) {
 	baseURL := fmt.Sprintf("http://%s:%s", host, port.Port())
 
 	// GET /tree?branch=main must return 200 with an empty JSON array on a fresh DB.
-	resp, err := http.Get(baseURL + "/tree?branch=main")
+	resp, err := http.Get(baseURL + "/repos/default/tree?branch=main")
 	if err != nil {
 		t.Fatalf("GET /tree: %v", err)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -59,47 +59,48 @@ type CommitFile struct {
 
 const defaultLimit = 100
 
-// MaterializeTree returns the current file tree for a branch, optionally at a
-// specific sequence. Pagination uses afterPath as the cursor.
-func (s *Store) MaterializeTree(ctx context.Context, branch string, atSequence *int64, limit int, afterPath string) ([]TreeEntry, error) {
+// MaterializeTree returns the current file tree for a branch in a repo,
+// optionally at a specific sequence. Pagination uses afterPath as the cursor.
+func (s *Store) MaterializeTree(ctx context.Context, repo, branch string, atSequence *int64, limit int, afterPath string) ([]TreeEntry, error) {
 	if limit <= 0 {
 		limit = defaultLimit
 	}
 
 	// The CTE computes the latest version of each path by combining:
-	//   - commits on the requested branch
+	//   - commits on the requested branch (within repo)
 	//   - commits on main up to the branch's base_sequence (inherited files)
 	// For main itself, base_sequence=0 so the second arm matches nothing.
 	const q = `
 WITH branch_info AS (
-    SELECT base_sequence FROM branches WHERE name = $1
+    SELECT base_sequence FROM branches WHERE repo = $1 AND name = $2
 ),
 latest AS (
     SELECT DISTINCT ON (fc.path)
         fc.path, fc.version_id
     FROM file_commits fc
     CROSS JOIN branch_info bi
-    WHERE (
-        fc.branch = $1
+    WHERE fc.repo = $1
+    AND (
+        fc.branch = $2
         OR (fc.branch = 'main' AND fc.sequence <= bi.base_sequence)
     )
-    AND ($2::bigint IS NULL OR fc.sequence <= $2)
+    AND ($3::bigint IS NULL OR fc.sequence <= $3)
     ORDER BY fc.path, fc.sequence DESC
 )
 SELECT l.path, l.version_id::text, d.content_hash
 FROM latest l
-JOIN documents d ON d.version_id = l.version_id
+JOIN documents d ON d.version_id = l.version_id AND d.repo = $1
 WHERE l.version_id IS NOT NULL
-  AND ($3::text = '' OR l.path > $3)
+  AND ($4::text = '' OR l.path > $4)
 ORDER BY l.path
-LIMIT $4`
+LIMIT $5`
 
 	var at interface{}
 	if atSequence != nil {
 		at = *atSequence
 	}
 
-	rows, err := s.db.QueryContext(ctx, q, branch, at, afterPath, limit)
+	rows, err := s.db.QueryContext(ctx, q, repo, branch, at, afterPath, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -116,23 +117,24 @@ LIMIT $4`
 	return entries, rows.Err()
 }
 
-// GetFile returns a file's content for a branch, optionally at a specific sequence.
+// GetFile returns a file's content for a branch in a repo, optionally at a specific sequence.
 // Returns nil, nil if the file does not exist or was deleted.
-func (s *Store) GetFile(ctx context.Context, branch, path string, atSequence *int64) (*FileContent, error) {
+func (s *Store) GetFile(ctx context.Context, repo, branch, path string, atSequence *int64) (*FileContent, error) {
 	const q = `
 WITH branch_info AS (
-    SELECT base_sequence FROM branches WHERE name = $1
+    SELECT base_sequence FROM branches WHERE repo = $1 AND name = $2
 )
 SELECT fc.version_id, d.content_hash, d.content
 FROM file_commits fc
 CROSS JOIN branch_info bi
-LEFT JOIN documents d ON d.version_id = fc.version_id
-WHERE (
-    fc.branch = $1
+LEFT JOIN documents d ON d.version_id = fc.version_id AND d.repo = $1
+WHERE fc.repo = $1
+AND (
+    fc.branch = $2
     OR (fc.branch = 'main' AND fc.sequence <= bi.base_sequence)
 )
-AND fc.path = $2
-AND ($3::bigint IS NULL OR fc.sequence <= $3)
+AND fc.path = $3
+AND ($4::bigint IS NULL OR fc.sequence <= $4)
 ORDER BY fc.sequence DESC
 LIMIT 1`
 
@@ -145,7 +147,7 @@ LIMIT 1`
 	var contentHash sql.NullString
 	var content []byte
 
-	err := s.db.QueryRowContext(ctx, q, branch, path, at).Scan(&versionID, &contentHash, &content)
+	err := s.db.QueryRowContext(ctx, q, repo, branch, path, at).Scan(&versionID, &contentHash, &content)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -166,36 +168,37 @@ LIMIT 1`
 	}, nil
 }
 
-// GetFileHistory returns the change history for a file on a branch.
+// GetFileHistory returns the change history for a file on a branch in a repo.
 // Pagination: afterSequence is the cursor (exclusive); pass nil for the first page.
-func (s *Store) GetFileHistory(ctx context.Context, branch, path string, limit int, afterSequence *int64) ([]FileHistoryEntry, error) {
+func (s *Store) GetFileHistory(ctx context.Context, repo, branch, path string, limit int, afterSequence *int64) ([]FileHistoryEntry, error) {
 	if limit <= 0 {
 		limit = defaultLimit
 	}
 
 	const q = `
 WITH branch_info AS (
-    SELECT base_sequence FROM branches WHERE name = $1
+    SELECT base_sequence FROM branches WHERE repo = $1 AND name = $2
 )
 SELECT fc.sequence, fc.version_id::text, c.message, c.author, c.created_at
 FROM file_commits fc
 CROSS JOIN branch_info bi
-JOIN commits c ON c.sequence = fc.sequence
-WHERE (
-    fc.branch = $1
+JOIN commits c ON c.sequence = fc.sequence AND c.repo = $1
+WHERE fc.repo = $1
+AND (
+    fc.branch = $2
     OR (fc.branch = 'main' AND fc.sequence <= bi.base_sequence)
 )
-AND fc.path = $2
-AND ($3::bigint IS NULL OR fc.sequence < $3)
+AND fc.path = $3
+AND ($4::bigint IS NULL OR fc.sequence < $4)
 ORDER BY fc.sequence DESC
-LIMIT $4`
+LIMIT $5`
 
 	var after interface{}
 	if afterSequence != nil {
 		after = *afterSequence
 	}
 
-	rows, err := s.db.QueryContext(ctx, q, branch, path, after, limit)
+	rows, err := s.db.QueryContext(ctx, q, repo, branch, path, after, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -244,19 +247,20 @@ type DiffResult struct {
 	Conflicts     []ConflictEntry `json:"conflicts,omitempty"`
 }
 
-// ListBranches returns all branches, optionally filtered by status.
-func (s *Store) ListBranches(ctx context.Context, statusFilter string) ([]BranchInfo, error) {
+// ListBranches returns all branches in a repo, optionally filtered by status.
+func (s *Store) ListBranches(ctx context.Context, repo, statusFilter string) ([]BranchInfo, error) {
 	var rows *sql.Rows
 	var err error
 
 	if statusFilter != "" {
 		rows, err = s.db.QueryContext(ctx,
-			"SELECT name, head_sequence, base_sequence, status FROM branches WHERE status = $1::branch_status ORDER BY name",
-			statusFilter,
+			"SELECT name, head_sequence, base_sequence, status FROM branches WHERE repo = $1 AND status = $2::branch_status ORDER BY name",
+			repo, statusFilter,
 		)
 	} else {
 		rows, err = s.db.QueryContext(ctx,
-			"SELECT name, head_sequence, base_sequence, status FROM branches ORDER BY name",
+			"SELECT name, head_sequence, base_sequence, status FROM branches WHERE repo = $1 ORDER BY name",
+			repo,
 		)
 	}
 	if err != nil {
@@ -277,13 +281,13 @@ func (s *Store) ListBranches(ctx context.Context, statusFilter string) ([]Branch
 
 // GetDiff returns the files changed on a branch relative to its base_sequence,
 // plus any conflicting paths that were also changed on main.
-func (s *Store) GetDiff(ctx context.Context, branch string) (*DiffResult, error) {
+func (s *Store) GetDiff(ctx context.Context, repo, branch string) (*DiffResult, error) {
 	// Get the branch's base_sequence.
 	var baseSeq int64
 	var status string
 	err := s.db.QueryRowContext(ctx,
-		"SELECT base_sequence, status FROM branches WHERE name = $1",
-		branch,
+		"SELECT base_sequence, status FROM branches WHERE repo = $1 AND name = $2",
+		repo, branch,
 	).Scan(&baseSeq, &status)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -293,13 +297,13 @@ func (s *Store) GetDiff(ctx context.Context, branch string) (*DiffResult, error)
 	}
 
 	// Branch changes: latest version of each path changed on branch since base.
-	branchChanges, err := s.latestChanges(ctx, branch, baseSeq)
+	branchChanges, err := s.latestChanges(ctx, repo, branch, baseSeq)
 	if err != nil {
 		return nil, err
 	}
 
 	// Main changes: latest version of each path changed on main since base.
-	mainChanges, err := s.latestChanges(ctx, "main", baseSeq)
+	mainChanges, err := s.latestChanges(ctx, repo, "main", baseSeq)
 	if err != nil {
 		return nil, err
 	}
@@ -341,15 +345,15 @@ func (s *Store) GetDiff(ctx context.Context, branch string) (*DiffResult, error)
 }
 
 // latestChanges returns the latest version of each path changed on a branch
-// since the given base sequence.
-func (s *Store) latestChanges(ctx context.Context, branch string, baseSeq int64) (map[string]*string, error) {
+// in a repo since the given base sequence.
+func (s *Store) latestChanges(ctx context.Context, repo, branch string, baseSeq int64) (map[string]*string, error) {
 	const q = `
 SELECT DISTINCT ON (path) path, version_id::text
 FROM file_commits
-WHERE branch = $1 AND sequence > $2
+WHERE repo = $1 AND branch = $2 AND sequence > $3
 ORDER BY path, sequence DESC`
 
-	rows, err := s.db.QueryContext(ctx, q, branch, baseSeq)
+	rows, err := s.db.QueryContext(ctx, q, repo, branch, baseSeq)
 	if err != nil {
 		return nil, err
 	}
@@ -372,17 +376,17 @@ ORDER BY path, sequence DESC`
 	return changes, rows.Err()
 }
 
-// GetCommit returns all file changes in a single atomic commit (by sequence).
-// Returns nil, nil if no commit exists with that sequence.
-func (s *Store) GetCommit(ctx context.Context, sequence int64) (*CommitDetail, error) {
+// GetCommit returns all file changes in a single atomic commit (by sequence) within a repo.
+// Returns nil, nil if no commit exists with that sequence in the repo.
+func (s *Store) GetCommit(ctx context.Context, repo string, sequence int64) (*CommitDetail, error) {
 	const q = `
 SELECT fc.commit_id::text, fc.path, fc.version_id::text, fc.branch, c.message, c.author, c.created_at
 FROM file_commits fc
-JOIN commits c ON c.sequence = fc.sequence
-WHERE fc.sequence = $1
+JOIN commits c ON c.sequence = fc.sequence AND c.repo = $1
+WHERE fc.repo = $1 AND fc.sequence = $2
 ORDER BY fc.path`
 
-	rows, err := s.db.QueryContext(ctx, q, sequence)
+	rows, err := s.db.QueryContext(ctx, q, repo, sequence)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -77,7 +77,7 @@ func TestMaterializeTree(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("head of main", func(t *testing.T) {
-		entries, err := s.MaterializeTree(ctx, "main", nil, 100, "")
+		entries, err := s.MaterializeTree(ctx, "default", "main", nil, 100, "")
 		if err != nil {
 			t.Fatalf("MaterializeTree: %v", err)
 		}
@@ -98,7 +98,7 @@ func TestMaterializeTree(t *testing.T) {
 
 	t.Run("at sequence 1", func(t *testing.T) {
 		seq := int64(1)
-		entries, err := s.MaterializeTree(ctx, "main", &seq, 100, "")
+		entries, err := s.MaterializeTree(ctx, "default", "main", &seq, 100, "")
 		if err != nil {
 			t.Fatalf("MaterializeTree: %v", err)
 		}
@@ -113,7 +113,7 @@ func TestMaterializeTree(t *testing.T) {
 
 	t.Run("at sequence 3 includes deleted file", func(t *testing.T) {
 		seq := int64(3)
-		entries, err := s.MaterializeTree(ctx, "main", &seq, 100, "")
+		entries, err := s.MaterializeTree(ctx, "default", "main", &seq, 100, "")
 		if err != nil {
 			t.Fatalf("MaterializeTree: %v", err)
 		}
@@ -124,7 +124,7 @@ func TestMaterializeTree(t *testing.T) {
 	})
 
 	t.Run("pagination", func(t *testing.T) {
-		entries, err := s.MaterializeTree(ctx, "main", nil, 1, "")
+		entries, err := s.MaterializeTree(ctx, "default", "main", nil, 1, "")
 		if err != nil {
 			t.Fatalf("MaterializeTree: %v", err)
 		}
@@ -136,7 +136,7 @@ func TestMaterializeTree(t *testing.T) {
 		}
 
 		// Second page
-		entries2, err := s.MaterializeTree(ctx, "main", nil, 1, entries[0].Path)
+		entries2, err := s.MaterializeTree(ctx, "default", "main", nil, 1, entries[0].Path)
 		if err != nil {
 			t.Fatalf("MaterializeTree page 2: %v", err)
 		}
@@ -156,7 +156,7 @@ func TestGetFile(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("current version", func(t *testing.T) {
-		fc, err := s.GetFile(ctx, "main", "hello.txt", nil)
+		fc, err := s.GetFile(ctx, "default", "main", "hello.txt", nil)
 		if err != nil {
 			t.Fatalf("GetFile: %v", err)
 		}
@@ -173,7 +173,7 @@ func TestGetFile(t *testing.T) {
 
 	t.Run("at sequence 1", func(t *testing.T) {
 		seq := int64(1)
-		fc, err := s.GetFile(ctx, "main", "hello.txt", &seq)
+		fc, err := s.GetFile(ctx, "default", "main", "hello.txt", &seq)
 		if err != nil {
 			t.Fatalf("GetFile: %v", err)
 		}
@@ -186,7 +186,7 @@ func TestGetFile(t *testing.T) {
 	})
 
 	t.Run("deleted file returns nil", func(t *testing.T) {
-		fc, err := s.GetFile(ctx, "main", "deleted.txt", nil)
+		fc, err := s.GetFile(ctx, "default", "main", "deleted.txt", nil)
 		if err != nil {
 			t.Fatalf("GetFile: %v", err)
 		}
@@ -196,7 +196,7 @@ func TestGetFile(t *testing.T) {
 	})
 
 	t.Run("nonexistent file", func(t *testing.T) {
-		fc, err := s.GetFile(ctx, "main", "nope.txt", nil)
+		fc, err := s.GetFile(ctx, "default", "main", "nope.txt", nil)
 		if err != nil {
 			t.Fatalf("GetFile: %v", err)
 		}
@@ -213,7 +213,7 @@ func TestGetFileHistory(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("hello.txt history", func(t *testing.T) {
-		entries, err := s.GetFileHistory(ctx, "main", "hello.txt", 100, nil)
+		entries, err := s.GetFileHistory(ctx, "default", "main", "hello.txt", 100, nil)
 		if err != nil {
 			t.Fatalf("GetFileHistory: %v", err)
 		}
@@ -230,7 +230,7 @@ func TestGetFileHistory(t *testing.T) {
 	})
 
 	t.Run("deleted.txt history includes delete", func(t *testing.T) {
-		entries, err := s.GetFileHistory(ctx, "main", "deleted.txt", 100, nil)
+		entries, err := s.GetFileHistory(ctx, "default", "main", "deleted.txt", 100, nil)
 		if err != nil {
 			t.Fatalf("GetFileHistory: %v", err)
 		}
@@ -248,7 +248,7 @@ func TestGetFileHistory(t *testing.T) {
 
 	t.Run("pagination with after cursor", func(t *testing.T) {
 		after := int64(2)
-		entries, err := s.GetFileHistory(ctx, "main", "hello.txt", 100, &after)
+		entries, err := s.GetFileHistory(ctx, "default", "main", "hello.txt", 100, &after)
 		if err != nil {
 			t.Fatalf("GetFileHistory: %v", err)
 		}
@@ -268,7 +268,7 @@ func TestGetCommit(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("multi-file commit", func(t *testing.T) {
-		detail, err := s.GetCommit(ctx, 1)
+		detail, err := s.GetCommit(ctx, "default", 1)
 		if err != nil {
 			t.Fatalf("GetCommit: %v", err)
 		}
@@ -297,7 +297,7 @@ func TestGetCommit(t *testing.T) {
 	})
 
 	t.Run("single-file commit", func(t *testing.T) {
-		detail, err := s.GetCommit(ctx, 2)
+		detail, err := s.GetCommit(ctx, "default", 2)
 		if err != nil {
 			t.Fatalf("GetCommit: %v", err)
 		}
@@ -310,7 +310,7 @@ func TestGetCommit(t *testing.T) {
 	})
 
 	t.Run("delete commit has nil version_id", func(t *testing.T) {
-		detail, err := s.GetCommit(ctx, 4)
+		detail, err := s.GetCommit(ctx, "default", 4)
 		if err != nil {
 			t.Fatalf("GetCommit: %v", err)
 		}
@@ -323,7 +323,7 @@ func TestGetCommit(t *testing.T) {
 	})
 
 	t.Run("nonexistent sequence", func(t *testing.T) {
-		detail, err := s.GetCommit(ctx, 999)
+		detail, err := s.GetCommit(ctx, "default", 999)
 		if err != nil {
 			t.Fatalf("GetCommit: %v", err)
 		}
@@ -351,7 +351,7 @@ func TestListBranches(t *testing.T) {
 	}
 
 	t.Run("all branches", func(t *testing.T) {
-		branches, err := s.ListBranches(ctx, "")
+		branches, err := s.ListBranches(ctx, "default", "")
 		if err != nil {
 			t.Fatalf("ListBranches: %v", err)
 		}
@@ -365,7 +365,7 @@ func TestListBranches(t *testing.T) {
 	})
 
 	t.Run("filter active", func(t *testing.T) {
-		branches, err := s.ListBranches(ctx, "active")
+		branches, err := s.ListBranches(ctx, "default", "active")
 		if err != nil {
 			t.Fatalf("ListBranches: %v", err)
 		}
@@ -375,7 +375,7 @@ func TestListBranches(t *testing.T) {
 	})
 
 	t.Run("filter merged", func(t *testing.T) {
-		branches, err := s.ListBranches(ctx, "merged")
+		branches, err := s.ListBranches(ctx, "default", "merged")
 		if err != nil {
 			t.Fatalf("ListBranches: %v", err)
 		}
@@ -419,7 +419,7 @@ func TestGetDiff(t *testing.T) {
 	}
 
 	t.Run("diff shows branch changes", func(t *testing.T) {
-		result, err := s.GetDiff(ctx, "feature/diff")
+		result, err := s.GetDiff(ctx, "default", "feature/diff")
 		if err != nil {
 			t.Fatalf("GetDiff: %v", err)
 		}
@@ -435,7 +435,7 @@ func TestGetDiff(t *testing.T) {
 		// Main also changed hello.txt at seq 3-4 (deleted.txt at seq 3, 4),
 		// but hello.txt was only changed at seq 2 on main (which is <= base_sequence=2).
 		// So no conflicts by default from the seed data because main changes at seq 3,4 are deleted.txt.
-		result, err := s.GetDiff(ctx, "feature/diff")
+		result, err := s.GetDiff(ctx, "default", "feature/diff")
 		if err != nil {
 			t.Fatalf("GetDiff: %v", err)
 		}
@@ -448,7 +448,7 @@ func TestGetDiff(t *testing.T) {
 
 	t.Run("diff includes main_changes", func(t *testing.T) {
 		// Main changed deleted.txt at seq 3 (add) and seq 4 (delete) since base=2.
-		result, err := s.GetDiff(ctx, "feature/diff")
+		result, err := s.GetDiff(ctx, "default", "feature/diff")
 		if err != nil {
 			t.Fatalf("GetDiff: %v", err)
 		}
@@ -461,7 +461,7 @@ func TestGetDiff(t *testing.T) {
 	})
 
 	t.Run("nonexistent branch", func(t *testing.T) {
-		result, err := s.GetDiff(ctx, "nonexistent")
+		result, err := s.GetDiff(ctx, "default", "nonexistent")
 		if err != nil {
 			t.Fatalf("GetDiff: %v", err)
 		}
@@ -513,7 +513,7 @@ func TestGetDiff_WithConflict(t *testing.T) {
 		}
 	}
 
-	result, err := s.GetDiff(ctx, "feature/conflict")
+	result, err := s.GetDiff(ctx, "default", "feature/conflict")
 	if err != nil {
 		t.Fatalf("GetDiff: %v", err)
 	}
@@ -553,7 +553,7 @@ func TestBranchTree(t *testing.T) {
 		}
 	}
 
-	entries, err := s.MaterializeTree(ctx, "feature/test", nil, 100, "")
+	entries, err := s.MaterializeTree(ctx, "default", "feature/test", nil, 100, "")
 	if err != nil {
 		t.Fatalf("MaterializeTree: %v", err)
 	}


### PR DESCRIPTION
## Summary

- **Migration 003**: adds `repos` table, scopes all 7 data tables with a `repo TEXT NOT NULL DEFAULT 'default'` column, changes `branches` PK to `(repo, name)`, drops and updates FKs, updates all indexes to lead with `repo`. Seeds `default` repo + `main` branch on startup.
- **Routes**: all existing routes are now prefixed `/repos/:name/...`. New endpoints: `POST /repos`, `GET /repos`, `GET /repos/:name`, `DELETE /repos/:name` (hard delete, transaction).
- **Store**: all `db.Store` and `store.Store` functions accept `repo` as part of the request or as an explicit parameter.
- **CLI**: `Config` gains a `Repo` field; `ds init` accepts a `--repo` flag or parses the repo from a `/repos/:name` URL suffix. All API calls use `repoBase(cfg) = remote + "/repos/" + repo`.
- **Tests**: all existing tests updated for new signatures and routes. New tests: `TestCreateRepo_*`, `TestDeleteRepo_*`, `TestRepoIsolation_*`, `TestIntegrationMultiRepo_FullIsolation`, `TestIntegrationDeleteRepo_CleansUp`, `TestHandleCreateRepo_*`, etc.
- **IAP merge conflict resolved**: combined with PR #36 (IAP middleware) — repo-scoped routes are wrapped by `IAPMiddleware`; author always comes from `IdentityFromContext`.

## Key decisions carried through
- Per-repo document isolation (no cross-repo dedup)
- Hard delete (`DELETE /repos/:name` removes everything in one transaction)
- No legacy route deprecation — cut over immediately
- Global BIGSERIAL sequences (gaps per-repo acceptable)
- `DEFAULT 'default'` on all `repo` columns so raw test SQL inserts continue to work

## Test plan
- [x] `go test ./... -short` passes (all packages green)
- [x] `TestRepoIsolation_*` — two repos can't see each other's branches/commits
- [x] `TestDeleteRepo_RemovesAllData` — all tables cleared for deleted repo
- [x] `TestDeleteRepo_DoesNotAffectOtherRepo` — sibling repo unaffected
- [x] `TestIntegrationMultiRepo_FullIsolation` — end-to-end two-repo isolation via HTTP
- [x] `TestIntegrationDeleteRepo_CleansUp` — repo 404s after delete
- [x] Full CLI e2e workflow passes against real DB

## Opportunities noted (not implemented)
- Per-repo sequence counters (cleaner UX; deferred per issue decision)
- `DELETE /repos/:name` authorization gate (depends on #28 RBAC)
- Deprecation redirect from legacy unscoped routes (explicitly cut-over per task spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)