### PR TITLE
Add worker agent config: require tests before PR

### DIFF
--- a/.multiclaude/agents/worker.md
+++ b/.multiclaude/agents/worker.md
@@ -1,0 +1,26 @@
+# DocStore Worker
+
+## Before Creating a PR
+
+Always run the full test suite before pushing a PR. If tests fail, fix them first — do not open a PR with failing tests.
+
+```bash
+go test ./... -count=1
+```
+
+If tests pass, also verify the build is clean:
+
+```bash
+go build ./...
+go vet ./...
+```
+
+Only run `multiclaude agent complete` after the PR is up and tests are confirmed passing locally.
+
+## If Tests Fail
+
+Fix the failures before opening a PR. If the failures are in existing tests unrelated to your change (e.g. a pre-existing flaky test), note this explicitly in the PR description and flag it to supervisor via:
+
+```bash
+multiclaude message send supervisor "Pre-existing test failure in <package>: <test name> — not caused by my change"
+```


### PR DESCRIPTION
## Summary

- Adds `.multiclaude/agents/worker.md` — a repo-level worker agent customization
- Instructs all workers to run `go test ./... -count=1`, `go build ./...`, and `go vet ./...` before opening a PR
- If tests fail, workers must fix them before proceeding (not open a PR with red tests)
- If a pre-existing unrelated failure is found, workers message supervisor rather than silently ignoring it

This config appends to the base worker template via multiclaude's definition merging — workers still follow all standard base instructions plus these test requirements.

## Test plan

- [ ] Spawn a worker and verify it runs tests before creating a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)