### PR TITLE
Fix two inaccuracies in OPERATIONS.md

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -92,7 +92,7 @@ ko build ./cmd/docstore
 | `--dev-identity`    | Same as `DEV_IDENTITY` env var; bypasses IAP JWT validation              |
 | `--bootstrap-admin` | Same as `BOOTSTRAP_ADMIN` env var; grants bootstrap admin access         |
 
-Environment variables take precedence over omitted flags. If both the flag and the env var are set, the flag wins (the env var is only read when the flag is empty string).
+The flag takes precedence over the env var; the env var is only used as a fallback when the flag is not set (empty string).
 
 ### Example Cloud Run deployment
 
@@ -921,14 +921,17 @@ The server uses the standard `log` package. All startup events, migration status
 8. Create your first repo:
    ```bash
    curl -X POST https://<url>/repos \
-     -H "Authorization: Bearer $(gcloud auth print-identity-token)" \
      -H "Content-Type: application/json" \
      -d '{"name": "myrepo"}'
    ```
+   > **Note:** When IAP is enabled, the proxy automatically injects the
+   > `X-Goog-IAP-JWT-Assertion` header — clients never set it directly.
+   > The examples above work as-is when the request passes through IAP.
+   > For local testing with `--dev-identity`, no auth header is needed since
+   > IAP validation is bypassed entirely.
 9. Grant yourself admin:
    ```bash
    curl -X PUT https://<url>/repos/myrepo/roles/you@example.com \
-     -H "Authorization: Bearer $(gcloud auth print-identity-token)" \
      -H "Content-Type: application/json" \
      -d '{"role": "admin"}'
    ```


### PR DESCRIPTION
## Summary

- **Env var precedence wording (line ~95):** The previous text contradicted itself ("env vars take precedence" then "flag wins"). Rewrote to clearly state: the flag takes precedence; the env var is only used as a fallback when the flag is empty. Verified against `cmd/docstore/main.go` logic.

- **First deployment runbook (lines ~920-935):** Removed incorrect `-H "Authorization: Bearer ..."` from curl examples. The server reads `X-Goog-IAP-JWT-Assertion`, not `Authorization`. When IAP is enabled the proxy injects that header automatically — clients never set it directly. Added a note explaining this and that `--dev-identity` bypasses IAP validation so no auth header is needed for local testing.

## Test plan
- [x] `go test ./... -count=1` — all tests pass
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] Documentation-only change; no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)