### PR TITLE
Add binary file support (issue #66)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-ds test lint clean
+.PHONY: build build-ds test lint clean db-reset
 
 BINARY := docstore
 BUILD_DIR := bin
@@ -18,3 +18,9 @@ lint:
 
 clean:
 	rm -rf $(BUILD_DIR)
+
+# db-reset drops and recreates the public schema, destroying all data.
+# Migrations will re-run automatically on the next server start.
+# Requires DATABASE_URL to be set.
+db-reset:
+	psql "$(DATABASE_URL)" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO PUBLIC;"

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -138,6 +138,18 @@ Rollbacks must be applied manually using the `migrate` CLI tool if needed:
 migrate -database "$DATABASE_URL" -path internal/db/migrations down 1
 ```
 
+### Schema reset (destructive)
+
+Use this procedure when a migration has been applied in-place to an existing migration file (rather than added as a new numbered migration). All data will be lost.
+
+1. Reset the database:
+   ```bash
+   DATABASE_URL=<your-url> make db-reset
+   ```
+2. Deploy or restart the server — migrations re-run automatically on startup via m.Up().
+
+The db-reset target drops and recreates the public schema using psql. This removes all tables including schema_migrations, so the server treats the database as fresh on next start.
+
 ---
 
 ## IAP Authentication

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/tui"
@@ -171,6 +173,20 @@ func hashFile(path string) (string, error) {
 func HashBytes(data []byte) string {
 	h := sha256.Sum256(data)
 	return hex.EncodeToString(h[:])
+}
+
+// detectContentType returns a MIME type string for binary files, or empty string
+// for text files. Binary detection uses utf8.Valid; the MIME type is derived from
+// the file extension, defaulting to "application/octet-stream".
+func detectContentType(path string, content []byte) string {
+	if utf8.Valid(content) {
+		return ""
+	}
+	ct := mime.TypeByExtension(filepath.Ext(path))
+	if ct == "" {
+		ct = "application/octet-stream"
+	}
+	return ct
 }
 
 // isDirty returns true if there are local uncommitted changes.
@@ -352,7 +368,8 @@ func (a *App) Commit(message string) error {
 			if err != nil {
 				return err
 			}
-			files = append(files, model.FileChange{Path: path, Content: content})
+			ct := detectContentType(path, content)
+			files = append(files, model.FileChange{Path: path, Content: content, ContentType: ct})
 		}
 	}
 
@@ -695,6 +712,8 @@ func (a *App) Diff() error {
 		for _, d := range diffResp.BranchChanges {
 			if d.VersionID == nil {
 				fmt.Fprintf(a.Out, "  deleted: %s\n", d.Path)
+			} else if d.Binary {
+				fmt.Fprintf(a.Out, "  changed: %s [binary]\n", d.Path)
 			} else {
 				fmt.Fprintf(a.Out, "  changed: %s\n", d.Path)
 			}
@@ -706,6 +725,8 @@ func (a *App) Diff() error {
 		for _, d := range diffResp.MainChanges {
 			if d.VersionID == nil {
 				fmt.Fprintf(a.Out, "  deleted: %s\n", d.Path)
+			} else if d.Binary {
+				fmt.Fprintf(a.Out, "  changed: %s [binary]\n", d.Path)
 			} else {
 				fmt.Fprintf(a.Out, "  changed: %s\n", d.Path)
 			}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1158,6 +1158,46 @@ func TestLoadStateMissing(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// detectContentType
+// ---------------------------------------------------------------------------
+
+func TestDetectContentType(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		content []byte
+		want    string
+	}{
+		{
+			name:    "valid UTF-8 text returns empty",
+			path:    "hello.txt",
+			content: []byte("hello world"),
+			want:    "",
+		},
+		{
+			name:    "known binary extension with non-UTF-8 bytes returns image/png",
+			path:    "image.png",
+			content: []byte{0xFF, 0xFE, 0x00, 0x01},
+			want:    "image/png",
+		},
+		{
+			name:    "unknown extension with non-UTF-8 bytes returns application/octet-stream",
+			path:    "data.bin",
+			content: []byte{0xFF, 0xFE, 0x00, 0x01},
+			want:    "application/octet-stream",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectContentType(tt.path, tt.content)
+			if got != tt.want {
+				t.Errorf("detectContentType(%q, ...) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // HashBytes
 // ---------------------------------------------------------------------------
 

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -772,3 +772,44 @@ func TestIntegrationShow_FileContent(t *testing.T) {
 		t.Errorf("expected file content in Show output:\n%s", wsOut.String())
 	}
 }
+
+// TestIntegrationBinaryFile verifies that committing a binary file succeeds and
+// that ds diff shows [binary] for that file on the branch diff.
+func TestIntegrationBinaryFile(t *testing.T) {
+	srv := newRealServer(t)
+
+	ws, wsOut := newTestApp(t, srv)
+	if err := ws.Init(srv.URL, "", "alice"); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// Create a feature branch so the binary file shows up in diff.
+	if err := ws.CheckoutNew("feature/binary"); err != nil {
+		t.Fatalf("CheckoutNew: %v", err)
+	}
+
+	// Write a binary file (non-UTF-8 bytes).
+	binContent := []byte{0xFF, 0xFE, 0x00, 0x01, 0x02, 0x03}
+	if err := os.WriteFile(filepath.Join(ws.Dir, "image.png"), binContent, 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Commit should succeed.
+	if err := ws.Commit("add binary file"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// Diff should show image.png as [binary].
+	wsOut.Reset()
+	if err := ws.Diff(); err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+
+	output := wsOut.String()
+	if !strings.Contains(output, "image.png") {
+		t.Errorf("expected image.png in diff output:\n%s", output)
+	}
+	if !strings.Contains(output, "[binary]") {
+		t.Errorf("expected [binary] in diff output:\n%s", output)
+	}
+}

--- a/internal/db/migrations/000001_initial_schema.up.sql
+++ b/internal/db/migrations/000001_initial_schema.up.sql
@@ -31,6 +31,7 @@ CREATE TABLE documents (
     path         TEXT NOT NULL,
     content      BYTEA NOT NULL,
     content_hash TEXT NOT NULL,
+    content_type TEXT,
     created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
     created_by   TEXT NOT NULL,
     repo         TEXT NOT NULL DEFAULT 'default/default' REFERENCES repos (name)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -352,10 +352,14 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 			if errors.Is(err, sql.ErrNoRows) {
 				// Insert new document.
 				existingID = uuid.New().String()
+				var contentType sql.NullString
+				if f.ContentType != "" {
+					contentType = sql.NullString{String: f.ContentType, Valid: true}
+				}
 				_, err = tx.ExecContext(ctx,
-					`INSERT INTO documents (repo, version_id, path, content, content_hash, created_at, created_by)
-					 VALUES ($1, $2, $3, $4, $5, now(), $6)`,
-					req.Repo, existingID, f.Path, f.Content, contentHash, req.Author,
+					`INSERT INTO documents (repo, version_id, path, content, content_hash, content_type, created_at, created_by)
+					 VALUES ($1, $2, $3, $4, $5, $6, now(), $7)`,
+					req.Repo, existingID, f.Path, f.Content, contentHash, contentType, req.Author,
 				)
 				if err != nil {
 					return nil, fmt.Errorf("insert document: %w", err)

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -56,6 +56,7 @@ type FileResponse struct {
 	VersionID   string `json:"version_id"`
 	ContentHash string `json:"content_hash"`
 	Content     []byte `json:"content"`
+	ContentType string `json:"content_type,omitempty"`
 }
 
 // ---------------------------------------------------------------------------
@@ -66,6 +67,7 @@ type FileResponse struct {
 type DiffEntry struct {
 	Path      string  `json:"path"`
 	VersionID *string `json:"version_id"` // nil means deleted
+	Binary    bool    `json:"binary,omitempty"`
 }
 
 // ConflictEntry represents a file that was changed on both main and the branch.
@@ -134,8 +136,9 @@ type BranchStatusResponse struct {
 // FileChange is one file in a commit request.
 // A nil Content means delete.
 type FileChange struct {
-	Path    string `json:"path"`
-	Content []byte `json:"content,omitempty"`
+	Path        string `json:"path"`
+	Content     []byte `json:"content,omitempty"`
+	ContentType string `json:"content_type,omitempty"`
 }
 
 // CommitRequest is the body for POST /repos/:name/commit.

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -64,6 +64,7 @@ type Document struct {
 	Path        string    `json:"path"`
 	Content     []byte    `json:"content"`
 	ContentHash string    `json:"content_hash"`
+	ContentType string    `json:"content_type,omitempty"`
 	CreatedAt   time.Time `json:"created_at"`
 	CreatedBy   string    `json:"created_by"`
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -822,10 +822,10 @@ func (s *server) handleDiff(w http.ResponseWriter, r *http.Request) {
 		MainChanges:   make([]model.DiffEntry, len(result.MainChanges)),
 	}
 	for i, e := range result.BranchChanges {
-		resp.BranchChanges[i] = model.DiffEntry{Path: e.Path, VersionID: e.VersionID}
+		resp.BranchChanges[i] = model.DiffEntry{Path: e.Path, VersionID: e.VersionID, Binary: e.Binary}
 	}
 	for i, e := range result.MainChanges {
-		resp.MainChanges[i] = model.DiffEntry{Path: e.Path, VersionID: e.VersionID}
+		resp.MainChanges[i] = model.DiffEntry{Path: e.Path, VersionID: e.VersionID, Binary: e.Binary}
 	}
 	for _, c := range result.Conflicts {
 		resp.Conflicts = append(resp.Conflicts, model.ConflictEntry{

--- a/internal/store/binary_test.go
+++ b/internal/store/binary_test.go
@@ -1,0 +1,22 @@
+package store
+
+import "testing"
+
+func TestIsBinaryContentType(t *testing.T) {
+	tests := []struct {
+		ct   string
+		want bool
+	}{
+		{"", false},
+		{"text/plain", false},
+		{"text/plain; charset=utf-8", false},
+		{"image/png", true},
+		{"application/octet-stream", true},
+	}
+	for _, tt := range tests {
+		got := isBinaryContentType(tt.ct)
+		if got != tt.want {
+			t.Errorf("isBinaryContentType(%q) = %v, want %v", tt.ct, got, tt.want)
+		}
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"time"
 )
 
@@ -29,6 +30,7 @@ type FileContent struct {
 	VersionID   string `json:"version_id"`
 	ContentHash string `json:"content_hash"`
 	Content     []byte `json:"content"`
+	ContentType string `json:"content_type,omitempty"`
 }
 
 // FileHistoryEntry is one change to a file.
@@ -124,7 +126,7 @@ func (s *Store) GetFile(ctx context.Context, repo, branch, path string, atSequen
 WITH branch_info AS (
     SELECT base_sequence FROM branches WHERE repo = $1 AND name = $2
 )
-SELECT fc.version_id, d.content_hash, d.content
+SELECT fc.version_id, d.content_hash, d.content, d.content_type
 FROM file_commits fc
 CROSS JOIN branch_info bi
 LEFT JOIN documents d ON d.version_id = fc.version_id AND d.repo = $1
@@ -146,8 +148,9 @@ LIMIT 1`
 	var versionID sql.NullString
 	var contentHash sql.NullString
 	var content []byte
+	var contentType sql.NullString
 
-	err := s.db.QueryRowContext(ctx, q, repo, branch, path, at).Scan(&versionID, &contentHash, &content)
+	err := s.db.QueryRowContext(ctx, q, repo, branch, path, at).Scan(&versionID, &contentHash, &content, &contentType)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -165,6 +168,7 @@ LIMIT 1`
 		VersionID:   versionID.String,
 		ContentHash: contentHash.String,
 		Content:     content,
+		ContentType: contentType.String,
 	}, nil
 }
 
@@ -231,6 +235,7 @@ type BranchInfo struct {
 type DiffEntry struct {
 	Path      string  `json:"path"`
 	VersionID *string `json:"version_id"`
+	Binary    bool    `json:"binary,omitempty"`
 }
 
 // ConflictEntry represents a file changed on both main and the branch.
@@ -310,21 +315,22 @@ func (s *Store) GetDiff(ctx context.Context, repo, branch string) (*DiffResult, 
 
 	result := &DiffResult{}
 
-	for path, vid := range branchChanges {
+	for path, change := range branchChanges {
 		result.BranchChanges = append(result.BranchChanges, DiffEntry{
 			Path:      path,
-			VersionID: vid,
+			VersionID: change.versionID,
+			Binary:    isBinaryContentType(change.contentType),
 		})
 
 		// Check for conflicts.
-		if mainVID, ok := mainChanges[path]; ok {
+		if mainChange, ok := mainChanges[path]; ok {
 			mainV := ""
-			if mainVID != nil {
-				mainV = *mainVID
+			if mainChange.versionID != nil {
+				mainV = *mainChange.versionID
 			}
 			branchV := ""
-			if vid != nil {
-				branchV = *vid
+			if change.versionID != nil {
+				branchV = *change.versionID
 			}
 			result.Conflicts = append(result.Conflicts, ConflictEntry{
 				Path:            path,
@@ -334,24 +340,32 @@ func (s *Store) GetDiff(ctx context.Context, repo, branch string) (*DiffResult, 
 		}
 	}
 
-	for path, vid := range mainChanges {
+	for path, change := range mainChanges {
 		result.MainChanges = append(result.MainChanges, DiffEntry{
 			Path:      path,
-			VersionID: vid,
+			VersionID: change.versionID,
+			Binary:    isBinaryContentType(change.contentType),
 		})
 	}
 
 	return result, nil
 }
 
-// latestChanges returns the latest version of each path changed on a branch
-// in a repo since the given base sequence.
-func (s *Store) latestChanges(ctx context.Context, repo, branch string, baseSeq int64) (map[string]*string, error) {
+// diffChangeInfo holds a version ID and content_type for a single file change.
+type diffChangeInfo struct {
+	versionID   *string
+	contentType string
+}
+
+// latestChanges returns the latest version and content_type of each path changed
+// on a branch in a repo since the given base sequence.
+func (s *Store) latestChanges(ctx context.Context, repo, branch string, baseSeq int64) (map[string]diffChangeInfo, error) {
 	const q = `
-SELECT DISTINCT ON (path) path, version_id::text
-FROM file_commits
-WHERE repo = $1 AND branch = $2 AND sequence > $3
-ORDER BY path, sequence DESC`
+SELECT DISTINCT ON (fc.path) fc.path, fc.version_id::text, d.content_type
+FROM file_commits fc
+LEFT JOIN documents d ON d.version_id = fc.version_id AND d.repo = $1
+WHERE fc.repo = $1 AND fc.branch = $2 AND fc.sequence > $3
+ORDER BY fc.path, fc.sequence DESC`
 
 	rows, err := s.db.QueryContext(ctx, q, repo, branch, baseSeq)
 	if err != nil {
@@ -359,21 +373,27 @@ ORDER BY path, sequence DESC`
 	}
 	defer rows.Close()
 
-	changes := make(map[string]*string)
+	changes := make(map[string]diffChangeInfo)
 	for rows.Next() {
 		var path string
 		var vid sql.NullString
-		if err := rows.Scan(&path, &vid); err != nil {
+		var ct sql.NullString
+		if err := rows.Scan(&path, &vid, &ct); err != nil {
 			return nil, err
 		}
+		var versionID *string
 		if vid.Valid {
 			v := vid.String
-			changes[path] = &v
-		} else {
-			changes[path] = nil
+			versionID = &v
 		}
+		changes[path] = diffChangeInfo{versionID: versionID, contentType: ct.String}
 	}
 	return changes, rows.Err()
+}
+
+// isBinaryContentType reports whether a content_type indicates binary content.
+func isBinaryContentType(ct string) bool {
+	return ct != "" && !strings.HasPrefix(ct, "text/")
 }
 
 // GetCommit returns all file changes in a single atomic commit (by sequence) within a repo.

--- a/internal/tui/branchdetail.go
+++ b/internal/tui/branchdetail.go
@@ -281,8 +281,9 @@ func (m branchDetailModel) renderTabs() string {
 
 // diffFile groups a path and its change type.
 type diffFile struct {
-	path     string
+	path       string
 	changeType string // "+", "-", "~"
+	binary     bool
 }
 
 func diffFiles(d *model.DiffResponse, baseTreePaths map[string]bool) []diffFile {
@@ -291,13 +292,15 @@ func diffFiles(d *model.DiffResponse, baseTreePaths map[string]bool) []diffFile 
 	}
 	var files []diffFile
 	for _, e := range d.BranchChanges {
+		var changeType string
 		if e.VersionID == nil {
-			files = append(files, diffFile{path: e.Path, changeType: "-"})
+			changeType = "-"
 		} else if len(baseTreePaths) > 0 && !baseTreePaths[e.Path] {
-			files = append(files, diffFile{path: e.Path, changeType: "+"})
+			changeType = "+"
 		} else {
-			files = append(files, diffFile{path: e.Path, changeType: "~"})
+			changeType = "~"
 		}
+		files = append(files, diffFile{path: e.Path, changeType: changeType, binary: e.Binary})
 	}
 	return files
 }
@@ -325,18 +328,25 @@ func (m branchDetailModel) renderDiff() string {
 			iconStyled = styleModified.Render("~")
 		}
 
-		line := fmt.Sprintf("%s %s", iconStyled, f.path)
-		if i == m.diffCursor {
-			line = styleSelected.Render(prefix + iconStyled + " " + f.path)
-			sb.WriteString(line + "\n")
-		} else {
-			sb.WriteString(prefix + line + "\n")
+		pathLabel := f.path
+		if f.binary {
+			pathLabel = f.path + " [binary]"
 		}
 
-		// If expanded, show a placeholder hunk (the server returns full diff content
-		// in the diff response, but simple path listing is our primary view).
+		if i == m.diffCursor {
+			line := styleSelected.Render(prefix + iconStyled + " " + pathLabel)
+			sb.WriteString(line + "\n")
+		} else {
+			sb.WriteString(prefix + iconStyled + " " + pathLabel + "\n")
+		}
+
+		// If expanded, show placeholder or binary notice.
 		if m.expandedFiles[i] {
-			sb.WriteString(styleModified.Render("    (file contents diff not available in current view)") + "\n")
+			if f.binary {
+				sb.WriteString(styleModified.Render("    binary file, no preview") + "\n")
+			} else {
+				sb.WriteString(styleModified.Render("    (file contents diff not available in current view)") + "\n")
+			}
 		}
 	}
 	return sb.String()


### PR DESCRIPTION
## Summary

- **Schema**: add nullable `content_type TEXT` column to `documents` table in `000001_initial_schema.up.sql` (updated in-place per issue instructions, no new migration file)
- **Model/API**: `ContentType` added to `Document`, `FileChange`, `FileResponse`; `Binary bool` added to `DiffEntry`
- **DB store**: `Commit` passes `content_type` through to document insert (stored as SQL NULL for text files)
- **Read store**: `GetFile` selects `content_type`; `latestChanges` joins `documents` to get `content_type`, and `GetDiff` uses it to populate `Binary` on diff entries
- **Server**: `handleDiff` propagates `Binary` flag through to API response
- **CLI**: `ds commit` detects binary files with `utf8.Valid`; uses `mime.TypeByExtension` with `application/octet-stream` fallback; `ds diff` shows `[binary]` label on binary files
- **TUI**: diff panel shows `[binary]` label; expanding a binary file shows "binary file, no preview"
- **Makefile**: `db-reset` target drops/recreates the public schema (migrations re-run on next start)

## ⚠️ DB Reset Required Before Merging

This PR modifies `000001_initial_schema.up.sql` directly (not a new migration). The running database must be reset before deploying. See issue #66 for the procedure:

```bash
make db-reset  # requires DATABASE_URL to be set
```

Or manually:
```bash
psql "$DATABASE_URL" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO PUBLIC;"
```

Then restart the server — migrations will re-run automatically via `m.Up()`.

## Test plan

- [x] `go build ./...` — clean build
- [x] `go vet ./...` — no issues
- [x] `go test ./... -count=1` — all tests pass (cli, db, server, store, tui)
- [ ] Manual: commit a binary file (e.g. PNG), verify `content_type` stored in DB
- [ ] Manual: `ds diff` shows `[binary]` for binary-typed diff entries
- [ ] Manual: TUI diff panel shows `[binary]` label and "binary file, no preview" on expand

## Opportunities (not implemented)

- Tree endpoint could include `content_type` for richer client-side display
- `ds show` could detect and warn about binary content before printing
- TUI could show content_type in a file detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)