### PR TITLE
Implement ds log, ds show, ds rebase, ds resolve (closes #31)

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/dlorenc/docstore/internal/cli"
 )
@@ -19,7 +20,11 @@ commands:
   checkout <branch>                      Switch to an existing branch
   pull                                   Sync files from the server
   merge                                  Merge current branch into main
-  diff                                   Show branch diff from server`
+  diff                                   Show branch diff from server
+  log [path] [--limit N]                 Show commit history (default limit 20)
+  show <sequence> [path]                 Show commit or file at a sequence
+  rebase                                 Rebase current branch onto main
+  resolve <path>                         Resolve a merge/rebase conflict`
 
 func main() {
 	if len(os.Args) < 2 {
@@ -102,6 +107,50 @@ func main() {
 
 	case "diff":
 		err = app.Diff()
+
+	case "log":
+		path := ""
+		limit := 20
+		for i := 1; i < len(args); i++ {
+			if args[i] == "--limit" && i+1 < len(args) {
+				n, convErr := strconv.Atoi(args[i+1])
+				if convErr != nil || n < 1 {
+					fmt.Fprintln(os.Stderr, "usage: ds log [path] [--limit N]")
+					os.Exit(1)
+				}
+				limit = n
+				i++
+			} else if len(args[i]) > 0 && args[i][0] != '-' {
+				path = args[i]
+			}
+		}
+		err = app.Log(path, limit)
+
+	case "show":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: ds show <sequence> [path]")
+			os.Exit(1)
+		}
+		seq, convErr := strconv.ParseInt(args[1], 10, 64)
+		if convErr != nil {
+			fmt.Fprintln(os.Stderr, "usage: ds show <sequence> [path]")
+			os.Exit(1)
+		}
+		filePath := ""
+		if len(args) > 2 {
+			filePath = args[2]
+		}
+		err = app.Show(seq, filePath)
+
+	case "rebase":
+		err = app.Rebase()
+
+	case "resolve":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: ds resolve <path>")
+			os.Exit(1)
+		}
+		err = app.Resolve(args[1])
 
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", cmd)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -15,9 +15,34 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/dlorenc/docstore/internal/model"
 )
+
+// commitInfo is a local type for decoding GET /commit/:seq server responses.
+type commitInfo struct {
+	Sequence  int64            `json:"sequence"`
+	Branch    string           `json:"branch"`
+	Message   string           `json:"message"`
+	Author    string           `json:"author"`
+	CreatedAt time.Time        `json:"created_at"`
+	Files     []commitFileInfo `json:"files"`
+}
+
+type commitFileInfo struct {
+	Path      string  `json:"path"`
+	VersionID *string `json:"version_id"`
+}
+
+// fileHistEntry is a local type for decoding file history server responses.
+type fileHistEntry struct {
+	Sequence  int64     `json:"sequence"`
+	VersionID *string   `json:"version_id"`
+	Message   string    `json:"message"`
+	Author    string    `json:"author"`
+	CreatedAt time.Time `json:"created_at"`
+}
 
 const configDir = ".docstore"
 const configFile = "config.json"
@@ -741,4 +766,373 @@ type treeEntry struct {
 	Path        string `json:"path"`
 	VersionID   string `json:"version_id"`
 	ContentHash string `json:"content_hash"`
+}
+
+// Log shows commit history for the current branch.
+// If path is non-empty, shows file-specific history via /file/:path/history.
+// If path is empty, walks backward from the branch head sequence.
+// Results are newest-first, capped at limit (default 20).
+func (a *App) Log(path string, limit int) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	if path != "" {
+		return a.logFile(cfg, path, limit)
+	}
+	return a.logBranch(cfg, limit)
+}
+
+func (a *App) logBranch(cfg *Config, limit int) error {
+	resp, err := a.httpGet(cfg, repoBase(cfg)+"/branches")
+	if err != nil {
+		return fmt.Errorf("fetching branches: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var branches []model.Branch
+	if err := json.NewDecoder(resp.Body).Decode(&branches); err != nil {
+		return fmt.Errorf("decoding branches: %w", err)
+	}
+
+	var headSeq, baseSeq int64
+	found := false
+	for _, b := range branches {
+		if b.Name == cfg.Branch {
+			headSeq = b.HeadSequence
+			baseSeq = b.BaseSequence
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("branch %q not found", cfg.Branch)
+	}
+	if headSeq == 0 {
+		fmt.Fprintf(a.Out, "No commits on branch '%s'\n", cfg.Branch)
+		return nil
+	}
+
+	count := 0
+	for seq := headSeq; seq > baseSeq && count < limit; seq-- {
+		commitResp, err := a.httpGet(cfg, fmt.Sprintf("%s/commit/%d", repoBase(cfg), seq))
+		if err != nil {
+			return fmt.Errorf("fetching commit %d: %w", seq, err)
+		}
+		if commitResp.StatusCode == http.StatusNotFound {
+			commitResp.Body.Close()
+			continue
+		}
+		if commitResp.StatusCode != http.StatusOK {
+			commitResp.Body.Close()
+			continue
+		}
+		var ci commitInfo
+		if err := json.NewDecoder(commitResp.Body).Decode(&ci); err != nil {
+			commitResp.Body.Close()
+			continue
+		}
+		commitResp.Body.Close()
+
+		if ci.Branch != cfg.Branch {
+			continue
+		}
+		fmt.Fprintf(a.Out, "seq %-4d  %-12s  %s  %s\n",
+			ci.Sequence, ci.Author, ci.CreatedAt.Format("2006-01-02"), ci.Message)
+		count++
+	}
+
+	if count == 0 {
+		fmt.Fprintf(a.Out, "No commits on branch '%s'\n", cfg.Branch)
+	}
+	return nil
+}
+
+func (a *App) logFile(cfg *Config, path string, limit int) error {
+	q := url.Values{}
+	q.Set("branch", cfg.Branch)
+	q.Set("limit", fmt.Sprintf("%d", limit))
+
+	resp, err := a.httpGet(cfg, repoBase(cfg)+"/file/"+path+"/history?"+q.Encode())
+	if err != nil {
+		return fmt.Errorf("fetching history: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+
+	var entries []fileHistEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		return fmt.Errorf("decoding history: %w", err)
+	}
+
+	if len(entries) == 0 {
+		fmt.Fprintf(a.Out, "No history for '%s' on branch '%s'\n", path, cfg.Branch)
+		return nil
+	}
+	for _, e := range entries {
+		fmt.Fprintf(a.Out, "seq %-4d  %-12s  %s  %s\n",
+			e.Sequence, e.Author, e.CreatedAt.Format("2006-01-02"), e.Message)
+	}
+	return nil
+}
+
+// Show inspects a specific commit or a file's content at a given sequence.
+// If path is empty, lists all files changed in that commit.
+// If path is non-empty, prints the file's content at that sequence.
+func (a *App) Show(sequence int64, path string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	if path != "" {
+		return a.showFile(cfg, sequence, path)
+	}
+	return a.showCommit(cfg, sequence)
+}
+
+func (a *App) showCommit(cfg *Config, sequence int64) error {
+	resp, err := a.httpGet(cfg, fmt.Sprintf("%s/commit/%d", repoBase(cfg), sequence))
+	if err != nil {
+		return fmt.Errorf("fetching commit: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("commit %d not found", sequence)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+
+	var ci commitInfo
+	if err := json.NewDecoder(resp.Body).Decode(&ci); err != nil {
+		return fmt.Errorf("decoding commit: %w", err)
+	}
+
+	fmt.Fprintf(a.Out, "commit %d\n", ci.Sequence)
+	fmt.Fprintf(a.Out, "branch:  %s\n", ci.Branch)
+	fmt.Fprintf(a.Out, "author:  %s\n", ci.Author)
+	fmt.Fprintf(a.Out, "date:    %s\n", ci.CreatedAt.Format("2006-01-02"))
+	fmt.Fprintf(a.Out, "message: %s\n", ci.Message)
+	if len(ci.Files) > 0 {
+		fmt.Fprintf(a.Out, "\nFiles:\n")
+		for _, f := range ci.Files {
+			if f.VersionID == nil {
+				fmt.Fprintf(a.Out, "  %s  (deleted)\n", f.Path)
+			} else {
+				fmt.Fprintf(a.Out, "  %s  (changed)\n", f.Path)
+			}
+		}
+	}
+	return nil
+}
+
+func (a *App) showFile(cfg *Config, sequence int64, path string) error {
+	q := url.Values{}
+	q.Set("branch", cfg.Branch)
+	q.Set("at", fmt.Sprintf("%d", sequence))
+
+	resp, err := a.httpGet(cfg, repoBase(cfg)+"/file/"+path+"?"+q.Encode())
+	if err != nil {
+		return fmt.Errorf("fetching file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("file %q not found at sequence %d", path, sequence)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+
+	var fileResp model.FileResponse
+	if err := json.NewDecoder(resp.Body).Decode(&fileResp); err != nil {
+		return fmt.Errorf("decoding file: %w", err)
+	}
+	fmt.Fprintf(a.Out, "%s", fileResp.Content)
+	if len(fileResp.Content) > 0 && fileResp.Content[len(fileResp.Content)-1] != '\n' {
+		fmt.Fprintln(a.Out)
+	}
+	return nil
+}
+
+// Rebase rebases the current branch onto main's latest head.
+// On success it updates state.json with the new head sequence.
+// On conflict it writes <path>.main and <path>.branch for each conflicting file
+// and returns a non-nil error.
+func (a *App) Rebase() error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	if cfg.Branch == "main" {
+		return fmt.Errorf("cannot rebase main")
+	}
+
+	req := model.RebaseRequest{Branch: cfg.Branch, Author: cfg.Author}
+	resp, err := a.postJSON(cfg, repoBase(cfg)+"/rebase", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode == http.StatusConflict {
+		var conflictErr model.RebaseConflictError
+		if err := json.Unmarshal(body, &conflictErr); err == nil && len(conflictErr.Conflicts) > 0 {
+			return a.writeRebaseConflictFiles(cfg, conflictErr.Conflicts)
+		}
+		return fmt.Errorf("server error (status %d)", resp.StatusCode)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp model.ErrorResponse
+		if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error != "" {
+			return fmt.Errorf("server error: %s", errResp.Error)
+		}
+		return fmt.Errorf("server error (status %d)", resp.StatusCode)
+	}
+
+	var rebaseResp model.RebaseResponse
+	if err := json.Unmarshal(body, &rebaseResp); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	st, err := a.loadState()
+	if err != nil {
+		return err
+	}
+	st.Sequence = rebaseResp.NewHeadSequence
+	if err := a.saveState(st); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(a.Out, "Rebased '%s' onto main (base: %d, head: %d, %d commits replayed)\n",
+		cfg.Branch, rebaseResp.NewBaseSequence, rebaseResp.NewHeadSequence, rebaseResp.CommitsReplayed)
+	return nil
+}
+
+// writeRebaseConflictFiles fetches both the main and branch versions of each
+// conflicting file and writes them to <path>.main and <path>.branch on disk.
+func (a *App) writeRebaseConflictFiles(cfg *Config, conflicts []model.ConflictEntry) error {
+	for _, c := range conflicts {
+		mainContent, err := a.fetchFileBytesForBranch(cfg, c.Path, "main")
+		if err != nil {
+			return fmt.Errorf("fetching main version of %s: %w", c.Path, err)
+		}
+		branchContent, err := a.fetchFileBytesForBranch(cfg, c.Path, cfg.Branch)
+		if err != nil {
+			return fmt.Errorf("fetching branch version of %s: %w", c.Path, err)
+		}
+
+		mainDst := filepath.Join(a.Dir, filepath.FromSlash(c.Path+".main"))
+		branchDst := filepath.Join(a.Dir, filepath.FromSlash(c.Path+".branch"))
+		if err := os.MkdirAll(filepath.Dir(mainDst), 0755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(mainDst, mainContent, 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", mainDst, err)
+		}
+		if err := os.WriteFile(branchDst, branchContent, 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", branchDst, err)
+		}
+		fmt.Fprintf(a.Out, "conflict: %s (wrote %s.main, %s.branch)\n", c.Path, c.Path, c.Path)
+	}
+	return fmt.Errorf("rebase aborted due to conflicts")
+}
+
+// fetchFileBytesForBranch fetches a file's raw content bytes from the server.
+func (a *App) fetchFileBytesForBranch(cfg *Config, path, branch string) ([]byte, error) {
+	q := url.Values{}
+	q.Set("branch", branch)
+	resp, err := a.httpGet(cfg, repoBase(cfg)+"/file/"+path+"?"+q.Encode())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return []byte{}, nil // file deleted on that side
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server error (status %d)", resp.StatusCode)
+	}
+
+	var fileResp model.FileResponse
+	if err := json.NewDecoder(resp.Body).Decode(&fileResp); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return fileResp.Content, nil
+}
+
+// Resolve resolves a merge/rebase conflict for path.
+// It expects <path>.main and <path>.branch to exist on disk (written by Rebase),
+// reads the resolved content from <path> itself, commits it to the current branch,
+// and removes the conflict files.
+func (a *App) Resolve(path string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+
+	mainConflict := filepath.Join(a.Dir, filepath.FromSlash(path+".main"))
+	branchConflict := filepath.Join(a.Dir, filepath.FromSlash(path+".branch"))
+
+	if _, err := os.Stat(mainConflict); os.IsNotExist(err) {
+		return fmt.Errorf("no conflict file found: %s.main (run 'ds rebase' first)", path)
+	}
+	if _, err := os.Stat(branchConflict); os.IsNotExist(err) {
+		return fmt.Errorf("no conflict file found: %s.branch (run 'ds rebase' first)", path)
+	}
+
+	resolvedPath := filepath.Join(a.Dir, filepath.FromSlash(path))
+	content, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		return fmt.Errorf("reading resolved file %s: %w", path, err)
+	}
+
+	req := model.CommitRequest{
+		Branch:  cfg.Branch,
+		Files:   []model.FileChange{{Path: path, Content: content}},
+		Message: fmt.Sprintf("resolve conflict in %s", path),
+		Author:  cfg.Author,
+	}
+
+	resp, err := a.postJSON(cfg, repoBase(cfg)+"/commit", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return a.readError(resp)
+	}
+
+	var commitResp model.CommitResponse
+	if err := json.NewDecoder(resp.Body).Decode(&commitResp); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	st, err := a.loadState()
+	if err != nil {
+		return err
+	}
+	st.Sequence = commitResp.Sequence
+	st.Files[path] = HashBytes(content)
+	if err := a.saveState(st); err != nil {
+		return err
+	}
+
+	os.Remove(mainConflict)
+	os.Remove(branchConflict)
+
+	fmt.Fprintf(a.Out, "resolved %s, committed as sequence %d\n", path, commitResp.Sequence)
+	return nil
 }

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -2,12 +2,14 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dlorenc/docstore/internal/model"
 )
@@ -1128,4 +1130,453 @@ func TestHashBytes(t *testing.T) {
 	if h != want {
 		t.Errorf("hash = %q, want %q", h, want)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Log
+// ---------------------------------------------------------------------------
+
+func TestLog_FullHistory(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/repos/default/branches":
+			json.NewEncoder(w).Encode([]model.Branch{
+				{Name: "feature/x", HeadSequence: 3, BaseSequence: 0},
+			})
+		case r.Method == "GET" && r.URL.Path == "/repos/default/commit/3":
+			json.NewEncoder(w).Encode(commitInfo{
+				Sequence: 3, Branch: "feature/x", Author: "alice",
+				CreatedAt: mustParseTime("2026-04-14"), Message: "add tests",
+			})
+		case r.Method == "GET" && r.URL.Path == "/repos/default/commit/2":
+			// commit 2 is on main — should be skipped
+			json.NewEncoder(w).Encode(commitInfo{
+				Sequence: 2, Branch: "main", Author: "bob",
+				CreatedAt: mustParseTime("2026-04-14"), Message: "main commit",
+			})
+		case r.Method == "GET" && r.URL.Path == "/repos/default/commit/1":
+			json.NewEncoder(w).Encode(commitInfo{
+				Sequence: 1, Branch: "feature/x", Author: "alice",
+				CreatedAt: mustParseTime("2026-04-14"), Message: "initial",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "feature/x", "alice")
+
+	if err := app.Log("", 20); err != nil {
+		t.Fatal(err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "seq 3") {
+		t.Errorf("expected seq 3 in output:\n%s", output)
+	}
+	if !strings.Contains(output, "add tests") {
+		t.Errorf("expected message 'add tests' in output:\n%s", output)
+	}
+	if !strings.Contains(output, "seq 1") {
+		t.Errorf("expected seq 1 in output:\n%s", output)
+	}
+	if strings.Contains(output, "main commit") {
+		t.Errorf("main commits should not appear:\n%s", output)
+	}
+	// newest first: seq 3 before seq 1
+	if strings.Index(output, "seq 3") > strings.Index(output, "seq 1") {
+		t.Errorf("expected seq 3 before seq 1 (newest first):\n%s", output)
+	}
+}
+
+func TestLog_FileHistory(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "GET" && r.URL.Path == "/repos/default/file/README.md/history" {
+			if r.URL.Query().Get("branch") != "main" {
+				t.Errorf("expected branch=main, got %q", r.URL.Query().Get("branch"))
+			}
+			json.NewEncoder(w).Encode([]fileHistEntry{
+				{Sequence: 5, Author: "alice", CreatedAt: mustParseTime("2026-04-14"), Message: "update readme"},
+				{Sequence: 1, Author: "alice", CreatedAt: mustParseTime("2026-04-13"), Message: "add readme"},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	if err := app.Log("README.md", 20); err != nil {
+		t.Fatal(err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "seq 5") {
+		t.Errorf("expected seq 5 in output:\n%s", output)
+	}
+	if !strings.Contains(output, "update readme") {
+		t.Errorf("expected 'update readme' in output:\n%s", output)
+	}
+	if !strings.Contains(output, "seq 1") {
+		t.Errorf("expected seq 1 in output:\n%s", output)
+	}
+}
+
+func TestLog_Limit(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/repos/default/branches":
+			json.NewEncoder(w).Encode([]model.Branch{
+				{Name: "main", HeadSequence: 3, BaseSequence: 0},
+			})
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/repos/default/commit/"):
+			callCount++
+			seq := int64(0)
+			fmt.Sscanf(r.URL.Path, "/repos/default/commit/%d", &seq)
+			json.NewEncoder(w).Encode(commitInfo{
+				Sequence: seq, Branch: "main", Author: "alice",
+				CreatedAt: mustParseTime("2026-04-14"), Message: fmt.Sprintf("commit %d", seq),
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	if err := app.Log("", 1); err != nil {
+		t.Fatal(err)
+	}
+
+	output := out.String()
+	// Should only show seq 3 (limit=1, newest first)
+	if !strings.Contains(output, "seq 3") {
+		t.Errorf("expected seq 3 in output:\n%s", output)
+	}
+	if strings.Contains(output, "seq 2") || strings.Contains(output, "seq 1") {
+		t.Errorf("limit=1 should only show 1 entry:\n%s", output)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Show
+// ---------------------------------------------------------------------------
+
+func TestShow_Commit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/repos/default/commit/5" {
+			w.Header().Set("Content-Type", "application/json")
+			vid := "v1"
+			json.NewEncoder(w).Encode(commitInfo{
+				Sequence:  5,
+				Branch:    "feature/x",
+				Author:    "alice",
+				CreatedAt: mustParseTime("2026-04-14"),
+				Message:   "add test file",
+				Files: []commitFileInfo{
+					{Path: "src/main_test.go", VersionID: &vid},
+					{Path: "removed.go", VersionID: nil},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "feature/x", "alice")
+
+	if err := app.Show(5, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "commit 5") {
+		t.Errorf("expected 'commit 5' in output:\n%s", output)
+	}
+	if !strings.Contains(output, "src/main_test.go") {
+		t.Errorf("expected file path in output:\n%s", output)
+	}
+	if !strings.Contains(output, "removed.go") {
+		t.Errorf("expected deleted file in output:\n%s", output)
+	}
+	if !strings.Contains(output, "deleted") {
+		t.Errorf("expected 'deleted' label in output:\n%s", output)
+	}
+}
+
+func TestShow_FileAtSequence(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/repos/default/file/README.md" {
+			if r.URL.Query().Get("at") != "5" {
+				t.Errorf("expected at=5, got %q", r.URL.Query().Get("at"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(model.FileResponse{
+				Path:    "README.md",
+				Content: []byte("hello world"),
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	if err := app.Show(5, "README.md"); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(out.String(), "hello world") {
+		t.Errorf("expected file content in output:\n%s", out.String())
+	}
+}
+
+func TestShow_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(model.ErrorResponse{Error: "commit not found"})
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	err := app.Show(99, "")
+	if err == nil || !strings.Contains(err.Error(), "99") {
+		t.Errorf("expected error mentioning sequence 99, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rebase
+// ---------------------------------------------------------------------------
+
+func TestRebase_Success(t *testing.T) {
+	var gotReq model.RebaseRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/repos/default/rebase" {
+			json.NewDecoder(r.Body).Decode(&gotReq)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(model.RebaseResponse{
+				NewBaseSequence: 5,
+				NewHeadSequence: 7,
+				CommitsReplayed: 2,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "feature/x", "alice")
+
+	if err := app.Rebase(); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotReq.Branch != "feature/x" {
+		t.Errorf("rebase branch = %q, want %q", gotReq.Branch, "feature/x")
+	}
+
+	// state.json should have updated head sequence.
+	st, _ := app.loadState()
+	if st.Sequence != 7 {
+		t.Errorf("state.sequence = %d, want 7", st.Sequence)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "Rebased") {
+		t.Errorf("expected 'Rebased' in output:\n%s", output)
+	}
+	if !strings.Contains(output, "feature/x") {
+		t.Errorf("expected branch name in output:\n%s", output)
+	}
+	if !strings.Contains(output, "2 commits replayed") {
+		t.Errorf("expected commit count in output:\n%s", output)
+	}
+}
+
+func TestRebase_Conflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/repos/default/rebase":
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(model.RebaseConflictError{
+				Conflicts: []model.ConflictEntry{
+					{Path: "README.md", MainVersionID: "v-main", BranchVersionID: "v-branch"},
+				},
+			})
+		case r.Method == "GET" && r.URL.Path == "/repos/default/file/README.md":
+			branch := r.URL.Query().Get("branch")
+			if branch == "main" {
+				json.NewEncoder(w).Encode(model.FileResponse{Path: "README.md", Content: []byte("main version")})
+			} else {
+				json.NewEncoder(w).Encode(model.FileResponse{Path: "README.md", Content: []byte("branch version")})
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "feature/x", "alice")
+
+	err := app.Rebase()
+	if err == nil || !strings.Contains(err.Error(), "conflict") {
+		t.Errorf("expected conflict error, got: %v", err)
+	}
+
+	// Conflict files should be written to disk.
+	mainContent, readErr := os.ReadFile(filepath.Join(app.Dir, "README.md.main"))
+	if readErr != nil {
+		t.Fatalf("expected README.md.main to be written: %v", readErr)
+	}
+	if string(mainContent) != "main version" {
+		t.Errorf("README.md.main = %q, want %q", string(mainContent), "main version")
+	}
+
+	branchContent, readErr := os.ReadFile(filepath.Join(app.Dir, "README.md.branch"))
+	if readErr != nil {
+		t.Fatalf("expected README.md.branch to be written: %v", readErr)
+	}
+	if string(branchContent) != "branch version" {
+		t.Errorf("README.md.branch = %q, want %q", string(branchContent), "branch version")
+	}
+
+	if !strings.Contains(out.String(), "README.md") {
+		t.Errorf("expected conflict path in output:\n%s", out.String())
+	}
+}
+
+func TestRebase_OnMain(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	initWorkspace(t, app, "http://test", "main", "alice")
+
+	err := app.Rebase()
+	if err == nil || !strings.Contains(err.Error(), "cannot rebase main") {
+		t.Errorf("expected 'cannot rebase main' error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resolve
+// ---------------------------------------------------------------------------
+
+func TestResolve_CommitsResolvedFile(t *testing.T) {
+	var gotReq model.CommitRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/repos/default/commit" {
+			json.NewDecoder(r.Body).Decode(&gotReq)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(model.CommitResponse{Sequence: 8})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "feature/x", "alice")
+
+	// Write conflict files and the resolved file.
+	writeFile(t, app, "README.md.main", "main version")
+	writeFile(t, app, "README.md.branch", "branch version")
+	writeFile(t, app, "README.md", "resolved content")
+
+	if err := app.Resolve("README.md"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(gotReq.Files) != 1 || gotReq.Files[0].Path != "README.md" {
+		t.Errorf("expected commit for README.md, got: %v", gotReq.Files)
+	}
+	if string(gotReq.Files[0].Content) != "resolved content" {
+		t.Errorf("committed content = %q, want %q", string(gotReq.Files[0].Content), "resolved content")
+	}
+
+	// State should be updated.
+	st, _ := app.loadState()
+	if st.Sequence != 8 {
+		t.Errorf("state.sequence = %d, want 8", st.Sequence)
+	}
+	if _, ok := st.Files["README.md"]; !ok {
+		t.Error("expected README.md in state files")
+	}
+
+	if !strings.Contains(out.String(), "resolved README.md") {
+		t.Errorf("expected resolution confirmation in output:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "sequence 8") {
+		t.Errorf("expected sequence number in output:\n%s", out.String())
+	}
+}
+
+func TestResolve_CleansUpConflictFiles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(model.CommitResponse{Sequence: 9})
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "feature/x", "alice")
+
+	writeFile(t, app, "src/file.go.main", "main")
+	writeFile(t, app, "src/file.go.branch", "branch")
+	writeFile(t, app, "src/file.go", "resolved")
+
+	if err := app.Resolve("src/file.go"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Conflict files should be removed.
+	if _, err := os.Stat(filepath.Join(app.Dir, "src/file.go.main")); !os.IsNotExist(err) {
+		t.Error("expected src/file.go.main to be removed")
+	}
+	if _, err := os.Stat(filepath.Join(app.Dir, "src/file.go.branch")); !os.IsNotExist(err) {
+		t.Error("expected src/file.go.branch to be removed")
+	}
+	// Resolved file should still exist.
+	if _, err := os.Stat(filepath.Join(app.Dir, "src/file.go")); err != nil {
+		t.Errorf("expected src/file.go to still exist: %v", err)
+	}
+}
+
+func TestResolve_NoConflictFiles(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	initWorkspace(t, app, "http://test", "feature/x", "alice")
+
+	err := app.Resolve("README.md")
+	if err == nil || !strings.Contains(err.Error(), "README.md.main") {
+		t.Errorf("expected error about missing conflict file, got: %v", err)
+	}
+}
+
+// mustParseTime parses a date string for use in tests.
+func mustParseTime(s string) time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return t
 }

--- a/internal/cli/e2e_test.go
+++ b/internal/cli/e2e_test.go
@@ -192,3 +192,140 @@ func TestFullWorkflow(t *testing.T) {
 		t.Errorf("ws2 state.files = %d, want 2 after pull", len(st2.Files))
 	}
 }
+
+// TestCLILog_EndToEnd verifies that ds log returns commits in newest-first order.
+func TestCLILog_EndToEnd(t *testing.T) {
+	srv := newRealServer(t)
+
+	ws, out := newTestApp(t, srv)
+	if err := ws.Init(srv.URL, "", "alice"); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	writeFile(t, ws, "a.txt", "aaa")
+	if err := ws.Commit("first commit"); err != nil {
+		t.Fatalf("Commit 1: %v", err)
+	}
+
+	writeFile(t, ws, "b.txt", "bbb")
+	if err := ws.Commit("second commit"); err != nil {
+		t.Fatalf("Commit 2: %v", err)
+	}
+
+	out.Reset()
+	if err := ws.Log("", 20); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "second commit") {
+		t.Errorf("expected 'second commit' in log output:\n%s", output)
+	}
+	if !strings.Contains(output, "first commit") {
+		t.Errorf("expected 'first commit' in log output:\n%s", output)
+	}
+	// newest first: second commit appears before first commit
+	if strings.Index(output, "second commit") > strings.Index(output, "first commit") {
+		t.Errorf("expected newest commit first:\n%s", output)
+	}
+}
+
+// TestCLIRebase_EndToEnd exercises the full rebase workflow with a real server.
+func TestCLIRebase_EndToEnd(t *testing.T) {
+	srv := newRealServer(t)
+
+	ws, _ := newTestApp(t, srv)
+	if err := ws.Init(srv.URL, "", "alice"); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// Commit something to main.
+	writeFile(t, ws, "main.txt", "main content")
+	if err := ws.Commit("base commit"); err != nil {
+		t.Fatalf("Commit base: %v", err)
+	}
+
+	// Create a feature branch and commit.
+	if err := ws.CheckoutNew("feature/rebase-test"); err != nil {
+		t.Fatalf("CheckoutNew: %v", err)
+	}
+	writeFile(t, ws, "feature.txt", "feature content")
+	if err := ws.Commit("feature commit"); err != nil {
+		t.Fatalf("Commit feature: %v", err)
+	}
+
+	// Advance main past the feature branch base.
+	if err := ws.Checkout("main"); err != nil {
+		t.Fatalf("Checkout main: %v", err)
+	}
+	writeFile(t, ws, "main2.txt", "more main content")
+	if err := ws.Commit("main advance"); err != nil {
+		t.Fatalf("Commit main advance: %v", err)
+	}
+
+	// Go back to feature branch and rebase.
+	if err := ws.Checkout("feature/rebase-test"); err != nil {
+		t.Fatalf("Checkout feature: %v", err)
+	}
+
+	wsOut := &strings.Builder{}
+	ws.Out = wsOut
+	if err := ws.Rebase(); err != nil {
+		t.Fatalf("Rebase: %v", err)
+	}
+
+	if !strings.Contains(wsOut.String(), "Rebased") {
+		t.Errorf("expected 'Rebased' in output:\n%s", wsOut.String())
+	}
+
+	// state.json sequence should be updated.
+	st, _ := ws.loadState()
+	if st.Sequence == 0 {
+		t.Error("expected non-zero sequence in state after rebase")
+	}
+}
+
+// TestCLIResolve_EndToEnd exercises the resolve workflow: write conflict files,
+// create a resolved version, call Resolve, verify commit and cleanup.
+func TestCLIResolve_EndToEnd(t *testing.T) {
+	srv := newRealServer(t)
+
+	ws, _ := newTestApp(t, srv)
+	if err := ws.Init(srv.URL, "", "alice"); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// Create a branch so we can commit to it.
+	if err := ws.CheckoutNew("feature/resolve-test"); err != nil {
+		t.Fatalf("CheckoutNew: %v", err)
+	}
+
+	// Simulate conflict files written by a rebase.
+	writeFile(t, ws, "README.md.main", "main version")
+	writeFile(t, ws, "README.md.branch", "branch version")
+	writeFile(t, ws, "README.md", "resolved version")
+
+	wsOut := &strings.Builder{}
+	ws.Out = wsOut
+	if err := ws.Resolve("README.md"); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if !strings.Contains(wsOut.String(), "resolved README.md") {
+		t.Errorf("expected resolution message in output:\n%s", wsOut.String())
+	}
+
+	// Conflict files should be gone.
+	if _, err := os.Stat(filepath.Join(ws.Dir, "README.md.main")); !os.IsNotExist(err) {
+		t.Error("expected README.md.main to be removed")
+	}
+	if _, err := os.Stat(filepath.Join(ws.Dir, "README.md.branch")); !os.IsNotExist(err) {
+		t.Error("expected README.md.branch to be removed")
+	}
+
+	// State should track README.md.
+	st, _ := ws.loadState()
+	if _, ok := st.Files["README.md"]; !ok {
+		t.Error("expected README.md in state files after resolve")
+	}
+}


### PR DESCRIPTION
## Summary

Implements the four remaining CLI commands from issue #31, all using `/repos/:name/` URL prefix from multitenancy (#35):

- **`ds log [path] [--limit N]`**: shows branch history newest-first. Without path, walks backward from branch head via `GET /commit/:seq`, filtering to commits on the current branch. With path, uses `GET /file/:path/history?branch=<current>&limit=N`.
- **`ds show <sequence> [path]`**: without path lists all files changed in a commit; with path prints raw file content at that sequence.
- **`ds rebase`**: `POST /repos/:name/rebase`, updates `state.json` on success. On 409 conflict, fetches both main and branch versions of each conflicting file and writes `<path>.main` / `<path>.branch`, then exits non-zero.
- **`ds resolve <path>`**: expects `<path>.main` and `<path>.branch` on disk, reads the resolved file at `<path>`, commits it, updates state, and cleans up conflict files.

## Test plan

- [x] 12 unit tests in `internal/cli/app_test.go` — all from issue spec:
  - `TestLog_FullHistory`, `TestLog_FileHistory`, `TestLog_Limit`
  - `TestShow_Commit`, `TestShow_FileAtSequence`, `TestShow_NotFound`
  - `TestRebase_Success`, `TestRebase_Conflict`, `TestRebase_OnMain`
  - `TestResolve_CommitsResolvedFile`, `TestResolve_CleansUpConflictFiles`, `TestResolve_NoConflictFiles`
- [x] 3 e2e integration tests in `internal/cli/e2e_test.go` using real Postgres via testcontainers:
  - `TestCLILog_EndToEnd`, `TestCLIRebase_EndToEnd`, `TestCLIResolve_EndToEnd`
- [x] Full test suite passes: `go test ./... -count=1`

## Notes / Future opportunities

- `ds log` full-branch walkback is O(head-base) API calls. A dedicated `GET /repos/:name/branch/:name/commits` server endpoint would be more efficient and could be added later.
- `ds resolve` auto-generates the commit message as `"resolve conflict in <path>"`. Could accept `-m` flag in a future PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)