### PR TITLE
Add merge/rebase conflict body assertions and branch lifecycle edge case tests

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -682,9 +682,13 @@ func nullStr(s *string) string {
 }
 
 // DeleteBranch marks a branch as abandoned. It returns ErrBranchNotFound if
-// the branch does not exist, and ErrBranchNotActive if it is already merged
-// or abandoned (i.e. not active).
+// the branch does not exist, ErrBranchNotActive if it is already merged,
+// abandoned, or is the protected "main" branch.
 func (s *Store) DeleteBranch(ctx context.Context, repo, name string) error {
+	if name == "main" {
+		return ErrBranchNotActive
+	}
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -502,6 +502,15 @@ func TestMerge_Conflict(t *testing.T) {
 	if conflicts[0].Path != "shared.txt" {
 		t.Errorf("expected conflict on shared.txt, got %q", conflicts[0].Path)
 	}
+	if conflicts[0].MainVersionID == "" {
+		t.Error("expected non-empty MainVersionID")
+	}
+	if conflicts[0].BranchVersionID == "" {
+		t.Error("expected non-empty BranchVersionID")
+	}
+	if conflicts[0].MainVersionID == conflicts[0].BranchVersionID {
+		t.Error("expected MainVersionID and BranchVersionID to differ")
+	}
 
 	// Branch should still be active (merge was aborted).
 	var status string
@@ -986,6 +995,15 @@ func TestRebase_Conflict(t *testing.T) {
 	}
 	if conflicts[0].Path != "shared.txt" {
 		t.Errorf("expected conflict on shared.txt, got %q", conflicts[0].Path)
+	}
+	if conflicts[0].MainVersionID == "" {
+		t.Error("expected non-empty MainVersionID")
+	}
+	if conflicts[0].BranchVersionID == "" {
+		t.Error("expected non-empty BranchVersionID")
+	}
+	if conflicts[0].MainVersionID == conflicts[0].BranchVersionID {
+		t.Error("expected MainVersionID and BranchVersionID to differ")
 	}
 }
 
@@ -2463,5 +2481,276 @@ func TestPurge_IsAtomic(t *testing.T) {
 	d.QueryRow("SELECT count(*) FROM branches WHERE repo = 'default' AND name = 'feature/atomic'").Scan(&branchCount)
 	if branchCount != 1 {
 		t.Errorf("branch should still exist after failed purge, count=%d", branchCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Conflict body assertions — multiple conflicts
+// ---------------------------------------------------------------------------
+
+func TestMerge_MultipleConflicts(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Commit to main (seq=1): two files that will both conflict.
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:   "default",
+		Branch: "main",
+		Files: []model.FileChange{
+			{Path: "alpha.txt", Content: []byte("alpha original")},
+			{Path: "beta.txt", Content: []byte("beta original")},
+		},
+		Message: "initial",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Create branch (base=1).
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/multi-conflict"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+
+	// Main modifies both files (seq=2).
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:   "default",
+		Branch: "main",
+		Files: []model.FileChange{
+			{Path: "alpha.txt", Content: []byte("alpha main")},
+			{Path: "beta.txt", Content: []byte("beta main")},
+		},
+		Message: "main edit",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("main commit: %v", err)
+	}
+
+	// Branch modifies both files (seq=3).
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:   "default",
+		Branch: "feature/multi-conflict",
+		Files: []model.FileChange{
+			{Path: "alpha.txt", Content: []byte("alpha branch")},
+			{Path: "beta.txt", Content: []byte("beta branch")},
+		},
+		Message: "branch edit",
+		Author:  "bob",
+	})
+	if err != nil {
+		t.Fatalf("branch commit: %v", err)
+	}
+
+	_, conflicts, err := s.Merge(ctx, model.MergeRequest{Repo: "default", Branch: "feature/multi-conflict"})
+	if err != ErrMergeConflict {
+		t.Fatalf("expected ErrMergeConflict, got %v", err)
+	}
+	if len(conflicts) != 2 {
+		t.Fatalf("expected 2 conflicts, got %d", len(conflicts))
+	}
+
+	// Collect conflict paths to verify both are reported.
+	paths := make(map[string]MergeConflict, 2)
+	for _, c := range conflicts {
+		paths[c.Path] = c
+	}
+	for _, path := range []string{"alpha.txt", "beta.txt"} {
+		c, ok := paths[path]
+		if !ok {
+			t.Errorf("expected conflict on %s not found", path)
+			continue
+		}
+		if c.MainVersionID == "" {
+			t.Errorf("%s: expected non-empty MainVersionID", path)
+		}
+		if c.BranchVersionID == "" {
+			t.Errorf("%s: expected non-empty BranchVersionID", path)
+		}
+		if c.MainVersionID == c.BranchVersionID {
+			t.Errorf("%s: MainVersionID and BranchVersionID should differ", path)
+		}
+	}
+}
+
+func TestRebase_MultipleConflicts(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Commit to main (seq=1).
+	_, err := s.Commit(ctx, model.CommitRequest{
+		Repo:   "default",
+		Branch: "main",
+		Files: []model.FileChange{
+			{Path: "alpha.txt", Content: []byte("alpha original")},
+			{Path: "beta.txt", Content: []byte("beta original")},
+		},
+		Message: "initial",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Create branch (base=1).
+	_, err = s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/rebase-multi"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+
+	// Branch modifies both files (seq=2).
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:   "default",
+		Branch: "feature/rebase-multi",
+		Files: []model.FileChange{
+			{Path: "alpha.txt", Content: []byte("alpha branch")},
+			{Path: "beta.txt", Content: []byte("beta branch")},
+		},
+		Message: "branch edit",
+		Author:  "bob",
+	})
+	if err != nil {
+		t.Fatalf("branch commit: %v", err)
+	}
+
+	// Main modifies both files (seq=3).
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:   "default",
+		Branch: "main",
+		Files: []model.FileChange{
+			{Path: "alpha.txt", Content: []byte("alpha main")},
+			{Path: "beta.txt", Content: []byte("beta main")},
+		},
+		Message: "main edit",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("main commit: %v", err)
+	}
+
+	_, conflicts, err := s.Rebase(ctx, model.RebaseRequest{Repo: "default", Branch: "feature/rebase-multi"})
+	if err != ErrRebaseConflict {
+		t.Fatalf("expected ErrRebaseConflict, got %v", err)
+	}
+	if len(conflicts) != 2 {
+		t.Fatalf("expected 2 conflicts, got %d", len(conflicts))
+	}
+
+	paths := make(map[string]MergeConflict, 2)
+	for _, c := range conflicts {
+		paths[c.Path] = c
+	}
+	for _, path := range []string{"alpha.txt", "beta.txt"} {
+		c, ok := paths[path]
+		if !ok {
+			t.Errorf("expected conflict on %s not found", path)
+			continue
+		}
+		if c.MainVersionID == "" {
+			t.Errorf("%s: expected non-empty MainVersionID", path)
+		}
+		if c.BranchVersionID == "" {
+			t.Errorf("%s: expected non-empty BranchVersionID", path)
+		}
+		if c.MainVersionID == c.BranchVersionID {
+			t.Errorf("%s: MainVersionID and BranchVersionID should differ", path)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Branch lifecycle edge cases
+// ---------------------------------------------------------------------------
+
+func TestDeleteBranch_MainBranch(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	err := s.DeleteBranch(ctx, "default", "main")
+	if err != ErrBranchNotActive {
+		t.Fatalf("expected ErrBranchNotActive when deleting main, got %v", err)
+	}
+
+	// Verify main is still active.
+	var status string
+	if err := d.QueryRow("SELECT status FROM branches WHERE name = 'main'").Scan(&status); err != nil {
+		t.Fatalf("query branch: %v", err)
+	}
+	if status != "active" {
+		t.Errorf("expected main to remain active, got %q", status)
+	}
+}
+
+func TestMerge_AlreadyMergedBranch(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Create branch, commit, then merge it.
+	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/once"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
+		Branch:  "feature/once",
+		Files:   []model.FileChange{{Path: "f.txt", Content: []byte("content")}},
+		Message: "work",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	_, _, err = s.Merge(ctx, model.MergeRequest{Repo: "default", Branch: "feature/once"})
+	if err != nil {
+		t.Fatalf("first merge: %v", err)
+	}
+
+	// Second merge of the same branch must fail.
+	_, _, err = s.Merge(ctx, model.MergeRequest{Repo: "default", Branch: "feature/once"})
+	if err != ErrBranchNotActive {
+		t.Fatalf("expected ErrBranchNotActive on second merge, got %v", err)
+	}
+}
+
+func TestCommit_ToMergedBranch(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Create branch, commit, merge it, then try to commit again.
+	_, err := s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default", Name: "feature/merged"})
+	if err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
+		Branch:  "feature/merged",
+		Files:   []model.FileChange{{Path: "x.txt", Content: []byte("x")}},
+		Message: "initial",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("initial commit: %v", err)
+	}
+	_, _, err = s.Merge(ctx, model.MergeRequest{Repo: "default", Branch: "feature/merged"})
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+
+	// Commit to merged branch must fail.
+	_, err = s.Commit(ctx, model.CommitRequest{
+		Repo:    "default",
+		Branch:  "feature/merged",
+		Files:   []model.FileChange{{Path: "x.txt", Content: []byte("updated")}},
+		Message: "post-merge commit",
+		Author:  "alice",
+	})
+	if err != ErrBranchNotActive {
+		t.Fatalf("expected ErrBranchNotActive for commit to merged branch, got %v", err)
 	}
 }

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -1270,6 +1270,278 @@ func TestIntegrationRBAC_CrossRepoIsolation(t *testing.T) {
 // Purge integration tests
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Merge/rebase conflict body assertions (HTTP-level)
+// ---------------------------------------------------------------------------
+
+func TestIntegrationMerge_ConflictBody(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	post := func(path, body string) *http.Response {
+		t.Helper()
+		resp, err := http.Post(srv.URL+path, "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		return resp
+	}
+
+	// Step 1: Commit to main — shared.txt (seq=1).
+	r := post("/repos/default/commit", `{"branch":"main","message":"init","files":[{"path":"shared.txt","content":"b3JpZ2luYWw="}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("commit to main: expected 201, got %d", r.StatusCode)
+	}
+
+	// Step 2: Create branch (base=1).
+	r = post("/repos/default/branch", `{"name":"feature/merge-conflict"}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("create branch: expected 201, got %d", r.StatusCode)
+	}
+
+	// Step 3: Main modifies shared.txt (seq=2).
+	r = post("/repos/default/commit", `{"branch":"main","message":"main update","files":[{"path":"shared.txt","content":"bWFpbi11cGRhdGU="}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("commit to main: expected 201, got %d", r.StatusCode)
+	}
+
+	// Step 4: Branch modifies shared.txt (seq=3).
+	r = post("/repos/default/commit", `{"branch":"feature/merge-conflict","message":"branch update","files":[{"path":"shared.txt","content":"YnJhbmNoLXVwZGF0ZQ=="}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("commit to branch: expected 201, got %d", r.StatusCode)
+	}
+
+	// Step 5: POST /merge — must return 409 with conflict body.
+	r = post("/repos/default/merge", `{"branch":"feature/merge-conflict"}`)
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusConflict {
+		var errBody map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&errBody)
+		t.Fatalf("POST /merge: expected 409, got %d; body: %v", r.StatusCode, errBody)
+	}
+
+	var conflictResp struct {
+		Conflicts []struct {
+			Path            string `json:"path"`
+			MainVersionID   string `json:"main_version_id"`
+			BranchVersionID string `json:"branch_version_id"`
+		} `json:"conflicts"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&conflictResp); err != nil {
+		t.Fatalf("decode conflict response: %v", err)
+	}
+	if len(conflictResp.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d", len(conflictResp.Conflicts))
+	}
+	c := conflictResp.Conflicts[0]
+	if c.Path != "shared.txt" {
+		t.Errorf("expected conflict path shared.txt, got %q", c.Path)
+	}
+	if c.MainVersionID == "" {
+		t.Error("expected non-empty main_version_id")
+	}
+	if c.BranchVersionID == "" {
+		t.Error("expected non-empty branch_version_id")
+	}
+	if c.MainVersionID == c.BranchVersionID {
+		t.Error("main_version_id and branch_version_id must differ")
+	}
+}
+
+func TestIntegrationRebase_ConflictBody(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	post := func(path, body string) *http.Response {
+		t.Helper()
+		resp, err := http.Post(srv.URL+path, "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		return resp
+	}
+
+	// Step 1: Commit to main — shared.txt (seq=1).
+	r := post("/repos/default/commit", `{"branch":"main","message":"init","files":[{"path":"shared.txt","content":"b3JpZ2luYWw="}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("commit to main: expected 201, got %d", r.StatusCode)
+	}
+
+	// Step 2: Create branch (base=1).
+	r = post("/repos/default/branch", `{"name":"feature/rebase-conflict"}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("create branch: expected 201, got %d", r.StatusCode)
+	}
+
+	// Step 3: Branch modifies shared.txt (seq=2).
+	r = post("/repos/default/commit", `{"branch":"feature/rebase-conflict","message":"branch update","files":[{"path":"shared.txt","content":"YnJhbmNoLXVwZGF0ZQ=="}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("commit to branch: expected 201, got %d", r.StatusCode)
+	}
+
+	// Step 4: Main modifies shared.txt (seq=3).
+	r = post("/repos/default/commit", `{"branch":"main","message":"main update","files":[{"path":"shared.txt","content":"bWFpbi11cGRhdGU="}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("commit to main: expected 201, got %d", r.StatusCode)
+	}
+
+	// Step 5: POST /rebase — must return 409 with conflict body.
+	r = post("/repos/default/rebase", `{"branch":"feature/rebase-conflict"}`)
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusConflict {
+		var errBody map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&errBody)
+		t.Fatalf("POST /rebase: expected 409, got %d; body: %v", r.StatusCode, errBody)
+	}
+
+	var conflictResp struct {
+		Conflicts []struct {
+			Path            string `json:"path"`
+			MainVersionID   string `json:"main_version_id"`
+			BranchVersionID string `json:"branch_version_id"`
+		} `json:"conflicts"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&conflictResp); err != nil {
+		t.Fatalf("decode conflict response: %v", err)
+	}
+	if len(conflictResp.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d", len(conflictResp.Conflicts))
+	}
+	c := conflictResp.Conflicts[0]
+	if c.Path != "shared.txt" {
+		t.Errorf("expected conflict path shared.txt, got %q", c.Path)
+	}
+	if c.MainVersionID == "" {
+		t.Error("expected non-empty main_version_id")
+	}
+	if c.BranchVersionID == "" {
+		t.Error("expected non-empty branch_version_id")
+	}
+	if c.MainVersionID == c.BranchVersionID {
+		t.Error("main_version_id and branch_version_id must differ")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Branch lifecycle edge cases (HTTP-level)
+// ---------------------------------------------------------------------------
+
+func TestIntegrationBranchLifecycle_MergeAfterMerge(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	post := func(path, body string) *http.Response {
+		t.Helper()
+		resp, err := http.Post(srv.URL+path, "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		return resp
+	}
+
+	// Create branch and commit to it.
+	r := post("/repos/default/branch", `{"name":"feature/once"}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("create branch: expected 201, got %d", r.StatusCode)
+	}
+	r = post("/repos/default/commit", `{"branch":"feature/once","message":"work","files":[{"path":"f.txt","content":"dGVzdA=="}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("commit: expected 201, got %d", r.StatusCode)
+	}
+
+	// First merge — should succeed.
+	r = post("/repos/default/merge", `{"branch":"feature/once"}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		t.Fatalf("first merge: expected 200, got %d", r.StatusCode)
+	}
+
+	// Second merge of already-merged branch — should fail with 409.
+	r = post("/repos/default/merge", `{"branch":"feature/once"}`)
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusConflict {
+		t.Fatalf("second merge: expected 409, got %d", r.StatusCode)
+	}
+}
+
+func TestIntegrationBranchLifecycle_CommitAfterMerge(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	post := func(path, body string) *http.Response {
+		t.Helper()
+		resp, err := http.Post(srv.URL+path, "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		return resp
+	}
+
+	// Create branch, commit, and merge it.
+	r := post("/repos/default/branch", `{"name":"feature/commit-after-merge"}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("create branch: expected 201, got %d", r.StatusCode)
+	}
+	r = post("/repos/default/commit", `{"branch":"feature/commit-after-merge","message":"initial","files":[{"path":"g.txt","content":"dGVzdA=="}]}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("commit: expected 201, got %d", r.StatusCode)
+	}
+	r = post("/repos/default/merge", `{"branch":"feature/commit-after-merge"}`)
+	r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		t.Fatalf("merge: expected 200, got %d", r.StatusCode)
+	}
+
+	// Commit to merged branch — must fail with 409.
+	r = post("/repos/default/commit", `{"branch":"feature/commit-after-merge","message":"post-merge","files":[{"path":"g.txt","content":"dXBkYXRlZA=="}]}`)
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusConflict {
+		t.Fatalf("commit after merge: expected 409, got %d", r.StatusCode)
+	}
+}
+
+func TestIntegrationBranchLifecycle_RebaseMain(t *testing.T) {
+	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	writeStore := dbpkg.NewStore(database)
+	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/repos/default/rebase", "application/json",
+		strings.NewReader(`{"branch":"main"}`))
+	if err != nil {
+		t.Fatalf("POST /rebase: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("rebase main: expected 400, got %d", resp.StatusCode)
+	}
+}
+
 func TestIntegrationPurge_FullFlow(t *testing.T) {
 	database := testutil.TestDB(t, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -612,6 +612,12 @@ func TestHandleMerge_Conflict(t *testing.T) {
 	if errResp.Conflicts[0].Path != "conflict.txt" {
 		t.Errorf("expected conflict.txt, got %q", errResp.Conflicts[0].Path)
 	}
+	if errResp.Conflicts[0].MainVersionID != "v1" {
+		t.Errorf("expected main_version_id v1, got %q", errResp.Conflicts[0].MainVersionID)
+	}
+	if errResp.Conflicts[0].BranchVersionID != "v2" {
+		t.Errorf("expected branch_version_id v2, got %q", errResp.Conflicts[0].BranchVersionID)
+	}
 }
 
 func TestHandleMerge_BranchNotFound(t *testing.T) {
@@ -629,6 +635,24 @@ func TestHandleMerge_BranchNotFound(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleMerge_BranchNotActive(t *testing.T) {
+	store := &mockStore{
+		mergeFn: func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
+			return nil, nil, db.ErrBranchNotActive
+		},
+	}
+	srv := New(store, nil, devID, devID)
+
+	body, _ := json.Marshal(model.MergeRequest{Branch: "merged-branch"})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/merge", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d; body: %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -826,6 +850,12 @@ func TestHandleRebase_Conflict(t *testing.T) {
 	}
 	if errResp.Conflicts[0].Path != "conflict.txt" {
 		t.Errorf("expected conflict.txt, got %q", errResp.Conflicts[0].Path)
+	}
+	if errResp.Conflicts[0].MainVersionID != "v1" {
+		t.Errorf("expected main_version_id v1, got %q", errResp.Conflicts[0].MainVersionID)
+	}
+	if errResp.Conflicts[0].BranchVersionID != "v2" {
+		t.Errorf("expected branch_version_id v2, got %q", errResp.Conflicts[0].BranchVersionID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Store layer**: Added `name == "main"` guard in `DeleteBranch()` (consistent with existing `Rebase()` guard)
- **`internal/db/store_test.go`**: 7 new/updated tests
  - Updated `TestMerge_Conflict` and `TestRebase_Conflict` to assert `MainVersionID`/`BranchVersionID` non-empty and distinct
  - New `TestMerge_MultipleConflicts` and `TestRebase_MultipleConflicts` — verify all conflicting paths reported with correct version IDs
  - New `TestDeleteBranch_MainBranch` — `DeleteBranch("main")` returns `ErrBranchNotActive`
  - New `TestMerge_AlreadyMergedBranch` — second `Merge()` call returns `ErrBranchNotActive`
  - New `TestCommit_ToMergedBranch` — `Commit()` to merged branch returns `ErrBranchNotActive`
- **`internal/server/server_test.go`**: 3 new/updated tests
  - Updated `TestHandleMerge_Conflict` and `TestHandleRebase_Conflict` to assert `main_version_id`/`branch_version_id` in the 409 body
  - New `TestHandleMerge_BranchNotActive` — 409 response when merging an inactive branch
- **`internal/server/integration_test.go`**: 5 new tests
  - `TestIntegrationMerge_ConflictBody` — end-to-end HTTP 409 with full conflict body (path + both version IDs)
  - `TestIntegrationRebase_ConflictBody` — same for rebase
  - `TestIntegrationBranchLifecycle_MergeAfterMerge` — 409 on second merge attempt
  - `TestIntegrationBranchLifecycle_CommitAfterMerge` — 409 on commit to merged branch
  - `TestIntegrationBranchLifecycle_RebaseMain` — 400 on `POST /rebase` with `branch=main`

## Pre-existing test failure

`TestDeleteRepo_RemovesAllData` fails intermittently with Docker port-binding failures (`port "5432/tcp" not found`). This is unrelated to this PR — it's a Docker resource issue in the test environment.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All new tests pass: `go test ./internal/db/... ./internal/server/... -run "TestMerge_Conflict|TestRebase_Conflict|TestMerge_Multiple|TestRebase_Multiple|TestDeleteBranch_Main|TestMerge_AlreadyMerged|TestCommit_ToMerged|TestHandleMerge|TestHandleRebase|TestIntegrationMerge_Conflict|TestIntegrationRebase_Conflict|TestIntegrationBranchLifecycle"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)