### PR TITLE
Bake default remote URL into ds binary via ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,13 @@
 
 BINARY := docstore
 BUILD_DIR := bin
+DEFAULT_REMOTE ?= https://docstore-efuj4cj54a-uc.a.run.app
 
 build:
 	go build -o $(BUILD_DIR)/$(BINARY) ./cmd/docstore
 
 build-ds:
-	go build -o $(BUILD_DIR)/ds ./cmd/ds
+	go build -ldflags "-X main.defaultRemote=$(DEFAULT_REMOTE)" -o $(BUILD_DIR)/ds ./cmd/ds
 
 test:
 	go test ./...

--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -6,14 +6,19 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/dlorenc/docstore/internal/cli"
 )
 
+// defaultRemote is the compiled-in default server URL, injected via -ldflags.
+// If empty, ds init requires an explicit remote URL.
+var defaultRemote string
+
 const usage = `usage: ds <command> [args]
 
 commands:
-  init <remote-url> [--author <name>]            Initialize a docstore workspace
+  init [<remote-url>] [--author <name>]          Initialize a docstore workspace
   status                                          Show changed files
   commit -m "message"                             Commit all changes
   checkout -b <branch>                            Create and switch to a new branch
@@ -56,14 +61,20 @@ func main() {
 
 	switch cmd {
 	case "init":
-		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "usage: ds init <remote-url> [--author <name>]")
+		remote := defaultRemote
+		flagStart := 1
+		if len(args) >= 2 && !strings.HasPrefix(args[1], "--") {
+			remote = args[1]
+			flagStart = 2
+		}
+		if remote == "" {
+			fmt.Fprintln(os.Stderr, "usage: ds init [<remote-url>] [--author <name>]")
+			fmt.Fprintln(os.Stderr, "error: no remote URL provided and no default compiled in")
 			os.Exit(1)
 		}
-		remote := args[1]
 		repo := ""
 		author := ""
-		for i := 2; i < len(args); i++ {
+		for i := flagStart; i < len(args); i++ {
 			if args[i] == "--author" && i+1 < len(args) {
 				author = args[i+1]
 				i++


### PR DESCRIPTION
## Summary

- \`Makefile\`: adds \`DEFAULT_REMOTE\` variable (defaults to the Cloud Run instance URL); \`build-ds\` now passes \`-ldflags \"-X main.defaultRemote=$(DEFAULT_REMOTE)\"\`
- \`cmd/ds/main.go\`: adds \`var defaultRemote string\` (injectable via ldflags); \`ds init\` now uses the compiled-in default when no URL argument is given

## Usage

\`\`\`bash
# Build with Cloud Run default baked in — ds init works with no URL
make build-ds

# Override for a different deployment
DEFAULT_REMOTE=https://other.example.com make build-ds

# Still works explicitly
ds init https://custom.example.com
\`\`\`

## Rebase note

Branch was rebased from an old base (merge base \`046429a\`) onto current main (\`6a05f62\`). The PR previously showed ~1900 lines of already-merged TUI code (PR #63). After rebase, the diff is now exactly the intended 2-file change (~18 lines).

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] All tests pass (TestDockerSmoke fails due to pre-existing Docker infra issue, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)