### PR TITLE
Fix bugs and issues from TUI/CLI code review (b6a7190)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1106,11 +1106,10 @@ func (a *App) Branches(status string) error {
 		return fmt.Errorf("decoding branches: %w", err)
 	}
 
-	fmt.Fprintf(a.Out, "%-30s %-6s %-6s %-30s %-10s\n", "BRANCH", "HEAD", "BASE", "AUTHOR", "STATUS")
+	fmt.Fprintf(a.Out, "%-30s %-6s %-6s %-10s\n", "BRANCH", "HEAD", "BASE", "STATUS")
 	for _, b := range branches {
-		// Author is not directly available in Branch model; use empty placeholder.
-		fmt.Fprintf(a.Out, "%-30s %-6d %-6d %-30s %-10s\n",
-			b.Name, b.HeadSequence, b.BaseSequence, "", string(b.Status))
+		fmt.Fprintf(a.Out, "%-30s %-6d %-6d %-10s\n",
+			b.Name, b.HeadSequence, b.BaseSequence, string(b.Status))
 	}
 	return nil
 }
@@ -1131,7 +1130,7 @@ func (a *App) Reviews(branch string) error {
 		return err
 	}
 
-	resp, err := a.httpGet(cfg, repoBase(cfg)+"/branch/"+branch+"/reviews")
+	resp, err := a.httpGet(cfg, repoBase(cfg)+"/branch/"+url.PathEscape(branch)+"/reviews")
 	if err != nil {
 		return fmt.Errorf("fetching reviews: %w", err)
 	}
@@ -1212,7 +1211,7 @@ func (a *App) Checks(branch string) error {
 		branch = cfg.Branch
 	}
 
-	resp, err := a.httpGet(cfg, repoBase(cfg)+"/branch/"+branch+"/checks")
+	resp, err := a.httpGet(cfg, repoBase(cfg)+"/branch/"+url.PathEscape(branch)+"/checks")
 	if err != nil {
 		return fmt.Errorf("fetching checks: %w", err)
 	}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1978,6 +1978,114 @@ func TestCheckSubmit_InvalidStatus(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// --branch override flag (ISSUE-9)
+// ---------------------------------------------------------------------------
+
+func TestReviews_ExplicitBranchOverride(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/reviews") {
+			gotPath = r.URL.Path
+			json.NewEncoder(w).Encode([]model.Review{})
+			return
+		}
+		json.NewEncoder(w).Encode([]model.Branch{
+			{Name: "feature/other", HeadSequence: 3},
+		})
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice") // workspace is on "main"
+
+	app.Reviews("feature/other") // explicit --branch different from workspace branch
+	if !strings.Contains(gotPath, "feature") {
+		t.Errorf("expected URL to contain explicit branch name, got path: %s", gotPath)
+	}
+	if strings.Contains(gotPath, "main") {
+		t.Errorf("URL should not reference workspace branch 'main', got path: %s", gotPath)
+	}
+}
+
+func TestChecks_ExplicitBranchOverride(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/checks") {
+			gotPath = r.URL.Path
+			json.NewEncoder(w).Encode([]model.CheckRun{})
+			return
+		}
+		json.NewEncoder(w).Encode([]model.Branch{
+			{Name: "feature/other", HeadSequence: 3},
+		})
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	app.Checks("feature/other")
+	if !strings.Contains(gotPath, "feature") {
+		t.Errorf("expected URL to contain explicit branch name, got path: %s", gotPath)
+	}
+	if strings.Contains(gotPath, "main") {
+		t.Errorf("URL should not reference workspace branch 'main', got path: %s", gotPath)
+	}
+}
+
+func TestReviewSubmit_ExplicitBranchOverride(t *testing.T) {
+	var gotReq model.CreateReviewRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/repos/default/default/-/review" {
+			json.NewDecoder(r.Body).Decode(&gotReq)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(model.CreateReviewResponse{ID: "r-override", Sequence: 7})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice") // workspace is on "main"
+
+	if err := app.Review("feature/other", "approved", "LGTM"); err != nil {
+		t.Fatal(err)
+	}
+	if gotReq.Branch != "feature/other" {
+		t.Errorf("branch in request body = %q, want %q", gotReq.Branch, "feature/other")
+	}
+}
+
+func TestCheckSubmit_ExplicitBranchOverride(t *testing.T) {
+	var gotReq model.CreateCheckRunRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/repos/default/default/-/check" {
+			json.NewDecoder(r.Body).Decode(&gotReq)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(model.CreateCheckRunResponse{ID: "c-override", Sequence: 7})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice") // workspace is on "main"
+
+	if err := app.Check("feature/other", "ci/build", "passed"); err != nil {
+		t.Fatal(err)
+	}
+	if gotReq.Branch != "feature/other" {
+		t.Errorf("branch in request body = %q, want %q", gotReq.Branch, "feature/other")
+	}
+}
+
 // mustParseTime parses a date string for use in tests.
 func mustParseTime(s string) time.Time {
 	t, err := time.Parse("2006-01-02", s)

--- a/internal/tui/branchdetail.go
+++ b/internal/tui/branchdetail.go
@@ -26,11 +26,12 @@ type branchDetailModel struct {
 	loading bool
 	err     error
 
-	diff     *model.DiffResponse
-	reviews  []model.Review
-	checks   []model.CheckRun
-	headSeq  int64
-	baseSeq  int64
+	diff          *model.DiffResponse
+	reviews       []model.Review
+	checks        []model.CheckRun
+	headSeq       int64
+	baseSeq       int64
+	baseTreePaths map[string]bool
 
 	activePanel    panel
 	diffCursor     int
@@ -71,6 +72,10 @@ func (m branchDetailModel) Update(msg tea.Msg) (branchDetailModel, tea.Cmd) {
 			if msg.String() == "esc" {
 				m.showReviewOverlay = false
 				return m, nil
+			}
+			if msg.String() == "ctrl+c" {
+				m.quit = true
+				return m, tea.Quit
 			}
 		case reviewSubmittedMsg:
 			if msg.err == nil {
@@ -133,6 +138,7 @@ func (m branchDetailModel) Update(msg tea.Msg) (branchDetailModel, tea.Cmd) {
 			m.checks = msg.checks
 			m.headSeq = msg.headSeq
 			m.baseSeq = msg.baseSeq
+			m.baseTreePaths = msg.baseTreePaths
 		}
 
 	case mergeResultMsg:
@@ -179,7 +185,7 @@ func (m branchDetailModel) Update(msg tea.Msg) (branchDetailModel, tea.Cmd) {
 
 		case "enter":
 			if m.activePanel == panelDiff && m.diff != nil {
-				files := diffFiles(m.diff)
+				files := diffFiles(m.diff, m.baseTreePaths)
 				if m.diffCursor >= 0 && m.diffCursor < len(files) {
 					m.expandedFiles[m.diffCursor] = !m.expandedFiles[m.diffCursor]
 				}
@@ -187,7 +193,7 @@ func (m branchDetailModel) Update(msg tea.Msg) (branchDetailModel, tea.Cmd) {
 
 		case "j", "down":
 			if m.activePanel == panelDiff && m.diff != nil {
-				files := diffFiles(m.diff)
+				files := diffFiles(m.diff, m.baseTreePaths)
 				if m.diffCursor < len(files)-1 {
 					m.diffCursor++
 				}
@@ -279,7 +285,7 @@ type diffFile struct {
 	changeType string // "+", "-", "~"
 }
 
-func diffFiles(d *model.DiffResponse) []diffFile {
+func diffFiles(d *model.DiffResponse, baseTreePaths map[string]bool) []diffFile {
 	if d == nil {
 		return nil
 	}
@@ -287,6 +293,8 @@ func diffFiles(d *model.DiffResponse) []diffFile {
 	for _, e := range d.BranchChanges {
 		if e.VersionID == nil {
 			files = append(files, diffFile{path: e.Path, changeType: "-"})
+		} else if len(baseTreePaths) > 0 && !baseTreePaths[e.Path] {
+			files = append(files, diffFile{path: e.Path, changeType: "+"})
 		} else {
 			files = append(files, diffFile{path: e.Path, changeType: "~"})
 		}
@@ -298,7 +306,7 @@ func (m branchDetailModel) renderDiff() string {
 	if m.diff == nil {
 		return "  No diff data.\n"
 	}
-	files := diffFiles(m.diff)
+	files := diffFiles(m.diff, m.baseTreePaths)
 	if len(files) == 0 {
 		return "  No changes on this branch.\n"
 	}

--- a/internal/tui/branchdetail_test.go
+++ b/internal/tui/branchdetail_test.go
@@ -1,0 +1,69 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestDiffFiles_Classification(t *testing.T) {
+	vID := strPtr("v1")
+	diff := &model.DiffResponse{
+		BranchChanges: []model.DiffEntry{
+			{Path: "existing.go", VersionID: vID},  // in base tree → modified
+			{Path: "newfile.go", VersionID: vID},   // not in base tree → new
+			{Path: "deleted.go", VersionID: nil},   // nil VersionID → deleted
+		},
+	}
+	baseTreePaths := map[string]bool{
+		"existing.go": true,
+	}
+
+	files := diffFiles(diff, baseTreePaths)
+	if len(files) != 3 {
+		t.Fatalf("expected 3 files, got %d", len(files))
+	}
+
+	byPath := make(map[string]string)
+	for _, f := range files {
+		byPath[f.path] = f.changeType
+	}
+
+	if byPath["existing.go"] != "~" {
+		t.Errorf("existing.go: want '~', got %q", byPath["existing.go"])
+	}
+	if byPath["newfile.go"] != "+" {
+		t.Errorf("newfile.go: want '+', got %q", byPath["newfile.go"])
+	}
+	if byPath["deleted.go"] != "-" {
+		t.Errorf("deleted.go: want '-', got %q", byPath["deleted.go"])
+	}
+}
+
+func TestDiffFiles_EmptyBaseTree(t *testing.T) {
+	// When base tree is empty, all non-deleted files should be "~" (unchanged behaviour).
+	vID := strPtr("v1")
+	diff := &model.DiffResponse{
+		BranchChanges: []model.DiffEntry{
+			{Path: "file.go", VersionID: vID},
+		},
+	}
+
+	files := diffFiles(diff, nil)
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	if files[0].changeType != "~" {
+		t.Errorf("want '~' when base tree is nil, got %q", files[0].changeType)
+	}
+
+	files = diffFiles(diff, map[string]bool{})
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	if files[0].changeType != "~" {
+		t.Errorf("want '~' when base tree is empty, got %q", files[0].changeType)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -131,12 +131,13 @@ type branchesLoadedMsg struct {
 }
 
 type branchDetailLoadedMsg struct {
-	diff     *model.DiffResponse
-	reviews  []model.Review
-	checks   []model.CheckRun
-	headSeq  int64
-	baseSeq  int64
-	err      error
+	diff          *model.DiffResponse
+	reviews       []model.Review
+	checks        []model.CheckRun
+	headSeq       int64
+	baseSeq       int64
+	baseTreePaths map[string]bool
+	err           error
 }
 
 type mergeResultMsg struct {
@@ -179,13 +180,21 @@ func loadBranches(c *tuiClient) tea.Cmd {
 		for _, b := range branches {
 			s := branchSummary{branch: b}
 
-			// Fetch reviews.
+			// Fetch reviews (explicit close per iteration; deduplicate per reviewer).
 			rResp, rErr := c.get("/branch/" + url.PathEscape(b.Name) + "/reviews")
 			if rErr == nil {
-				defer rResp.Body.Close()
 				var reviews []model.Review
-				if jsonErr := json.NewDecoder(rResp.Body).Decode(&reviews); jsonErr == nil {
+				jsonErr := json.NewDecoder(rResp.Body).Decode(&reviews)
+				rResp.Body.Close()
+				if jsonErr == nil {
+					latest := make(map[string]model.Review)
 					for _, r := range reviews {
+						prev, ok := latest[r.Reviewer]
+						if !ok || r.CreatedAt.After(prev.CreatedAt) {
+							latest[r.Reviewer] = r
+						}
+					}
+					for _, r := range latest {
 						if r.Sequence == b.HeadSequence {
 							if r.Status == model.ReviewApproved {
 								s.approved++
@@ -197,12 +206,13 @@ func loadBranches(c *tuiClient) tea.Cmd {
 				}
 			}
 
-			// Fetch checks.
+			// Fetch checks (explicit close per iteration).
 			cResp, cErr := c.get("/branch/" + url.PathEscape(b.Name) + "/checks")
 			if cErr == nil {
-				defer cResp.Body.Close()
 				var checks []model.CheckRun
-				if jsonErr := json.NewDecoder(cResp.Body).Decode(&checks); jsonErr == nil {
+				jsonErr := json.NewDecoder(cResp.Body).Decode(&checks)
+				cResp.Body.Close()
+				if jsonErr == nil {
 					for _, ch := range checks {
 						if ch.Sequence == b.HeadSequence {
 							switch ch.Status {
@@ -227,8 +237,8 @@ func loadBranches(c *tuiClient) tea.Cmd {
 
 func loadBranchDetail(c *tuiClient, branchName string) tea.Cmd {
 	return func() tea.Msg {
-		// Get branch head/base.
-		bResp, err := c.get("/branches?status=active")
+		// BUG-7: Fetch all branches (not filtered by status) so merged/closed branches are found.
+		bResp, err := c.get("/branches")
 		if err != nil {
 			return branchDetailLoadedMsg{err: err}
 		}
@@ -257,6 +267,20 @@ func loadBranchDetail(c *tuiClient, branchName string) tea.Cmd {
 			return branchDetailLoadedMsg{err: err}
 		}
 
+		// BUG-5: Fetch the base tree to classify files as new (+) vs modified (~).
+		baseTreePaths := make(map[string]bool)
+		treeURL := fmt.Sprintf("/tree?branch=%s&at=%d", url.QueryEscape(branchName), baseSeq)
+		tResp, tErr := c.get(treeURL)
+		if tErr == nil {
+			var treeEntries []model.TreeEntry
+			if jsonErr := json.NewDecoder(tResp.Body).Decode(&treeEntries); jsonErr == nil {
+				for _, e := range treeEntries {
+					baseTreePaths[e.Path] = true
+				}
+			}
+			tResp.Body.Close()
+		}
+
 		// Reviews.
 		rResp, err := c.get("/branch/" + url.PathEscape(branchName) + "/reviews")
 		if err != nil {
@@ -280,11 +304,12 @@ func loadBranchDetail(c *tuiClient, branchName string) tea.Cmd {
 		}
 
 		return branchDetailLoadedMsg{
-			diff:    &diff,
-			reviews: reviews,
-			checks:  checks,
-			headSeq: headSeq,
-			baseSeq: baseSeq,
+			diff:          &diff,
+			reviews:       reviews,
+			checks:        checks,
+			headSeq:       headSeq,
+			baseSeq:       baseSeq,
+			baseTreePaths: baseTreePaths,
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes 8 bugs/issues identified in code review of the TUI and CLI implementation (commit b6a7190).

- **BUG-1** (`internal/tui/model.go`): Replace `defer` inside `loadBranches` loop with explicit `Body.Close()` after each decode to prevent HTTP body leaks.
- **BUG-2** (`internal/tui/model.go`): Deduplicate reviews per reviewer (keep latest by `CreatedAt`) before counting approved/rejected in the branch list summary, matching the detail panel logic.
- **BUG-5** (`internal/tui/model.go`, `branchdetail.go`): After fetching the diff in `loadBranchDetail`, fetch `GET /tree?branch=<branch>&at=<baseSeq>` to get the base tree. `diffFiles()` now classifies files absent from the base tree as new (`+`) rather than modified (`~`). Unit tests added in `branchdetail_test.go`.
- **BUG-7** (`internal/tui/model.go`): Remove `?status=active` filter from `/branches` call in `loadBranchDetail` so the detail panel still works for merged/closed branches.
- **ISSUE-1** (`internal/cli/app.go`): Apply `url.PathEscape` to branch name in `Reviews()` and `Checks()` HTTP GET URLs, matching the TUI behaviour.
- **ISSUE-2** (`internal/cli/app.go`): Remove the always-blank `AUTHOR` column from `ds branches` output.
- **ISSUE-6** (`internal/tui/branchdetail.go`): Intercept `ctrl+c` when the review overlay is open and return `tea.Quit` instead of forwarding to the textarea.
- **ISSUE-9** (`internal/cli/app_test.go`): Add four tests verifying that an explicit `--branch` value overrides the workspace branch for `Reviews`, `Checks`, `Review`, and `Check`.

## Test plan

- [x] `go test ./... -count=1` — all packages pass
- [x] `go build ./...` and `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)