### PR TITLE
Add org, repo, and role management CLI commands (issue #72)

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -36,7 +36,20 @@ commands:
   checks [--branch <name>]                        List check runs for a branch
   check --name <n> --status passed|failed [--branch <name>]  Report a CI check
   import-git <path> [--mode squash|replay]        Import a git repo into docstore main
-  tui                                             Launch the terminal UI`
+  tui                                             Launch the terminal UI
+
+  orgs                                            List organizations
+  orgs create <name>                              Create an organization
+  orgs delete <name>                              Delete an organization
+  orgs repos <name>                               List repos in an organization
+
+  repos                                           List repositories
+  repos create <owner> <name>                     Create a repository
+  repos delete <name>                             Delete a repository (e.g. acme/myrepo)
+
+  roles                                           List roles for the current repo
+  roles set <identity> <role>                     Set a role (reader/writer/maintainer/admin)
+  roles delete <identity>                         Delete a role assignment`
 
 func main() {
 	if len(os.Args) < 2 {
@@ -51,9 +64,10 @@ func main() {
 	}
 
 	app := &cli.App{
-		Dir:  dir,
-		Out:  os.Stdout,
-		HTTP: http.DefaultClient,
+		Dir:           dir,
+		Out:           os.Stdout,
+		HTTP:          http.DefaultClient,
+		DefaultRemote: defaultRemote,
 	}
 
 	args := os.Args[1:]
@@ -275,6 +289,84 @@ func main() {
 
 	case "tui":
 		err = app.TUI()
+
+	case "orgs":
+		if len(args) < 2 {
+			err = app.Orgs()
+		} else {
+			switch args[1] {
+			case "create":
+				if len(args) < 3 {
+					fmt.Fprintln(os.Stderr, "usage: ds orgs create <name>")
+					os.Exit(1)
+				}
+				err = app.OrgsCreate(args[2])
+			case "delete":
+				if len(args) < 3 {
+					fmt.Fprintln(os.Stderr, "usage: ds orgs delete <name>")
+					os.Exit(1)
+				}
+				err = app.OrgsDelete(args[2])
+			case "repos":
+				if len(args) < 3 {
+					fmt.Fprintln(os.Stderr, "usage: ds orgs repos <name>")
+					os.Exit(1)
+				}
+				err = app.OrgsRepos(args[2])
+			default:
+				fmt.Fprintf(os.Stderr, "unknown orgs subcommand: %s\n", args[1])
+				fmt.Fprintln(os.Stderr, usage)
+				os.Exit(1)
+			}
+		}
+
+	case "repos":
+		if len(args) < 2 {
+			err = app.Repos()
+		} else {
+			switch args[1] {
+			case "create":
+				if len(args) < 4 {
+					fmt.Fprintln(os.Stderr, "usage: ds repos create <owner> <name>")
+					os.Exit(1)
+				}
+				err = app.ReposCreate(args[2], args[3])
+			case "delete":
+				if len(args) < 3 {
+					fmt.Fprintln(os.Stderr, "usage: ds repos delete <name>")
+					os.Exit(1)
+				}
+				err = app.ReposDelete(args[2])
+			default:
+				fmt.Fprintf(os.Stderr, "unknown repos subcommand: %s\n", args[1])
+				fmt.Fprintln(os.Stderr, usage)
+				os.Exit(1)
+			}
+		}
+
+	case "roles":
+		if len(args) < 2 {
+			err = app.Roles()
+		} else {
+			switch args[1] {
+			case "set":
+				if len(args) < 4 {
+					fmt.Fprintln(os.Stderr, "usage: ds roles set <identity> <role>")
+					os.Exit(1)
+				}
+				err = app.RolesSet(args[2], args[3])
+			case "delete":
+				if len(args) < 3 {
+					fmt.Fprintln(os.Stderr, "usage: ds roles delete <identity>")
+					os.Exit(1)
+				}
+				err = app.RolesDelete(args[2])
+			default:
+				fmt.Fprintf(os.Stderr, "unknown roles subcommand: %s\n", args[1])
+				fmt.Fprintln(os.Stderr, usage)
+				os.Exit(1)
+			}
+		}
 
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", cmd)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -69,9 +69,10 @@ type State struct {
 
 // App is the CLI application. All fields are injectable for testing.
 type App struct {
-	Dir  string       // working directory
-	Out  io.Writer    // output writer
-	HTTP *http.Client // HTTP client (mockable)
+	Dir           string       // working directory
+	Out           io.Writer    // output writer
+	HTTP          *http.Client // HTTP client (mockable)
+	DefaultRemote string       // fallback remote URL when no config file exists
 }
 
 func (a *App) configPath() string {
@@ -92,6 +93,22 @@ func (a *App) loadConfig() (*Config, error) {
 		return nil, fmt.Errorf("corrupt config: %w", err)
 	}
 	return &cfg, nil
+}
+
+// loadRemote returns the server remote URL. It first tries to read
+// .docstore/config.json; if absent it falls back to App.DefaultRemote.
+func (a *App) loadRemote() (string, error) {
+	data, err := os.ReadFile(a.configPath())
+	if err == nil {
+		var cfg Config
+		if jsonErr := json.Unmarshal(data, &cfg); jsonErr == nil && cfg.Remote != "" {
+			return cfg.Remote, nil
+		}
+	}
+	if a.DefaultRemote != "" {
+		return a.DefaultRemote, nil
+	}
+	return "", fmt.Errorf("not a docstore workspace (run 'ds init' first)")
 }
 
 func (a *App) saveConfig(cfg *Config) error {
@@ -762,6 +779,52 @@ func (a *App) httpGet(cfg *Config, urlStr string) (*http.Response, error) {
 		return nil, err
 	}
 	req.Header.Set("X-DocStore-Identity", cfg.Author)
+	return a.HTTP.Do(req)
+}
+
+// doGET sends a GET request without requiring a workspace config.
+func (a *App) doGET(urlStr string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", urlStr, nil)
+	if err != nil {
+		return nil, err
+	}
+	return a.HTTP.Do(req)
+}
+
+// doDELETE sends a DELETE request without requiring a workspace config.
+func (a *App) doDELETE(urlStr string) (*http.Response, error) {
+	req, err := http.NewRequest("DELETE", urlStr, nil)
+	if err != nil {
+		return nil, err
+	}
+	return a.HTTP.Do(req)
+}
+
+// doPOSTJSON sends a POST request with JSON body without requiring a workspace config.
+func (a *App) doPOSTJSON(urlStr string, body interface{}) (*http.Response, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("POST", urlStr, bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return a.HTTP.Do(req)
+}
+
+// doPUTJSON sends a PUT request with JSON body without requiring a workspace config.
+func (a *App) doPUTJSON(urlStr string, body interface{}) (*http.Response, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("PUT", urlStr, bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
 	return a.HTTP.Do(req)
 }
 
@@ -1589,5 +1652,244 @@ func (a *App) importGitSquash(cfg *Config, repoPath string) error {
 	}
 
 	fmt.Fprintf(a.Out, "Done. 1 commit imported (%d files).\n", len(filePaths))
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Org management
+// ---------------------------------------------------------------------------
+
+// Orgs lists all organizations.
+func (a *App) Orgs() error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doGET(remote + "/orgs")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var r model.ListOrgsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "%-30s  %-20s  %s\n", "NAME", "CREATED BY", "CREATED AT")
+	for _, org := range r.Orgs {
+		fmt.Fprintf(a.Out, "%-30s  %-20s  %s\n", org.Name, org.CreatedBy, org.CreatedAt.Format("2006-01-02"))
+	}
+	return nil
+}
+
+// OrgsCreate creates a new organization.
+func (a *App) OrgsCreate(name string) error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doPOSTJSON(remote+"/orgs", model.CreateOrgRequest{Name: name})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		return a.readError(resp)
+	}
+	var org model.Org
+	if err := json.NewDecoder(resp.Body).Decode(&org); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "Created org '%s'\n", org.Name)
+	return nil
+}
+
+// OrgsDelete deletes an organization (fails if it still has repos).
+func (a *App) OrgsDelete(name string) error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doDELETE(remote + "/orgs/" + name)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusConflict {
+		return fmt.Errorf("org '%s' still has repos", name)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Deleted org '%s'\n", name)
+	return nil
+}
+
+// OrgsRepos lists repositories within an organization.
+func (a *App) OrgsRepos(orgName string) error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doGET(remote + "/orgs/" + orgName + "/repos")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var r model.ReposResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "%-30s  %-20s  %-20s  %s\n", "NAME", "OWNER", "CREATED BY", "CREATED AT")
+	for _, repo := range r.Repos {
+		fmt.Fprintf(a.Out, "%-30s  %-20s  %-20s  %s\n", repo.Name, repo.Owner, repo.CreatedBy, repo.CreatedAt.Format("2006-01-02"))
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Repo management
+// ---------------------------------------------------------------------------
+
+// Repos lists all repositories.
+func (a *App) Repos() error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doGET(remote + "/repos")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var r model.ReposResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "%-30s  %-20s  %-20s  %s\n", "NAME", "OWNER", "CREATED BY", "CREATED AT")
+	for _, repo := range r.Repos {
+		fmt.Fprintf(a.Out, "%-30s  %-20s  %-20s  %s\n", repo.Name, repo.Owner, repo.CreatedBy, repo.CreatedAt.Format("2006-01-02"))
+	}
+	return nil
+}
+
+// ReposCreate creates a new repository under the given owner organization.
+func (a *App) ReposCreate(owner, name string) error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doPOSTJSON(remote+"/repos", model.CreateRepoRequest{Owner: owner, Name: name})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("org '%s' not found", owner)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return a.readError(resp)
+	}
+	var repo model.Repo
+	if err := json.NewDecoder(resp.Body).Decode(&repo); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "Created repo '%s'\n", repo.Name)
+	return nil
+}
+
+// ReposDelete deletes a repository by full name (e.g., "acme/myrepo").
+func (a *App) ReposDelete(name string) error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doDELETE(remote + "/repos/" + name + "/-/")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Deleted repo '%s'\n", name)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Role management
+// ---------------------------------------------------------------------------
+
+// Roles lists roles for the current repository.
+func (a *App) Roles() error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doGET(repoBase(cfg) + "/roles")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var r model.RolesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "%-30s  %s\n", "IDENTITY", "ROLE")
+	for _, role := range r.Roles {
+		fmt.Fprintf(a.Out, "%-30s  %s\n", role.Identity, string(role.Role))
+	}
+	return nil
+}
+
+// RolesSet grants or updates a role for an identity on the current repository.
+func (a *App) RolesSet(identity, role string) error {
+	switch model.RoleType(role) {
+	case model.RoleReader, model.RoleWriter, model.RoleMaintainer, model.RoleAdmin:
+	default:
+		return fmt.Errorf("role must be one of: reader, writer, maintainer, admin")
+	}
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doPUTJSON(repoBase(cfg)+"/roles/"+identity, model.SetRoleRequest{Role: model.RoleType(role)})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Set role '%s' for '%s'\n", role, identity)
+	return nil
+}
+
+// RolesDelete removes a role assignment for an identity on the current repository.
+func (a *App) RolesDelete(identity string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doDELETE(repoBase(cfg) + "/roles/" + identity)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Deleted role for '%s'\n", identity)
 	return nil
 }

--- a/internal/cli/e2e_test.go
+++ b/internal/cli/e2e_test.go
@@ -329,3 +329,196 @@ func TestCLIResolve_EndToEnd(t *testing.T) {
 		t.Error("expected README.md in state files after resolve")
 	}
 }
+
+// TestOrgs_EndToEnd verifies org creation, listing, and deletion via a real server.
+func TestOrgs_EndToEnd(t *testing.T) {
+	srv := newRealServer(t)
+	app, out := newTestApp(t, srv)
+	app.DefaultRemote = srv.URL
+
+	// Create org.
+	if err := app.OrgsCreate("e2eorg"); err != nil {
+		t.Fatalf("OrgsCreate: %v", err)
+	}
+	if !strings.Contains(out.String(), "Created org 'e2eorg'") {
+		t.Errorf("expected creation message, got: %s", out.String())
+	}
+
+	// List orgs — should include new org.
+	out.Reset()
+	if err := app.Orgs(); err != nil {
+		t.Fatalf("Orgs: %v", err)
+	}
+	if !strings.Contains(out.String(), "e2eorg") {
+		t.Errorf("expected 'e2eorg' in listing, got: %s", out.String())
+	}
+
+	// Delete org.
+	out.Reset()
+	if err := app.OrgsDelete("e2eorg"); err != nil {
+		t.Fatalf("OrgsDelete: %v", err)
+	}
+	if !strings.Contains(out.String(), "Deleted org 'e2eorg'") {
+		t.Errorf("expected deletion message, got: %s", out.String())
+	}
+
+	// Org should no longer appear in listing.
+	out.Reset()
+	if err := app.Orgs(); err != nil {
+		t.Fatalf("Orgs after delete: %v", err)
+	}
+	if strings.Contains(out.String(), "e2eorg") {
+		t.Errorf("expected 'e2eorg' to be gone, got: %s", out.String())
+	}
+}
+
+// TestRepos_EndToEnd verifies repo creation, listing (global and per-org), and deletion.
+func TestRepos_EndToEnd(t *testing.T) {
+	srv := newRealServer(t)
+	app, out := newTestApp(t, srv)
+	app.DefaultRemote = srv.URL
+
+	// Create org.
+	if err := app.OrgsCreate("repoorg"); err != nil {
+		t.Fatalf("OrgsCreate: %v", err)
+	}
+
+	// Create repo.
+	out.Reset()
+	if err := app.ReposCreate("repoorg", "myrepo"); err != nil {
+		t.Fatalf("ReposCreate: %v", err)
+	}
+	if !strings.Contains(out.String(), "Created repo 'repoorg/myrepo'") {
+		t.Errorf("expected creation message, got: %s", out.String())
+	}
+
+	// List repos — should include new repo.
+	out.Reset()
+	if err := app.Repos(); err != nil {
+		t.Fatalf("Repos: %v", err)
+	}
+	if !strings.Contains(out.String(), "repoorg/myrepo") {
+		t.Errorf("expected 'repoorg/myrepo' in listing, got: %s", out.String())
+	}
+
+	// List org repos.
+	out.Reset()
+	if err := app.OrgsRepos("repoorg"); err != nil {
+		t.Fatalf("OrgsRepos: %v", err)
+	}
+	if !strings.Contains(out.String(), "repoorg/myrepo") {
+		t.Errorf("expected 'repoorg/myrepo' in org repo listing, got: %s", out.String())
+	}
+
+	// Delete repo.
+	out.Reset()
+	if err := app.ReposDelete("repoorg/myrepo"); err != nil {
+		t.Fatalf("ReposDelete: %v", err)
+	}
+	if !strings.Contains(out.String(), "Deleted repo 'repoorg/myrepo'") {
+		t.Errorf("expected deletion message, got: %s", out.String())
+	}
+
+	// Repo should no longer appear in listing.
+	out.Reset()
+	if err := app.Repos(); err != nil {
+		t.Fatalf("Repos after delete: %v", err)
+	}
+	if strings.Contains(out.String(), "repoorg/myrepo") {
+		t.Errorf("expected 'repoorg/myrepo' to be gone, got: %s", out.String())
+	}
+}
+
+// TestRoles_EndToEnd verifies role assignment, listing, and deletion via a real server.
+func TestRoles_EndToEnd(t *testing.T) {
+	srv := newRealServer(t)
+	app, out := newTestApp(t, srv)
+	app.DefaultRemote = srv.URL
+
+	// Create org and repo.
+	if err := app.OrgsCreate("roleorg"); err != nil {
+		t.Fatalf("OrgsCreate: %v", err)
+	}
+	if err := app.ReposCreate("roleorg", "rolerepo"); err != nil {
+		t.Fatalf("ReposCreate: %v", err)
+	}
+
+	// Set up a workspace config pointing to the new repo (roles commands need config).
+	if err := os.MkdirAll(filepath.Join(app.Dir, configDir), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.saveConfig(&Config{Remote: srv.URL, Repo: "roleorg/rolerepo", Branch: "main", Author: "test@example.com"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set role.
+	out.Reset()
+	if err := app.RolesSet("alice@example.com", "writer"); err != nil {
+		t.Fatalf("RolesSet: %v", err)
+	}
+	if !strings.Contains(out.String(), "Set role 'writer' for 'alice@example.com'") {
+		t.Errorf("expected set message, got: %s", out.String())
+	}
+
+	// List roles.
+	out.Reset()
+	if err := app.Roles(); err != nil {
+		t.Fatalf("Roles: %v", err)
+	}
+	if !strings.Contains(out.String(), "alice@example.com") {
+		t.Errorf("expected 'alice@example.com' in roles listing, got: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "writer") {
+		t.Errorf("expected 'writer' role in listing, got: %s", out.String())
+	}
+
+	// Delete role.
+	out.Reset()
+	if err := app.RolesDelete("alice@example.com"); err != nil {
+		t.Fatalf("RolesDelete: %v", err)
+	}
+	if !strings.Contains(out.String(), "Deleted role for 'alice@example.com'") {
+		t.Errorf("expected deletion message, got: %s", out.String())
+	}
+}
+
+// TestLoadRemote_Fallback verifies that loadRemote() uses DefaultRemote when no config exists.
+func TestLoadRemote_Fallback(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	app.DefaultRemote = "https://example.com"
+
+	remote, err := app.loadRemote()
+	if err != nil {
+		t.Fatalf("loadRemote: %v", err)
+	}
+	if remote != "https://example.com" {
+		t.Errorf("loadRemote = %q, want %q", remote, "https://example.com")
+	}
+}
+
+// TestLoadRemote_NoConfig verifies that loadRemote() errors when no config or DefaultRemote.
+func TestLoadRemote_NoConfig(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+
+	_, err := app.loadRemote()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a docstore workspace") {
+		t.Errorf("expected workspace error, got: %v", err)
+	}
+}
+
+// TestRolesSet_InvalidRole verifies client-side role validation.
+func TestRolesSet_InvalidRole(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	initWorkspace(t, app, "http://localhost", "main", "alice")
+
+	err := app.RolesSet("alice@example.com", "superadmin")
+	if err == nil {
+		t.Fatal("expected error for invalid role, got nil")
+	}
+	if !strings.Contains(err.Error(), "role must be one of") {
+		t.Errorf("expected role validation error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `ds orgs`, `ds repos`, `ds roles` subcommand groups (issue #72)
- Adds `App.DefaultRemote` field + `loadRemote()` helper so org/repo commands work outside a workspace
- Adds raw HTTP helpers (`doGET`/`doDELETE`/`doPOSTJSON`/`doPUTJSON`) for config-free API calls
- Client-side role validation for `roles set` (reader/writer/maintainer/admin)
- Two-level dispatch wired in `cmd/ds/main.go` for all new commands
- Updated usage string with all new subcommands
- 6 new e2e tests against real Postgres: `TestOrgs_EndToEnd`, `TestRepos_EndToEnd`, `TestRoles_EndToEnd`, `TestLoadRemote_Fallback`, `TestLoadRemote_NoConfig`, `TestRolesSet_InvalidRole`

## Commands added

```
ds orgs                            List organizations
ds orgs create <name>              Create an organization
ds orgs delete <name>              Delete an organization
ds orgs repos <name>               List repos in an organization

ds repos                           List repositories
ds repos create <owner> <name>     Create a repository
ds repos delete <name>             Delete a repository (e.g. acme/myrepo)

ds roles                           List roles for the current repo
ds roles set <identity> <role>     Set a role (reader/writer/maintainer/admin)
ds roles delete <identity>         Delete a role assignment
```

## Test plan

- [x] `go test ./... -count=1` passes (all packages)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] New e2e tests exercise create/list/delete for orgs, repos, and roles
- [x] `loadRemote()` fallback tested (DefaultRemote, missing config error)
- [x] Role validation tested (invalid role string returns error before HTTP call)

## Notes for follow-up

- `defaultRemote` in `main.go` is empty by default; can be set at build time via `-ldflags "-X main.defaultRemote=https://..."` for pre-configured deployments
- Role commands still require a workspace config (for repo path) — this matches the issue spec

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)