### PR TITLE
Add parseDayDuration unit tests

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1288,3 +1288,37 @@ func TestHandlePurge_RepoNotFound(t *testing.T) {
 		t.Fatalf("expected 404, got %d; body: %s", rec.Code, rec.Body.String())
 	}
 }
+
+func TestParseDayDuration(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"1d", 24 * time.Hour, false},
+		{"7d", 7 * 24 * time.Hour, false},
+		{"30d", 30 * 24 * time.Hour, false},
+		{"365d", 365 * 24 * time.Hour, false},
+		// invalid inputs
+		{"0d", 0, true},
+		{"-1d", 0, true},
+		{"7h", 0, true},
+		{"7", 0, true},
+		{"d", 0, true},
+		{"", 0, true},
+		{"abcd", 0, true},
+		{"1.5d", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseDayDuration(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseDayDuration(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parseDayDuration(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `TestParseDayDuration` to `internal/server/server_test.go`, covering valid inputs (`1d`, `7d`, `30d`, `365d`) and all invalid edge cases (`0d`, `-1d`, hour format, missing suffix, empty string, non-numeric, fractional)

## Context

The task asked for purge tests covering `Store.Purge`, `parseDayDuration`, and the HTTP purge endpoint. On investigation:

- `Store.Purge` unit tests: already present in `internal/db/store_test.go` (10 tests: merged branches, abandoned branches, OlderThan threshold, active branch protection, main protection, orphaned document deletion, shared document retention, reviews/checks cleanup, dry run, atomicity)
- HTTP purge endpoint: already tested in `internal/server/server_test.go` (success, dry_run, invalid duration, repo not found) and full integration test in `integration_test.go`
- `parseDayDuration`: **missing** — this PR adds those tests

## Test plan

- [x] `go test ./... -count=1` passes (all packages green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)