### PR TITLE
Add structured logging (log/slog) throughout server, middleware, db, and main

### DIFF
--- a/cmd/docstore/main.go
+++ b/cmd/docstore/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -21,6 +21,17 @@ func main() {
 	bootstrapAdmin := flag.String("bootstrap-admin", "", "identity granted admin access to repos with no admin assigned yet")
 	flag.Parse()
 
+	// Set up structured logger based on LOG_FORMAT env var.
+	// Default is JSON (GCP Cloud Run picks this up natively).
+	var handler slog.Handler
+	if os.Getenv("LOG_FORMAT") == "text" {
+		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
+	} else {
+		handler = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
+	}
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+
 	// Also accept DEV_IDENTITY and BOOTSTRAP_ADMIN env vars for container-based testing.
 	if *devIdentity == "" {
 		*devIdentity = os.Getenv("DEV_IDENTITY")
@@ -30,10 +41,10 @@ func main() {
 	}
 
 	if *devIdentity != "" {
-		log.Printf("WARNING: IAP JWT validation disabled; using dev identity %q", *devIdentity)
+		logger.Warn("IAP JWT validation disabled", "dev_identity", *devIdentity)
 	}
 	if *bootstrapAdmin != "" {
-		log.Printf("bootstrap admin: %q (has admin access to repos with no admin)", *bootstrapAdmin)
+		logger.Info("bootstrap admin configured", "identity", *bootstrapAdmin)
 	}
 
 	port := os.Getenv("PORT")
@@ -43,18 +54,22 @@ func main() {
 
 	dsn := os.Getenv("DATABASE_URL")
 	if dsn == "" {
-		log.Fatal("DATABASE_URL environment variable is required")
+		logger.Error("DATABASE_URL environment variable is required")
+		os.Exit(1)
 	}
 
 	database, err := db.Open(dsn)
 	if err != nil {
-		log.Fatalf("database open: %v", err)
+		logger.Error("failed to connect to database", "error", err)
+		os.Exit(1)
 	}
 	defer database.Close()
 
 	if err := db.RunMigrations(database); err != nil {
-		log.Fatalf("run migrations: %v", err)
+		logger.Error("failed to run migrations", "error", err)
+		os.Exit(1)
 	}
+	logger.Info("migrations complete")
 
 	commitStore := db.NewStore(database)
 	srv := server.New(commitStore, database, *devIdentity, *bootstrapAdmin)
@@ -69,9 +84,10 @@ func main() {
 
 	// Start server in background.
 	go func() {
-		log.Printf("docstore listening on :%s", port)
+		logger.Info("starting server", "port", port, "dev_identity", *devIdentity != "")
 		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("server error: %v", err)
+			logger.Error("server error", "error", err)
+			os.Exit(1)
 		}
 	}()
 
@@ -79,12 +95,13 @@ func main() {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
-	log.Println("shutting down...")
+	logger.Info("shutting down")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := httpServer.Shutdown(ctx); err != nil {
-		log.Fatalf("shutdown error: %v", err)
+		logger.Error("shutdown error", "error", err)
+		os.Exit(1)
 	}
-	log.Println("stopped")
+	logger.Info("stopped")
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -3,6 +3,8 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"log/slog"
+	"net/url"
 )
 
 // Open opens a PostgreSQL connection using the provided DSN.
@@ -15,5 +17,15 @@ func Open(dsn string) (*sql.DB, error) {
 		db.Close()
 		return nil, fmt.Errorf("db ping: %w", err)
 	}
+	slog.Info("database connected", "dsn_host", extractHost(dsn))
 	return db, nil
+}
+
+// extractHost returns just the hostname from a DSN, avoiding logging credentials.
+func extractHost(dsn string) string {
+	u, err := url.Parse(dsn)
+	if err != nil || u.Host == "" {
+		return "unknown"
+	}
+	return u.Hostname()
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/dlorenc/docstore/internal/model"
@@ -65,9 +66,14 @@ func (s *Store) CreateRepo(ctx context.Context, req model.CreateRepoRequest) (*m
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		slog.Error("tx begin failed", "op", "create_repo", "error", err)
 		return nil, fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			slog.Error("tx rollback failed", "op", "create_repo", "error", rollbackErr)
+		}
+	}()
 
 	var r model.Repo
 	err = tx.QueryRowContext(ctx,
@@ -102,9 +108,14 @@ func (s *Store) CreateRepo(ctx context.Context, req model.CreateRepoRequest) (*m
 func (s *Store) DeleteRepo(ctx context.Context, name string) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		slog.Error("tx begin failed", "op", "delete_repo", "error", err)
 		return fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			slog.Error("tx rollback failed", "op", "delete_repo", "error", rollbackErr)
+		}
+	}()
 
 	// Verify repo exists.
 	var exists bool
@@ -178,9 +189,14 @@ func (s *Store) GetRepo(ctx context.Context, name string) (*model.Repo, error) {
 func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		slog.Error("tx begin failed", "op", "commit", "error", err)
 		return nil, fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			slog.Error("tx rollback failed", "op", "commit", "error", rollbackErr)
+		}
+	}()
 
 	// Lock the branch row and read current state.
 	var headSeq int64
@@ -286,9 +302,14 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 func (s *Store) CreateBranch(ctx context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		slog.Error("tx begin failed", "op", "create_branch", "error", err)
 		return nil, fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			slog.Error("tx rollback failed", "op", "create_branch", "error", rollbackErr)
+		}
+	}()
 
 	// Read main's head to set as the base_sequence.
 	// If main doesn't exist the repo itself doesn't exist.
@@ -335,11 +356,18 @@ func (s *Store) CreateBranch(ctx context.Context, req model.CreateBranchRequest)
 //
 // On conflict, it returns a non-nil []MergeConflict and ErrMergeConflict.
 func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []MergeConflict, error) {
+	slog.Debug("merge started", "repo", req.Repo, "branch", req.Branch)
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		slog.Error("tx begin failed", "op", "merge", "error", err)
 		return nil, nil, fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			slog.Error("tx rollback failed", "op", "merge", "error", rollbackErr)
+		}
+	}()
 
 	// Lock main first, then source branch — consistent ordering prevents deadlocks.
 	var mainHead int64
@@ -386,6 +414,7 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 		if err := tx.Commit(); err != nil {
 			return nil, nil, fmt.Errorf("commit tx: %w", err)
 		}
+		slog.Info("merge complete", "repo", req.Repo, "branch", req.Branch, "sequence", mainHead, "files", 0)
 		return &model.MergeResponse{Sequence: mainHead}, nil, nil
 	}
 
@@ -455,6 +484,7 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 		return nil, nil, fmt.Errorf("commit tx: %w", err)
 	}
 
+	slog.Info("merge complete", "repo", req.Repo, "branch", req.Branch, "sequence", newSeq, "files", len(branchChanges))
 	return &model.MergeResponse{Sequence: newSeq}, nil, nil
 }
 
@@ -466,11 +496,18 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 		return nil, nil, ErrBranchNotActive
 	}
 
+	slog.Debug("rebase started", "repo", req.Repo, "branch", req.Branch)
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		slog.Error("tx begin failed", "op", "rebase", "error", err)
 		return nil, nil, fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			slog.Error("tx rollback failed", "op", "rebase", "error", rollbackErr)
+		}
+	}()
 
 	// Lock main first, then source branch — consistent ordering prevents deadlocks.
 	var mainHead int64
@@ -517,6 +554,7 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 		if err := tx.Commit(); err != nil {
 			return nil, nil, fmt.Errorf("commit tx: %w", err)
 		}
+		slog.Info("rebase complete", "repo", req.Repo, "branch", req.Branch, "commits_replayed", 0)
 		return &model.RebaseResponse{
 			NewBaseSequence: mainHead,
 			NewHeadSequence: mainHead,
@@ -594,6 +632,7 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 		return nil, nil, fmt.Errorf("commit tx: %w", err)
 	}
 
+	slog.Info("rebase complete", "repo", req.Repo, "branch", req.Branch, "commits_replayed", len(groups))
 	return &model.RebaseResponse{
 		NewBaseSequence: mainHead,
 		NewHeadSequence: lastSeq,
@@ -687,9 +726,14 @@ func nullStr(s *string) string {
 func (s *Store) DeleteBranch(ctx context.Context, repo, name string) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		slog.Error("tx begin failed", "op", "delete_branch", "error", err)
 		return fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			slog.Error("tx rollback failed", "op", "delete_branch", "error", rollbackErr)
+		}
+	}()
 
 	var status string
 	err = tx.QueryRowContext(ctx,
@@ -725,9 +769,14 @@ func (s *Store) DeleteBranch(ctx context.Context, repo, name string) error {
 func (s *Store) CreateReview(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		slog.Error("tx begin failed", "op", "create_review", "error", err)
 		return nil, fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			slog.Error("tx rollback failed", "op", "create_review", "error", rollbackErr)
+		}
+	}()
 
 	var headSeq, baseSeq int64
 	err = tx.QueryRowContext(ctx,
@@ -826,9 +875,14 @@ func (s *Store) ListReviews(ctx context.Context, repo, branch string, atSeq *int
 func (s *Store) CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string) (*model.CheckRun, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		slog.Error("tx begin failed", "op", "create_check_run", "error", err)
 		return nil, fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			slog.Error("tx rollback failed", "op", "create_check_run", "error", rollbackErr)
+		}
+	}()
 
 	var headSeq int64
 	err = tx.QueryRowContext(ctx,
@@ -1002,11 +1056,18 @@ type PurgeResult struct {
 // req.OlderThan. If req.DryRun is true, counts are returned without any rows being
 // deleted. All deletes happen within a single transaction.
 func (s *Store) Purge(ctx context.Context, req PurgeRequest) (*PurgeResult, error) {
+	slog.Debug("purge started", "repo", req.Repo, "older_than", req.OlderThan, "dry_run", req.DryRun)
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		slog.Error("tx begin failed", "op", "purge", "error", err)
 		return nil, fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			slog.Error("tx rollback failed", "op", "purge", "error", rollbackErr)
+		}
+	}()
 
 	// Verify repo exists.
 	var exists bool
@@ -1132,6 +1193,8 @@ func (s *Store) Purge(ctx context.Context, req PurgeRequest) (*PurgeResult, erro
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit tx: %w", err)
 	}
+
+	slog.Info("purge complete", "repo", req.Repo, "branches_purged", result.BranchesPurged, "docs_deleted", result.DocumentsDeleted)
 	return &result, nil
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -41,11 +42,13 @@ func (s *server) handleReview(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, db.ErrSelfApproval):
 			writeError(w, http.StatusForbidden, "reviewer cannot approve their own commits")
 		default:
+			slog.Error("internal error", "op", "review", "repo", repo, "error", err)
 			writeError(w, http.StatusInternalServerError, "internal server error")
 		}
 		return
 	}
 
+	slog.Info("review submitted", "repo", repo, "branch", req.Branch, "reviewer", reviewer, "status", req.Status)
 	writeJSON(w, http.StatusCreated, model.CreateReviewResponse{
 		ID:       review.ID,
 		Sequence: review.Sequence,
@@ -81,6 +84,7 @@ func (s *server) handleCheck(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, db.ErrBranchNotFound):
 			writeError(w, http.StatusNotFound, "branch not found")
 		default:
+			slog.Error("internal error", "op", "check", "repo", repo, "error", err)
 			writeError(w, http.StatusInternalServerError, "internal server error")
 		}
 		return
@@ -175,6 +179,7 @@ func parseDayDuration(s string) (time.Duration, error) {
 // handlePurge implements POST /repos/:name/purge
 func (s *server) handlePurge(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
+	identity := IdentityFromContext(r.Context())
 
 	var req model.PurgeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -202,11 +207,13 @@ func (s *server) handlePurge(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, db.ErrRepoNotFound):
 			writeError(w, http.StatusNotFound, "repo not found")
 		default:
+			slog.Error("internal error", "op", "purge", "repo", repo, "error", err)
 			writeError(w, http.StatusInternalServerError, "internal server error")
 		}
 		return
 	}
 
+	slog.Info("purge complete", "repo", repo, "dry_run", req.DryRun, "branches_purged", result.BranchesPurged, "docs_deleted", result.DocumentsDeleted, "by", identity)
 	writeJSON(w, http.StatusOK, model.PurgeResponse{
 		BranchesPurged:     result.BranchesPurged,
 		FileCommitsDeleted: result.FileCommitsDeleted,
@@ -259,10 +266,13 @@ func (s *server) handleCreateRepo(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, db.ErrRepoExists):
 			writeError(w, http.StatusConflict, "repo already exists")
 		default:
+			slog.Error("internal error", "op", "create_repo", "repo", req.Name, "error", err)
 			writeError(w, http.StatusInternalServerError, "internal server error")
 		}
 		return
 	}
+
+	slog.Info("repo created", "repo", repo.Name, "by", IdentityFromContext(r.Context()))
 	writeJSON(w, http.StatusCreated, repo)
 }
 
@@ -304,10 +314,13 @@ func (s *server) handleDeleteRepo(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, db.ErrRepoNotFound):
 			writeError(w, http.StatusNotFound, "repo not found")
 		default:
+			slog.Error("internal error", "op", "delete_repo", "repo", name, "error", err)
 			writeError(w, http.StatusInternalServerError, "internal server error")
 		}
 		return
 	}
+
+	slog.Info("repo deleted", "repo", name, "by", IdentityFromContext(r.Context()))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -557,11 +570,13 @@ func (s *server) handleCreateBranch(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, db.ErrRepoNotFound):
 			writeError(w, http.StatusNotFound, "repo not found")
 		default:
+			slog.Error("internal error", "op", "create_branch", "repo", repo, "error", err)
 			writeError(w, http.StatusInternalServerError, "internal server error")
 		}
 		return
 	}
 
+	slog.Info("branch created", "repo", repo, "branch", req.Name, "by", IdentityFromContext(r.Context()))
 	writeJSON(w, http.StatusCreated, resp)
 }
 
@@ -582,11 +597,13 @@ func (s *server) handleDeleteBranch(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, db.ErrBranchNotActive):
 			writeError(w, http.StatusConflict, "branch is already merged or abandoned")
 		default:
+			slog.Error("internal error", "op", "delete_branch", "repo", repo, "branch", bname, "error", err)
 			writeError(w, http.StatusInternalServerError, "internal server error")
 		}
 		return
 	}
 
+	slog.Info("branch deleted", "repo", repo, "branch", bname, "by", IdentityFromContext(r.Context()))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -629,10 +646,12 @@ func (s *server) handleSetRole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.commitStore.SetRole(r.Context(), repo, identity, req.Role); err != nil {
+		slog.Error("internal error", "op", "set_role", "repo", repo, "identity", identity, "error", err)
 		writeError(w, http.StatusInternalServerError, "internal server error")
 		return
 	}
 
+	slog.Info("role assigned", "repo", repo, "identity", identity, "role", req.Role, "by", IdentityFromContext(r.Context()))
 	writeJSON(w, http.StatusOK, model.Role{Identity: identity, Role: req.Role})
 }
 
@@ -651,11 +670,13 @@ func (s *server) handleDeleteRole(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, db.ErrRoleNotFound):
 			writeError(w, http.StatusNotFound, "role not found")
 		default:
+			slog.Error("internal error", "op", "delete_role", "repo", repo, "identity", identity, "error", err)
 			writeError(w, http.StatusInternalServerError, "internal server error")
 		}
 		return
 	}
 
+	slog.Info("role removed", "repo", repo, "identity", identity, "by", IdentityFromContext(r.Context()))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -689,6 +710,7 @@ func (s *server) handleRebase(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, db.ErrRebaseConflict):
+			slog.Warn("rebase conflict", "repo", repo, "branch", req.Branch, "conflicts", len(conflicts))
 			apiConflicts := make([]model.ConflictEntry, len(conflicts))
 			for i, c := range conflicts {
 				apiConflicts[i] = model.ConflictEntry{
@@ -703,11 +725,13 @@ func (s *server) handleRebase(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, db.ErrBranchNotActive):
 			writeError(w, http.StatusBadRequest, "branch is not active")
 		default:
+			slog.Error("internal error", "op", "rebase", "repo", repo, "branch", req.Branch, "error", err)
 			writeError(w, http.StatusInternalServerError, "internal server error")
 		}
 		return
 	}
 
+	slog.Info("branch rebased", "repo", repo, "branch", req.Branch, "by", req.Author, "commits_replayed", resp.CommitsReplayed)
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -741,6 +765,7 @@ func (s *server) handleMerge(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, db.ErrMergeConflict):
+			slog.Warn("merge conflict", "repo", repo, "branch", req.Branch, "conflicts", len(conflicts))
 			// Convert conflicts to API response.
 			apiConflicts := make([]model.ConflictEntry, len(conflicts))
 			for i, c := range conflicts {
@@ -756,10 +781,12 @@ func (s *server) handleMerge(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, db.ErrBranchNotActive):
 			writeError(w, http.StatusConflict, "branch is not active")
 		default:
+			slog.Error("internal error", "op", "merge", "repo", repo, "branch", req.Branch, "error", err)
 			writeError(w, http.StatusInternalServerError, "internal server error")
 		}
 		return
 	}
 
+	slog.Info("branch merged", "repo", repo, "branch", req.Branch, "by", req.Author, "sequence", resp.Sequence)
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"strings"
@@ -37,6 +38,90 @@ func IdentityFromContext(ctx context.Context) string {
 func RoleFromContext(ctx context.Context) model.RoleType {
 	v, _ := ctx.Value(roleKey).(model.RoleType)
 	return v
+}
+
+// --- Request logger ---
+
+// requestLog is a mutable capture placed in context by RequestLogger so that
+// inner middleware (IAPMiddleware) can write the authenticated identity back
+// for use in the access log.
+type requestLog struct {
+	identity string
+}
+
+type requestLogKey struct{}
+
+func requestLogFromContext(ctx context.Context) *requestLog {
+	v, _ := ctx.Value(requestLogKey{}).(*requestLog)
+	return v
+}
+
+// responseWriter wraps http.ResponseWriter to capture the status code and bytes written.
+type responseWriter struct {
+	http.ResponseWriter
+	status int
+	bytes  int
+}
+
+func (rw *responseWriter) WriteHeader(status int) {
+	rw.status = status
+	rw.ResponseWriter.WriteHeader(status)
+}
+
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	n, err := rw.ResponseWriter.Write(b)
+	rw.bytes += n
+	return n, err
+}
+
+// repoFromPath extracts the repo name from any /repos/:name... URL path.
+// Returns "" for non-repo paths.
+func repoFromPath(path string) string {
+	const prefix = "/repos/"
+	if !strings.HasPrefix(path, prefix) {
+		return ""
+	}
+	rest := path[len(prefix):]
+	if slash := strings.IndexByte(rest, '/'); slash != -1 {
+		return rest[:slash]
+	}
+	return rest
+}
+
+// RequestLogger returns an HTTP middleware that logs one structured line per
+// request on completion. It uses a requestLog capture in the context so that
+// IAPMiddleware can write back the authenticated identity.
+func RequestLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rl := &requestLog{}
+		r = r.WithContext(context.WithValue(r.Context(), requestLogKey{}, rl))
+		rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
+
+		next.ServeHTTP(rw, r)
+
+		durationMs := time.Since(start).Milliseconds()
+		repo := repoFromPath(r.URL.Path)
+
+		args := []any{
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", rw.status,
+			"duration_ms", durationMs,
+			"identity", rl.identity,
+			"repo", repo,
+			"bytes", rw.bytes,
+		}
+
+		switch {
+		case rw.status >= 500:
+			slog.Error("request", args...)
+		case rw.status >= 400:
+			slog.Warn("request", args...)
+		default:
+			slog.Info("request", args...)
+		}
+	})
 }
 
 // --- RBAC middleware ---
@@ -70,6 +155,7 @@ func RBACMiddleware(roles RoleStore, bootstrapAdmin string) func(http.Handler) h
 			if bootstrapAdmin != "" && identity == bootstrapAdmin {
 				hasAdmin, err := roles.HasAdmin(r.Context(), repo)
 				if err == nil && !hasAdmin {
+					slog.Info("bootstrap admin granted", "identity", identity, "repo", repo)
 					ctx := context.WithValue(r.Context(), roleKey, model.RoleAdmin)
 					next.ServeHTTP(w, r.WithContext(ctx))
 					return
@@ -79,11 +165,13 @@ func RBACMiddleware(roles RoleStore, bootstrapAdmin string) func(http.Handler) h
 
 			role, err := roles.GetRole(r.Context(), repo, identity)
 			if err != nil {
+				slog.Warn("access denied", "identity", identity, "repo", repo, "reason", "no_role", "path", r.URL.Path)
 				writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
 				return
 			}
 
 			if !roleAllows(role.Role, r.Method, subPath, r) {
+				slog.Warn("access denied", "identity", identity, "repo", repo, "role", role.Role, "method", r.Method, "sub_path", subPath, "path", r.URL.Path)
 				writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
 				return
 			}
@@ -185,6 +273,9 @@ func newMiddleware(devIdentity string, fetchKey func(kid string) (*rsa.PublicKey
 	if devIdentity != "" {
 		return func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if rl := requestLogFromContext(r.Context()); rl != nil {
+					rl.identity = devIdentity
+				}
 				ctx := context.WithValue(r.Context(), identityKey, devIdentity)
 				next.ServeHTTP(w, r.WithContext(ctx))
 			})
@@ -194,13 +285,18 @@ func newMiddleware(devIdentity string, fetchKey func(kid string) (*rsa.PublicKey
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			token := r.Header.Get("X-Goog-IAP-JWT-Assertion")
 			if token == "" {
+				slog.Warn("auth failed", "reason", "missing_token", "path", r.URL.Path)
 				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthenticated"})
 				return
 			}
 			email, err := validateIAPJWT(token, fetchKey)
 			if err != nil {
+				slog.Warn("auth failed", "reason", "invalid_jwt", "path", r.URL.Path, "error", err)
 				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthenticated"})
 				return
+			}
+			if rl := requestLogFromContext(r.Context()); rl != nil {
+				rl.identity = email
 			}
 			ctx := context.WithValue(r.Context(), identityKey, email)
 			next.ServeHTTP(w, r.WithContext(ctx))
@@ -376,4 +472,3 @@ func jwkToRSA(nB64, eB64 string) (*rsa.PublicKey, error) {
 	}
 	return &rsa.PublicKey{N: n, E: e}, nil
 }
-

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/dlorenc/docstore/internal/db"
@@ -104,7 +105,7 @@ func New(writeStore WriteStore, database *sql.DB, devIdentity, bootstrapAdmin st
 		routed = RBACMiddleware(writeStore, bootstrapAdmin)(inner)
 	}
 	outer.Handle("/", IAPMiddleware(devIdentity)(routed))
-	return outer
+	return RequestLogger(outer)
 }
 
 type server struct {
@@ -155,11 +156,13 @@ func (s *server) handleCommit(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, db.ErrBranchNotActive):
 			writeJSON(w, http.StatusConflict, map[string]string{"error": "branch is not active"})
 		default:
+			slog.Error("internal error", "op", "commit", "repo", repo, "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 		}
 		return
 	}
 
+	slog.Info("commit created", "repo", repo, "branch", req.Branch, "sequence", resp.Sequence, "files", len(req.Files), "author", req.Author)
 	writeJSON(w, http.StatusCreated, resp)
 }
 


### PR DESCRIPTION
## Summary

- **cmd/docstore/main.go**: Replace `log` with `log/slog`. JSON output by default (GCP Cloud Run native), text when `LOG_FORMAT=text`. Structured startup/shutdown events.
- **internal/db/db.go**: Log `database connected` with host only (no credentials); add `extractHost` helper that safely parses DSN.
- **internal/db/store.go**: Log `tx begin failed` / `tx rollback failed` (slog.Error) for all 10 transactional operations. Add Debug/Info boundary logging for Merge, Rebase, and Purge (operation start + completion with key metrics).
- **internal/server/middleware.go**: Add `RequestLogger` as outermost middleware with `responseWriter` wrapper capturing status code and bytes. Uses a `requestLog` capture pattern in context so `IAPMiddleware` can write the authenticated identity back for the access log. Logs auth failures (`missing_token`, `invalid_jwt`) and RBAC denials/bootstrap grants.
- **internal/server/server.go**: Register `RequestLogger(outer)` as the outermost wrapper. Add `commit created` (Info) and `internal error` (Error) to `handleCommit`.
- **internal/server/handlers.go**: Add `slog.Info` for every successful write operation (repo create/delete, branch create/delete, merge, rebase, role assign/remove, review submit, purge). Add `slog.Warn` for merge/rebase conflicts. Add `slog.Error` for unexpected 500s on all write paths.

**No new dependencies** — `log/slog` is stdlib (Go 1.21+; this module targets 1.25.1).

## Acceptance criteria met

- `go build ./...` ✅
- `go test ./...` ✅ (all packages pass)
- JSON output on stdout when LOG_FORMAT is unset ✅
- Text output when LOG_FORMAT=text ✅
- Every write operation produces at least one log line ✅
- Every auth/RBAC failure produces a Warn log ✅
- Every 5xx produces an Error log ✅
- No sensitive data logged (no JWT tokens, no file content, no credentials) ✅

## Notes

- The `requestLog` capture pattern (outer middleware stores a `*requestLog` in context; IAPMiddleware writes identity to it) avoids coupling while enabling correct identity in the access log for all authenticated routes.
- `/healthz` is also logged by `RequestLogger` (it's on the outer mux and the logger wraps the whole thing). Identity will be `""` for healthz since IAP doesn't run for it — correct behavior.
- Debug-level DB boundary logs (merge/rebase/purge started) won't appear at the default `LevelInfo`. They're available when log level is lowered for debugging.
- The bold-tiger refactor (org naming changes) will need minor field-value updates but the approach is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)