### PR TITLE
Fix org refactor review gaps: error handling, validation, test cleanup

### DIFF
--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -175,6 +175,45 @@ func TestInitRepoFlagStripsURLSuffix(t *testing.T) {
 	}
 }
 
+// TestInitCanonicalTrailingDash verifies that Init strips the trailing "/-"
+// from the canonical URL form (e.g. https://host/repos/owner/name/-).
+func TestInitCanonicalTrailingDash(t *testing.T) {
+	// The mock server registers the /repos/default/myrepo/-/* paths that Init will call.
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/repos/default/myrepo/-/tree":
+			json.NewEncoder(w).Encode([]treeEntry{})
+		case r.Method == "GET" && r.URL.Path == "/repos/default/myrepo/-/branches":
+			json.NewEncoder(w).Encode([]model.Branch{{Name: "main", HeadSequence: 0}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+
+	// Pass the canonical trailing-/- URL form with no explicit --repo flag.
+	canonicalURL := srv.URL + "/repos/default/myrepo/-"
+	if err := app.Init(canonicalURL, "", "carol"); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	cfg, err := app.loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Remote must be the bare host.
+	if cfg.Remote != srv.URL {
+		t.Errorf("remote = %q, want %q (trailing /- must be stripped)", cfg.Remote, srv.URL)
+	}
+	if cfg.Repo != "default/myrepo" {
+		t.Errorf("repo = %q, want %q", cfg.Repo, "default/myrepo")
+	}
+}
+
 func TestInitDefaultAuthor(t *testing.T) {
 	srv := newEmptyRepoServer(t)
 	defer srv.Close()

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -25,6 +25,7 @@ var (
 	ErrRepoExists      = errors.New("repo already exists")
 	ErrOrgNotFound     = errors.New("org not found")
 	ErrOrgExists       = errors.New("org already exists")
+	ErrOrgHasRepos     = errors.New("org has repos")
 	ErrRoleNotFound    = errors.New("role not found")
 	ErrSelfApproval    = errors.New("reviewer cannot approve their own commits")
 )
@@ -114,11 +115,14 @@ func (s *Store) ListOrgs(ctx context.Context) ([]model.Org, error) {
 	return orgs, rows.Err()
 }
 
-// DeleteOrg hard-deletes an org. Returns ErrOrgNotFound if it doesn't exist.
-// Note: all repos (and their data) under this org must be deleted first.
+// DeleteOrg hard-deletes an org. Returns ErrOrgNotFound if it doesn't exist
+// and ErrOrgHasRepos if there are repos still owned by this org.
 func (s *Store) DeleteOrg(ctx context.Context, name string) error {
 	result, err := s.db.ExecContext(ctx, "DELETE FROM orgs WHERE name = $1", name)
 	if err != nil {
+		if isForeignKeyViolation(err) {
+			return ErrOrgHasRepos
+		}
 		return fmt.Errorf("delete org: %w", err)
 	}
 	n, err := result.RowsAffected()

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -5,8 +5,8 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
-	"strings"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -22,6 +22,9 @@ import (
 //	/repos/acme/team/sub/-/commit    → ("acme/team/sub", "commit", true)
 //	/repos/acme/myrepo               → ("acme/myrepo", "", true)  // bare repo
 //	/something/else                  → ("", "", false)
+//
+// NOTE: repoAndSubPath in middleware.go parses the same "/-/" URL format for
+// RBAC purposes. Both functions must be kept in sync if the URL structure changes.
 func parseRepoPath(path string) (repoName, endpoint string, ok bool) {
 	const prefix = "/repos/"
 	if !strings.HasPrefix(path, prefix) {
@@ -209,6 +212,10 @@ func (s *server) handleCreateOrg(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "name is required")
 		return
 	}
+	if strings.ContainsRune(req.Name, '/') {
+		writeError(w, http.StatusBadRequest, "org name may not contain '/'")
+		return
+	}
 
 	identity := IdentityFromContext(r.Context())
 	org, err := s.commitStore.CreateOrg(r.Context(), req.Name, identity)
@@ -261,6 +268,8 @@ func (s *server) handleDeleteOrg(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, db.ErrOrgNotFound):
 			writeError(w, http.StatusNotFound, "org not found")
+		case errors.Is(err, db.ErrOrgHasRepos):
+			writeError(w, http.StatusConflict, "org has repos; delete them first")
 		default:
 			writeError(w, http.StatusInternalServerError, "internal server error")
 		}
@@ -272,6 +281,14 @@ func (s *server) handleDeleteOrg(w http.ResponseWriter, r *http.Request) {
 // handleListOrgRepos implements GET /orgs/{org}/repos
 func (s *server) handleListOrgRepos(w http.ResponseWriter, r *http.Request) {
 	owner := r.PathValue("org")
+	if _, err := s.commitStore.GetOrg(r.Context(), owner); err != nil {
+		if errors.Is(err, db.ErrOrgNotFound) {
+			writeError(w, http.StatusNotFound, "org not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
 	repos, err := s.commitStore.ListOrgRepos(r.Context(), owner)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "query failed")
@@ -526,6 +543,11 @@ func (s *server) handleCreateRepo(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Name == "" {
 		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	fullName := req.FullName()
+	if strings.SplitN(fullName, "/", 2)[0] != req.Owner {
+		writeError(w, http.StatusBadRequest, "owner must match first segment of repo name")
 		return
 	}
 	if req.CreatedBy == "" {

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -190,6 +190,9 @@ func RBACMiddleware(roles RoleStore, bootstrapAdmin string) func(http.Handler) h
 //	/repos/acme/myrepo/-/commit  →  ("acme/myrepo", "commit")
 //	/repos/acme/team/sub/-/tree  →  ("acme/team/sub", "tree")
 //	/repos/acme/myrepo            →  ("", "")  — bare repo, no RBAC check needed
+//
+// NOTE: parseRepoPath in handlers.go parses the same "/-/" URL format for routing.
+// Both functions must be kept in sync if the URL structure changes.
 func repoAndSubPath(path string) (repo, subPath string) {
 	const prefix = "/repos/"
 	if !strings.HasPrefix(path, prefix) {

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -398,10 +398,10 @@ func TestRBACMiddleware_BootstrapAdmin(t *testing.T) {
 }
 
 func TestRBACMiddleware_RepoIsolation(t *testing.T) {
-	// alice is admin in repo-a but has NO role in repo-b.
+	// alice is admin in orgA/myrepo but has NO role in orgB/myrepo.
 	store := &mockRoleStore{
 		getRoleFn: func(_ context.Context, repo, identity string) (*model.Role, error) {
-			if repo == "repo-a/repo-a" && identity == "alice@example.com" {
+			if repo == "orgA/myrepo" && identity == "alice@example.com" {
 				return &model.Role{Identity: identity, Role: model.RoleAdmin}, nil
 			}
 			return nil, dbpkg.ErrRoleNotFound
@@ -409,16 +409,16 @@ func TestRBACMiddleware_RepoIsolation(t *testing.T) {
 	}
 	h := rbacTestServer(store, "", "alice@example.com")
 
-	// Alice can access repo-a.
-	rec := rbacDo(t, h, http.MethodGet, "/repos/repo-a/repo-a/-/tree", "")
+	// Alice can access orgA/myrepo.
+	rec := rbacDo(t, h, http.MethodGet, "/repos/orgA/myrepo/-/tree", "")
 	if rec.Code != http.StatusOK {
-		t.Fatalf("repo-a GET: expected 200, got %d", rec.Code)
+		t.Fatalf("orgA/myrepo GET: expected 200, got %d", rec.Code)
 	}
 
-	// Alice has no access to repo-b.
-	rec = rbacDo(t, h, http.MethodGet, "/repos/repo-b/repo-b/-/tree", "")
+	// Alice has no access to orgB/myrepo.
+	rec = rbacDo(t, h, http.MethodGet, "/repos/orgB/myrepo/-/tree", "")
 	if rec.Code != http.StatusForbidden {
-		t.Fatalf("repo-b GET: expected 403, got %d", rec.Code)
+		t.Fatalf("orgB/myrepo GET: expected 403, got %d", rec.Code)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1392,3 +1392,84 @@ func TestParseDayDuration(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Org handler tests
+// ---------------------------------------------------------------------------
+
+func TestHandleDeleteOrg_OrgHasRepos(t *testing.T) {
+	ms := &mockStore{
+		deleteOrgFn: func(ctx context.Context, name string) error {
+			return db.ErrOrgHasRepos
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodDelete, "/orgs/acme", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleDeleteOrg_NotFound(t *testing.T) {
+	ms := &mockStore{
+		deleteOrgFn: func(ctx context.Context, name string) error {
+			return db.ErrOrgNotFound
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodDelete, "/orgs/noexist", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleListOrgRepos_OrgNotFound(t *testing.T) {
+	ms := &mockStore{
+		getOrgFn: func(ctx context.Context, name string) (*model.Org, error) {
+			return nil, db.ErrOrgNotFound
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/orgs/noexist/repos", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCreateOrg_SlashInName(t *testing.T) {
+	ms := &mockStore{}
+	srv := New(ms, nil, devID, devID)
+	body, _ := json.Marshal(map[string]string{"name": "bad/name"})
+	req := httptest.NewRequest(http.MethodPost, "/orgs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCreateRepo_OwnerSlashMismatch(t *testing.T) {
+	ms := &mockStore{}
+	srv := New(ms, nil, devID, devID)
+	// Owner contains a slash — first segment "acme" != "acme/team"
+	body, _ := json.Marshal(map[string]string{"owner": "acme/team", "name": "myrepo"})
+	req := httptest.NewRequest(http.MethodPost, "/repos", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Addresses review feedback on #59 (Add org concept and slash-in-name repo support). This PR should be merged after #59.

- **`ErrOrgHasRepos` sentinel**: `DeleteOrg` now detects FK violation (23503) and returns a typed error instead of wrapping a raw postgres error
- **409 on delete-org-with-repos**: `handleDeleteOrg` maps `ErrOrgHasRepos` → 409 Conflict with message `"org has repos; delete them first"`
- **404 on list-repos-for-nonexistent-org**: `handleListOrgRepos` now checks org existence before listing (previously returned empty list silently)
- **Slash validation in CreateOrg**: org names containing `/` are rejected with 400
- **Owner validation in CreateRepo**: validates owner equals first path segment of `FullName()`, catching owners with embedded slashes
- **Middleware test naming**: `TestRBACMiddleware_RepoIsolation` renamed from `repo-a/repo-a` to `orgA/myrepo` so org and short-name are distinct
- **Import ordering**: `store_test.go` stdlib imports sorted alphabetically
- **Cross-reference comments**: `parseRepoPath` (handlers.go) and `repoAndSubPath` (middleware.go) note each other for sync awareness
- **New CLI test**: `TestInitCanonicalTrailingDash` covers URLs ending in `/-`
- **New handler tests**: unit tests for all new error paths

## Test plan

- [x] `go test ./... -count=1 -short` passes (all packages green)
- [x] `go build ./...` and `go vet ./...` clean

## Notes

- Org deletion cascade (auto-delete repos) intentionally not implemented — callers must delete repos first; the 409 response provides clear guidance
- No org-level RBAC added (out of scope per ROADMAP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)