### PR TITLE
Fix migration 001 branch seed broken by multitenancy PK change

### DIFF
--- a/internal/db/migrations/000001_initial_schema.up.sql
+++ b/internal/db/migrations/000001_initial_schema.up.sql
@@ -80,5 +80,5 @@ CREATE INDEX IF NOT EXISTS idx_check_runs_branch_seq_name ON check_runs (branch,
 
 -- Seed the main branch
 INSERT INTO branches (name, head_sequence, base_sequence, status)
-VALUES ('main', 0, 0, 'active')
-ON CONFLICT (name) DO NOTHING;
+SELECT 'main', 0, 0, 'active'
+WHERE NOT EXISTS (SELECT 1 FROM branches WHERE name = 'main');


### PR DESCRIPTION
## Problem

Every deploy since #38 has been failing at startup with:

```
pq: there is no unique or exclusion constraint matching the ON CONFLICT specification (42P10)
```

Migration 001 seeds the `main` branch with `ON CONFLICT (name) DO NOTHING`. After multitenancy (#37) changed the `branches` primary key from `(name)` to `(repo, name)`, re-running migration 001 on startup fails because `(name)` alone no longer matches any unique constraint.

## Fix

Replace `ON CONFLICT (name) DO NOTHING` with `WHERE NOT EXISTS (SELECT 1 FROM branches WHERE name = 'main')`. This is constraint-independent and safe to re-run regardless of the current schema.

## Test plan

- [x] `go test ./internal/db/...` passes locally
- [ ] Deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)