### PR TITLE
Fix three minor gaps in import-git implementation

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1442,6 +1442,7 @@ func (a *App) ImportGit(repoPath, mode string) error {
 
 // importGitReplay imports each non-merge git commit as one docstore commit.
 func (a *App) importGitReplay(cfg *Config, repoPath string) error {
+	// %s captures only the subject line; multi-line commit bodies are not imported.
 	out, err := exec.Command("git", "-C", repoPath, "log", "--reverse", "--no-merges", "--format=%H|%ae|%s", "HEAD").Output()
 	if err != nil {
 		return fmt.Errorf("git log failed: %w", err)

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -2413,3 +2413,115 @@ func TestImportGitDeletedFiles(t *testing.T) {
 		t.Errorf("expected deleted file with nil content in second commit; got %+v", deleteReq.Files)
 	}
 }
+
+func TestImportGitReplayBinaryFile(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Test User",
+			"GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=Test User",
+			"GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-b", "main")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test User")
+
+	binData := []byte{0xFF, 0xFE, 0x00, 0x01}
+	if err := os.WriteFile(filepath.Join(dir, "image.png"), binData, 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "image.png")
+	run("commit", "-m", "Add binary image")
+
+	var capturedReqs []model.CommitRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/commit") {
+			var req model.CommitRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			capturedReqs = append(capturedReqs, req)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(model.CommitResponse{Sequence: int64(len(capturedReqs))})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "importer")
+
+	if err := app.ImportGit(dir, "replay"); err != nil {
+		t.Fatalf("ImportGit replay: %v", err)
+	}
+
+	if len(capturedReqs) != 1 {
+		t.Fatalf("expected 1 commit request, got %d", len(capturedReqs))
+	}
+
+	foundPNG := false
+	for _, f := range capturedReqs[0].Files {
+		if f.Path == "image.png" && f.ContentType == "image/png" {
+			foundPNG = true
+		}
+	}
+	if !foundPNG {
+		t.Errorf("expected image.png with ContentType image/png; got %+v", capturedReqs[0].Files)
+	}
+}
+
+func TestImportGitDefaultMode(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	gitDir := initTestGitRepo(t, []map[string]string{
+		{"readme.txt": "hello\n"},
+	})
+
+	var capturedReqs []model.CommitRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/commit") {
+			var req model.CommitRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			capturedReqs = append(capturedReqs, req)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(model.CommitResponse{Sequence: int64(len(capturedReqs))})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "importer")
+
+	// Empty string mode should default to "replay".
+	if err := app.ImportGit(gitDir, ""); err != nil {
+		t.Fatalf("ImportGit default mode: %v", err)
+	}
+
+	if len(capturedReqs) != 1 {
+		t.Fatalf("expected 1 commit request, got %d", len(capturedReqs))
+	}
+}


### PR DESCRIPTION
## Summary

- **Gap 1 (binary file test)**: Added `TestImportGitReplayBinaryFile` — creates a git repo with a binary `.png` file (`[]byte{0xFF, 0xFE, 0x00, 0x01}`), runs ImportGit in replay mode, and asserts the captured `CommitRequest` has `ContentType == "image/png"` for the `.png` file.
- **Gap 2 (default mode test)**: Added `TestImportGitDefaultMode` — calls `app.ImportGit(gitDir, "")` and asserts it succeeds with one commit posted, covering the `mode == "" → "replay"` default code path.
- **Gap 3 (truncation comment)**: Added a comment above the `git log` exec.Command line in `importGitReplay` documenting that `%s` captures only the subject line and multi-line commit bodies are silently truncated.

## Test plan

- [x] `go test ./internal/cli/... -run TestImportGit` — all 7 ImportGit tests pass
- [x] `go test ./...` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)