### PR TITLE
Fix three code review issues: BUG-2, BUG-5, ISSUE-9

### DIFF
--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1983,17 +1983,21 @@ func TestCheckSubmit_InvalidStatus(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestReviews_ExplicitBranchOverride(t *testing.T) {
-	var gotPath string
+	var gotReviewsPath, gotBranchesPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if strings.Contains(r.URL.Path, "/reviews") {
-			gotPath = r.URL.Path
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/reviews"):
+			gotReviewsPath = r.URL.EscapedPath()
 			json.NewEncoder(w).Encode([]model.Review{})
-			return
+		case strings.HasSuffix(r.URL.Path, "/branches"):
+			gotBranchesPath = r.URL.EscapedPath()
+			json.NewEncoder(w).Encode([]model.Branch{
+				{Name: "feature/other", HeadSequence: 3},
+			})
+		default:
+			http.NotFound(w, r)
 		}
-		json.NewEncoder(w).Encode([]model.Branch{
-			{Name: "feature/other", HeadSequence: 3},
-		})
 	}))
 	defer srv.Close()
 
@@ -2001,26 +2005,30 @@ func TestReviews_ExplicitBranchOverride(t *testing.T) {
 	initWorkspace(t, app, srv.URL, "main", "alice") // workspace is on "main"
 
 	app.Reviews("feature/other") // explicit --branch different from workspace branch
-	if !strings.Contains(gotPath, "feature") {
-		t.Errorf("expected URL to contain explicit branch name, got path: %s", gotPath)
+
+	wantReviewsPath := "/repos/default/default/-/branch/feature%2Fother/reviews"
+	if gotReviewsPath != wantReviewsPath {
+		t.Errorf("reviews URL = %q, want %q", gotReviewsPath, wantReviewsPath)
 	}
-	if strings.Contains(gotPath, "main") {
-		t.Errorf("URL should not reference workspace branch 'main', got path: %s", gotPath)
+	wantBranchesPath := "/repos/default/default/-/branches"
+	if gotBranchesPath != wantBranchesPath {
+		t.Errorf("branches URL = %q, want %q", gotBranchesPath, wantBranchesPath)
 	}
 }
 
 func TestChecks_ExplicitBranchOverride(t *testing.T) {
-	var gotPath string
+	var gotChecksPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if strings.Contains(r.URL.Path, "/checks") {
-			gotPath = r.URL.Path
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/checks"):
+			gotChecksPath = r.URL.EscapedPath()
 			json.NewEncoder(w).Encode([]model.CheckRun{})
-			return
+		default:
+			json.NewEncoder(w).Encode([]model.Branch{
+				{Name: "feature/other", HeadSequence: 3},
+			})
 		}
-		json.NewEncoder(w).Encode([]model.Branch{
-			{Name: "feature/other", HeadSequence: 3},
-		})
 	}))
 	defer srv.Close()
 
@@ -2028,11 +2036,10 @@ func TestChecks_ExplicitBranchOverride(t *testing.T) {
 	initWorkspace(t, app, srv.URL, "main", "alice")
 
 	app.Checks("feature/other")
-	if !strings.Contains(gotPath, "feature") {
-		t.Errorf("expected URL to contain explicit branch name, got path: %s", gotPath)
-	}
-	if strings.Contains(gotPath, "main") {
-		t.Errorf("URL should not reference workspace branch 'main', got path: %s", gotPath)
+
+	wantChecksPath := "/repos/default/default/-/branch/feature%2Fother/checks"
+	if gotChecksPath != wantChecksPath {
+		t.Errorf("checks URL = %q, want %q", gotChecksPath, wantChecksPath)
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -195,7 +195,7 @@ func loadBranches(c *tuiClient) tea.Cmd {
 						}
 					}
 					for _, r := range latest {
-						if r.Sequence == b.HeadSequence {
+						if r.Sequence >= b.HeadSequence {
 							if r.Status == model.ReviewApproved {
 								s.approved++
 							} else if r.Status == model.ReviewRejected {
@@ -267,18 +267,33 @@ func loadBranchDetail(c *tuiClient, branchName string) tea.Cmd {
 			return branchDetailLoadedMsg{err: err}
 		}
 
-		// BUG-5: Fetch the base tree to classify files as new (+) vs modified (~).
+		// BUG-5 fix: Fetch the base tree with pagination to handle repos with >100 files.
 		baseTreePaths := make(map[string]bool)
-		treeURL := fmt.Sprintf("/tree?branch=%s&at=%d", url.QueryEscape(branchName), baseSeq)
-		tResp, tErr := c.get(treeURL)
-		if tErr == nil {
-			var treeEntries []model.TreeEntry
-			if jsonErr := json.NewDecoder(tResp.Body).Decode(&treeEntries); jsonErr == nil {
-				for _, e := range treeEntries {
-					baseTreePaths[e.Path] = true
-				}
+		const treePageSize = 500
+		var afterCursor string
+		for {
+			treeURL := fmt.Sprintf("/tree?branch=%s&at=%d&limit=%d",
+				url.QueryEscape(branchName), baseSeq, treePageSize)
+			if afterCursor != "" {
+				treeURL += "&after=" + url.QueryEscape(afterCursor)
 			}
+			tResp, tErr := c.get(treeURL)
+			if tErr != nil {
+				break
+			}
+			var treeEntries []model.TreeEntry
+			jsonErr := json.NewDecoder(tResp.Body).Decode(&treeEntries)
 			tResp.Body.Close()
+			if jsonErr != nil {
+				break
+			}
+			for _, e := range treeEntries {
+				baseTreePaths[e.Path] = true
+			}
+			if len(treeEntries) < treePageSize {
+				break // last page
+			}
+			afterCursor = treeEntries[len(treeEntries)-1].Path
 		}
 
 		// Reviews.


### PR DESCRIPTION
## Summary

- **BUG-2** (`internal/tui/model.go`): Changed `r.Sequence == b.HeadSequence` to `r.Sequence >= b.HeadSequence` in `loadBranches` summary counting. The detail panel marks reviews as stale only when `r.Sequence < headSeq` (i.e., counts reviews as current when `>= headSeq`), but the list summary was using `==`, causing the two panels to disagree.

- **BUG-5** (`internal/tui/model.go`): Implemented pagination for the base tree fetch in `loadBranchDetail`. The previous single-request fetch was capped at the server default (100 items). Now fetches in a loop with `?limit=500&after=<lastPath>` cursor pagination per the DESIGN.md spec, stopping when a page returns fewer than 500 items. Repos with >100 files no longer misclassify new files as modified.

- **ISSUE-9** (`internal/cli/app_test.go`): Replaced weak `strings.Contains(gotPath, "feature")` assertions in `TestReviews_ExplicitBranchOverride` and `TestChecks_ExplicitBranchOverride` with exact URL equality checks. Uses `r.URL.EscapedPath()` in the mock server to capture the raw percent-encoded path, then asserts the exact paths (`feature%2Fother`). Also adds assertion for the branches (head sequence) URL in the Reviews test.

## Test plan

- [x] All existing tests pass (`go test ./... -count=1`)
- [x] Build and vet clean (`go build ./... && go vet ./...`)
- [x] `TestReviews_ExplicitBranchOverride` and `TestChecks_ExplicitBranchOverride` now fail if the wrong branch name or encoding is used in the URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)