### PR TITLE
Implement reviews and check runs (closes #29)

### DIFF
--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -15,8 +15,11 @@ var migration002 string
 //go:embed migrations/000003_multitenancy.up.sql
 var migration003 string
 
+//go:embed migrations/000004_reviews_checks.up.sql
+var migration004 string
+
 // MigrationSQL is the combined SQL for all schema migrations, run in order.
-var MigrationSQL = migration001 + "\n" + migration002 + "\n" + migration003
+var MigrationSQL = migration001 + "\n" + migration002 + "\n" + migration003 + "\n" + migration004
 
 //go:embed migrations/000001_initial_schema.down.sql
 var MigrationDownSQL string

--- a/internal/db/migrations/000004_reviews_checks.up.sql
+++ b/internal/db/migrations/000004_reviews_checks.up.sql
@@ -1,0 +1,18 @@
+-- Migration 004: Add body to reviews; add composite FK constraints on reviews and check_runs
+
+-- 1. Add body column to reviews (idempotent)
+DO $$ BEGIN
+    ALTER TABLE reviews ADD COLUMN body TEXT;
+EXCEPTION WHEN duplicate_column THEN null; END $$;
+
+-- 2. Add composite FK from reviews to branches(repo, name)
+DO $$ BEGIN
+    ALTER TABLE reviews ADD CONSTRAINT reviews_repo_branch_fk
+        FOREIGN KEY (repo, branch) REFERENCES branches(repo, name);
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- 3. Add composite FK from check_runs to branches(repo, name)
+DO $$ BEGIN
+    ALTER TABLE check_runs ADD CONSTRAINT check_runs_repo_branch_fk
+        FOREIGN KEY (repo, branch) REFERENCES branches(repo, name);
+EXCEPTION WHEN duplicate_object THEN null; END $$;

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/google/uuid"
@@ -21,6 +22,7 @@ var (
 	ErrRebaseConflict  = errors.New("rebase conflict")
 	ErrRepoNotFound    = errors.New("repo not found")
 	ErrRepoExists      = errors.New("repo already exists")
+	ErrSelfApproval    = errors.New("reviewer cannot approve their own commits")
 )
 
 // rebaseFile is one file within a replayed commit group.
@@ -713,6 +715,191 @@ func (s *Store) DeleteBranch(ctx context.Context, repo, name string) error {
 	}
 
 	return tx.Commit()
+}
+
+// CreateReview records a review for a branch at its current head_sequence.
+// Returns ErrBranchNotFound if the branch doesn't exist.
+// Returns ErrSelfApproval if the reviewer authored any commits on the branch and
+// is attempting to approve (status == ReviewApproved).
+func (s *Store) CreateReview(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	var headSeq, baseSeq int64
+	err = tx.QueryRowContext(ctx,
+		"SELECT head_sequence, base_sequence FROM branches WHERE repo = $1 AND name = $2 FOR UPDATE",
+		repo, branch,
+	).Scan(&headSeq, &baseSeq)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrBranchNotFound
+		}
+		return nil, fmt.Errorf("lock branch: %w", err)
+	}
+
+	// Self-approval: reviewer cannot approve if they authored any branch commits.
+	if status == model.ReviewApproved {
+		var count int
+		err = tx.QueryRowContext(ctx,
+			"SELECT count(*) FROM commits WHERE repo = $1 AND branch = $2 AND sequence > $3 AND author = $4",
+			repo, branch, baseSeq, reviewer,
+		).Scan(&count)
+		if err != nil {
+			return nil, fmt.Errorf("check self-approval: %w", err)
+		}
+		if count > 0 {
+			return nil, ErrSelfApproval
+		}
+	}
+
+	id := uuid.New().String()
+	var createdAt time.Time
+	var nullBody sql.NullString
+	if body != "" {
+		nullBody = sql.NullString{String: body, Valid: true}
+	}
+	err = tx.QueryRowContext(ctx,
+		`INSERT INTO reviews (id, repo, branch, reviewer, sequence, status, body)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)
+		 RETURNING created_at`,
+		id, repo, branch, reviewer, headSeq, string(status), nullBody,
+	).Scan(&createdAt)
+	if err != nil {
+		return nil, fmt.Errorf("insert review: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit tx: %w", err)
+	}
+
+	return &model.Review{
+		ID:        id,
+		Branch:    branch,
+		Reviewer:  reviewer,
+		Sequence:  headSeq,
+		Status:    status,
+		Body:      body,
+		CreatedAt: createdAt,
+	}, nil
+}
+
+// ListReviews returns reviews for a branch in the given repo, ordered by
+// created_at DESC. If atSeq is non-nil, only reviews at that sequence are
+// returned.
+func (s *Store) ListReviews(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error) {
+	q := `SELECT id, reviewer, sequence, status, COALESCE(body, ''), created_at
+	      FROM reviews
+	      WHERE repo = $1 AND branch = $2`
+	args := []interface{}{repo, branch}
+	if atSeq != nil {
+		q += " AND sequence = $3"
+		args = append(args, *atSeq)
+	}
+	q += " ORDER BY created_at DESC"
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var reviews []model.Review
+	for rows.Next() {
+		var rev model.Review
+		rev.Branch = branch
+		var statusStr string
+		if err := rows.Scan(&rev.ID, &rev.Reviewer, &rev.Sequence, &statusStr, &rev.Body, &rev.CreatedAt); err != nil {
+			return nil, err
+		}
+		rev.Status = model.ReviewStatus(statusStr)
+		reviews = append(reviews, rev)
+	}
+	return reviews, rows.Err()
+}
+
+// CreateCheckRun records a CI check run for a branch at its current
+// head_sequence. Returns ErrBranchNotFound if the branch doesn't exist.
+func (s *Store) CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string) (*model.CheckRun, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	var headSeq int64
+	err = tx.QueryRowContext(ctx,
+		"SELECT head_sequence FROM branches WHERE repo = $1 AND name = $2 FOR UPDATE",
+		repo, branch,
+	).Scan(&headSeq)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrBranchNotFound
+		}
+		return nil, fmt.Errorf("lock branch: %w", err)
+	}
+
+	id := uuid.New().String()
+	var createdAt time.Time
+	err = tx.QueryRowContext(ctx,
+		`INSERT INTO check_runs (id, repo, branch, sequence, check_name, status, reporter)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)
+		 RETURNING created_at`,
+		id, repo, branch, headSeq, checkName, string(status), reporter,
+	).Scan(&createdAt)
+	if err != nil {
+		return nil, fmt.Errorf("insert check_run: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit tx: %w", err)
+	}
+
+	return &model.CheckRun{
+		ID:        id,
+		Branch:    branch,
+		Sequence:  headSeq,
+		CheckName: checkName,
+		Status:    status,
+		Reporter:  reporter,
+		CreatedAt: createdAt,
+	}, nil
+}
+
+// ListCheckRuns returns check runs for a branch in the given repo, ordered by
+// created_at DESC. If atSeq is non-nil, only check runs at that sequence are
+// returned.
+func (s *Store) ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error) {
+	q := `SELECT id, sequence, check_name, status, reporter, created_at
+	      FROM check_runs
+	      WHERE repo = $1 AND branch = $2`
+	args := []interface{}{repo, branch}
+	if atSeq != nil {
+		q += " AND sequence = $3"
+		args = append(args, *atSeq)
+	}
+	q += " ORDER BY created_at DESC"
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var checkRuns []model.CheckRun
+	for rows.Next() {
+		var cr model.CheckRun
+		cr.Branch = branch
+		var statusStr string
+		if err := rows.Scan(&cr.ID, &cr.Sequence, &cr.CheckName, &statusStr, &cr.Reporter, &cr.CreatedAt); err != nil {
+			return nil, err
+		}
+		cr.Status = model.CheckRunStatus(statusStr)
+		checkRuns = append(checkRuns, cr)
+	}
+	return checkRuns, rows.Err()
 }
 
 // isDuplicateKeyError checks if a PostgreSQL error is a unique violation (23505).

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"testing"
 
 	"github.com/dlorenc/docstore/internal/model"
@@ -1560,4 +1561,315 @@ func TestRepoIsolation_Merge(t *testing.T) {
 	}
 
 	_ = resp
+}
+
+// ---------------------------------------------------------------------------
+// Review store tests
+// ---------------------------------------------------------------------------
+
+func TestCreateReview_Success(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Commit to main so head_sequence > 0 and reviewable by a different author.
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "main",
+		Files:   []model.FileChange{{Path: "f.txt", Content: []byte("v1")}},
+		Message: "init", Author: "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	rev, err := s.CreateReview(ctx, "default", "main", "bob@example.com", model.ReviewApproved, "LGTM")
+	if err != nil {
+		t.Fatalf("CreateReview: %v", err)
+	}
+	if rev.ID == "" {
+		t.Error("expected non-empty id")
+	}
+	if rev.Sequence != 1 {
+		t.Errorf("expected sequence 1, got %d", rev.Sequence)
+	}
+	if rev.Status != model.ReviewApproved {
+		t.Errorf("expected approved, got %q", rev.Status)
+	}
+	if rev.Body != "LGTM" {
+		t.Errorf("expected body LGTM, got %q", rev.Body)
+	}
+}
+
+func TestCreateReview_RecordedAtHeadSequence(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Two commits on main by alice.
+	for i := 0; i < 2; i++ {
+		_, err := s.Commit(ctx, model.CommitRequest{
+			Repo: "default", Branch: "main",
+			Files:   []model.FileChange{{Path: "f.txt", Content: []byte("v" + string(rune('1'+i)))}},
+			Message: "commit", Author: "alice@example.com",
+		})
+		if err != nil {
+			t.Fatalf("commit %d: %v", i, err)
+		}
+	}
+
+	// bob reviews at head (seq=2).
+	rev, err := s.CreateReview(ctx, "default", "main", "bob@example.com", model.ReviewApproved, "")
+	if err != nil {
+		t.Fatalf("CreateReview: %v", err)
+	}
+	if rev.Sequence != 2 {
+		t.Errorf("expected sequence 2 (head), got %d", rev.Sequence)
+	}
+}
+
+func TestCreateReview_StaleAfterCommit(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "main",
+		Files:   []model.FileChange{{Path: "f.txt", Content: []byte("v1")}},
+		Message: "init", Author: "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Bob reviews at seq=1.
+	rev, err := s.CreateReview(ctx, "default", "main", "bob@example.com", model.ReviewApproved, "")
+	if err != nil {
+		t.Fatalf("CreateReview: %v", err)
+	}
+	if rev.Sequence != 1 {
+		t.Fatalf("expected sequence 1, got %d", rev.Sequence)
+	}
+
+	// A new commit advances head_sequence to 2.
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "main",
+		Files:   []model.FileChange{{Path: "f.txt", Content: []byte("v2")}},
+		Message: "update", Author: "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// The review at seq=1 is now stale: head_sequence is now 2.
+	var headSeq int64
+	err = d.QueryRow("SELECT head_sequence FROM branches WHERE name = 'main'").Scan(&headSeq)
+	if err != nil {
+		t.Fatalf("query branch: %v", err)
+	}
+	if headSeq != 2 {
+		t.Fatalf("expected head_sequence 2 after commit, got %d", headSeq)
+	}
+	// The review's sequence (1) no longer matches head (2) — it is stale.
+	if rev.Sequence == headSeq {
+		t.Error("expected review to be stale (sequence != head_sequence)")
+	}
+}
+
+func TestListReviews_ByBranch(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "main",
+		Files:   []model.FileChange{{Path: "f.txt", Content: []byte("v1")}},
+		Message: "init", Author: "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Two reviews by different users.
+	_, err = s.CreateReview(ctx, "default", "main", "bob@example.com", model.ReviewApproved, "LGTM")
+	if err != nil {
+		t.Fatalf("review 1: %v", err)
+	}
+	_, err = s.CreateReview(ctx, "default", "main", "carol@example.com", model.ReviewRejected, "needs work")
+	if err != nil {
+		t.Fatalf("review 2: %v", err)
+	}
+
+	reviews, err := s.ListReviews(ctx, "default", "main", nil)
+	if err != nil {
+		t.Fatalf("ListReviews: %v", err)
+	}
+	if len(reviews) != 2 {
+		t.Fatalf("expected 2 reviews, got %d", len(reviews))
+	}
+	// Most recent first (carol reviewed last).
+	if reviews[0].Reviewer != "carol@example.com" {
+		t.Errorf("expected first review by carol, got %q", reviews[0].Reviewer)
+	}
+}
+
+func TestCreateReview_SelfApproval(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// alice commits to main.
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "main",
+		Files:   []model.FileChange{{Path: "f.txt", Content: []byte("v1")}},
+		Message: "init", Author: "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// alice tries to approve her own commit.
+	_, err = s.CreateReview(ctx, "default", "main", "alice@example.com", model.ReviewApproved, "")
+	if !errors.Is(err, ErrSelfApproval) {
+		t.Fatalf("expected ErrSelfApproval, got %v", err)
+	}
+}
+
+func TestReviewRepoIsolation(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Create two repos.
+	for _, repo := range []string{"repo-a", "repo-b"} {
+		if _, err := s.CreateRepo(ctx, model.CreateRepoRequest{Name: repo}); err != nil {
+			t.Fatalf("CreateRepo %s: %v", repo, err)
+		}
+	}
+
+	// alice commits to repo-a.
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo: "repo-a", Branch: "main",
+		Files:   []model.FileChange{{Path: "f.txt", Content: []byte("a")}},
+		Message: "init", Author: "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit repo-a: %v", err)
+	}
+
+	// bob reviews repo-a.
+	_, err = s.CreateReview(ctx, "repo-a", "main", "bob@example.com", model.ReviewApproved, "")
+	if err != nil {
+		t.Fatalf("review repo-a: %v", err)
+	}
+
+	// Reviews in repo-b must be empty.
+	reviews, err := s.ListReviews(ctx, "repo-b", "main", nil)
+	if err != nil {
+		t.Fatalf("ListReviews repo-b: %v", err)
+	}
+	if len(reviews) != 0 {
+		t.Errorf("expected 0 reviews in repo-b, got %d", len(reviews))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Check-run store tests
+// ---------------------------------------------------------------------------
+
+func TestCreateCheckRun_Success(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	cr, err := s.CreateCheckRun(ctx, "default", "main", "ci/build", model.CheckRunPassed, "ci-bot")
+	if err != nil {
+		t.Fatalf("CreateCheckRun: %v", err)
+	}
+	if cr.ID == "" {
+		t.Error("expected non-empty id")
+	}
+	if cr.Sequence != 0 {
+		t.Errorf("expected sequence 0 (no commits yet), got %d", cr.Sequence)
+	}
+	if cr.Status != model.CheckRunPassed {
+		t.Errorf("expected passed, got %q", cr.Status)
+	}
+	if cr.Reporter != "ci-bot" {
+		t.Errorf("expected reporter ci-bot, got %q", cr.Reporter)
+	}
+}
+
+func TestCreateCheckRun_RecordedAtHeadSequence(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "main",
+		Files:   []model.FileChange{{Path: "f.txt", Content: []byte("v1")}},
+		Message: "init", Author: "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	cr, err := s.CreateCheckRun(ctx, "default", "main", "ci/build", model.CheckRunPassed, "ci-bot")
+	if err != nil {
+		t.Fatalf("CreateCheckRun: %v", err)
+	}
+	if cr.Sequence != 1 {
+		t.Errorf("expected sequence 1 (head), got %d", cr.Sequence)
+	}
+}
+
+func TestListCheckRuns_ByBranch(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.CreateCheckRun(ctx, "default", "main", "ci/build", model.CheckRunPassed, "ci-bot")
+	if err != nil {
+		t.Fatalf("check 1: %v", err)
+	}
+	_, err = s.CreateCheckRun(ctx, "default", "main", "ci/lint", model.CheckRunFailed, "ci-bot")
+	if err != nil {
+		t.Fatalf("check 2: %v", err)
+	}
+
+	crs, err := s.ListCheckRuns(ctx, "default", "main", nil)
+	if err != nil {
+		t.Fatalf("ListCheckRuns: %v", err)
+	}
+	if len(crs) != 2 {
+		t.Fatalf("expected 2 check runs, got %d", len(crs))
+	}
+}
+
+func TestListCheckRuns_LatestPerName(t *testing.T) {
+	d := testutil.TestDB(t, MigrationSQL)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// First run: pending
+	_, err := s.CreateCheckRun(ctx, "default", "main", "ci/build", model.CheckRunPending, "ci-bot")
+	if err != nil {
+		t.Fatalf("check 1: %v", err)
+	}
+	// Second run: passed (same check_name, more recent)
+	_, err = s.CreateCheckRun(ctx, "default", "main", "ci/build", model.CheckRunPassed, "ci-bot")
+	if err != nil {
+		t.Fatalf("check 2: %v", err)
+	}
+
+	crs, err := s.ListCheckRuns(ctx, "default", "main", nil)
+	if err != nil {
+		t.Fatalf("ListCheckRuns: %v", err)
+	}
+	if len(crs) != 2 {
+		t.Fatalf("expected 2 check runs total, got %d", len(crs))
+	}
+	// Most recent first: passed should be first.
+	if crs[0].Status != model.CheckRunPassed {
+		t.Errorf("expected most recent check run (passed) first, got %q", crs[0].Status)
+	}
 }

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -232,6 +232,7 @@ type RebaseConflictError struct {
 type CreateReviewRequest struct {
 	Branch string       `json:"branch"`
 	Status ReviewStatus `json:"status"`
+	Body   string       `json:"body,omitempty"`
 }
 
 // CreateReviewResponse is the response for POST /review.

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -93,6 +93,7 @@ type Review struct {
 	Reviewer  string       `json:"reviewer"`
 	Sequence  int64        `json:"sequence"`
 	Status    ReviewStatus `json:"status"`
+	Body      string       `json:"body,omitempty"`
 	CreatedAt time.Time    `json:"created_at"`
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -12,6 +12,151 @@ import (
 	"github.com/dlorenc/docstore/internal/store"
 )
 
+// handleReview implements POST /repos/:name/review
+func (s *server) handleReview(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	reviewer := IdentityFromContext(r.Context())
+
+	var req model.CreateReviewRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Branch == "" {
+		writeError(w, http.StatusBadRequest, "branch is required")
+		return
+	}
+	if req.Status == "" {
+		writeError(w, http.StatusBadRequest, "status is required")
+		return
+	}
+
+	review, err := s.commitStore.CreateReview(r.Context(), repo, req.Branch, reviewer, req.Status, req.Body)
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrBranchNotFound):
+			writeError(w, http.StatusNotFound, "branch not found")
+		case errors.Is(err, db.ErrSelfApproval):
+			writeError(w, http.StatusForbidden, "reviewer cannot approve their own commits")
+		default:
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, model.CreateReviewResponse{
+		ID:       review.ID,
+		Sequence: review.Sequence,
+	})
+}
+
+// handleCheck implements POST /repos/:name/check
+func (s *server) handleCheck(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	reporter := IdentityFromContext(r.Context())
+
+	var req model.CreateCheckRunRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Branch == "" {
+		writeError(w, http.StatusBadRequest, "branch is required")
+		return
+	}
+	if req.CheckName == "" {
+		writeError(w, http.StatusBadRequest, "check_name is required")
+		return
+	}
+	if req.Status == "" {
+		writeError(w, http.StatusBadRequest, "status is required")
+		return
+	}
+
+	cr, err := s.commitStore.CreateCheckRun(r.Context(), repo, req.Branch, req.CheckName, req.Status, reporter)
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrBranchNotFound):
+			writeError(w, http.StatusNotFound, "branch not found")
+		default:
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, model.CreateCheckRunResponse{
+		ID:       cr.ID,
+		Sequence: cr.Sequence,
+	})
+}
+
+// handleBranchGet dispatches GET /repos/:name/branch/{branch...} to the
+// appropriate sub-resource handler based on the path suffix.
+// Branch names may contain slashes (e.g. "feature/x"), so we use a trailing
+// wildcard and strip the sub-resource suffix manually — the same technique
+// used by handleFile for the "/history" suffix.
+func (s *server) handleBranchGet(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	branchPath := r.PathValue("branch")
+
+	switch {
+	case strings.HasSuffix(branchPath, "/reviews"):
+		branch := strings.TrimSuffix(branchPath, "/reviews")
+		s.handleGetReviews(w, r, repo, branch)
+	case strings.HasSuffix(branchPath, "/checks"):
+		branch := strings.TrimSuffix(branchPath, "/checks")
+		s.handleGetChecks(w, r, repo, branch)
+	default:
+		writeError(w, http.StatusNotFound, "not found")
+	}
+}
+
+// handleGetReviews serves GET /repos/:name/branch/:branch/reviews
+func (s *server) handleGetReviews(w http.ResponseWriter, r *http.Request, repo, branch string) {
+	var atSeq *int64
+	if v := r.URL.Query().Get("at"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid 'at' parameter")
+			return
+		}
+		atSeq = &n
+	}
+
+	reviews, err := s.commitStore.ListReviews(r.Context(), repo, branch, atSeq)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if reviews == nil {
+		reviews = []model.Review{}
+	}
+	writeJSON(w, http.StatusOK, reviews)
+}
+
+// handleGetChecks serves GET /repos/:name/branch/:branch/checks
+func (s *server) handleGetChecks(w http.ResponseWriter, r *http.Request, repo, branch string) {
+	var atSeq *int64
+	if v := r.URL.Query().Get("at"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid 'at' parameter")
+			return
+		}
+		atSeq = &n
+	}
+
+	checkRuns, err := s.commitStore.ListCheckRuns(r.Context(), repo, branch, atSeq)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if checkRuns == nil {
+		checkRuns = []model.CheckRun{}
+	}
+	writeJSON(w, http.StatusOK, checkRuns)
+}
+
 func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, map[string]string{"error": msg})
 }

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -859,3 +859,226 @@ func TestIntegrationDeleteRepo_CleansUp(t *testing.T) {
 		t.Fatalf("expected 404 after delete, got %d", resp.StatusCode)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Review and check-run integration tests
+// ---------------------------------------------------------------------------
+
+func TestIntegrationReviewFlow(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, "alice@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	post := func(path, body string) *http.Response {
+		t.Helper()
+		resp, err := http.Post(srv.URL+path, "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		return resp
+	}
+
+	// Step 1: Create a branch.
+	r := post("/repos/default/branch", `{"name":"feature/rev"}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("create branch: expected 201, got %d", r.StatusCode)
+	}
+
+	// Step 2: alice commits to the branch.
+	r = post("/repos/default/commit", `{"branch":"feature/rev","message":"work","files":[{"path":"f.txt","content":"dGVzdA=="}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("commit: expected 201, got %d", r.StatusCode)
+	}
+
+	// Step 3: alice tries to approve her own commit — should get 403.
+	r = post("/repos/default/review", `{"branch":"feature/rev","status":"approved","body":"self approve"}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusForbidden {
+		t.Fatalf("self-approval: expected 403, got %d", r.StatusCode)
+	}
+
+	// Step 4: Switch server identity to bob who hasn't committed anything.
+	handlerBob := server.New(writeStore, database, "bob@example.com")
+	srvBob := httptest.NewServer(handlerBob)
+	defer srvBob.Close()
+
+	r, err := http.Post(srvBob.URL+"/repos/default/review", "application/json",
+		strings.NewReader(`{"branch":"feature/rev","status":"approved","body":"LGTM"}`))
+	if err != nil {
+		t.Fatalf("bob review: %v", err)
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("bob review: expected 201, got %d", r.StatusCode)
+	}
+
+	var reviewResp struct {
+		ID       string `json:"id"`
+		Sequence int64  `json:"sequence"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reviewResp); err != nil {
+		t.Fatalf("decode review response: %v", err)
+	}
+	if reviewResp.ID == "" {
+		t.Error("expected non-empty review id")
+	}
+
+	// Step 5: GET reviews for the branch — should return 1 review.
+	getResp, err := http.Get(srv.URL + "/repos/default/branch/feature/rev/reviews")
+	if err != nil {
+		t.Fatalf("GET reviews: %v", err)
+	}
+	defer getResp.Body.Close()
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET reviews: expected 200, got %d", getResp.StatusCode)
+	}
+
+	var reviews []struct {
+		ID       string `json:"id"`
+		Reviewer string `json:"reviewer"`
+		Status   string `json:"status"`
+	}
+	if err := json.NewDecoder(getResp.Body).Decode(&reviews); err != nil {
+		t.Fatalf("decode reviews: %v", err)
+	}
+	if len(reviews) != 1 {
+		t.Fatalf("expected 1 review, got %d", len(reviews))
+	}
+	if reviews[0].Status != "approved" {
+		t.Errorf("expected status approved, got %q", reviews[0].Status)
+	}
+
+	// Step 6: alice makes another commit — the prior review becomes stale.
+	r2, err := http.Post(srv.URL+"/repos/default/commit", "application/json",
+		strings.NewReader(`{"branch":"feature/rev","message":"update","files":[{"path":"f.txt","content":"dXBkYXRlZA=="}]}`))
+	if err != nil {
+		t.Fatalf("second commit: %v", err)
+	}
+	var commitResp struct{ Sequence int64 `json:"sequence"` }
+	json.NewDecoder(r2.Body).Decode(&commitResp)
+	r2.Body.Close()
+	if r2.StatusCode != http.StatusCreated {
+		t.Fatalf("second commit: expected 201, got %d", r2.StatusCode)
+	}
+
+	// The old review's sequence should differ from current head_sequence.
+	if reviewResp.Sequence == commitResp.Sequence {
+		t.Error("expected review to be stale after new commit")
+	}
+}
+
+func TestIntegrationCheckRunFlow(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, "ci-bot@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	post := func(path, body string) *http.Response {
+		t.Helper()
+		resp, err := http.Post(srv.URL+path, "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		return resp
+	}
+
+	// Create a check run on main.
+	r := post("/repos/default/check", `{"branch":"main","check_name":"ci/build","status":"passed"}`)
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("create check: expected 201, got %d", r.StatusCode)
+	}
+
+	var checkResp struct {
+		ID       string `json:"id"`
+		Sequence int64  `json:"sequence"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&checkResp); err != nil {
+		t.Fatalf("decode check response: %v", err)
+	}
+	if checkResp.ID == "" {
+		t.Error("expected non-empty check run id")
+	}
+
+	// GET checks for main.
+	getResp, err := http.Get(srv.URL + "/repos/default/branch/main/checks")
+	if err != nil {
+		t.Fatalf("GET checks: %v", err)
+	}
+	defer getResp.Body.Close()
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET checks: expected 200, got %d", getResp.StatusCode)
+	}
+
+	var checks []struct {
+		ID        string `json:"id"`
+		CheckName string `json:"check_name"`
+		Status    string `json:"status"`
+	}
+	if err := json.NewDecoder(getResp.Body).Decode(&checks); err != nil {
+		t.Fatalf("decode checks: %v", err)
+	}
+	if len(checks) != 1 {
+		t.Fatalf("expected 1 check run, got %d", len(checks))
+	}
+	if checks[0].Status != "passed" {
+		t.Errorf("expected status passed, got %q", checks[0].Status)
+	}
+}
+
+func TestIntegrationReviewRepoIsolation(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.MigrationSQL)
+	writeStore := dbpkg.NewStore(database)
+	// alice is the reviewer; bob is the committer so alice can approve
+	handler := server.New(writeStore, database, "alice@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	post := func(path, body string) *http.Response {
+		t.Helper()
+		resp, err := http.Post(srv.URL+path, "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		return resp
+	}
+
+	// Create two repos.
+	for _, name := range []string{"repo-x", "repo-y"} {
+		r := post("/repos", `{"name":"`+name+`"}`)
+		r.Body.Close()
+		if r.StatusCode != http.StatusCreated {
+			t.Fatalf("create repo %s: expected 201, got %d", name, r.StatusCode)
+		}
+	}
+
+	// alice leaves a review on repo-x/main
+	r := post("/repos/repo-x/review", `{"branch":"main","status":"approved"}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("review repo-x: expected 201, got %d", r.StatusCode)
+	}
+
+	// GET /repos/repo-y/branch/main/reviews must be empty.
+	getResp, err := http.Get(srv.URL + "/repos/repo-y/branch/main/reviews")
+	if err != nil {
+		t.Fatalf("GET reviews repo-y: %v", err)
+	}
+	defer getResp.Body.Close()
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET reviews: expected 200, got %d", getResp.StatusCode)
+	}
+
+	var reviews []interface{}
+	if err := json.NewDecoder(getResp.Body).Decode(&reviews); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(reviews) != 0 {
+		t.Errorf("expected 0 reviews in repo-y, got %d", len(reviews))
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,6 +26,12 @@ type WriteStore interface {
 	Merge(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error)
 	DeleteBranch(ctx context.Context, repo, name string) error
 	Rebase(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []db.MergeConflict, error)
+
+	// Review and check-run operations
+	CreateReview(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error)
+	ListReviews(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error)
+	CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string) (*model.CheckRun, error)
+	ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error)
 }
 
 // CommitStore is an alias for backward compatibility with tests.
@@ -61,14 +67,17 @@ func New(writeStore WriteStore, database *sql.DB, devIdentity string) http.Handl
 	inner.HandleFunc("GET /repos/{name}/diff", s.handleDiff)
 	inner.HandleFunc("GET /repos/{name}/branches", s.handleBranches)
 	inner.HandleFunc("GET /repos/{name}/branch/{bname}/status", notImplemented)
+	// Branch sub-resource reads; {branch...} handles names that contain slashes.
+	// More-specific {bname}/status route above wins for /status paths.
+	inner.HandleFunc("GET /repos/{name}/branch/{branch...}", s.handleBranchGet)
 
 	// Repo-scoped write endpoints
 	inner.HandleFunc("POST /repos/{name}/commit", s.handleCommit)
 	inner.HandleFunc("POST /repos/{name}/branch", s.handleCreateBranch)
 	inner.HandleFunc("POST /repos/{name}/merge", s.handleMerge)
 	inner.HandleFunc("POST /repos/{name}/rebase", s.handleRebase)
-	inner.HandleFunc("POST /repos/{name}/review", notImplemented)
-	inner.HandleFunc("POST /repos/{name}/check", notImplemented)
+	inner.HandleFunc("POST /repos/{name}/review", s.handleReview)
+	inner.HandleFunc("POST /repos/{name}/check", s.handleCheck)
 	inner.HandleFunc("DELETE /repos/{name}/branch/{bname...}", s.handleDeleteBranch)
 
 	outer.Handle("/", IAPMiddleware(devIdentity)(inner))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,15 +15,19 @@ import (
 
 // mockStore implements WriteStore for testing.
 type mockStore struct {
-	commitFn       func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error)
-	createBranchFn func(ctx context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error)
-	mergeFn        func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error)
-	deleteBranchFn func(ctx context.Context, repo, name string) error
-	rebaseFn       func(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []db.MergeConflict, error)
-	createRepoFn   func(ctx context.Context, req model.CreateRepoRequest) (*model.Repo, error)
-	deleteRepoFn   func(ctx context.Context, name string) error
-	listReposFn    func(ctx context.Context) ([]model.Repo, error)
-	getRepoFn      func(ctx context.Context, name string) (*model.Repo, error)
+	commitFn        func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error)
+	createBranchFn  func(ctx context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error)
+	mergeFn         func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error)
+	deleteBranchFn  func(ctx context.Context, repo, name string) error
+	rebaseFn        func(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []db.MergeConflict, error)
+	createRepoFn    func(ctx context.Context, req model.CreateRepoRequest) (*model.Repo, error)
+	deleteRepoFn    func(ctx context.Context, name string) error
+	listReposFn     func(ctx context.Context) ([]model.Repo, error)
+	getRepoFn       func(ctx context.Context, name string) (*model.Repo, error)
+	createReviewFn  func(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error)
+	listReviewsFn   func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error)
+	createCheckRunFn func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string) (*model.CheckRun, error)
+	listCheckRunsFn  func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error)
 }
 
 func (m *mockStore) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
@@ -89,6 +93,34 @@ func (m *mockStore) GetRepo(ctx context.Context, name string) (*model.Repo, erro
 	return &model.Repo{Name: name}, nil
 }
 
+func (m *mockStore) CreateReview(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error) {
+	if m.createReviewFn != nil {
+		return m.createReviewFn(ctx, repo, branch, reviewer, status, body)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockStore) ListReviews(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error) {
+	if m.listReviewsFn != nil {
+		return m.listReviewsFn(ctx, repo, branch, atSeq)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockStore) CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string) (*model.CheckRun, error) {
+	if m.createCheckRunFn != nil {
+		return m.createCheckRunFn(ctx, repo, branch, checkName, status, reporter)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockStore) ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error) {
+	if m.listCheckRunsFn != nil {
+		return m.listCheckRunsFn(ctx, repo, branch, atSeq)
+	}
+	return nil, errors.New("not implemented")
+}
+
 func TestHealthEndpoint(t *testing.T) {
 	// /healthz is exempt from IAP auth, so devIdentity="" is fine here.
 	srv := New(nil, nil, "")
@@ -117,8 +149,6 @@ func TestNotImplementedEndpoints(t *testing.T) {
 		method string
 		path   string
 	}{
-		{"POST", "/repos/default/review"},
-		{"POST", "/repos/default/check"},
 		{"GET", "/repos/default/branch/main/status"},
 	}
 
@@ -866,5 +896,229 @@ func TestHandleRebase_RepoNotFound(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Review handler tests
+// ---------------------------------------------------------------------------
+
+func TestHandleReview_Success(t *testing.T) {
+	const identity = "reviewer@example.com"
+	store := &mockStore{
+		createReviewFn: func(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error) {
+			if repo != "default" {
+				t.Errorf("expected repo default, got %q", repo)
+			}
+			if branch != "feature/x" {
+				t.Errorf("expected branch feature/x, got %q", branch)
+			}
+			if reviewer != identity {
+				t.Errorf("expected reviewer %q from context, got %q", identity, reviewer)
+			}
+			if status != model.ReviewApproved {
+				t.Errorf("expected status approved, got %q", status)
+			}
+			if body != "LGTM" {
+				t.Errorf("expected body LGTM, got %q", body)
+			}
+			return &model.Review{ID: "review-uuid", Sequence: 5}, nil
+		},
+	}
+	srv := New(store, nil, identity)
+
+	b, _ := json.Marshal(model.CreateReviewRequest{Branch: "feature/x", Status: model.ReviewApproved, Body: "LGTM"})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/review", bytes.NewReader(b))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp model.CreateReviewResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ID != "review-uuid" {
+		t.Errorf("expected id review-uuid, got %q", resp.ID)
+	}
+	if resp.Sequence != 5 {
+		t.Errorf("expected sequence 5, got %d", resp.Sequence)
+	}
+}
+
+func TestHandleReview_SelfApproval(t *testing.T) {
+	store := &mockStore{
+		createReviewFn: func(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error) {
+			return nil, db.ErrSelfApproval
+		},
+	}
+	srv := New(store, nil, devID)
+
+	b, _ := json.Marshal(model.CreateReviewRequest{Branch: "feature/x", Status: model.ReviewApproved})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/review", bytes.NewReader(b))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+}
+
+func TestHandleReview_BranchNotFound(t *testing.T) {
+	store := &mockStore{
+		createReviewFn: func(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error) {
+			return nil, db.ErrBranchNotFound
+		},
+	}
+	srv := New(store, nil, devID)
+
+	b, _ := json.Marshal(model.CreateReviewRequest{Branch: "nonexistent", Status: model.ReviewApproved})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/review", bytes.NewReader(b))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Check-run handler tests
+// ---------------------------------------------------------------------------
+
+func TestHandleCheck_Success(t *testing.T) {
+	const identity = "ci-bot@example.com"
+	store := &mockStore{
+		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string) (*model.CheckRun, error) {
+			if repo != "default" {
+				t.Errorf("expected repo default, got %q", repo)
+			}
+			if branch != "feature/x" {
+				t.Errorf("expected branch feature/x, got %q", branch)
+			}
+			if checkName != "ci/build" {
+				t.Errorf("expected check_name ci/build, got %q", checkName)
+			}
+			if status != model.CheckRunPassed {
+				t.Errorf("expected status passed, got %q", status)
+			}
+			if reporter != identity {
+				t.Errorf("expected reporter %q from context, got %q", identity, reporter)
+			}
+			return &model.CheckRun{ID: "check-uuid", Sequence: 3}, nil
+		},
+	}
+	srv := New(store, nil, identity)
+
+	b, _ := json.Marshal(model.CreateCheckRunRequest{Branch: "feature/x", CheckName: "ci/build", Status: model.CheckRunPassed})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/check", bytes.NewReader(b))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp model.CreateCheckRunResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ID != "check-uuid" {
+		t.Errorf("expected id check-uuid, got %q", resp.ID)
+	}
+	if resp.Sequence != 3 {
+		t.Errorf("expected sequence 3, got %d", resp.Sequence)
+	}
+}
+
+func TestHandleCheck_BranchNotFound(t *testing.T) {
+	store := &mockStore{
+		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string) (*model.CheckRun, error) {
+			return nil, db.ErrBranchNotFound
+		},
+	}
+	srv := New(store, nil, devID)
+
+	b, _ := json.Marshal(model.CreateCheckRunRequest{Branch: "nonexistent", CheckName: "ci/build", Status: model.CheckRunPassed})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/check", bytes.NewReader(b))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GET reviews/checks handler tests
+// ---------------------------------------------------------------------------
+
+func TestHandleGetReviews(t *testing.T) {
+	store := &mockStore{
+		listReviewsFn: func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error) {
+			if repo != "default" {
+				t.Errorf("expected repo default, got %q", repo)
+			}
+			if branch != "feature/x" {
+				t.Errorf("expected branch feature/x, got %q", branch)
+			}
+			return []model.Review{
+				{ID: "r1", Branch: "feature/x", Reviewer: "alice", Sequence: 2, Status: model.ReviewApproved},
+			}, nil
+		},
+	}
+	srv := New(store, nil, devID)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/branch/feature/x/reviews", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var reviews []model.Review
+	if err := json.NewDecoder(rec.Body).Decode(&reviews); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(reviews) != 1 {
+		t.Fatalf("expected 1 review, got %d", len(reviews))
+	}
+	if reviews[0].ID != "r1" {
+		t.Errorf("expected id r1, got %q", reviews[0].ID)
+	}
+}
+
+func TestHandleGetChecks(t *testing.T) {
+	store := &mockStore{
+		listCheckRunsFn: func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error) {
+			if repo != "default" {
+				t.Errorf("expected repo default, got %q", repo)
+			}
+			if branch != "feature/x" {
+				t.Errorf("expected branch feature/x, got %q", branch)
+			}
+			return []model.CheckRun{
+				{ID: "cr1", Branch: "feature/x", CheckName: "ci/build", Sequence: 2, Status: model.CheckRunPassed, Reporter: "ci-bot"},
+			}, nil
+		},
+	}
+	srv := New(store, nil, devID)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/branch/feature/x/checks", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var checkRuns []model.CheckRun
+	if err := json.NewDecoder(rec.Body).Decode(&checkRuns); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(checkRuns) != 1 {
+		t.Fatalf("expected 1 check run, got %d", len(checkRuns))
+	}
+	if checkRuns[0].ID != "cr1" {
+		t.Errorf("expected id cr1, got %q", checkRuns[0].ID)
 	}
 }


### PR DESCRIPTION
## Summary

- **Migration 004**: adds `body TEXT` column to `reviews` table and composite `FOREIGN KEY (repo, branch) REFERENCES branches(repo, name)` constraints on both `reviews` and `check_runs`
- **Store layer** (`internal/db/store.go`): four new methods on `db.Store`:
  - `CreateReview` — records a review at the branch's current `head_sequence`; blocks self-approval (reviewer authored any branch commit) with `ErrSelfApproval`
  - `ListReviews` — returns reviews ordered by `created_at DESC`, optional `?at=sequence` filter
  - `CreateCheckRun` — records a CI check at `head_sequence`
  - `ListCheckRuns` — returns check runs ordered by `created_at DESC`
- **HTTP handlers** (`handlers.go`): `handleReview` (POST), `handleCheck` (POST), `handleBranchGet` (GET dispatcher for `/reviews` and `/checks`)
- **Routing** (`server.go`): uses `GET /repos/{name}/branch/{branch...}` with suffix dispatch so branch names containing `/` (e.g. `feature/x`) work correctly — same technique as `handleFile`
- **`WriteStore` interface** extended with the four new methods; `mockStore` in tests updated accordingly

## Tests

All tests from issue spec implemented and passing:

**Store tests** (`internal/db/store_test.go`):
- `TestCreateReview_Success`, `TestCreateReview_RecordedAtHeadSequence`, `TestCreateReview_StaleAfterCommit`
- `TestListReviews_ByBranch`, `TestCreateReview_SelfApproval` (ErrSelfApproval)
- `TestReviewRepoIsolation`
- `TestCreateCheckRun_Success`, `TestCreateCheckRun_RecordedAtHeadSequence`
- `TestListCheckRuns_ByBranch`, `TestListCheckRuns_LatestPerName`

**Handler tests** (`internal/server/server_test.go`):
- `TestHandleReview_Success`, `TestHandleReview_SelfApproval` (403), `TestHandleReview_BranchNotFound` (404)
- `TestHandleCheck_Success`, `TestHandleCheck_BranchNotFound` (404)
- `TestHandleGetReviews`, `TestHandleGetChecks`

**Integration tests** (`internal/server/integration_test.go`):
- `TestIntegrationReviewFlow` — create branch, commit, self-approval blocked, other user approves, new commit makes prior review stale
- `TestIntegrationCheckRunFlow` — create check run, GET checks
- `TestIntegrationReviewRepoIsolation` — reviews in repo-x not visible in repo-y

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` passes (all packages)

## Opportunities noted (not implemented)

- The `GET /repos/{name}/branch/{branch...}` catch-all could later handle the not-yet-implemented `/{bname}/status` for multi-segment branch names
- `ListCheckRuns` currently returns all check runs; a future endpoint could return "latest per name" for merge gate evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)