### PR TITLE
Add ds import-git command (issue #68)

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -30,6 +30,7 @@ commands:
   review --status approved|rejected [--body "…"] [--branch <name>]  Submit a review
   checks [--branch <name>]                        List check runs for a branch
   check --name <n> --status passed|failed [--branch <name>]  Report a CI check
+  import-git <path> [--mode squash|replay]        Import a git repo into docstore main
   tui                                             Launch the terminal UI`
 
 func main() {
@@ -245,6 +246,21 @@ func main() {
 			os.Exit(1)
 		}
 		err = app.Check(branch, name, status)
+
+	case "import-git":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: ds import-git <path> [--mode squash|replay]")
+			os.Exit(1)
+		}
+		repoPath := args[1]
+		mode := "replay"
+		for i := 2; i < len(args); i++ {
+			if args[i] == "--mode" && i+1 < len(args) {
+				mode = args[i+1]
+				i++
+			}
+		}
+		err = app.ImportGit(repoPath, mode)
 
 	case "tui":
 		err = app.TUI()

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
 	"sort"
@@ -1404,5 +1405,188 @@ func (a *App) Resolve(path string) error {
 	os.Remove(branchConflict)
 
 	fmt.Fprintf(a.Out, "resolved %s, committed as sequence %d\n", path, commitResp.Sequence)
+	return nil
+}
+
+// ImportGit imports a local git repository's default branch into docstore main.
+// mode must be "replay" (default) or "squash".
+// Shells out to git via os/exec — no new library dependency.
+func (a *App) ImportGit(repoPath, mode string) error {
+	if mode == "" {
+		mode = "replay"
+	}
+	if mode != "replay" && mode != "squash" {
+		return fmt.Errorf("mode must be 'replay' or 'squash'")
+	}
+
+	// Verify the path is a git repository.
+	if _, err := os.Stat(filepath.Join(repoPath, ".git")); os.IsNotExist(err) {
+		return fmt.Errorf("%s is not a git repository (no .git directory)", repoPath)
+	}
+
+	// Verify git is available in PATH.
+	if _, err := exec.LookPath("git"); err != nil {
+		return fmt.Errorf("git not found in PATH: %w", err)
+	}
+
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+
+	if mode == "squash" {
+		return a.importGitSquash(cfg, repoPath)
+	}
+	return a.importGitReplay(cfg, repoPath)
+}
+
+// importGitReplay imports each non-merge git commit as one docstore commit.
+func (a *App) importGitReplay(cfg *Config, repoPath string) error {
+	out, err := exec.Command("git", "-C", repoPath, "log", "--reverse", "--no-merges", "--format=%H|%ae|%s", "HEAD").Output()
+	if err != nil {
+		return fmt.Errorf("git log failed: %w", err)
+	}
+
+	raw := strings.TrimRight(string(out), "\n")
+	if raw == "" {
+		fmt.Fprintf(a.Out, "No commits to import.\n")
+		return nil
+	}
+	lines := strings.Split(raw, "\n")
+	total := len(lines)
+	fmt.Fprintf(a.Out, "Importing %d commits from %s...\n", total, repoPath)
+
+	for i, line := range lines {
+		parts := strings.SplitN(line, "|", 3)
+		if len(parts) != 3 {
+			return fmt.Errorf("unexpected git log output: %q", line)
+		}
+		sha, email, subject := parts[0], parts[1], parts[2]
+		shortSHA := sha
+		if len(shortSHA) > 7 {
+			shortSHA = shortSHA[:7]
+		}
+		fmt.Fprintf(a.Out, "  %d/%d %s %q (%s)\n", i+1, total, shortSHA, subject, email)
+
+		// List files changed in this commit. --root handles the initial commit (no parent).
+		filesOut, err := exec.Command("git", "-C", repoPath, "diff-tree", "--no-commit-id", "--root", "-r", "--name-status", sha).Output()
+		if err != nil {
+			return fmt.Errorf("git diff-tree failed for %s: %w", shortSHA, err)
+		}
+
+		var changes []model.FileChange
+		for _, fline := range strings.Split(strings.TrimRight(string(filesOut), "\n"), "\n") {
+			if fline == "" {
+				continue
+			}
+			fp := strings.SplitN(fline, "\t", 2)
+			if len(fp) != 2 {
+				continue
+			}
+			status, path := fp[0], filepath.ToSlash(fp[1])
+			switch status {
+			case "A", "M":
+				content, err := exec.Command("git", "-C", repoPath, "show", sha+":"+path).Output()
+				if err != nil {
+					return fmt.Errorf("git show failed for %s:%s: %w", shortSHA, path, err)
+				}
+				ct := detectContentType(path, content)
+				changes = append(changes, model.FileChange{Path: path, Content: content, ContentType: ct})
+			case "D":
+				changes = append(changes, model.FileChange{Path: path}) // nil Content = delete
+			}
+		}
+
+		if len(changes) == 0 {
+			continue
+		}
+
+		msg := fmt.Sprintf("[git-author: %s] %s", email, subject)
+		req := model.CommitRequest{
+			Branch:  "main",
+			Files:   changes,
+			Message: msg,
+			Author:  cfg.Author,
+		}
+
+		resp, err := a.postJSON(cfg, repoBase(cfg)+"/commit", req)
+		if err != nil {
+			return fmt.Errorf("commit failed for %s: %w", shortSHA, err)
+		}
+		if resp.StatusCode != http.StatusCreated {
+			apiErr := a.readError(resp)
+			resp.Body.Close()
+			return fmt.Errorf("commit failed for %s: %w", shortSHA, apiErr)
+		}
+		resp.Body.Close()
+	}
+
+	fmt.Fprintf(a.Out, "Done. %d commits imported.\n", total)
+	return nil
+}
+
+// importGitSquash imports the entire repo at HEAD as a single docstore commit.
+func (a *App) importGitSquash(cfg *Config, repoPath string) error {
+	// Detect default branch name.
+	branchOut, err := exec.Command("git", "-C", repoPath, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		return fmt.Errorf("git rev-parse failed: %w", err)
+	}
+	branch := strings.TrimSpace(string(branchOut))
+
+	// List all files at HEAD.
+	filesOut, err := exec.Command("git", "-C", repoPath, "ls-tree", "-r", "HEAD", "--name-only").Output()
+	if err != nil {
+		return fmt.Errorf("git ls-tree failed: %w", err)
+	}
+
+	var filePaths []string
+	for _, f := range strings.Split(strings.TrimRight(string(filesOut), "\n"), "\n") {
+		if f != "" {
+			filePaths = append(filePaths, f)
+		}
+	}
+
+	fmt.Fprintf(a.Out, "Collecting files from HEAD... %d files\n", len(filePaths))
+
+	// Get short SHA.
+	shaOut, err := exec.Command("git", "-C", repoPath, "rev-parse", "--short", "HEAD").Output()
+	if err != nil {
+		return fmt.Errorf("git rev-parse --short failed: %w", err)
+	}
+	shortSHA := strings.TrimSpace(string(shaOut))
+
+	var changes []model.FileChange
+	for _, path := range filePaths {
+		content, err := exec.Command("git", "-C", repoPath, "show", "HEAD:"+path).Output()
+		if err != nil {
+			return fmt.Errorf("git show failed for %s: %w", path, err)
+		}
+		slashPath := filepath.ToSlash(path)
+		ct := detectContentType(slashPath, content)
+		changes = append(changes, model.FileChange{Path: slashPath, Content: content, ContentType: ct})
+	}
+
+	fmt.Fprintf(a.Out, "Importing as single commit...\n")
+
+	msg := fmt.Sprintf("[git-import] Squashed import of %s (%d files, HEAD %s)", branch, len(filePaths), shortSHA)
+	req := model.CommitRequest{
+		Branch:  "main",
+		Files:   changes,
+		Message: msg,
+		Author:  cfg.Author,
+	}
+
+	resp, err := a.postJSON(cfg, repoBase(cfg)+"/commit", req)
+	if err != nil {
+		return fmt.Errorf("commit failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return a.readError(resp)
+	}
+
+	fmt.Fprintf(a.Out, "Done. 1 commit imported (%d files).\n", len(filePaths))
 	return nil
 }

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -2140,4 +2141,275 @@ func mustParseTime(s string) time.Time {
 		panic(err)
 	}
 	return t
+}
+
+// ---------------------------------------------------------------------------
+// ImportGit
+// ---------------------------------------------------------------------------
+
+// initTestGitRepo creates a minimal git repo in dir with the given commits.
+// Each commit is a map of filename -> content strings.
+func initTestGitRepo(t *testing.T, commits []map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Test User",
+			"GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=Test User",
+			"GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-b", "main")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test User")
+
+	for i, files := range commits {
+		for name, content := range files {
+			full := filepath.Join(dir, name)
+			if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			run("add", name)
+		}
+		run("commit", "-m", fmt.Sprintf("Commit %d", i+1))
+	}
+	return dir
+}
+
+func TestImportGitReplay(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	gitDir := initTestGitRepo(t, []map[string]string{
+		{"hello.txt": "hello world\n"},
+		{"world.txt": "goodbye\n"},
+	})
+
+	var capturedReqs []model.CommitRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/commit") {
+			var req model.CommitRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			capturedReqs = append(capturedReqs, req)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(model.CommitResponse{Sequence: int64(len(capturedReqs))})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "importer")
+
+	if err := app.ImportGit(gitDir, "replay"); err != nil {
+		t.Fatalf("ImportGit replay: %v", err)
+	}
+
+	// Should have 2 commits (one per git commit).
+	if len(capturedReqs) != 2 {
+		t.Fatalf("expected 2 commit requests, got %d", len(capturedReqs))
+	}
+
+	// First commit: hello.txt added.
+	if !strings.Contains(capturedReqs[0].Message, "[git-author: test@example.com]") {
+		t.Errorf("message[0] = %q, want [git-author: ...] prefix", capturedReqs[0].Message)
+	}
+	if capturedReqs[0].Branch != "main" {
+		t.Errorf("branch[0] = %q, want main", capturedReqs[0].Branch)
+	}
+	found := false
+	for _, f := range capturedReqs[0].Files {
+		if f.Path == "hello.txt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected hello.txt in first commit files")
+	}
+
+	// Second commit: world.txt added.
+	found = false
+	for _, f := range capturedReqs[1].Files {
+		if f.Path == "world.txt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected world.txt in second commit files")
+	}
+
+	outStr := out.String()
+	if !strings.Contains(outStr, "Importing 2 commits") {
+		t.Errorf("output missing 'Importing 2 commits': %s", outStr)
+	}
+	if !strings.Contains(outStr, "Done. 2 commits imported.") {
+		t.Errorf("output missing 'Done.' line: %s", outStr)
+	}
+}
+
+func TestImportGitSquash(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	gitDir := initTestGitRepo(t, []map[string]string{
+		{"a.txt": "aaa\n", "b.txt": "bbb\n"},
+	})
+
+	var capturedReqs []model.CommitRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/commit") {
+			var req model.CommitRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			capturedReqs = append(capturedReqs, req)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(model.CommitResponse{Sequence: 1})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "importer")
+
+	if err := app.ImportGit(gitDir, "squash"); err != nil {
+		t.Fatalf("ImportGit squash: %v", err)
+	}
+
+	// Should have exactly 1 commit.
+	if len(capturedReqs) != 1 {
+		t.Fatalf("expected 1 commit request, got %d", len(capturedReqs))
+	}
+
+	req := capturedReqs[0]
+	if !strings.Contains(req.Message, "[git-import] Squashed import of") {
+		t.Errorf("squash message = %q, want [git-import] Squashed import of...", req.Message)
+	}
+	if req.Branch != "main" {
+		t.Errorf("branch = %q, want main", req.Branch)
+	}
+	if len(req.Files) != 2 {
+		t.Errorf("expected 2 files, got %d", len(req.Files))
+	}
+
+	outStr := out.String()
+	if !strings.Contains(outStr, "Collecting files from HEAD") {
+		t.Errorf("output missing 'Collecting files' line: %s", outStr)
+	}
+	if !strings.Contains(outStr, "Done. 1 commit imported") {
+		t.Errorf("output missing 'Done.' line: %s", outStr)
+	}
+}
+
+func TestImportGitInvalidMode(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	initWorkspace(t, app, "http://localhost", "main", "user")
+	err := app.ImportGit(t.TempDir(), "badmode")
+	if err == nil || !strings.Contains(err.Error(), "mode must be") {
+		t.Errorf("expected mode error, got %v", err)
+	}
+}
+
+func TestImportGitNotARepo(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	initWorkspace(t, app, "http://localhost", "main", "user")
+	dir := t.TempDir() // no .git
+	err := app.ImportGit(dir, "replay")
+	if err == nil || !strings.Contains(err.Error(), "not a git repository") {
+		t.Errorf("expected 'not a git repository' error, got %v", err)
+	}
+}
+
+func TestImportGitDeletedFiles(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	// First commit adds a file, second commit deletes it.
+	gitDir := initTestGitRepo(t, []map[string]string{
+		{"toDelete.txt": "gone\n"},
+	})
+	// Add a delete commit.
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = gitDir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Test User",
+			"GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=Test User",
+			"GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.Remove(filepath.Join(gitDir, "toDelete.txt")); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "-A")
+	run("commit", "-m", "Delete toDelete.txt")
+
+	var capturedReqs []model.CommitRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/commit") {
+			var req model.CommitRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			capturedReqs = append(capturedReqs, req)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(model.CommitResponse{Sequence: int64(len(capturedReqs))})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "importer")
+
+	if err := app.ImportGit(gitDir, "replay"); err != nil {
+		t.Fatalf("ImportGit replay: %v", err)
+	}
+
+	if len(capturedReqs) != 2 {
+		t.Fatalf("expected 2 commit requests, got %d", len(capturedReqs))
+	}
+
+	// Second commit should have a delete (nil content after JSON unmarshal = empty/missing).
+	deleteReq := capturedReqs[1]
+	foundDelete := false
+	for _, f := range deleteReq.Files {
+		if f.Path == "toDelete.txt" && f.Content == nil {
+			foundDelete = true
+		}
+	}
+	if !foundDelete {
+		t.Errorf("expected deleted file with nil content in second commit; got %+v", deleteReq.Files)
+	}
 }


### PR DESCRIPTION
## Summary

- Adds `ImportGit(repoPath, mode string) error` to `internal/cli/app.go` using `os/exec` (no new library dependency)
- Wires as `import-git` subcommand in `cmd/ds/main.go`
- Two modes: **replay** (default, one docstore commit per git commit) and **squash** (all files at HEAD as one commit)

## Key design details

- **Replay mode**: uses `git log --reverse --no-merges --format=%H|%ae|%s HEAD` to list commits oldest-first; `git diff-tree --no-commit-id --root -r --name-status <sha>` per commit (note: `--root` is required to handle the initial commit which has no parent); `git show <sha>:<path>` for file content
- **Squash mode**: `git ls-tree -r HEAD --name-only` + `git show HEAD:<path>` per file; single commit with `[git-import] Squashed import of <branch> (<N> files, HEAD <sha>)` message
- **Author attribution**: replay commits get `[git-author: email] original subject` format
- **Deleted files**: `D` status in diff-tree → `FileChange{Path: path}` (nil Content = delete convention)
- **Binary files**: uses existing `detectContentType()` as specified
- **Error handling**: clear messages for missing `.git`, git not in PATH, git command failures, API failures

## Test plan

- [x] `TestImportGitReplay` — verifies 2 commits produced from 2-commit git repo, message format, file content
- [x] `TestImportGitSquash` — verifies single commit with correct message and file count
- [x] `TestImportGitInvalidMode` — verifies mode validation error
- [x] `TestImportGitNotARepo` — verifies error for path without `.git`
- [x] `TestImportGitDeletedFiles` — verifies deleted files get nil Content in replay mode
- [x] `go test ./... -count=1` passes

## Bug found and fixed

The issue description claimed `git diff-tree` on the first (root) commit "correctly diffs against the empty tree — all files show as A. No special handling needed." This is incorrect: without `--root`, git diff-tree on a root commit returns no output. Added `--root` flag to fix.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)