### PR TITLE
Update docs for org support and new URL structure

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,7 +6,15 @@ A simplified version control system built on a versioned document store. One lon
 
 ## Data Model
 
-Seven tables. Documents and file_commits are append-only. Branches are mutable (head_sequence and status are updated in place).
+Eight tables. Documents and file_commits are append-only. Branches are mutable (head_sequence and status are updated in place).
+
+**orgs** is the top-level namespace. Every repo belongs to exactly one org. The org name must equal the first path segment of the repo's full name.
+
+| Column | Type | Notes |
+|---|---|---|
+| name | text | PK — e.g. `acme` |
+| created_at | timestamp | |
+| created_by | text | identity that created the org |
 
 **documents** stores immutable file versions. Every save creates a new row.
 
@@ -38,16 +46,28 @@ Seven tables. Documents and file_commits are append-only. Branches are mutable (
 | version_id | uuid | FK → documents, null = delete |
 | branch | text | `main` or `feature/*` |
 
+**repos** are named tenants owned by an org. The name is the full path (e.g. `acme/myrepo` or `acme/team/subrepo`); the owner is always the first path segment.
+
+| Column | Type | Notes |
+|---|---|---|
+| name | text | PK — full path, e.g. `acme/myrepo` |
+| owner | text | FK → orgs, must equal `split_part(name, '/', 1)` |
+| created_at | timestamp | |
+| created_by | text | |
+
 **branches** are named pointers.
 
 | Column | Type | Notes |
 |---|---|---|
-| name | text | PK |
+| repo | text | FK → repos |
+| name | text | branch name (may contain `/`) |
 | head_sequence | bigint | latest sequence on this branch |
 | base_sequence | bigint | where it forked from main |
 | status | enum | active / merged / abandoned |
 | created_at | timestamp | |
 | created_by | text | identity that created the branch |
+
+Primary key: `(repo, name)`.
 
 **roles** maps identities to coarse-grained permissions.
 
@@ -157,66 +177,115 @@ At policy evaluation time, the engine reads OWNERS from the materialized `main` 
 
 All endpoints are REST. Sequences are returned in every mutation response. List endpoints (`/tree`, `/file/:path/history`, `/commit/:sequence`) accept `?limit=N&after=cursor` for pagination. The cursor is the last `sequence` (or `path` for tree) from the previous page. Default limit is 100.
 
-**Reads**
+### URL structure
 
-`GET /tree?branch=main&at=sequence` — Materialize. Returns `[{path, version_id, content_hash}]` for every live file at that sequence. Omit `at` for head.
+Org and repo management endpoints are at the top level:
 
-`GET /file/:path/history?branch=main` — File history. Returns `[{sequence, version_id, message, author, created_at}]` ordered by sequence desc.
+```
+POST   /orgs                     create an org
+GET    /orgs                     list orgs
+GET    /orgs/{org}               get an org
+DELETE /orgs/{org}               delete an org (fails if org has repos)
+GET    /orgs/{org}/repos         list repos in an org
 
-`GET /file/:path?branch=main&at=sequence` — Get file content at a point in time.
+POST   /repos                    create a repo
+GET    /repos                    list all repos
+```
 
-`GET /diff?branch=feature/x` — PR diff. Returns files changed on the branch relative to its `base_sequence`, plus any conflicting paths on main since that base.
+All repo-scoped operations use a `/-/` separator to unambiguously separate the (possibly slash-containing) repo name from the endpoint:
 
-`GET /commit/:sequence` — Show all files changed in a single atomic commit.
+```
+GET    /repos/acme/myrepo/-/tree
+POST   /repos/acme/myrepo/-/commit
+GET    /repos/acme/team/subrepo/-/branches
+```
 
-`GET /branches` — List all branches. Returns `[{name, head_sequence, base_sequence, status}]`. Supports `?status=active` filter.
+The pattern is `/repos/{full-repo-name}/-/{endpoint}`. The full repo name may contain multiple slashes (e.g. `acme/team/subrepo`).
 
-`GET /branch/:name/status` — Evaluate all merge policies for a branch without actually merging. Returns `{mergeable: bool, policies: [{name, pass, reason}]}`. Useful for UI status checks and CI gates.
+### Org endpoints
 
-`GET /branch/:name/reviews` — List reviews for a branch. Returns `[{id, reviewer, sequence, status, body, created_at}]` ordered by created_at desc.
+`POST /orgs` — Create an org. Body: `{name}`.
 
-`GET /branch/:name/checks` — List check runs for a branch. Returns `[{id, sequence, check_name, status, reporter, created_at}]` ordered by created_at desc.
+`GET /orgs` — List all orgs.
 
-**Writes**
+`GET /orgs/{org}` — Get a single org.
 
-`POST /commit` — Commit one or more file changes atomically. Body: `{branch, files: [{path, content}], message}`. Policy-evaluated: the engine checks the actor's role and the target branch (e.g., direct commits to `main` can be blocked by policy). Allocates a single sequence number, writes one row to commits and one row per file to file_commits (all referencing that sequence), advances the branch head.
+`DELETE /orgs/{org}` — Delete an org. Returns `409 Conflict` if the org still has repos.
 
-`POST /branch` — Create a branch. Body: `{name}`. Policy-evaluated. Sets `base_sequence` to main's current head.
+`GET /orgs/{org}/repos` — List repos belonging to an org.
 
-`POST /merge` — Merge a branch into main. Body: `{branch}`. Policy-evaluated: the engine evaluates all merge policies (required reviews, passing checks, OWNERS approval) before proceeding. On policy failure, returns `{policies: [{name, pass, reason}]}` with a 403. **Staleness rule**: the server only includes reviews and check_runs whose `sequence` matches the branch's current `head_sequence` in the policy input. Any new commit to the branch advances `head_sequence`, which automatically invalidates all prior reviews and checks — policies see an empty list until the branch is re-reviewed and re-checked at the new head. The merge uses `base_sequence` from the branches table as the fork point:
+### Repo endpoints
+
+`POST /repos` — Create a repo. Body: `{owner, name}` where `owner` is the org name and `name` is the repo path within the org (may contain slashes). The full repo identifier is `owner/name`.
+
+`GET /repos` — List all repos.
+
+`GET /repos/{full-name}` — Get a repo by its full name.
+
+`DELETE /repos/{full-name}` — Hard-delete a repo.
+
+### Repo-scoped reads
+
+`GET /repos/{name}/-/tree?branch=main&at=sequence` — Materialize. Returns `[{path, version_id, content_hash}]` for every live file at that sequence. Omit `at` for head.
+
+`GET /repos/{name}/-/file/:path/history?branch=main` — File history. Returns `[{sequence, version_id, message, author, created_at}]` ordered by sequence desc.
+
+`GET /repos/{name}/-/file/:path?branch=main&at=sequence` — Get file content at a point in time.
+
+`GET /repos/{name}/-/diff?branch=feature/x` — PR diff. Returns files changed on the branch relative to its `base_sequence`, plus any conflicting paths on main since that base.
+
+`GET /repos/{name}/-/commit/:sequence` — Show all files changed in a single atomic commit.
+
+`GET /repos/{name}/-/branches` — List all branches. Returns `[{name, head_sequence, base_sequence, status}]`. Supports `?status=active` filter.
+
+`GET /repos/{name}/-/branch/:bname/status` — Evaluate all merge policies for a branch without actually merging. Returns `{mergeable: bool, policies: [{name, pass, reason}]}`. Useful for UI status checks and CI gates.
+
+`GET /repos/{name}/-/branch/:bname/reviews` — List reviews for a branch. Returns `[{id, reviewer, sequence, status, body, created_at}]` ordered by created_at desc.
+
+`GET /repos/{name}/-/branch/:bname/checks` — List check runs for a branch. Returns `[{id, sequence, check_name, status, reporter, created_at}]` ordered by created_at desc.
+
+### Repo-scoped writes
+
+`POST /repos/{name}/-/commit` — Commit one or more file changes atomically. Body: `{branch, files: [{path, content}], message}`. Policy-evaluated: the engine checks the actor's role and the target branch (e.g., direct commits to `main` can be blocked by policy). Allocates a single sequence number, writes one row to commits and one row per file to file_commits (all referencing that sequence), advances the branch head.
+
+`POST /repos/{name}/-/branch` — Create a branch. Body: `{name}`. Policy-evaluated. Sets `base_sequence` to main's current head.
+
+`POST /repos/{name}/-/merge` — Merge a branch into main. Body: `{branch}`. Policy-evaluated: the engine evaluates all merge policies (required reviews, passing checks, OWNERS approval) before proceeding. On policy failure, returns `{policies: [{name, pass, reason}]}` with a 403. **Staleness rule**: the server only includes reviews and check_runs whose `sequence` matches the branch's current `head_sequence` in the policy input. Any new commit to the branch advances `head_sequence`, which automatically invalidates all prior reviews and checks — policies see an empty list until the branch is re-reviewed and re-checked at the new head. The merge uses `base_sequence` from the branches table as the fork point:
 
 1. **Branch changes**: find the latest version of each path changed on the branch since `base_sequence` (`WHERE branch = :branch AND sequence > :base_sequence`, `DISTINCT ON (path) ... ORDER BY path, sequence DESC`).
 2. **Main changes**: find the latest version of each path changed on main since `base_sequence` (same query shape against `branch = 'main'`).
 3. **Conflict check**: any path that appears in both sets is a conflict — return `{conflicts: [...]}` and abort.
 4. **If clean**: insert new `file_commits` rows on main for each branch-changed path (all sharing a single new sequence), advance main's head, mark the branch as merged.
 
-`POST /rebase` — Rebase a branch onto main's current head. Body: `{branch}`. Policy-evaluated. The entire rebase runs in a single transaction. Replays the branch's file_commits grouped by their original sequence numbers, each group getting a new sequence. Updates the branch's `base_sequence` to main's current head. If any replayed path conflicts with a main change, the entire transaction rolls back and returns conflict details — no partial rebase state.
+`POST /repos/{name}/-/rebase` — Rebase a branch onto main's current head. Body: `{branch}`. Policy-evaluated. The entire rebase runs in a single transaction. Replays the branch's file_commits grouped by their original sequence numbers, each group getting a new sequence. Updates the branch's `base_sequence` to main's current head. If any replayed path conflicts with a main change, the entire transaction rolls back and returns conflict details — no partial rebase state.
 
-`POST /review` — Submit a review for a branch. Body: `{branch, status, body}` where status is `approved` or `rejected` and body is an optional comment. Policy-evaluated. The review is recorded against the branch's current `head_sequence`. New commits invalidate prior reviews (see staleness rule on `/merge`).
+`POST /repos/{name}/-/review` — Submit a review for a branch. Body: `{branch, status, body}` where status is `approved` or `rejected` and body is an optional comment. Policy-evaluated. The review is recorded against the branch's current `head_sequence`. New commits invalidate prior reviews (see staleness rule on `/merge`).
 
-`POST /check` — Report CI check status. Body: `{branch, check_name, status}` where status is `passed` or `failed`. Policy-evaluated: only identities authorized for a given `check_name` can report results (prevents spoofing CI status). Recorded against the branch's current `head_sequence`. New commits invalidate prior checks (see staleness rule on `/merge`).
+`POST /repos/{name}/-/check` — Report CI check status. Body: `{branch, check_name, status}` where status is `passed` or `failed`. Policy-evaluated: only identities authorized for a given `check_name` can report results (prevents spoofing CI status). Recorded against the branch's current `head_sequence`. New commits invalidate prior checks (see staleness rule on `/merge`).
 
-`DELETE /branch/:name` — Mark a branch as abandoned. Policy-evaluated.
+`DELETE /repos/{name}/-/branch/:bname` — Mark a branch as abandoned. Policy-evaluated.
 
-`POST /purge` — Delete `file_commits` and `commits` rows for branches with status `merged` or `abandoned`. Body: `{older_than}` where `older_than` is a duration (e.g. `"90d"`) — only branches whose last activity is older than this threshold are purged. Also deletes any `documents` rows whose `version_id` is no longer referenced by any remaining `file_commits` row. Policy-evaluated (admin-only). Returns `{branches_purged: N, file_commits_deleted: N, documents_deleted: N}`.
+`POST /repos/{name}/-/purge` — Delete `file_commits` and `commits` rows for branches with status `merged` or `abandoned`. Body: `{older_than}` where `older_than` is a duration (e.g. `"90d"`) — only branches whose last activity is older than this threshold are purged. Also deletes any `documents` rows whose `version_id` is no longer referenced by any remaining `file_commits` row. Policy-evaluated (admin-only). Returns `{branches_purged: N, file_commits_deleted: N, documents_deleted: N}`.
 
 ## Client
 
-A CLI that wraps the API. Working directory tracked via a `.docstore` config file containing the remote URL and current branch.
+A CLI that wraps the API. Working directory tracked via a `.docstore` config file containing the remote URL, repo name, and current branch.
 
 ```
 ds init <remote-url>
-ds checkout -b <branch>      # POST /branch
-ds status                     # diff local fs against GET /tree
-ds commit -m "message"        # POST /commit with all changed files atomically
-ds log [path]                 # GET /file/:path/history or full branch log
-ds diff                       # GET /diff for current branch
-ds merge                      # POST /merge
-ds rebase                     # POST /rebase
+ds checkout -b <branch>      # POST /repos/{repo}/-/branch
+ds status                     # diff local fs against GET /repos/{repo}/-/tree
+ds commit -m "message"        # POST /repos/{repo}/-/commit with all changed files atomically
+ds log [path]                 # GET /repos/{repo}/-/file/:path/history or full branch log
+ds diff                       # GET /repos/{repo}/-/diff for current branch
+ds merge                      # POST /repos/{repo}/-/merge
+ds rebase                     # POST /repos/{repo}/-/rebase
 ds pull                       # fetch latest tree for current branch, update local files
-ds checkout main              # switch branch, GET /tree to update local files
-ds show <sequence> [path]     # GET /tree?at=N or GET /file/:path?at=N
+ds checkout main              # switch branch, GET /repos/{repo}/-/tree to update local files
+ds show <sequence> [path]     # GET /repos/{repo}/-/commit/:seq or GET /repos/{repo}/-/file/:path?at=N
 ```
+
+The CLI stores the base server URL and repo name (e.g. `default/default`) separately in `.docstore/config.json`. The `ds init` command accepts the repo name either embedded in the URL (`https://host/repos/acme/myrepo`) or via the `--repo` flag. The default repo is `default/default`.
 
 **`ds pull` flow**:
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -20,6 +20,7 @@ This document covers deployment, configuration, API reference, database schema, 
                        ▼
              Cloud SQL (PostgreSQL)
              ┌─────────────────────┐
+             │ orgs                │
              │ repos               │
              │ branches            │
              │ commits             │
@@ -179,13 +180,17 @@ The `--bootstrap-admin` flag (or `BOOTSTRAP_ADMIN` env var) grants a specified i
 
 ```bash
 # 1. Deploy with --bootstrap-admin set to your identity
-# 2. Create the first repo
+# 2. Create an org and repo (the default org + repo are seeded by migration)
+curl -X POST https://docstore.example.com/orgs \
+  -H "Content-Type: application/json" \
+  -d '{"name": "acme"}'
+
 curl -X POST https://docstore.example.com/repos \
   -H "Content-Type: application/json" \
-  -d '{"name": "myrepo"}'
+  -d '{"owner": "acme", "name": "myrepo"}'
 
 # 3. Grant yourself (or someone) admin access
-curl -X PUT https://docstore.example.com/repos/myrepo/roles/alice@example.com \
+curl -X PUT https://docstore.example.com/repos/acme/myrepo/-/roles/alice@example.com \
   -H "Content-Type: application/json" \
   -d '{"role": "admin"}'
 
@@ -203,7 +208,25 @@ All endpoints (except `/healthz`) require authentication. Errors are returned as
 {"error": "human-readable message"}
 ```
 
-Base path for repo-scoped operations: `/repos/{name}`
+### URL structure
+
+Org and repo management are at the top level. All repo-scoped operations use the `/-/` separator to unambiguously separate the full repo name (which may contain slashes) from the endpoint:
+
+```
+POST   /orgs                             create an org
+GET    /orgs                             list orgs
+GET    /orgs/{org}                       get an org
+DELETE /orgs/{org}                       delete an org
+GET    /orgs/{org}/repos                 list repos in an org
+
+POST   /repos                            create a repo
+GET    /repos                            list all repos
+GET    /repos/{full-name}                get a repo (full-name may contain slashes)
+DELETE /repos/{full-name}                delete a repo
+
+GET    /repos/acme/myrepo/-/tree         example repo-scoped endpoint
+POST   /repos/acme/myrepo/-/commit       example repo-scoped endpoint
+```
 
 ---
 
@@ -219,29 +242,109 @@ No authentication required. Returns `200 OK` when the server is running.
 
 ---
 
-### Repo Management
+### Org Management
 
-#### `POST /repos`
+#### `POST /orgs`
 
-Create a new repository.
+Create a new org.
 
 **Request body:**
 ```json
-{
-  "name": "myrepo"
-}
+{"name": "acme"}
 ```
 
 **Response `201 Created`:**
 ```json
 {
-  "name": "myrepo",
+  "name": "acme",
   "created_at": "2024-01-15T12:00:00Z",
   "created_by": "alice@example.com"
 }
 ```
 
-**Errors:** `409 Conflict` if repo already exists.
+**Errors:** `409 Conflict` if org already exists.
+
+---
+
+#### `GET /orgs`
+
+List all orgs.
+
+**Response `200 OK`:**
+```json
+{
+  "orgs": [
+    {"name": "acme", "created_at": "...", "created_by": "..."}
+  ]
+}
+```
+
+---
+
+#### `GET /orgs/{org}`
+
+Get a single org.
+
+**Response `200 OK`:** same shape as an element of `GET /orgs`.
+
+**Errors:** `404 Not Found`.
+
+---
+
+#### `DELETE /orgs/{org}`
+
+Delete an org. Fails if the org still has repos.
+
+**Response:** `204 No Content`
+
+**Errors:** `404 Not Found`; `409 Conflict` if org has repos.
+
+---
+
+#### `GET /orgs/{org}/repos`
+
+List all repos owned by an org.
+
+**Response `200 OK`:**
+```json
+{
+  "repos": [
+    {"name": "acme/myrepo", "owner": "acme", "created_at": "...", "created_by": "..."}
+  ]
+}
+```
+
+---
+
+### Repo Management
+
+#### `POST /repos`
+
+Create a new repository. The repo is owned by an existing org.
+
+**Request body:**
+```json
+{
+  "owner": "acme",
+  "name": "myrepo"
+}
+```
+
+- `owner` — the org name (must already exist)
+- `name` — the repo path within the org (may contain slashes for subgroup nesting, e.g. `team/subrepo`)
+- The full repo identifier is `owner/name` (e.g. `acme/myrepo` or `acme/team/subrepo`)
+
+**Response `201 Created`:**
+```json
+{
+  "name": "acme/myrepo",
+  "owner": "acme",
+  "created_at": "2024-01-15T12:00:00Z",
+  "created_by": "alice@example.com"
+}
+```
+
+**Errors:** `409 Conflict` if repo already exists; `404 Not Found` if org does not exist.
 
 ---
 
@@ -253,7 +356,7 @@ List all repositories.
 ```json
 {
   "repos": [
-    {"name": "myrepo", "created_at": "...", "created_by": "..."}
+    {"name": "acme/myrepo", "owner": "acme", "created_at": "...", "created_by": "..."}
   ]
 }
 ```
@@ -262,7 +365,7 @@ List all repositories.
 
 #### `GET /repos/{name}`
 
-Get a single repository by name.
+Get a single repository by its full name (e.g. `acme/myrepo`).
 
 **Response `200 OK`:** same shape as an element of the `GET /repos` list.
 
@@ -282,7 +385,9 @@ Hard-delete a repository (all branches, commits, documents, and roles).
 
 ### Branches
 
-#### `GET /repos/{name}/branches`
+All branch endpoints use the `/-/` separator. For a repo named `acme/myrepo`, the URL is `/repos/acme/myrepo/-/branches`.
+
+#### `GET /repos/{name}/-/branches`
 
 List all branches in the repo.
 
@@ -309,7 +414,7 @@ List all branches in the repo.
 
 ---
 
-#### `POST /repos/{name}/branch`
+#### `POST /repos/{name}/-/branch`
 
 Create a new branch from the current `main` head. Branch names may contain slashes.
 
@@ -332,7 +437,7 @@ Create a new branch from the current `main` head. Branch names may contain slash
 
 ---
 
-#### `DELETE /repos/{name}/branch/{bname}`
+#### `DELETE /repos/{name}/-/branch/{bname}`
 
 Delete a branch. `main` cannot be deleted. Branch names may contain slashes.
 
@@ -346,7 +451,7 @@ Delete a branch. `main` cannot be deleted. Branch names may contain slashes.
 
 ### Commits
 
-#### `POST /repos/{name}/commit`
+#### `POST /repos/{name}/-/commit`
 
 Commit one or more file changes to a branch.
 
@@ -383,7 +488,7 @@ Commit one or more file changes to a branch.
 
 ---
 
-#### `GET /repos/{name}/commit/{sequence}`
+#### `GET /repos/{name}/-/commit/{sequence}`
 
 Get commit metadata and the list of files changed.
 
@@ -407,7 +512,7 @@ Get commit metadata and the list of files changed.
 
 ### Tree and File Content
 
-#### `GET /repos/{name}/tree`
+#### `GET /repos/{name}/-/tree`
 
 Materialize the full file tree for a branch at an optional sequence number. Supports cursor-based pagination.
 
@@ -432,7 +537,7 @@ Returns an empty array `[]` for empty trees.
 
 ---
 
-#### `GET /repos/{name}/file/{path...}`
+#### `GET /repos/{name}/-/file/{path...}`
 
 Get the content of a file on a branch at an optional sequence.
 
@@ -454,7 +559,7 @@ Get the content of a file on a branch at an optional sequence.
 
 ---
 
-#### `GET /repos/{name}/file/{path...}/history`
+#### `GET /repos/{name}/-/file/{path...}/history`
 
 Get the commit history for a file on a branch.
 
@@ -480,7 +585,7 @@ Get the commit history for a file on a branch.
 
 ### Diff
 
-#### `GET /repos/{name}/diff`
+#### `GET /repos/{name}/-/diff`
 
 Compare a branch against its base sequence on `main`, showing what changed on each side and any conflicts.
 
@@ -516,7 +621,7 @@ Compare a branch against its base sequence on `main`, showing what changed on ea
 
 ### Merge
 
-#### `POST /repos/{name}/merge`
+#### `POST /repos/{name}/-/merge`
 
 Merge a branch into `main`. Cannot merge `main` into itself.
 
@@ -553,7 +658,7 @@ Merge a branch into `main`. Cannot merge `main` into itself.
 
 ### Rebase
 
-#### `POST /repos/{name}/rebase`
+#### `POST /repos/{name}/-/rebase`
 
 Replay branch commits on top of the current `main` head. Updates the branch's `base_sequence` and `head_sequence`. Cannot rebase `main`.
 
@@ -594,7 +699,7 @@ Replay branch commits on top of the current `main` head. Updates the branch's `b
 
 ### Reviews
 
-#### `POST /repos/{name}/review`
+#### `POST /repos/{name}/-/review`
 
 Submit a review (approval, rejection, or dismissal) for a branch.
 
@@ -624,7 +729,7 @@ Status values: `approved`, `rejected`, `dismissed`.
 
 ---
 
-#### `GET /repos/{name}/branch/{branch}/reviews`
+#### `GET /repos/{name}/-/branch/{branch}/reviews`
 
 List reviews for a branch, optionally scoped to a specific head sequence.
 
@@ -650,7 +755,7 @@ List reviews for a branch, optionally scoped to a specific head sequence.
 
 ### Check Runs
 
-#### `POST /repos/{name}/check`
+#### `POST /repos/{name}/-/check`
 
 Report an external CI check run result for a branch.
 
@@ -677,7 +782,7 @@ Status values: `pending`, `passed`, `failed`.
 
 ---
 
-#### `GET /repos/{name}/branch/{branch}/checks`
+#### `GET /repos/{name}/-/branch/{branch}/checks`
 
 List check runs for a branch, optionally scoped to a specific head sequence.
 
@@ -705,7 +810,7 @@ List check runs for a branch, optionally scoped to a specific head sequence.
 
 All role endpoints require `admin` role.
 
-#### `GET /repos/{name}/roles`
+#### `GET /repos/{name}/-/roles`
 
 List all roles in the repo.
 
@@ -721,7 +826,7 @@ List all roles in the repo.
 
 ---
 
-#### `PUT /repos/{name}/roles/{identity}`
+#### `PUT /repos/{name}/-/roles/{identity}`
 
 Set or update the role for an identity. Identity may contain slashes (e.g. email addresses are routed correctly).
 
@@ -739,7 +844,7 @@ Valid roles: `reader`, `writer`, `maintainer`, `admin`.
 
 ---
 
-#### `DELETE /repos/{name}/roles/{identity}`
+#### `DELETE /repos/{name}/-/roles/{identity}`
 
 Remove an identity's role from the repo.
 
@@ -751,7 +856,7 @@ Remove an identity's role from the repo.
 
 ### Branch Status (Not Implemented)
 
-#### `GET /repos/{name}/branch/{bname}/status`
+#### `GET /repos/{name}/-/branch/{bname}/status`
 
 Returns `501 Not Implemented`. Intended for future policy evaluation (OPA integration).
 
@@ -759,19 +864,34 @@ Returns `501 Not Implemented`. Intended for future policy evaluation (OPA integr
 
 ## Database Schema
 
-All tables are scoped to a `repo` column (foreign key to `repos.name`). The schema is defined in `internal/db/migrations/000001_initial_schema.up.sql`.
+All data tables are scoped to a `repo` column (foreign key to `repos.name`). The schema is defined in `internal/db/migrations/000001_initial_schema.up.sql`.
+
+### `orgs`
+
+Top-level namespace. Every repo must belong to an org.
+
+| Column       | Type          | Description                        |
+|-------------|--------------|-------------------------------------|
+| `name`       | `TEXT PK`     | Unique org name (e.g. `acme`)      |
+| `created_at` | `TIMESTAMPTZ` | Creation timestamp                 |
+| `created_by` | `TEXT`        | Identity that created the org      |
+
+Seeded with a `default` org on migration.
+
+---
 
 ### `repos`
 
-Top-level namespace for multi-tenancy.
+Named tenants owned by an org. The full repo identifier is the `name` (e.g. `acme/myrepo`); `owner` is the first path segment and must match an existing org.
 
-| Column       | Type         | Description                        |
-|-------------|-------------|-------------------------------------|
-| `name`       | `TEXT PK`    | Unique repo name                   |
-| `created_at` | `TIMESTAMPTZ`| Creation timestamp                 |
-| `created_by` | `TEXT`       | Identity that created the repo     |
+| Column       | Type          | Description                                                    |
+|-------------|--------------|----------------------------------------------------------------|
+| `name`       | `TEXT PK`     | Full path, e.g. `acme/myrepo` or `acme/team/subrepo`         |
+| `owner`      | `TEXT`        | FK → `orgs.name`; must equal `split_part(name, '/', 1)`      |
+| `created_at` | `TIMESTAMPTZ` | Creation timestamp                                             |
+| `created_by` | `TEXT`        | Identity that created the repo                                 |
 
-Seeded with a `default` repo on migration.
+Seeded with a `default/default` repo (owned by org `default`) on migration.
 
 ---
 
@@ -905,7 +1025,7 @@ Index: `(repo, branch, sequence, check_name)`.
 
 ### Logging
 
-The server uses the standard `log` package. All startup events, migration status, and fatal errors are written to stderr. There is no structured logging; log aggregation relies on Cloud Run's default log collection.
+The server uses the standard `log/slog` package for structured JSON logging. All startup events, migration status, request details, and errors are written to stderr as JSON. Cloud Run's log collection will parse this automatically.
 
 ---
 
@@ -918,11 +1038,15 @@ The server uses the standard `log` package. All startup events, migration status
 5. Deploy to Cloud Run with `DATABASE_URL` and `BOOTSTRAP_ADMIN` set
 6. Enable IAP on the Cloud Run service
 7. Verify: `curl https://<url>/healthz` → `{"status":"ok"}`
-8. Create your first repo:
+8. Create an org and your first repo (migration seeds `default` org and `default/default` repo; skip if those are sufficient):
    ```bash
+   curl -X POST https://<url>/orgs \
+     -H "Content-Type: application/json" \
+     -d '{"name": "acme"}'
+
    curl -X POST https://<url>/repos \
      -H "Content-Type: application/json" \
-     -d '{"name": "myrepo"}'
+     -d '{"owner": "acme", "name": "myrepo"}'
    ```
    > **Note:** When IAP is enabled, the proxy automatically injects the
    > `X-Goog-IAP-JWT-Assertion` header — clients never set it directly.
@@ -931,8 +1055,8 @@ The server uses the standard `log` package. All startup events, migration status
    > IAP validation is bypassed entirely.
 9. Grant yourself admin:
    ```bash
-   curl -X PUT https://<url>/repos/myrepo/roles/you@example.com \
+   curl -X PUT https://<url>/repos/acme/myrepo/-/roles/you@example.com \
      -H "Content-Type: application/json" \
      -d '{"role": "admin"}'
    ```
-10. Initialize a local workspace: `ds init https://<url>/repos/myrepo`
+10. Initialize a local workspace: `ds init https://<url>/repos/acme/myrepo`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ DocStore is a version control system for structured documents, built on Postgres
 ## Overview
 
 - **Server-side VCS**: all history lives in Postgres; the working directory is a local cache
-- **Multi-repo**: one server hosts many named repositories
+- **Multi-repo**: one server hosts many named repositories, organized into orgs
+- **Orgs**: repos belong to an org; repo names are `owner/name` full paths (e.g. `acme/myrepo`)
 - **Branching model**: one permanent `main` branch; all work happens on named feature branches
 - **Content deduplication**: identical file contents are stored once (content-addressed by SHA256)
 - **RBAC**: per-repo roles (reader / writer / maintainer / admin)
@@ -28,8 +29,10 @@ make build-ds    # produces bin/ds
 
 ### 2. Initialize a workspace
 
+Repos are owned by orgs. The repo name is an `owner/name` full path (e.g. `acme/myrepo`).
+
 ```bash
-ds init https://docstore.example.com/repos/myrepo
+ds init https://docstore.example.com/repos/acme/myrepo
 ```
 
 This creates a `.docstore/` config directory and downloads the current tree from `main`.
@@ -37,10 +40,10 @@ This creates a `.docstore/` config directory and downloads the current tree from
 You can also pass the repo name separately:
 
 ```bash
-ds init https://docstore.example.com --repo myrepo
+ds init https://docstore.example.com --repo acme/myrepo
 ```
 
-If no repo is specified and the URL has no `/repos/` segment, the repo name defaults to `default`.
+If no repo is specified and the URL has no `/repos/` segment, the repo name defaults to `default/default`.
 
 ### 3. Make changes, commit, and push
 
@@ -91,14 +94,14 @@ ds init https://docstore.example.com/repos/myrepo --author alice@example.com
 
 Initialize a docstore workspace in the current directory.
 
-- `<remote-url>` — base server URL, optionally including the repo path (`https://host/repos/myrepo`)
+- `<remote-url>` — base server URL, optionally including the repo path (`https://host/repos/acme/myrepo`)
 - `--author <name>` — identity to use for commits (defaults to OS username)
-- `--repo <name>` — repo name on the server (overrides any name embedded in the URL; defaults to `default`)
+- `--repo <name>` — full repo name `owner/name` (overrides any name embedded in the URL; defaults to `default/default`)
 
 Creates `.docstore/config.json` and `.docstore/state.json`, then syncs files from `main`.
 
 ```bash
-ds init https://docstore.example.com/repos/docs --author jane@example.com
+ds init https://docstore.example.com/repos/acme/docs --author jane@example.com
 ```
 
 ---
@@ -330,18 +333,46 @@ ds merge
 
 ---
 
-## Server URL Format
+## Orgs and Repos
 
-The server exposes all repos under `/repos/:name`. You can give `ds init` the full path:
+Repos live under orgs. An org must be created before a repo can be created in it.
 
 ```bash
-ds init https://docstore.example.com/repos/myrepo
+# Create an org
+curl -X POST https://docstore.example.com/orgs \
+  -H "Content-Type: application/json" \
+  -d '{"name": "acme"}'
+
+# Create a repo in that org
+curl -X POST https://docstore.example.com/repos \
+  -H "Content-Type: application/json" \
+  -d '{"owner": "acme", "name": "myrepo"}'
+```
+
+The full repo name is `owner/name` (e.g. `acme/myrepo`). Repo names can contain additional slashes for subgroup nesting (e.g. `acme/team/subrepo`), in which case `acme` is still the owner (org) and `team/subrepo` is the repo name within that org.
+
+---
+
+## Server URL Format
+
+All repo-scoped API routes use a `/-/` separator to cleanly separate the full repo name (which may contain slashes) from the endpoint:
+
+```
+GET  /repos/acme/myrepo/-/tree
+POST /repos/acme/myrepo/-/commit
+GET  /repos/acme/team/subrepo/-/branches
+```
+
+For the CLI, you can give `ds init` the full path:
+
+```bash
+ds init https://docstore.example.com/repos/acme/myrepo
 ```
 
 Or the base URL with `--repo`:
 
 ```bash
-ds init https://docstore.example.com --repo myrepo
+ds init https://docstore.example.com --repo acme/myrepo
 ```
 
-Both are equivalent. The CLI stores only the base URL internally.
+Both are equivalent. The CLI stores only the base URL and repo name separately in `.docstore/config.json`. A fresh server seeds a `default` org and a `default/default` repo — the CLI defaults to this repo when no repo is specified.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,34 +4,35 @@
 
 These must land first. Each is an independent PR unless noted.
 
-- [ ] **Project scaffolding**: Go module setup, directory structure (`cmd/`, `internal/`, `pkg/`), Makefile, basic CI (lint + test)
-- [ ] **Database schema & migrations**: SQL migration files for all six tables (documents, file_commits, branches, roles, reviews, check_runs) with indexes per DESIGN.md
-- [ ] **Data model types**: Go types for all tables, plus request/response structs for the API
-- [ ] **Document store & content dedup**: `POST /commit` path — hash content, dedup against documents table, insert file_commits with atomic sequence allocation
-- [ ] **Tree materialization & file reads**: `GET /tree`, `GET /file/:path`, `GET /file/:path/history`, `GET /commit/:sequence`
-- [ ] **Branch management**: `POST /branch`, `DELETE /branch/:name`, `GET /branches`
-- [ ] **Merge engine**: `POST /merge` — conflict detection, fast-forward merge into main, branch status update
-- [ ] **Rebase**: `POST /rebase` — replay branch commits onto current main head
-- [ ] **Diff endpoint**: `GET /diff?branch=X` — files changed on branch vs base_sequence
+- [x] **Project scaffolding**: Go module setup, directory structure (`cmd/`, `internal/`, `pkg/`), Makefile, basic CI (lint + test)
+- [x] **Database schema & migrations**: SQL migration files with orgs, repos, branches, commits, documents, file_commits, roles, reviews, check_runs tables with indexes
+- [x] **Data model types**: Go types for all tables, plus request/response structs for the API
+- [x] **Document store & content dedup**: `POST /repos/{repo}/-/commit` path — hash content, dedup against documents table, insert file_commits with atomic sequence allocation
+- [x] **Tree materialization & file reads**: `GET /repos/{repo}/-/tree`, `GET /repos/{repo}/-/file/{path}`, `GET /repos/{repo}/-/file/{path}/history`, `GET /repos/{repo}/-/commit/{sequence}`
+- [x] **Branch management**: `POST /repos/{repo}/-/branch`, `DELETE /repos/{repo}/-/branch/{name}`, `GET /repos/{repo}/-/branches`
+- [x] **Merge engine**: `POST /repos/{repo}/-/merge` — conflict detection, fast-forward merge into main, branch status update
+- [x] **Rebase**: `POST /repos/{repo}/-/rebase` — replay branch commits onto current main head
+- [x] **Diff endpoint**: `GET /repos/{repo}/-/diff?branch=X` — files changed on branch vs base_sequence
+- [x] **Org support**: `orgs` table, org CRUD endpoints, `repos.owner` FK, `/-/` URL separator for slash-in-name repos
 
 ## P1 — Access Control & Reviews
 
 Depends on P0 server being functional.
 
-- [ ] **IAP authentication middleware**: Extract and validate identity from `X-Goog-IAP-JWT-Assertion` header
-- [ ] **Roles table & RBAC middleware**: Role lookup, coarse-grained permission checks (reader/writer/maintainer/admin)
-- [ ] **Review system**: `POST /review`, review storage, sequence-scoped approval tracking
-- [ ] **Check runs**: `POST /check`, check status storage, reporter authorization
+- [x] **IAP authentication middleware**: Extract and validate identity from `X-Goog-IAP-JWT-Assertion` header
+- [x] **Roles table & RBAC middleware**: Role lookup, coarse-grained permission checks (reader/writer/maintainer/admin)
+- [x] **Review system**: `POST /repos/{repo}/-/review`, review storage, sequence-scoped approval tracking
+- [x] **Check runs**: `POST /repos/{repo}/-/check`, check status storage, reporter authorization
 - [ ] **OPA policy engine integration**: Embed OPA, load policies from `.docstore/policy/*.rego`, evaluate on all write endpoints
 - [ ] **OWNERS files**: Parse OWNERS from materialized main tree, build owners map for policy input
-- [ ] **Branch status endpoint**: `GET /branch/:name/status` — evaluate merge policies without merging
+- [ ] **Branch status endpoint**: `GET /repos/{repo}/-/branch/{name}/status` — evaluate merge policies without merging (currently returns 501)
 
 ## P2 — CLI Client
 
 Can be developed in parallel with P1.
 
-- [ ] **CLI scaffolding**: `ds` command structure, `.docstore` config file management
-- [ ] **Core commands**: `init`, `checkout`, `status`, `commit`, `log`, `diff`
-- [ ] **Merge & rebase commands**: `merge`, `rebase`
-- [ ] **Conflict resolution**: Write conflict files, `ds resolve` command
-- [ ] **Local state management**: `.docstore/state.json`, local hash tracking for offline status
+- [x] **CLI scaffolding**: `ds` command structure, `.docstore` config file management
+- [x] **Core commands**: `init`, `checkout`, `status`, `commit`, `log`, `diff`
+- [x] **Merge & rebase commands**: `merge`, `rebase`
+- [x] **Conflict resolution**: Write conflict files, `ds resolve` command
+- [x] **Local state management**: `.docstore/state.json`, local hash tracking for offline status


### PR DESCRIPTION
## Summary

- **DESIGN.md**: Added `orgs` table to data model; updated `repos` table (added `owner` field); rewrote API section with org endpoints and `/-/` URL separator for all repo-scoped routes
- **README.md**: Updated overview to mention orgs; updated `ds init` examples and `--repo` default (`default/default`); updated Server URL Format section; added Orgs and Repos section with org/repo creation examples
- **OPERATIONS.md**: Added `orgs` to architecture diagram; added org management section to API reference; updated all repo-scoped endpoint paths to use `/-/` separator; updated `POST /repos` request body (`owner` + `name`); added `orgs` table to DB schema section; updated `repos` table schema to include `owner`; updated bootstrap admin and first deployment runbook examples; fixed logging section (now `log/slog` structured JSON, per PR #58)
- **ROADMAP.md**: Marked all P0 items done (including org support); marked IAP, RBAC, reviews, check runs as done (P1); marked all P2 CLI commands as done

## What's still not implemented (left as TODO in ROADMAP)
- OPA policy engine integration
- OWNERS files
- Branch status endpoint (currently returns 501)

## Notes / opportunities
- Org-level RBAC (creating/deleting orgs is ungated beyond IAP auth) is not yet implemented; could be noted in a future task
- `ds init` doesn't validate that `--repo` is in `owner/name` format

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./... -count=1 -short` all green
- [x] No code changes — docs only

Refs: #59 (org support + `/-/` URLs), #58 (structured logging), #60 (RBAC review gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)