### PR TITLE
Implement POST /repos/:name/purge (closes #48)

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -980,6 +980,161 @@ func (s *Store) HasAdmin(ctx context.Context, repo string) (bool, error) {
 }
 
 
+// PurgeRequest contains the parameters for a purge operation.
+type PurgeRequest struct {
+	Repo      string
+	OlderThan time.Duration
+	DryRun    bool
+}
+
+// PurgeResult contains the counts of rows affected (or that would be affected) by a purge.
+type PurgeResult struct {
+	BranchesPurged     int64
+	FileCommitsDeleted int64
+	CommitsDeleted     int64
+	DocumentsDeleted   int64
+	ReviewsDeleted     int64
+	CheckRunsDeleted   int64
+}
+
+// Purge deletes file_commits, commits, orphaned documents, reviews, check_runs,
+// and branch rows for merged/abandoned branches whose last activity is older than
+// req.OlderThan. If req.DryRun is true, counts are returned without any rows being
+// deleted. All deletes happen within a single transaction.
+func (s *Store) Purge(ctx context.Context, req PurgeRequest) (*PurgeResult, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Verify repo exists.
+	var exists bool
+	if err := tx.QueryRowContext(ctx,
+		"SELECT EXISTS(SELECT 1 FROM repos WHERE name = $1)", req.Repo,
+	).Scan(&exists); err != nil {
+		return nil, fmt.Errorf("check repo: %w", err)
+	}
+	if !exists {
+		return nil, ErrRepoNotFound
+	}
+
+	threshold := time.Now().Add(-req.OlderThan)
+
+	// Find eligible branches: merged or abandoned, last activity older than threshold, not main.
+	rows, err := tx.QueryContext(ctx, `
+		SELECT b.name
+		FROM branches b
+		LEFT JOIN commits c ON c.repo = b.repo AND c.sequence = b.head_sequence
+		WHERE b.repo = $1
+		  AND b.status IN ('merged', 'abandoned')
+		  AND b.name != 'main'
+		  AND COALESCE(c.created_at, b.created_at) < $2
+	`, req.Repo, threshold)
+	if err != nil {
+		return nil, fmt.Errorf("find eligible branches: %w", err)
+	}
+	var branches []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan branch: %w", err)
+		}
+		branches = append(branches, name)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate branches: %w", err)
+	}
+
+	// Nothing to purge — return early (defer will rollback the empty transaction).
+	if len(branches) == 0 {
+		return &PurgeResult{}, nil
+	}
+
+	var result PurgeResult
+	result.BranchesPurged = int64(len(branches))
+
+	// 1. Delete file_commits for the eligible branches.
+	res, err := tx.ExecContext(ctx,
+		`DELETE FROM file_commits WHERE repo = $1 AND branch = ANY($2)`,
+		req.Repo, pq.Array(branches),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("delete file_commits: %w", err)
+	}
+	result.FileCommitsDeleted, _ = res.RowsAffected()
+
+	// 2. Delete commits for those branches not referenced by any remaining file_commits.
+	res, err = tx.ExecContext(ctx,
+		`DELETE FROM commits
+		 WHERE repo = $1 AND branch = ANY($2)
+		   AND sequence NOT IN (
+		       SELECT DISTINCT sequence FROM file_commits WHERE repo = $1
+		   )`,
+		req.Repo, pq.Array(branches),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("delete commits: %w", err)
+	}
+	result.CommitsDeleted, _ = res.RowsAffected()
+
+	// 3. Delete reviews for the eligible branches.
+	res, err = tx.ExecContext(ctx,
+		`DELETE FROM reviews WHERE repo = $1 AND branch = ANY($2)`,
+		req.Repo, pq.Array(branches),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("delete reviews: %w", err)
+	}
+	result.ReviewsDeleted, _ = res.RowsAffected()
+
+	// 4. Delete check_runs for the eligible branches.
+	res, err = tx.ExecContext(ctx,
+		`DELETE FROM check_runs WHERE repo = $1 AND branch = ANY($2)`,
+		req.Repo, pq.Array(branches),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("delete check_runs: %w", err)
+	}
+	result.CheckRunsDeleted, _ = res.RowsAffected()
+
+	// 5. Delete orphaned documents (not referenced by any remaining file_commits in the repo).
+	res, err = tx.ExecContext(ctx,
+		`DELETE FROM documents
+		 WHERE repo = $1
+		   AND version_id NOT IN (
+		       SELECT DISTINCT version_id FROM file_commits
+		       WHERE repo = $1 AND version_id IS NOT NULL
+		   )`,
+		req.Repo,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("delete documents: %w", err)
+	}
+	result.DocumentsDeleted, _ = res.RowsAffected()
+
+	// 6. Delete the branch rows themselves.
+	_, err = tx.ExecContext(ctx,
+		`DELETE FROM branches WHERE repo = $1 AND name = ANY($2)`,
+		req.Repo, pq.Array(branches),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("delete branches: %w", err)
+	}
+
+	// For dry_run, return counts without committing (defer will rollback).
+	if req.DryRun {
+		return &result, nil
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit tx: %w", err)
+	}
+	return &result, nil
+}
+
 // isDuplicateKeyError checks if a PostgreSQL error is a unique violation (23505).
 func isDuplicateKeyError(err error) bool {
 	var pqErr *pq.Error

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -3,9 +3,11 @@ package db
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/testutil"
@@ -2010,5 +2012,456 @@ func TestRoleIsolation(t *testing.T) {
 	hasAdmin, err = s.HasAdmin(ctx, "repo-b")
 	if err != nil || hasAdmin {
 		t.Errorf("expected HasAdmin false for repo-b, got %v %v", hasAdmin, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Purge tests
+// ---------------------------------------------------------------------------
+
+// makeOld ages a branch and all its commits to 100 days ago so it is eligible
+// for purge with any threshold less than 100 days.
+func makeOld(t *testing.T, db *sql.DB, repo, branch string) {
+	t.Helper()
+	_, err := db.Exec(`UPDATE branches SET created_at = now() - interval '100 days' WHERE repo = $1 AND name = $2`, repo, branch)
+	if err != nil {
+		t.Fatalf("makeOld branches: %v", err)
+	}
+	_, err = db.Exec(`UPDATE commits SET created_at = now() - interval '100 days' WHERE repo = $1 AND branch = $2`, repo, branch)
+	if err != nil {
+		t.Fatalf("makeOld commits: %v", err)
+	}
+}
+
+func TestPurge_DeletesMergedBranches(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Commit something to main so the branch has a non-zero base.
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "main",
+		Files:   []model.FileChange{{Path: "base.txt", Content: []byte("base")}},
+		Message: "base", Author: "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit to main: %v", err)
+	}
+
+	// Create a branch, commit to it, then merge.
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/merged"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "feature/merged",
+		Files:   []model.FileChange{{Path: "f.txt", Content: []byte("branch work")}},
+		Message: "work", Author: "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit to branch: %v", err)
+	}
+	_, _, err = s.Merge(ctx, model.MergeRequest{Repo: "default", Branch: "feature/merged", Author: "alice"})
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+
+	// Make the branch and its commits appear old.
+	makeOld(t, d, "default", "feature/merged")
+
+	result, err := s.Purge(ctx, PurgeRequest{Repo: "default", OlderThan: 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+
+	if result.BranchesPurged != 1 {
+		t.Errorf("expected 1 branch purged, got %d", result.BranchesPurged)
+	}
+	if result.FileCommitsDeleted < 1 {
+		t.Errorf("expected at least 1 file_commit deleted, got %d", result.FileCommitsDeleted)
+	}
+	if result.CommitsDeleted < 1 {
+		t.Errorf("expected at least 1 commit deleted, got %d", result.CommitsDeleted)
+	}
+
+	// The branch row must be gone.
+	var count int
+	d.QueryRow("SELECT count(*) FROM branches WHERE repo = 'default' AND name = 'feature/merged'").Scan(&count)
+	if count != 0 {
+		t.Errorf("expected branch to be deleted, found %d rows", count)
+	}
+}
+
+func TestPurge_DeletesAbandonedBranches(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/abandoned"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "feature/abandoned",
+		Files:   []model.FileChange{{Path: "x.txt", Content: []byte("x")}},
+		Message: "x", Author: "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if err := s.DeleteBranch(ctx, "default", "feature/abandoned"); err != nil {
+		t.Fatalf("delete branch: %v", err)
+	}
+
+	makeOld(t, d, "default", "feature/abandoned")
+
+	result, err := s.Purge(ctx, PurgeRequest{Repo: "default", OlderThan: 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if result.BranchesPurged != 1 {
+		t.Errorf("expected 1 branch purged, got %d", result.BranchesPurged)
+	}
+
+	var count int
+	d.QueryRow("SELECT count(*) FROM branches WHERE repo = 'default' AND name = 'feature/abandoned'").Scan(&count)
+	if count != 0 {
+		t.Errorf("expected abandoned branch to be deleted, found %d rows", count)
+	}
+}
+
+func TestPurge_RespectsOlderThan(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Create a branch and merge it — timestamps are current (now), not old.
+	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/recent"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	_, _, err = s.Merge(ctx, model.MergeRequest{Repo: "default", Branch: "feature/recent", Author: "alice"})
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+
+	// Purge with 1-day threshold — recently merged branch must NOT be purged.
+	result, err := s.Purge(ctx, PurgeRequest{Repo: "default", OlderThan: 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if result.BranchesPurged != 0 {
+		t.Errorf("expected 0 branches purged, got %d", result.BranchesPurged)
+	}
+
+	var count int
+	d.QueryRow("SELECT count(*) FROM branches WHERE repo = 'default' AND name = 'feature/recent'").Scan(&count)
+	if count != 1 {
+		t.Errorf("expected recent branch to still exist, got count=%d", count)
+	}
+}
+
+func TestPurge_DoesNotTouchActiveBranches(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/active"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	// Age the branch row so it would be eligible if it were merged/abandoned.
+	makeOld(t, d, "default", "feature/active")
+
+	result, err := s.Purge(ctx, PurgeRequest{Repo: "default", OlderThan: 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if result.BranchesPurged != 0 {
+		t.Errorf("expected 0 branches purged (active branch must be skipped), got %d", result.BranchesPurged)
+	}
+}
+
+func TestPurge_DoesNotTouchMain(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "main",
+		Files:   []model.FileChange{{Path: "m.txt", Content: []byte("main")}},
+		Message: "m", Author: "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit to main: %v", err)
+	}
+	// Force main's created_at to be very old (should never be eligible due to name filter).
+	d.Exec(`UPDATE branches SET created_at = now() - interval '100 days' WHERE repo = 'default' AND name = 'main'`)
+	d.Exec(`UPDATE commits SET created_at = now() - interval '100 days' WHERE repo = 'default' AND branch = 'main'`)
+
+	result, err := s.Purge(ctx, PurgeRequest{Repo: "default", OlderThan: 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if result.BranchesPurged != 0 {
+		t.Errorf("expected main to be untouched, but %d branches purged", result.BranchesPurged)
+	}
+
+	// main must still exist.
+	var count int
+	d.QueryRow("SELECT count(*) FROM branches WHERE repo = 'default' AND name = 'main'").Scan(&count)
+	if count != 1 {
+		t.Errorf("expected main branch to still exist")
+	}
+}
+
+func TestPurge_OrphanedDocumentsDeleted(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Create a branch, commit a file, then abandon it without merging.
+	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/orphan"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	commitResp, err := s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "feature/orphan",
+		Files:   []model.FileChange{{Path: "orphan.txt", Content: []byte("unique orphan content")}},
+		Message: "orphan", Author: "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	// Record the version_id of the orphaned doc.
+	orphanVersionID := ""
+	if len(commitResp.Files) > 0 && commitResp.Files[0].VersionID != nil {
+		orphanVersionID = *commitResp.Files[0].VersionID
+	}
+
+	if err := s.DeleteBranch(ctx, "default", "feature/orphan"); err != nil {
+		t.Fatalf("delete branch: %v", err)
+	}
+	makeOld(t, d, "default", "feature/orphan")
+
+	result, err := s.Purge(ctx, PurgeRequest{Repo: "default", OlderThan: 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if result.DocumentsDeleted < 1 {
+		t.Errorf("expected at least 1 orphaned document deleted, got %d", result.DocumentsDeleted)
+	}
+
+	// The orphaned document must no longer exist.
+	if orphanVersionID != "" {
+		var count int
+		d.QueryRow("SELECT count(*) FROM documents WHERE version_id = $1", orphanVersionID).Scan(&count)
+		if count != 0 {
+			t.Errorf("orphaned document %s should have been deleted", orphanVersionID)
+		}
+	}
+}
+
+func TestPurge_SharedDocumentRetained(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Commit a file to main first.
+	mainResp, err := s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "main",
+		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("shared content")}},
+		Message: "main", Author: "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit to main: %v", err)
+	}
+	sharedVersionID := ""
+	if len(mainResp.Files) > 0 && mainResp.Files[0].VersionID != nil {
+		sharedVersionID = *mainResp.Files[0].VersionID
+	}
+
+	// Create a branch with the same content (will dedup to same version_id).
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/shared"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "feature/shared",
+		Files:   []model.FileChange{{Path: "shared.txt", Content: []byte("shared content")}},
+		Message: "branch", Author: "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit to branch: %v", err)
+	}
+	if err := s.DeleteBranch(ctx, "default", "feature/shared"); err != nil {
+		t.Fatalf("delete branch: %v", err)
+	}
+	makeOld(t, d, "default", "feature/shared")
+
+	result, err := s.Purge(ctx, PurgeRequest{Repo: "default", OlderThan: 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	// The shared document is still referenced by main's file_commits → must not be deleted.
+	if result.DocumentsDeleted != 0 {
+		t.Errorf("expected 0 documents deleted (shared with main), got %d", result.DocumentsDeleted)
+	}
+
+	if sharedVersionID != "" {
+		var count int
+		d.QueryRow("SELECT count(*) FROM documents WHERE version_id = $1", sharedVersionID).Scan(&count)
+		if count != 1 {
+			t.Errorf("shared document %s should still exist", sharedVersionID)
+		}
+	}
+}
+
+func TestPurge_DeletesReviewsAndChecks(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/rev"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "feature/rev",
+		Files:   []model.FileChange{{Path: "r.txt", Content: []byte("r")}},
+		Message: "r", Author: "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Add a review and a check_run for the branch.
+	_, err = s.CreateReview(ctx, "default", "feature/rev", "bob", model.ReviewApproved, "LGTM")
+	if err != nil {
+		t.Fatalf("create review: %v", err)
+	}
+	_, err = s.CreateCheckRun(ctx, "default", "feature/rev", "ci/build", model.CheckRunPassed, "ci-bot")
+	if err != nil {
+		t.Fatalf("create check_run: %v", err)
+	}
+
+	if err := s.DeleteBranch(ctx, "default", "feature/rev"); err != nil {
+		t.Fatalf("delete branch: %v", err)
+	}
+	makeOld(t, d, "default", "feature/rev")
+
+	result, err := s.Purge(ctx, PurgeRequest{Repo: "default", OlderThan: 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if result.ReviewsDeleted != 1 {
+		t.Errorf("expected 1 review deleted, got %d", result.ReviewsDeleted)
+	}
+	if result.CheckRunsDeleted != 1 {
+		t.Errorf("expected 1 check_run deleted, got %d", result.CheckRunsDeleted)
+	}
+}
+
+func TestPurge_DryRun(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/dry"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "feature/dry",
+		Files:   []model.FileChange{{Path: "d.txt", Content: []byte("dry run content")}},
+		Message: "dry", Author: "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if err := s.DeleteBranch(ctx, "default", "feature/dry"); err != nil {
+		t.Fatalf("delete branch: %v", err)
+	}
+	makeOld(t, d, "default", "feature/dry")
+
+	// Count before dry run.
+	var branchBefore, fcBefore int
+	d.QueryRow("SELECT count(*) FROM branches WHERE repo = 'default' AND name = 'feature/dry'").Scan(&branchBefore)
+	d.QueryRow("SELECT count(*) FROM file_commits WHERE repo = 'default' AND branch = 'feature/dry'").Scan(&fcBefore)
+
+	result, err := s.Purge(ctx, PurgeRequest{Repo: "default", OlderThan: 24 * time.Hour, DryRun: true})
+	if err != nil {
+		t.Fatalf("purge dry run: %v", err)
+	}
+
+	// Counts must be non-zero (something would be deleted).
+	if result.BranchesPurged != 1 {
+		t.Errorf("dry run: expected 1 branch, got %d", result.BranchesPurged)
+	}
+	if result.FileCommitsDeleted < 1 {
+		t.Errorf("dry run: expected file_commits > 0, got %d", result.FileCommitsDeleted)
+	}
+
+	// But no rows must actually have been deleted.
+	var branchAfter, fcAfter int
+	d.QueryRow("SELECT count(*) FROM branches WHERE repo = 'default' AND name = 'feature/dry'").Scan(&branchAfter)
+	d.QueryRow("SELECT count(*) FROM file_commits WHERE repo = 'default' AND branch = 'feature/dry'").Scan(&fcAfter)
+
+	if branchAfter != branchBefore {
+		t.Errorf("dry run must not delete branches: before=%d after=%d", branchBefore, branchAfter)
+	}
+	if fcAfter != fcBefore {
+		t.Errorf("dry run must not delete file_commits: before=%d after=%d", fcBefore, fcAfter)
+	}
+}
+
+func TestPurge_IsAtomic(t *testing.T) {
+	// Demonstrates that all deletes are committed together (or not at all).
+	// We use a pre-cancelled context so BeginTx fails before any deletions occur,
+	// verifying that no partial state is left behind.
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/atomic"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo: "default", Branch: "feature/atomic",
+		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("atomic")}},
+		Message: "atomic", Author: "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if err := s.DeleteBranch(ctx, "default", "feature/atomic"); err != nil {
+		t.Fatalf("delete branch: %v", err)
+	}
+	makeOld(t, d, "default", "feature/atomic")
+
+	var fcBefore int
+	d.QueryRow("SELECT count(*) FROM file_commits WHERE repo = 'default' AND branch = 'feature/atomic'").Scan(&fcBefore)
+
+	// Use a cancelled context — BeginTx will fail immediately.
+	cancelCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	_, err = s.Purge(cancelCtx, PurgeRequest{Repo: "default", OlderThan: 24 * time.Hour})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+
+	// Verify no data was changed.
+	var fcAfter int
+	d.QueryRow("SELECT count(*) FROM file_commits WHERE repo = 'default' AND branch = 'feature/atomic'").Scan(&fcAfter)
+	if fcAfter != fcBefore {
+		t.Errorf("partial deletion occurred: before=%d after=%d file_commits", fcBefore, fcAfter)
+	}
+
+	var branchCount int
+	d.QueryRow("SELECT count(*) FROM branches WHERE repo = 'default' AND name = 'feature/atomic'").Scan(&branchCount)
+	if branchCount != 1 {
+		t.Errorf("branch should still exist after failed purge, count=%d", branchCount)
 	}
 }

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -298,6 +298,26 @@ type RolesResponse struct {
 }
 
 // ---------------------------------------------------------------------------
+// POST /repos/:name/purge
+// ---------------------------------------------------------------------------
+
+// PurgeRequest is the body for POST /repos/:name/purge.
+type PurgeRequest struct {
+	OlderThan string `json:"older_than"`
+	DryRun    bool   `json:"dry_run,omitempty"`
+}
+
+// PurgeResponse is the response for POST /repos/:name/purge.
+type PurgeResponse struct {
+	BranchesPurged     int64 `json:"branches_purged"`
+	FileCommitsDeleted int64 `json:"file_commits_deleted"`
+	CommitsDeleted     int64 `json:"commits_deleted"`
+	DocumentsDeleted   int64 `json:"documents_deleted"`
+	ReviewsDeleted     int64 `json:"reviews_deleted"`
+	CheckRunsDeleted   int64 `json:"check_runs_deleted"`
+}
+
+// ---------------------------------------------------------------------------
 // Error
 // ---------------------------------------------------------------------------
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -3,9 +3,11 @@ package server
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/model"
@@ -155,6 +157,64 @@ func (s *server) handleGetChecks(w http.ResponseWriter, r *http.Request, repo, b
 		checkRuns = []model.CheckRun{}
 	}
 	writeJSON(w, http.StatusOK, checkRuns)
+}
+
+// parseDayDuration parses a duration string of the form "Nd" (e.g. "7d", "30d").
+// N must be a positive integer.
+func parseDayDuration(s string) (time.Duration, error) {
+	if len(s) < 2 || s[len(s)-1] != 'd' {
+		return 0, fmt.Errorf("invalid duration %q: must be of the form \"Nd\" (e.g. \"7d\")", s)
+	}
+	n, err := strconv.ParseInt(s[:len(s)-1], 10, 64)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("invalid duration %q: must be a positive integer followed by 'd'", s)
+	}
+	return time.Duration(n) * 24 * time.Hour, nil
+}
+
+// handlePurge implements POST /repos/:name/purge
+func (s *server) handlePurge(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+
+	var req model.PurgeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.OlderThan == "" {
+		writeError(w, http.StatusBadRequest, "older_than is required")
+		return
+	}
+
+	dur, err := parseDayDuration(req.OlderThan)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	result, err := s.commitStore.Purge(r.Context(), db.PurgeRequest{
+		Repo:      repo,
+		OlderThan: dur,
+		DryRun:    req.DryRun,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrRepoNotFound):
+			writeError(w, http.StatusNotFound, "repo not found")
+		default:
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusOK, model.PurgeResponse{
+		BranchesPurged:     result.BranchesPurged,
+		FileCommitsDeleted: result.FileCommitsDeleted,
+		CommitsDeleted:     result.CommitsDeleted,
+		DocumentsDeleted:   result.DocumentsDeleted,
+		ReviewsDeleted:     result.ReviewsDeleted,
+		CheckRunsDeleted:   result.CheckRunsDeleted,
+	})
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -1265,3 +1265,155 @@ func TestIntegrationRBAC_CrossRepoIsolation(t *testing.T) {
 		t.Fatalf("alice repo-y: expected 403, got %d", resp.StatusCode)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Purge integration tests
+// ---------------------------------------------------------------------------
+
+func TestIntegrationPurge_FullFlow(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	post := func(path, body string) *http.Response {
+		t.Helper()
+		resp, err := http.Post(srv.URL+path, "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		return resp
+	}
+	del := func(path string) *http.Response {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+path, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("DELETE %s: %v", path, err)
+		}
+		return resp
+	}
+
+	// Step 1: Commit to main.
+	r := post("/repos/default/commit", `{"branch":"main","message":"init","files":[{"path":"main.txt","content":"bWFpbg=="}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("commit to main: expected 201, got %d", r.StatusCode)
+	}
+
+	// Step 2: Create and merge a feature branch (tests merged-branch cleanup).
+	r = post("/repos/default/branch", `{"name":"feature/merged"}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("create merged branch: expected 201, got %d", r.StatusCode)
+	}
+	r = post("/repos/default/commit", `{"branch":"feature/merged","message":"work","files":[{"path":"merged.txt","content":"bWVyZ2Vk"}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("commit to merged branch: expected 201, got %d", r.StatusCode)
+	}
+	r = post("/repos/default/merge", `{"branch":"feature/merged"}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		t.Fatalf("merge: expected 200, got %d", r.StatusCode)
+	}
+
+	// Step 3: Create and abandon a second branch with a unique file (orphan candidate).
+	r = post("/repos/default/branch", `{"name":"feature/abandoned"}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("create abandoned branch: expected 201, got %d", r.StatusCode)
+	}
+	r = post("/repos/default/commit", `{"branch":"feature/abandoned","message":"abandoned work","files":[{"path":"abandoned-only.txt","content":"b3JwaGFu"}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("commit to abandoned branch: expected 201, got %d", r.StatusCode)
+	}
+	r = del("/repos/default/branch/feature/abandoned")
+	r.Body.Close()
+	if r.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete branch: expected 204, got %d", r.StatusCode)
+	}
+
+	// Step 4: Age both branches and their commits.
+	for _, branch := range []string{"feature/merged", "feature/abandoned"} {
+		if _, err := database.Exec(`UPDATE branches SET created_at = now() - interval '100 days' WHERE repo = 'default' AND name = $1`, branch); err != nil {
+			t.Fatalf("age branch %s: %v", branch, err)
+		}
+		if _, err := database.Exec(`UPDATE commits SET created_at = now() - interval '100 days' WHERE repo = 'default' AND branch = $1`, branch); err != nil {
+			t.Fatalf("age commits %s: %v", branch, err)
+		}
+	}
+
+	// Step 5: POST /purge with 1d threshold.
+	r = post("/repos/default/purge", `{"older_than":"1d"}`)
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		var errBody map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&errBody)
+		t.Fatalf("purge: expected 200, got %d; body: %v", r.StatusCode, errBody)
+	}
+	var purgeResp struct {
+		BranchesPurged     int64 `json:"branches_purged"`
+		FileCommitsDeleted int64 `json:"file_commits_deleted"`
+		CommitsDeleted     int64 `json:"commits_deleted"`
+		DocumentsDeleted   int64 `json:"documents_deleted"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&purgeResp); err != nil {
+		t.Fatalf("decode purge response: %v", err)
+	}
+
+	if purgeResp.BranchesPurged != 2 {
+		t.Errorf("expected 2 branches purged, got %d", purgeResp.BranchesPurged)
+	}
+	if purgeResp.FileCommitsDeleted < 2 {
+		t.Errorf("expected at least 2 file_commits deleted, got %d", purgeResp.FileCommitsDeleted)
+	}
+	if purgeResp.CommitsDeleted < 1 {
+		t.Errorf("expected at least 1 commit deleted, got %d", purgeResp.CommitsDeleted)
+	}
+	// abandoned-only.txt was never merged, so its document is orphaned.
+	if purgeResp.DocumentsDeleted < 1 {
+		t.Errorf("expected at least 1 orphaned document deleted, got %d", purgeResp.DocumentsDeleted)
+	}
+
+	// Step 6: Verify both branch rows are gone.
+	for _, branch := range []string{"feature/merged", "feature/abandoned"} {
+		var count int
+		if err := database.QueryRow("SELECT count(*) FROM branches WHERE repo = 'default' AND name = $1", branch).Scan(&count); err != nil {
+			t.Fatalf("query branch %s: %v", branch, err)
+		}
+		if count != 0 {
+			t.Errorf("expected branch %s to be deleted, found %d rows", branch, count)
+		}
+	}
+
+	// Step 7: Verify main is unaffected — its tree has main.txt and merged.txt.
+	treeResp, err := http.Get(srv.URL + "/repos/default/tree")
+	if err != nil {
+		t.Fatalf("GET /tree: %v", err)
+	}
+	defer treeResp.Body.Close()
+	if treeResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /tree: expected 200, got %d", treeResp.StatusCode)
+	}
+	var entries []struct{ Path string `json:"path"` }
+	if err := json.NewDecoder(treeResp.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode tree: %v", err)
+	}
+	// main should have main.txt and merged.txt (2 files).
+	if len(entries) != 2 {
+		t.Errorf("expected main tree to have 2 entries after purge, got %d", len(entries))
+	}
+	paths := make(map[string]bool)
+	for _, e := range entries {
+		paths[e.Path] = true
+	}
+	if !paths["main.txt"] {
+		t.Error("main.txt must still be present on main")
+	}
+	if !paths["merged.txt"] {
+		t.Error("merged.txt (from merged branch) must still be present on main")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -39,6 +39,9 @@ type WriteStore interface {
 	DeleteRole(ctx context.Context, repo, identity string) error
 	ListRoles(ctx context.Context, repo string) ([]model.Role, error)
 	HasAdmin(ctx context.Context, repo string) (bool, error)
+
+	// Purge
+	Purge(ctx context.Context, req db.PurgeRequest) (*db.PurgeResult, error)
 }
 
 // CommitStore is an alias for backward compatibility with tests.
@@ -86,6 +89,7 @@ func New(writeStore WriteStore, database *sql.DB, devIdentity, bootstrapAdmin st
 	inner.HandleFunc("POST /repos/{name}/rebase", s.handleRebase)
 	inner.HandleFunc("POST /repos/{name}/review", s.handleReview)
 	inner.HandleFunc("POST /repos/{name}/check", s.handleCheck)
+	inner.HandleFunc("POST /repos/{name}/purge", s.handlePurge)
 	inner.HandleFunc("DELETE /repos/{name}/branch/{bname...}", s.handleDeleteBranch)
 
 	// Role management endpoints

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/model"
@@ -33,6 +34,7 @@ type mockStore struct {
 	deleteRoleFn   func(ctx context.Context, repo, identity string) error
 	listRolesFn    func(ctx context.Context, repo string) ([]model.Role, error)
 	hasAdminFn     func(ctx context.Context, repo string) (bool, error)
+	purgeFn        func(ctx context.Context, req db.PurgeRequest) (*db.PurgeResult, error)
 }
 
 func (m *mockStore) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
@@ -159,6 +161,13 @@ func (m *mockStore) HasAdmin(ctx context.Context, repo string) (bool, error) {
 		return m.hasAdminFn(ctx, repo)
 	}
 	return false, nil
+}
+
+func (m *mockStore) Purge(ctx context.Context, req db.PurgeRequest) (*db.PurgeResult, error) {
+	if m.purgeFn != nil {
+		return m.purgeFn(ctx, req)
+	}
+	return nil, errors.New("not implemented")
 }
 
 func TestHealthEndpoint(t *testing.T) {
@@ -1160,5 +1169,122 @@ func TestHandleGetChecks(t *testing.T) {
 	}
 	if checkRuns[0].ID != "cr1" {
 		t.Errorf("expected id cr1, got %q", checkRuns[0].ID)
+	}
+}
+
+func TestHandlePurge_Success(t *testing.T) {
+	ms := &mockStore{
+		purgeFn: func(ctx context.Context, req db.PurgeRequest) (*db.PurgeResult, error) {
+			if req.Repo != "default" {
+				t.Errorf("expected repo 'default', got %q", req.Repo)
+			}
+			if req.OlderThan != 30*24*time.Hour {
+				t.Errorf("expected 30d duration, got %v", req.OlderThan)
+			}
+			if req.DryRun {
+				t.Error("expected dry_run=false")
+			}
+			return &db.PurgeResult{
+				BranchesPurged:     3,
+				FileCommitsDeleted: 12,
+				CommitsDeleted:     4,
+				DocumentsDeleted:   2,
+				ReviewsDeleted:     1,
+				CheckRunsDeleted:   1,
+			}, nil
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+
+	body, _ := json.Marshal(map[string]interface{}{"older_than": "30d"})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/purge", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp model.PurgeResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.BranchesPurged != 3 {
+		t.Errorf("expected 3 branches_purged, got %d", resp.BranchesPurged)
+	}
+	if resp.FileCommitsDeleted != 12 {
+		t.Errorf("expected 12 file_commits_deleted, got %d", resp.FileCommitsDeleted)
+	}
+}
+
+func TestHandlePurge_DryRun(t *testing.T) {
+	ms := &mockStore{
+		purgeFn: func(ctx context.Context, req db.PurgeRequest) (*db.PurgeResult, error) {
+			if !req.DryRun {
+				t.Error("expected dry_run=true")
+			}
+			return &db.PurgeResult{BranchesPurged: 2, CommitsDeleted: 5}, nil
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+
+	body, _ := json.Marshal(map[string]interface{}{"older_than": "7d", "dry_run": true})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/purge", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp model.PurgeResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.BranchesPurged != 2 {
+		t.Errorf("expected 2 branches_purged, got %d", resp.BranchesPurged)
+	}
+}
+
+func TestHandlePurge_InvalidDuration(t *testing.T) {
+	srv := New(&mockStore{}, nil, devID, devID)
+
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{"missing older_than", `{}`},
+		{"not a day format", `{"older_than":"90h"}`},
+		{"zero days", `{"older_than":"0d"}`},
+		{"negative days", `{"older_than":"-1d"}`},
+		{"non-numeric", `{"older_than":"abcd"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/repos/default/purge", bytes.NewReader([]byte(tt.payload)))
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d; body: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandlePurge_RepoNotFound(t *testing.T) {
+	ms := &mockStore{
+		purgeFn: func(ctx context.Context, req db.PurgeRequest) (*db.PurgeResult, error) {
+			return nil, db.ErrRepoNotFound
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+
+	body, _ := json.Marshal(map[string]interface{}{"older_than": "30d"})
+	req := httptest.NewRequest(http.MethodPost, "/repos/noexist/purge", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d; body: %s", rec.Code, rec.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

- Implements `POST /repos/:name/purge` per issue #48
- Deletes `file_commits`, `commits`, orphaned `documents`, `reviews`, `check_runs`, and `branches` rows for merged/abandoned branches older than the given threshold
- Supports `dry_run: true` mode (returns counts without deleting)
- All deletes in a single transaction; `dry_run` defers to rollback via Go's `defer tx.Rollback()` pattern

## Changes

**`internal/model/api.go`**: `PurgeRequest` (`older_than`, `dry_run`) and `PurgeResponse` (6 count fields)

**`internal/db/store.go`**: `PurgeRequest`, `PurgeResult` types + `Purge()` method
- Verifies repo exists inside transaction
- Finds eligible branches: `status IN ('merged','abandoned') AND name != 'main' AND COALESCE(commit.created_at, branch.created_at) < threshold`
- Deletes in order: file_commits → commits (not referenced by remaining file_commits) → reviews → check_runs → orphaned documents → branches
- `dry_run` returns counts without committing

**`internal/server/server.go`**: Added `Purge` to `WriteStore` interface; registered `POST /repos/{name}/purge`

**`internal/server/handlers.go`**: `parseDayDuration` helper (`"Nd"` format) + `handlePurge` handler (400 for bad duration, 404 for missing repo)

## Tests

Store tests (in `internal/db/store_test.go`):
- `TestPurge_DeletesMergedBranches`
- `TestPurge_DeletesAbandonedBranches`
- `TestPurge_RespectsOlderThan`
- `TestPurge_DoesNotTouchActiveBranches`
- `TestPurge_DoesNotTouchMain`
- `TestPurge_OrphanedDocumentsDeleted`
- `TestPurge_SharedDocumentRetained`
- `TestPurge_DeletesReviewsAndChecks`
- `TestPurge_DryRun`
- `TestPurge_IsAtomic`

Handler tests (in `internal/server/server_test.go`):
- `TestHandlePurge_Success`
- `TestHandlePurge_DryRun`
- `TestHandlePurge_InvalidDuration`
- `TestHandlePurge_RepoNotFound`

Integration test (in `internal/server/integration_test.go`):
- `TestIntegrationPurge_FullFlow` — creates + merges a branch, creates + abandons another, purges both, verifies data gone and main unaffected

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` all pass

## Notes for future work

- RBAC: purge is not yet in `roleAllows` (consistent with review/check pattern); add admin-only enforcement when that pattern is standardized
- Duration format: only supports `"Nd"` (days); could extend to support hours/weeks if needed

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)