### PR TITLE
Fix repo-not-found 404 on handleCommit, handleMerge, handleRebase

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -388,6 +388,9 @@ func (s *server) handleDeleteBranch(w http.ResponseWriter, r *http.Request) {
 // handleRebase implements POST /repos/:name/rebase
 func (s *server) handleRebase(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
 
 	var req model.RebaseRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -437,6 +440,9 @@ func (s *server) handleRebase(w http.ResponseWriter, r *http.Request) {
 // handleMerge implements POST /repos/:name/merge
 func (s *server) handleMerge(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
 
 	var req model.MergeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -82,6 +82,9 @@ type server struct {
 
 func (s *server) handleCommit(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
 
 	var req model.CommitRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -86,7 +86,7 @@ func (m *mockStore) GetRepo(ctx context.Context, name string) (*model.Repo, erro
 	if m.getRepoFn != nil {
 		return m.getRepoFn(ctx, name)
 	}
-	return nil, errors.New("not implemented")
+	return &model.Repo{Name: name}, nil
 }
 
 func TestHealthEndpoint(t *testing.T) {
@@ -796,5 +796,75 @@ func TestHandleRebase_BranchNotActive(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleCommit_RepoNotFound(t *testing.T) {
+	store := &mockStore{
+		getRepoFn: func(ctx context.Context, name string) (*model.Repo, error) {
+			return nil, db.ErrRepoNotFound
+		},
+		commitFn: func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
+			t.Fatal("store.Commit should not be called when repo does not exist")
+			return nil, nil
+		},
+	}
+	srv := New(store, nil, devID)
+
+	body, _ := json.Marshal(model.CommitRequest{
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("x")}},
+		Message: "m",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/repos/ghost/commit", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleMerge_RepoNotFound(t *testing.T) {
+	store := &mockStore{
+		getRepoFn: func(ctx context.Context, name string) (*model.Repo, error) {
+			return nil, db.ErrRepoNotFound
+		},
+		mergeFn: func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
+			t.Fatal("store.Merge should not be called when repo does not exist")
+			return nil, nil, nil
+		},
+	}
+	srv := New(store, nil, devID)
+
+	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/test"})
+	req := httptest.NewRequest(http.MethodPost, "/repos/ghost/merge", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleRebase_RepoNotFound(t *testing.T) {
+	store := &mockStore{
+		getRepoFn: func(ctx context.Context, name string) (*model.Repo, error) {
+			return nil, db.ErrRepoNotFound
+		},
+		rebaseFn: func(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []db.MergeConflict, error) {
+			t.Fatal("store.Rebase should not be called when repo does not exist")
+			return nil, nil, nil
+		},
+	}
+	srv := New(store, nil, devID)
+
+	body, _ := json.Marshal(model.RebaseRequest{Branch: "feature/test"})
+	req := httptest.NewRequest(http.MethodPost, "/repos/ghost/rebase", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d; body: %s", rec.Code, rec.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

- Add `validateRepo` checks to `handleCommit` (server.go), `handleMerge`, and `handleRebase` (handlers.go) — the same early-exit pattern already used by `handleTree`, `handleBranches`, `handleDiff`, and `handleFile` after PR #38
- Previously these three write endpoints had no explicit repo existence check; a missing repo would eventually cause FK violations to bubble up as opaque errors rather than a clean 404
- Update `mockStore.GetRepo` default to return a mock repo on success (instead of `errors.New("not implemented")`) so existing handler unit tests continue to pass after `validateRepo` runs at the top of each handler
- Add `TestHandleCommit_RepoNotFound`, `TestHandleMerge_RepoNotFound`, `TestHandleRebase_RepoNotFound`

## Test plan

- [ ] `go test ./...` passes (all 3 new tests added, all existing tests still pass)
- [ ] `go build ./... && go vet ./...` clean
- [ ] New tests assert 404 response and verify the underlying store method is never called when the repo is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)