### PR TITLE
Add test coverage: org DB layer, role handlers, file history, checks, reviews

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,0 +1,46 @@
+package db
+
+import "testing"
+
+func TestExtractHost(t *testing.T) {
+	tests := []struct {
+		name string
+		dsn  string
+		want string
+	}{
+		{
+			name: "postgres URL",
+			dsn:  "postgres://user:pass@localhost:5432/mydb",
+			want: "localhost",
+		},
+		{
+			name: "postgres URL with host only",
+			dsn:  "postgres://myhost/mydb",
+			want: "myhost",
+		},
+		{
+			name: "empty DSN",
+			dsn:  "",
+			want: "unknown",
+		},
+		{
+			name: "invalid URL",
+			dsn:  "://bad",
+			want: "unknown",
+		},
+		{
+			name: "key=value DSN (no host in URL form)",
+			dsn:  "host=myserver user=foo dbname=bar",
+			want: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractHost(tt.dsn)
+			if got != tt.want {
+				t.Errorf("extractHost(%q) = %q, want %q", tt.dsn, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -2755,3 +2755,251 @@ func TestCommit_ToMergedBranch(t *testing.T) {
 		t.Fatalf("expected ErrBranchNotActive for commit to merged branch, got %v", err)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Org CRUD tests
+// ---------------------------------------------------------------------------
+
+func TestCreateOrg(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	org, err := s.CreateOrg(ctx, "myorg", "alice@example.com")
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	if org.Name != "myorg" {
+		t.Errorf("expected name myorg, got %q", org.Name)
+	}
+	if org.CreatedBy != "alice@example.com" {
+		t.Errorf("expected created_by alice@example.com, got %q", org.CreatedBy)
+	}
+
+	// Duplicate name returns ErrOrgExists.
+	_, err = s.CreateOrg(ctx, "myorg", "bob@example.com")
+	if !errors.Is(err, ErrOrgExists) {
+		t.Errorf("expected ErrOrgExists on duplicate, got %v", err)
+	}
+}
+
+func TestCreateOrg_DefaultCreatedBy(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	org, err := s.CreateOrg(ctx, "auto-org", "")
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	if org.CreatedBy != "system" {
+		t.Errorf("expected created_by system, got %q", org.CreatedBy)
+	}
+}
+
+func TestDeleteOrg(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	if _, err := s.CreateOrg(ctx, "todelete", "alice"); err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+
+	// Delete succeeds.
+	if err := s.DeleteOrg(ctx, "todelete"); err != nil {
+		t.Fatalf("DeleteOrg: %v", err)
+	}
+
+	// Second delete returns ErrOrgNotFound.
+	if err := s.DeleteOrg(ctx, "todelete"); !errors.Is(err, ErrOrgNotFound) {
+		t.Errorf("expected ErrOrgNotFound on second delete, got %v", err)
+	}
+}
+
+func TestDeleteOrg_NotFound(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	err := s.DeleteOrg(ctx, "nonexistent")
+	if !errors.Is(err, ErrOrgNotFound) {
+		t.Errorf("expected ErrOrgNotFound, got %v", err)
+	}
+}
+
+func TestDeleteOrg_HasRepos(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	if _, err := s.CreateOrg(ctx, "orgwithrepos", "alice"); err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	if _, err := s.CreateRepo(ctx, model.CreateRepoRequest{Owner: "orgwithrepos", Name: "myrepo"}); err != nil {
+		t.Fatalf("CreateRepo: %v", err)
+	}
+
+	err := s.DeleteOrg(ctx, "orgwithrepos")
+	if !errors.Is(err, ErrOrgHasRepos) {
+		t.Errorf("expected ErrOrgHasRepos, got %v", err)
+	}
+}
+
+func TestListOrgRepos(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	if _, err := s.CreateOrg(ctx, "listorg", "alice"); err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+
+	// No repos yet.
+	repos, err := s.ListOrgRepos(ctx, "listorg")
+	if err != nil {
+		t.Fatalf("ListOrgRepos (empty): %v", err)
+	}
+	if len(repos) != 0 {
+		t.Errorf("expected 0 repos, got %d", len(repos))
+	}
+
+	// Create two repos.
+	for _, name := range []string{"alpha", "beta"} {
+		if _, err := s.CreateRepo(ctx, model.CreateRepoRequest{Owner: "listorg", Name: name}); err != nil {
+			t.Fatalf("CreateRepo %s: %v", name, err)
+		}
+	}
+
+	repos, err = s.ListOrgRepos(ctx, "listorg")
+	if err != nil {
+		t.Fatalf("ListOrgRepos: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(repos))
+	}
+	if repos[0].Name != "listorg/alpha" || repos[1].Name != "listorg/beta" {
+		t.Errorf("unexpected repo names: %v, %v", repos[0].Name, repos[1].Name)
+	}
+}
+
+func TestListRepos(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// default org already has default/default from migration.
+	repos, err := s.ListRepos(ctx)
+	if err != nil {
+		t.Fatalf("ListRepos: %v", err)
+	}
+	initialCount := len(repos)
+
+	// Create an extra org and repo.
+	if _, err := s.CreateOrg(ctx, "extra", "alice"); err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	if _, err := s.CreateRepo(ctx, model.CreateRepoRequest{Owner: "extra", Name: "newrepo"}); err != nil {
+		t.Fatalf("CreateRepo: %v", err)
+	}
+
+	repos, err = s.ListRepos(ctx)
+	if err != nil {
+		t.Fatalf("ListRepos after create: %v", err)
+	}
+	if len(repos) != initialCount+1 {
+		t.Errorf("expected %d repos, got %d", initialCount+1, len(repos))
+	}
+}
+
+func TestGetRepo(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// default/default exists from migration seed.
+	repo, err := s.GetRepo(ctx, "default/default")
+	if err != nil {
+		t.Fatalf("GetRepo: %v", err)
+	}
+	if repo.Name != "default/default" {
+		t.Errorf("expected name default/default, got %q", repo.Name)
+	}
+
+	// Non-existent repo.
+	_, err = s.GetRepo(ctx, "default/noexist")
+	if !errors.Is(err, ErrRepoNotFound) {
+		t.Errorf("expected ErrRepoNotFound, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListRoles DB test
+// ---------------------------------------------------------------------------
+
+func TestListRoles(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Empty initially.
+	roles, err := s.ListRoles(ctx, "default/default")
+	if err != nil {
+		t.Fatalf("ListRoles (empty): %v", err)
+	}
+	if len(roles) != 0 {
+		t.Errorf("expected 0 roles, got %d", len(roles))
+	}
+
+	// Add a couple of roles.
+	if err := s.SetRole(ctx, "default/default", "alice@example.com", model.RoleAdmin); err != nil {
+		t.Fatalf("SetRole alice: %v", err)
+	}
+	if err := s.SetRole(ctx, "default/default", "bob@example.com", model.RoleReader); err != nil {
+		t.Fatalf("SetRole bob: %v", err)
+	}
+
+	roles, err = s.ListRoles(ctx, "default/default")
+	if err != nil {
+		t.Fatalf("ListRoles: %v", err)
+	}
+	if len(roles) != 2 {
+		t.Fatalf("expected 2 roles, got %d", len(roles))
+	}
+	// Results should be ordered by identity.
+	if roles[0].Identity != "alice@example.com" || roles[0].Role != model.RoleAdmin {
+		t.Errorf("unexpected first role: %+v", roles[0])
+	}
+	if roles[1].Identity != "bob@example.com" || roles[1].Role != model.RoleReader {
+		t.Errorf("unexpected second role: %+v", roles[1])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// isForeignKeyViolation / isDuplicateKeyError helper tests
+// ---------------------------------------------------------------------------
+
+func TestIsForeignKeyViolation_NonPQError(t *testing.T) {
+	// A plain error should return false.
+	if isForeignKeyViolation(errors.New("some error")) {
+		t.Error("expected false for non-pq error")
+	}
+}
+
+func TestIsDuplicateKeyError_NonPQError(t *testing.T) {
+	if isDuplicateKeyError(errors.New("some error")) {
+		t.Error("expected false for non-pq error")
+	}
+}
+
+func TestIsForeignKeyViolation_FromDB(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Trying to create a repo for a non-existent org triggers a FK violation.
+	_, err := s.CreateRepo(ctx, model.CreateRepoRequest{Owner: "nosuchorg", Name: "somerepo"})
+	if !errors.Is(err, ErrOrgNotFound) {
+		t.Errorf("expected ErrOrgNotFound (wrapping FK violation), got %v", err)
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1473,3 +1473,335 @@ func TestHandleCreateRepo_OwnerSlashMismatch(t *testing.T) {
 		t.Errorf("expected 400, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Role management handler tests
+// ---------------------------------------------------------------------------
+
+func TestHandleListRoles_Success(t *testing.T) {
+	ms := &mockStore{
+		listRolesFn: func(ctx context.Context, repo string) ([]model.Role, error) {
+			return []model.Role{
+				{Identity: "alice@example.com", Role: model.RoleAdmin},
+				{Identity: "bob@example.com", Role: model.RoleReader},
+			}, nil
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/roles", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp model.RolesResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Roles) != 2 {
+		t.Errorf("expected 2 roles, got %d", len(resp.Roles))
+	}
+}
+
+func TestHandleListRoles_Empty(t *testing.T) {
+	ms := &mockStore{
+		listRolesFn: func(ctx context.Context, repo string) ([]model.Role, error) {
+			return nil, nil
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/roles", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp model.RolesResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Roles) != 0 {
+		t.Errorf("expected 0 roles, got %d", len(resp.Roles))
+	}
+}
+
+func TestHandleListRoles_InternalError(t *testing.T) {
+	ms := &mockStore{
+		listRolesFn: func(ctx context.Context, repo string) ([]model.Role, error) {
+			return nil, errors.New("db error")
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/roles", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+}
+
+func TestHandleSetRole_Success(t *testing.T) {
+	var capturedIdentity string
+	var capturedRole model.RoleType
+	ms := &mockStore{
+		setRoleFn: func(ctx context.Context, repo, identity string, role model.RoleType) error {
+			capturedIdentity = identity
+			capturedRole = role
+			return nil
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	body, _ := json.Marshal(model.SetRoleRequest{Role: model.RoleWriter})
+	req := httptest.NewRequest(http.MethodPut, "/repos/default/default/-/roles/alice@example.com", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if capturedIdentity != "alice@example.com" {
+		t.Errorf("expected identity alice@example.com, got %q", capturedIdentity)
+	}
+	if capturedRole != model.RoleWriter {
+		t.Errorf("expected role writer, got %q", capturedRole)
+	}
+}
+
+func TestHandleSetRole_InvalidRole(t *testing.T) {
+	ms := &mockStore{}
+	srv := New(ms, nil, devID, devID)
+	body, _ := json.Marshal(model.SetRoleRequest{Role: "superuser"})
+	req := httptest.NewRequest(http.MethodPut, "/repos/default/default/-/roles/alice@example.com", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleSetRole_InvalidJSON(t *testing.T) {
+	ms := &mockStore{}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodPut, "/repos/default/default/-/roles/alice@example.com", bytes.NewReader([]byte("not json")))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleSetRole_InternalError(t *testing.T) {
+	ms := &mockStore{
+		setRoleFn: func(ctx context.Context, repo, identity string, role model.RoleType) error {
+			return errors.New("db down")
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	body, _ := json.Marshal(model.SetRoleRequest{Role: model.RoleAdmin})
+	req := httptest.NewRequest(http.MethodPut, "/repos/default/default/-/roles/alice@example.com", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+}
+
+func TestHandleDeleteRole_Success(t *testing.T) {
+	ms := &mockStore{
+		deleteRoleFn: func(ctx context.Context, repo, identity string) error {
+			return nil
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodDelete, "/repos/default/default/-/roles/alice@example.com", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleDeleteRole_NotFound(t *testing.T) {
+	ms := &mockStore{
+		deleteRoleFn: func(ctx context.Context, repo, identity string) error {
+			return db.ErrRoleNotFound
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodDelete, "/repos/default/default/-/roles/nobody@example.com", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleDeleteRole_InternalError(t *testing.T) {
+	ms := &mockStore{
+		deleteRoleFn: func(ctx context.Context, repo, identity string) error {
+			return errors.New("db error")
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodDelete, "/repos/default/default/-/roles/alice@example.com", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleGetReviews additional paths
+// ---------------------------------------------------------------------------
+
+func TestHandleGetReviews_WithAtParam(t *testing.T) {
+	var capturedSeq *int64
+	ms := &mockStore{
+		listReviewsFn: func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error) {
+			capturedSeq = atSeq
+			return []model.Review{}, nil
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/main/reviews?at=5", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if capturedSeq == nil || *capturedSeq != 5 {
+		t.Errorf("expected at=5, got %v", capturedSeq)
+	}
+}
+
+func TestHandleGetReviews_InvalidAt(t *testing.T) {
+	ms := &mockStore{}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/main/reviews?at=notanumber", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleGetReviews_InternalError(t *testing.T) {
+	ms := &mockStore{
+		listReviewsFn: func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error) {
+			return nil, errors.New("db error")
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/main/reviews", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleGetChecks additional paths
+// ---------------------------------------------------------------------------
+
+func TestHandleGetChecks_WithAtParam(t *testing.T) {
+	var capturedSeq *int64
+	ms := &mockStore{
+		listCheckRunsFn: func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error) {
+			capturedSeq = atSeq
+			return []model.CheckRun{}, nil
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/main/checks?at=3", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if capturedSeq == nil || *capturedSeq != 3 {
+		t.Errorf("expected at=3, got %v", capturedSeq)
+	}
+}
+
+func TestHandleGetChecks_InvalidAt(t *testing.T) {
+	ms := &mockStore{}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/main/checks?at=bad", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleGetChecks_InternalError(t *testing.T) {
+	ms := &mockStore{
+		listCheckRunsFn: func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error) {
+			return nil, errors.New("db error")
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/main/checks", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleFileHistory additional paths
+// ---------------------------------------------------------------------------
+
+func TestHandleFileHistory_InvalidLimit(t *testing.T) {
+	ms := &mockStore{}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/file/hello.txt/history?limit=notanumber", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleFileHistory_ZeroLimit(t *testing.T) {
+	ms := &mockStore{}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/file/hello.txt/history?limit=0", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleFileHistory_InvalidAfter(t *testing.T) {
+	ms := &mockStore{}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/file/hello.txt/history?after=notanumber", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

- **internal/db/store_test.go**: Added tests for `CreateOrg` (success + duplicate → `ErrOrgExists`, empty `createdBy` → `system`), `DeleteOrg` (success, `ErrOrgNotFound`, `ErrOrgHasRepos`), `ListOrgRepos` (empty + populated), `ListRepos`, `GetRepo` (success + `ErrRepoNotFound`), `ListRoles` (empty + populated, ordered by identity), and `isForeignKeyViolation`/`isDuplicateKeyError` helpers
- **internal/db/db_test.go**: New file with unit tests for `extractHost` DSN parsing (postgres URL, empty DSN, invalid URL, key=value DSN)
- **internal/server/server_test.go**: Added tests for `handleListRoles` (success, empty, internal error), `handleSetRole` (success, invalid role, invalid JSON, internal error), `handleDeleteRole` (success, not found, internal error), `handleGetReviews`/`handleGetChecks` (invalid `?at` param, internal error paths), `handleFileHistory` (invalid limit, zero limit, invalid after param)

## Coverage Impact

All previously 0% functions are now exercised. Key gaps addressed:
- Org layer DB functions: CreateOrg, DeleteOrg, ListOrgRepos, ListRepos, GetRepo
- Role management handlers: handleListRoles, handleDeleteRole, handleSetRole  
- handleFileHistory: added 3 new error-path cases
- handleGetChecks/handleGetReviews: added invalid param + internal error paths
- isForeignKeyViolation helper: unit test + DB-level test
- extractHost: full unit test suite

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean  
- [x] `go test ./... -count=1` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)