### PR TITLE
Fix 5 code-review bugs from multitenancy PR #37

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -190,15 +190,17 @@ func (a *App) Init(remote, repo, author string) error {
 	}
 
 	// Extract repo from remote URL if embedded (e.g. https://host/repos/myrepo).
+	// Strip the /repos/:name suffix from the base URL whether or not --repo was
+	// provided explicitly, so that we never end up with a doubled path prefix.
 	baseRemote := strings.TrimRight(remote, "/")
-	if repo == "" {
-		if idx := strings.Index(baseRemote, "/repos/"); idx >= 0 {
+	if idx := strings.Index(baseRemote, "/repos/"); idx >= 0 {
+		if repo == "" {
 			parts := strings.SplitN(baseRemote[idx+len("/repos/"):], "/", 2)
 			repo = parts[0]
-			baseRemote = baseRemote[:idx]
-		} else {
-			repo = "default"
 		}
+		baseRemote = baseRemote[:idx]
+	} else if repo == "" {
+		repo = "default"
 	}
 
 	cfg := &Config{

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -132,6 +132,48 @@ func TestInitTrimsTrailingSlash(t *testing.T) {
 	}
 }
 
+// TestInitRepoFlagStripsURLSuffix verifies that when --repo is passed explicitly
+// alongside a URL that already contains /repos/:name, the /repos/:name suffix is
+// still stripped from baseRemote.  Without the fix this produced doubled paths
+// like .../repos/myrepo/repos/myrepo/...
+func TestInitRepoFlagStripsURLSuffix(t *testing.T) {
+	// The mock server registers the /repos/myrepo/* paths that Init will call.
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/repos/myrepo/tree":
+			json.NewEncoder(w).Encode([]treeEntry{})
+		case r.Method == "GET" && r.URL.Path == "/repos/myrepo/branches":
+			json.NewEncoder(w).Encode([]model.Branch{{Name: "main", HeadSequence: 0}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+
+	// Pass a URL that already embeds the /repos/myrepo suffix AND an explicit
+	// --repo flag with the same name.
+	embeddedURL := srv.URL + "/repos/myrepo"
+	if err := app.Init(embeddedURL, "myrepo", "carol"); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	cfg, err := app.loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Remote must be the bare host, not .../repos/myrepo.
+	if cfg.Remote != srv.URL {
+		t.Errorf("remote = %q, want %q (suffix must be stripped)", cfg.Remote, srv.URL)
+	}
+	if cfg.Repo != "myrepo" {
+		t.Errorf("repo = %q, want %q", cfg.Repo, "myrepo")
+	}
+}
+
 func TestInitDefaultAuthor(t *testing.T) {
 	srv := newEmptyRepoServer(t)
 	defer srv.Close()

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -52,14 +52,22 @@ func NewStore(db *sql.DB) *Store {
 	return &Store{db: db}
 }
 
-// CreateRepo creates a new repo. Returns ErrRepoExists if the name is taken.
+// CreateRepo creates a new repo and seeds its main branch in a single
+// transaction. Returns ErrRepoExists if the name is taken.
 func (s *Store) CreateRepo(ctx context.Context, req model.CreateRepoRequest) (*model.Repo, error) {
 	createdBy := req.CreatedBy
 	if createdBy == "" {
 		createdBy = "system"
 	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
 	var r model.Repo
-	err := s.db.QueryRowContext(ctx,
+	err = tx.QueryRowContext(ctx,
 		`INSERT INTO repos (name, created_by) VALUES ($1, $2)
 		 RETURNING name, created_at, created_by`,
 		req.Name, createdBy,
@@ -72,12 +80,16 @@ func (s *Store) CreateRepo(ctx context.Context, req model.CreateRepoRequest) (*m
 	}
 
 	// Seed the main branch for the new repo.
-	_, err = s.db.ExecContext(ctx,
+	_, err = tx.ExecContext(ctx,
 		"INSERT INTO branches (repo, name, head_sequence, base_sequence, status) VALUES ($1, 'main', 0, 0, 'active')",
 		req.Name,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("seed main branch: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit tx: %w", err)
 	}
 
 	return &r, nil
@@ -276,12 +288,16 @@ func (s *Store) CreateBranch(ctx context.Context, req model.CreateBranchRequest)
 	defer tx.Rollback()
 
 	// Read main's head to set as the base_sequence.
+	// If main doesn't exist the repo itself doesn't exist.
 	var mainHead int64
 	err = tx.QueryRowContext(ctx,
 		"SELECT head_sequence FROM branches WHERE repo = $1 AND name = 'main' FOR UPDATE",
 		req.Repo,
 	).Scan(&mainHead)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrRepoNotFound
+		}
 		return nil, fmt.Errorf("read main head: %w", err)
 	}
 
@@ -293,6 +309,9 @@ func (s *Store) CreateBranch(ctx context.Context, req model.CreateBranchRequest)
 	if err != nil {
 		if isDuplicateKeyError(err) {
 			return nil, ErrBranchExists
+		}
+		if isForeignKeyViolation(err) {
+			return nil, ErrRepoNotFound
 		}
 		return nil, fmt.Errorf("insert branch: %w", err)
 	}
@@ -701,6 +720,15 @@ func isDuplicateKeyError(err error) bool {
 	var pqErr *pq.Error
 	if errors.As(err, &pqErr) {
 		return pqErr.Code == "23505"
+	}
+	return false
+}
+
+// isForeignKeyViolation checks if a PostgreSQL error is a FK violation (23503).
+func isForeignKeyViolation(err error) bool {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pqErr.Code == "23503"
 	}
 	return false
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -1262,13 +1262,34 @@ func TestDeleteRepo_RemovesAllData(t *testing.T) {
 		t.Fatalf("Commit: %v", err)
 	}
 
+	// Seed a role, a review, and a check_run for the repo so we can verify
+	// they are all cleaned up on deletion.
+	_, err = d.Exec(
+		"INSERT INTO roles (repo, identity, role) VALUES ('todelete', 'alice', 'writer')",
+	)
+	if err != nil {
+		t.Fatalf("insert role: %v", err)
+	}
+	_, err = d.Exec(
+		"INSERT INTO reviews (repo, id, branch, reviewer, sequence, status) VALUES ('todelete', gen_random_uuid(), 'main', 'alice', 1, 'approved')",
+	)
+	if err != nil {
+		t.Fatalf("insert review: %v", err)
+	}
+	_, err = d.Exec(
+		"INSERT INTO check_runs (repo, id, branch, sequence, check_name, status, reporter) VALUES ('todelete', gen_random_uuid(), 'main', 1, 'ci', 'passed', 'ci-bot')",
+	)
+	if err != nil {
+		t.Fatalf("insert check_run: %v", err)
+	}
+
 	// Delete the repo.
 	if err := s.DeleteRepo(ctx, "todelete"); err != nil {
 		t.Fatalf("DeleteRepo: %v", err)
 	}
 
-	// All data should be gone.
-	for _, table := range []string{"branches", "commits", "file_commits", "documents"} {
+	// All data should be gone — including reviews, check_runs, and roles.
+	for _, table := range []string{"branches", "commits", "file_commits", "documents", "reviews", "check_runs", "roles"} {
 		var count int
 		err = d.QueryRow("SELECT count(*) FROM "+table+" WHERE repo = 'todelete'").Scan(&count)
 		if err != nil {
@@ -1335,6 +1356,52 @@ func TestDeleteRepo_NotFound(t *testing.T) {
 	ctx := context.Background()
 
 	err := s.DeleteRepo(ctx, "nonexistent")
+	if err != ErrRepoNotFound {
+		t.Fatalf("expected ErrRepoNotFound, got %v", err)
+	}
+}
+
+// TestCreateRepo_IsAtomic verifies that if the process were to fail between the
+// repo INSERT and the main-branch INSERT, the caller would not observe a half-
+// created repo.  Since we cannot inject a crash mid-transaction, we verify the
+// positive invariant: after a successful CreateRepo the repo and its main branch
+// always exist together.
+func TestCreateRepo_IsAtomic(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.CreateRepo(ctx, model.CreateRepoRequest{Name: "atomic-repo"})
+	if err != nil {
+		t.Fatalf("CreateRepo: %v", err)
+	}
+
+	// Both the repo row and its main branch must be present.
+	var repoExists bool
+	if err := d.QueryRow("SELECT EXISTS(SELECT 1 FROM repos WHERE name = 'atomic-repo')").Scan(&repoExists); err != nil {
+		t.Fatal(err)
+	}
+	if !repoExists {
+		t.Error("expected repo row to exist")
+	}
+
+	var branchStatus string
+	if err := d.QueryRow("SELECT status FROM branches WHERE repo = 'atomic-repo' AND name = 'main'").Scan(&branchStatus); err != nil {
+		t.Fatalf("expected main branch, got error: %v", err)
+	}
+	if branchStatus != "active" {
+		t.Errorf("expected main branch active, got %q", branchStatus)
+	}
+}
+
+// TestCreateBranch_RepoNotFound verifies that creating a branch for a repo that
+// does not exist returns ErrRepoNotFound rather than an opaque error.
+func TestCreateBranch_RepoNotFound(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "no-such-repo", Name: "feature/x"})
 	if err != ErrRepoNotFound {
 		t.Fatalf("expected ErrRepoNotFound, got %v", err)
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -16,6 +16,23 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, map[string]string{"error": msg})
 }
 
+// validateRepo checks that the named repo exists. It writes a 404 and returns
+// false when the repo is not found, so callers can do:
+//
+//	if !s.validateRepo(w, r, repo) { return }
+func (s *server) validateRepo(w http.ResponseWriter, r *http.Request, repo string) bool {
+	_, err := s.commitStore.GetRepo(r.Context(), repo)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			writeError(w, http.StatusNotFound, "repo not found")
+		} else {
+			writeError(w, http.StatusInternalServerError, "query failed")
+		}
+		return false
+	}
+	return true
+}
+
 // handleCreateRepo implements POST /repos
 func (s *server) handleCreateRepo(w http.ResponseWriter, r *http.Request) {
 	var req model.CreateRepoRequest
@@ -92,6 +109,9 @@ func (s *server) handleDeleteRepo(w http.ResponseWriter, r *http.Request) {
 // handleTree implements GET /repos/:name/tree?branch=main&at=N&limit=N&after=cursor
 func (s *server) handleTree(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
 	branch := r.URL.Query().Get("branch")
 	if branch == "" {
 		branch = "main"
@@ -137,6 +157,9 @@ func (s *server) handleTree(w http.ResponseWriter, r *http.Request) {
 // Query params: branch (default "main"), at (sequence), limit, after (cursor).
 func (s *server) handleFile(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
 	fullPath := r.PathValue("path")
 
 	// Check for /history suffix.
@@ -241,6 +264,9 @@ func (s *server) handleGetCommit(w http.ResponseWriter, r *http.Request) {
 // handleBranches implements GET /repos/:name/branches?status=active
 func (s *server) handleBranches(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
 	statusFilter := r.URL.Query().Get("status")
 
 	branches, err := s.readStore.ListBranches(r.Context(), repo, statusFilter)
@@ -257,6 +283,9 @@ func (s *server) handleBranches(w http.ResponseWriter, r *http.Request) {
 // handleDiff implements GET /repos/:name/diff?branch=X
 func (s *server) handleDiff(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
 	branch := r.URL.Query().Get("branch")
 	if branch == "" {
 		writeError(w, http.StatusBadRequest, "branch parameter is required")
@@ -320,6 +349,8 @@ func (s *server) handleCreateBranch(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, db.ErrBranchExists):
 			writeError(w, http.StatusConflict, "branch already exists")
+		case errors.Is(err, db.ErrRepoNotFound):
+			writeError(w, http.StatusNotFound, "repo not found")
 		default:
 			writeError(w, http.StatusInternalServerError, "internal server error")
 		}

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -19,6 +19,8 @@ func seed(t *testing.T, db *sql.DB) {
 	t.Helper()
 
 	stmts := []string{
+		// Ensure the 'default' repo row exists so validateRepo passes.
+		`INSERT INTO repos (name) VALUES ('default') ON CONFLICT DO NOTHING`,
 		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
 		 VALUES ('aaaaaaaa-0000-0000-0000-000000000001', 'hello.txt', 'hello world', 'hash_hello_v1', 'alice')`,
 		`INSERT INTO documents (version_id, path, content, content_hash, created_by)
@@ -57,7 +59,7 @@ func seed(t *testing.T, db *sql.DB) {
 func TestIntegrationTreeEndpoint(t *testing.T) {
 	db := testutil.TestDB(t, dbpkg.MigrationSQL)
 	seed(t, db)
-	handler := server.New(nil, db, "test@example.com")
+	handler := server.New(dbpkg.NewStore(db), db, "test@example.com")
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -84,7 +86,7 @@ func TestIntegrationTreeEndpoint(t *testing.T) {
 func TestIntegrationFileEndpoint(t *testing.T) {
 	db := testutil.TestDB(t, dbpkg.MigrationSQL)
 	seed(t, db)
-	handler := server.New(nil, db, "test@example.com")
+	handler := server.New(dbpkg.NewStore(db), db, "test@example.com")
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -175,7 +177,7 @@ func TestIntegrationBranchesEndpoint(t *testing.T) {
 		t.Fatalf("seed branch: %v", err)
 	}
 
-	handler := server.New(nil, database, "test@example.com")
+	handler := server.New(dbpkg.NewStore(database), database, "test@example.com")
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -241,7 +243,7 @@ func TestIntegrationDiffEndpoint(t *testing.T) {
 		}
 	}
 
-	handler := server.New(nil, database, "test@example.com")
+	handler := server.New(dbpkg.NewStore(database), database, "test@example.com")
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -375,6 +375,94 @@ func TestHandleCreateBranch_AlreadyExists(t *testing.T) {
 	}
 }
 
+func TestHandleCreateBranch_RepoNotFound(t *testing.T) {
+	store := &mockStore{
+		createBranchFn: func(ctx context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error) {
+			return nil, db.ErrRepoNotFound
+		},
+	}
+	srv := New(store, nil, devID)
+
+	body, _ := json.Marshal(model.CreateBranchRequest{Name: "feature/x"})
+	req := httptest.NewRequest(http.MethodPost, "/repos/nonexistent/branch", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+// --- validateRepo / nonexistent repo tests ---
+
+func TestHandleTree_RepoNotFound(t *testing.T) {
+	store := &mockStore{
+		getRepoFn: func(ctx context.Context, name string) (*model.Repo, error) {
+			return nil, db.ErrRepoNotFound
+		},
+	}
+	srv := New(store, nil, devID)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/ghost/tree?branch=main", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleBranches_RepoNotFound(t *testing.T) {
+	store := &mockStore{
+		getRepoFn: func(ctx context.Context, name string) (*model.Repo, error) {
+			return nil, db.ErrRepoNotFound
+		},
+	}
+	srv := New(store, nil, devID)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/ghost/branches", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleDiff_RepoNotFound(t *testing.T) {
+	store := &mockStore{
+		getRepoFn: func(ctx context.Context, name string) (*model.Repo, error) {
+			return nil, db.ErrRepoNotFound
+		},
+	}
+	srv := New(store, nil, devID)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/ghost/diff?branch=main", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleFile_RepoNotFound(t *testing.T) {
+	store := &mockStore{
+		getRepoFn: func(ctx context.Context, name string) (*model.Repo, error) {
+			return nil, db.ErrRepoNotFound
+		},
+	}
+	srv := New(store, nil, devID)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/ghost/file/foo.txt", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
 // --- POST /repos/default/merge tests ---
 
 func TestHandleMerge_Success(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes all 5 bugs identified in the code review of the multitenancy PR (#37):

- **[HIGH] CLI double-prefix bug** (`internal/cli/app.go`): `Init()` now strips the `/repos/:name` suffix from `baseRemote` regardless of whether `--repo` is provided explicitly, preventing doubled URL paths like `.../repos/myrepo/repos/myrepo/...`

- **[MEDIUM] CreateRepo not transactional** (`internal/db/store.go`): Wrapped the `repos` INSERT and `main` branch INSERT in a single transaction. A crash between them can no longer leave a repo with no main branch.

- **[MEDIUM] POST /repos/:name/branch returns 500 for nonexistent repo** (`internal/db/store.go`, `internal/server/handlers.go`): Added `isForeignKeyViolation` helper (checks pg code 23503). `CreateBranch` now returns `ErrRepoNotFound` when `SELECT ... main FOR UPDATE` yields no rows (repo not found) or when the INSERT hits a FK violation. Handler maps `ErrRepoNotFound` → 404.

- **[LOW] TestDeleteRepo_RemovesAllData misses reviews/check_runs/roles** (`internal/db/store_test.go`): Extended the cleanup-verification loop to include those three tables and seeds data into them before deletion so the assertions are meaningful.

- **[MEDIUM] Repo-scoped endpoints return 200/empty for nonexistent repos** (`internal/server/handlers.go`): Added `validateRepo` helper that calls `GetRepo` and writes 404 on `ErrRepoNotFound`. Called at the top of `handleTree`, `handleBranches`, `handleDiff`, and `handleFile`.

## Test plan

- [ ] `go test ./internal/cli/...` — covers `TestInitRepoFlagStripsURLSuffix` (fix 1)
- [ ] `go test ./internal/db/...` — covers `TestCreateRepo_IsAtomic`, `TestCreateBranch_RepoNotFound`, updated `TestDeleteRepo_RemovesAllData` (fixes 2, 3, 4)
- [ ] `go test ./internal/server/` — covers `TestHandleCreateBranch_RepoNotFound`, `TestHandleTree_RepoNotFound`, `TestHandleBranches_RepoNotFound`, `TestHandleDiff_RepoNotFound`, `TestHandleFile_RepoNotFound` (fixes 3, 5)

## Opportunities noted (not implemented)

- Other write endpoints (`POST /commit`, `/merge`, `/rebase`) could also benefit from `validateRepo` pre-checks to return consistent 404s instead of relying on FK errors bubbling up. Left as follow-up to keep scope focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)