### PR TITLE
Fix OPA policy engine bugs: package naming, input fields, OWNERS inheritance, eval errors, tests

### DIFF
--- a/internal/policy/cache.go
+++ b/internal/policy/cache.go
@@ -9,6 +9,13 @@ import (
 	"github.com/dlorenc/docstore/internal/store"
 )
 
+// ReadStore is the minimal interface for reading policy and OWNERS files.
+// *store.Store satisfies this interface.
+type ReadStore interface {
+	MaterializeTree(ctx context.Context, repo, branch string, atSeq *int64, limit int, afterPath string) ([]store.TreeEntry, error)
+	GetFile(ctx context.Context, repo, branch, path string, atSeq *int64) (*store.FileContent, error)
+}
+
 // cacheEntry holds a compiled engine and pre-loaded OWNERS map for one repo.
 type cacheEntry struct {
 	engine *Engine              // nil means no policies (bootstrap mode)
@@ -35,7 +42,7 @@ func NewCache() *Cache {
 // Load returns the compiled Engine and OWNERS map for the given repo, loading
 // them from the read store on first call. Returns nil, nil, nil in bootstrap
 // mode (no .rego files on the main branch).
-func (c *Cache) Load(ctx context.Context, repo string, readStore *store.Store) (*Engine, map[string][]string, error) {
+func (c *Cache) Load(ctx context.Context, repo string, readStore ReadStore) (*Engine, map[string][]string, error) {
 	// Fast path: already loaded.
 	c.mu.RLock()
 	if c.loaded[repo] {
@@ -75,7 +82,7 @@ func (c *Cache) Invalidate(repo string) {
 }
 
 // loadEntry fetches policy files and OWNERS from the main branch of a repo.
-func loadEntry(ctx context.Context, repo string, readStore *store.Store) (*cacheEntry, error) {
+func loadEntry(ctx context.Context, repo string, readStore ReadStore) (*cacheEntry, error) {
 	modules, err := loadPolicyModules(ctx, repo, readStore)
 	if err != nil {
 		return nil, fmt.Errorf("load policy modules: %w", err)
@@ -102,7 +109,7 @@ func loadEntry(ctx context.Context, repo string, readStore *store.Store) (*cache
 }
 
 // loadPolicyModules fetches all .rego files from .docstore/policy/ on main.
-func loadPolicyModules(ctx context.Context, repo string, readStore *store.Store) (map[string]string, error) {
+func loadPolicyModules(ctx context.Context, repo string, readStore ReadStore) (map[string]string, error) {
 	const policyDir = ".docstore/policy/"
 	modules := make(map[string]string)
 
@@ -134,7 +141,7 @@ func loadPolicyModules(ctx context.Context, repo string, readStore *store.Store)
 }
 
 // loadOwnerFiles fetches all OWNERS files from the main branch.
-func loadOwnerFiles(ctx context.Context, repo string, readStore *store.Store) (map[string][]byte, error) {
+func loadOwnerFiles(ctx context.Context, repo string, readStore ReadStore) (map[string][]byte, error) {
 	result := make(map[string][]byte)
 	afterPath := ""
 

--- a/internal/policy/cache_test.go
+++ b/internal/policy/cache_test.go
@@ -1,0 +1,100 @@
+package policy_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/policy"
+	"github.com/dlorenc/docstore/internal/store"
+)
+
+// mockReadStore is a minimal ReadStore for cache tests.
+// It counts how many times Load is called and returns no policies or OWNERS.
+type mockReadStore struct {
+	calls int
+}
+
+func (m *mockReadStore) MaterializeTree(ctx context.Context, repo, branch string, atSeq *int64, limit int, afterPath string) ([]store.TreeEntry, error) {
+	m.calls++
+	return nil, nil
+}
+
+func (m *mockReadStore) GetFile(ctx context.Context, repo, branch, path string, atSeq *int64) (*store.FileContent, error) {
+	return nil, nil
+}
+
+// TestCachePerRepo verifies that Invalidate(repoA) does not evict repoB's
+// cached entry.
+func TestCachePerRepo(t *testing.T) {
+	ctx := context.Background()
+	c := policy.NewCache()
+
+	rs := &mockReadStore{}
+
+	// Load both repos — each triggers one MaterializeTree call.
+	if _, _, err := c.Load(ctx, "repoA", rs); err != nil {
+		t.Fatalf("Load(repoA): %v", err)
+	}
+	if _, _, err := c.Load(ctx, "repoB", rs); err != nil {
+		t.Fatalf("Load(repoB): %v", err)
+	}
+	callsAfterBothLoaded := rs.calls
+
+	// Invalidate only repoA.
+	c.Invalidate("repoA")
+
+	// Load repoA again — should re-call the store.
+	if _, _, err := c.Load(ctx, "repoA", rs); err != nil {
+		t.Fatalf("Load(repoA) after invalidate: %v", err)
+	}
+	if rs.calls <= callsAfterBothLoaded {
+		t.Error("expected repoA to be reloaded after Invalidate")
+	}
+
+	callsBeforeRepoB := rs.calls
+
+	// Load repoB again — should NOT re-call the store (still cached).
+	if _, _, err := c.Load(ctx, "repoB", rs); err != nil {
+		t.Fatalf("Load(repoB) after invalidating repoA: %v", err)
+	}
+	if rs.calls != callsBeforeRepoB {
+		t.Error("expected repoB to remain cached after repoA was invalidated")
+	}
+}
+
+// TestCacheInvalidatedAfterMerge verifies that after Invalidate(repo) the next
+// Load triggers a reload (store is queried again) rather than serving the
+// cached entry.
+func TestCacheInvalidatedAfterMerge(t *testing.T) {
+	ctx := context.Background()
+	c := policy.NewCache()
+	rs := &mockReadStore{}
+
+	// First Load — populates the cache.
+	if _, _, err := c.Load(ctx, "testrepo", rs); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	callsAfterFirst := rs.calls
+	if callsAfterFirst == 0 {
+		t.Fatal("expected at least one store call on first Load")
+	}
+
+	// Second Load — should be served from cache, no new store calls.
+	if _, _, err := c.Load(ctx, "testrepo", rs); err != nil {
+		t.Fatalf("second Load: %v", err)
+	}
+	if rs.calls != callsAfterFirst {
+		t.Errorf("expected no new store calls on cached Load, got %d total (was %d)", rs.calls, callsAfterFirst)
+	}
+
+	// Invalidate the repo — clears the cache entry.
+	c.Invalidate("testrepo")
+
+	// Third Load — should re-query the store.
+	if _, _, err := c.Load(ctx, "testrepo", rs); err != nil {
+		t.Fatalf("Load after Invalidate: %v", err)
+	}
+	if rs.calls == callsAfterFirst {
+		t.Error("expected store to be queried again after Invalidate")
+	}
+}

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -1,7 +1,8 @@
 // Package policy implements OPA-based policy evaluation for merge operations.
 //
 // Each .rego file in .docstore/policy/ on the main branch defines one policy.
-// Policies must be in `package policy` and should define:
+// Policies must use 'package docstore.<policy_name>' (e.g.
+// 'package docstore.require_review') and should define:
 //
 //	default allow = false
 //	allow { ... }         // conditions under which the merge is permitted
@@ -14,10 +15,11 @@ package policy
 import (
 	"context"
 	"fmt"
-	"path"
 	"strings"
+	"time"
 
 	"github.com/dlorenc/docstore/internal/model"
+	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/rego"
 )
 
@@ -37,15 +39,17 @@ type CheckRunInput struct {
 
 // Input is the structured context passed to every policy evaluation.
 type Input struct {
-	Actor     string              `json:"actor"`
-	Role      string              `json:"role"`
-	Paths     []string            `json:"paths"`
-	Reviews   []ReviewInput       `json:"reviews"`
-	CheckRuns []CheckRunInput     `json:"check_runs"`
-	Owners    map[string][]string `json:"owners"`
-	Branch    string              `json:"branch"`
-	HeadSeq   int64               `json:"head_sequence"`
-	BaseSeq   int64               `json:"base_sequence"`
+	Actor        string              `json:"actor"`
+	ActorRoles   []string            `json:"actor_roles"`
+	Action       string              `json:"action"`
+	Repo         string              `json:"repo"`
+	Branch       string              `json:"branch"`
+	ChangedPaths []string            `json:"changed_paths"`
+	Reviews      []ReviewInput       `json:"reviews"`
+	CheckRuns    []CheckRunInput     `json:"check_runs"`
+	Owners       map[string][]string `json:"owners"`
+	HeadSeq      int64               `json:"head_sequence"`
+	BaseSeq      int64               `json:"base_sequence"`
 }
 
 // preparedPolicy holds compiled OPA queries for a single .rego file.
@@ -63,6 +67,8 @@ type Engine struct {
 
 // NewEngine compiles the given modules into an Engine.
 // modules maps filename (e.g. ".docstore/policy/require_review.rego") to rego source.
+// Each module must declare 'package docstore.<name>'; the policy name is derived
+// from the last segment of the package path.
 // Returns nil, nil if modules is empty (bootstrap mode).
 func NewEngine(ctx context.Context, modules map[string]string) (*Engine, error) {
 	if len(modules) == 0 {
@@ -71,10 +77,16 @@ func NewEngine(ctx context.Context, modules map[string]string) (*Engine, error) 
 
 	queries := make([]preparedPolicy, 0, len(modules))
 	for filename, src := range modules {
-		name := policyName(filename)
+		// Parse the module AST to extract the package path.
+		module, err := ast.ParseModule(filename, src)
+		if err != nil {
+			return nil, fmt.Errorf("parse policy %q: %w", filename, err)
+		}
+		pkgPath := module.Package.Path.String()
+		name := nameFromPackagePath(pkgPath)
 
 		allowPQ, err := rego.New(
-			rego.Query("data.policy.allow"),
+			rego.Query(pkgPath+".allow"),
 			rego.Module(filename, src),
 		).PrepareForEval(ctx)
 		if err != nil {
@@ -82,7 +94,7 @@ func NewEngine(ctx context.Context, modules map[string]string) (*Engine, error) 
 		}
 
 		reasonPQ, err := rego.New(
-			rego.Query("data.policy.reason"),
+			rego.Query(pkgPath+".reason"),
 			rego.Module(filename, src),
 		).PrepareForEval(ctx)
 		if err != nil {
@@ -118,16 +130,18 @@ func (e *Engine) Evaluate(ctx context.Context, input Input) ([]model.PolicyResul
 }
 
 // evalPrepared evaluates one compiled policy against the given input.
+// Wraps evaluation in a 5-second timeout to prevent infinite loops in Rego
+// from blocking request goroutines. Returns errors rather than converting them
+// to silent denies so broken policies surface as 500s in the handler.
 func evalPrepared(ctx context.Context, p preparedPolicy, input Input) (model.PolicyResult, error) {
+	// Wrap in a 5-second timeout to prevent runaway Rego evaluation.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
 	// Evaluate the allow rule.
 	allowRs, err := p.allowPQ.Eval(ctx, rego.EvalInput(input))
 	if err != nil {
-		// Treat evaluation errors as denials with an error reason.
-		return model.PolicyResult{
-			Name:   p.name,
-			Pass:   false,
-			Reason: fmt.Sprintf("evaluation error: %v", err),
-		}, nil
+		return model.PolicyResult{}, fmt.Errorf("allow eval: %w", err)
 	}
 
 	allow := false
@@ -151,8 +165,12 @@ func evalPrepared(ctx context.Context, p preparedPolicy, input Input) (model.Pol
 	return model.PolicyResult{Name: p.name, Pass: false, Reason: reason}, nil
 }
 
-// policyName extracts a human-readable policy name from its filename.
-func policyName(filename string) string {
-	base := path.Base(filename)
-	return strings.TrimSuffix(base, ".rego")
+// nameFromPackagePath extracts the policy name from an OPA package path.
+// E.g. "data.docstore.require_review" → "require_review".
+func nameFromPackagePath(pkgPath string) string {
+	idx := strings.LastIndex(pkgPath, ".")
+	if idx < 0 || idx == len(pkgPath)-1 {
+		return pkgPath
+	}
+	return pkgPath[idx+1:]
 }

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -34,7 +34,7 @@ func TestEngine_NilEvaluate(t *testing.T) {
 func TestEngine_Allow(t *testing.T) {
 	ctx := context.Background()
 	src := `
-package policy
+package docstore.require_review
 
 default allow = false
 
@@ -87,7 +87,7 @@ allow if {
 func TestEngine_DenyReason(t *testing.T) {
 	ctx := context.Background()
 	src := `
-package policy
+package docstore.require_check
 
 default allow = false
 default reason = "at least one passing check is required"
@@ -129,7 +129,7 @@ allow if {
 func TestEngine_MultipleModules(t *testing.T) {
 	ctx := context.Background()
 	reviewPolicy := `
-package policy
+package docstore.review
 
 default allow = false
 
@@ -138,7 +138,7 @@ allow if {
 }
 `
 	checkPolicy := `
-package policy
+package docstore.check
 
 default allow = false
 
@@ -176,7 +176,7 @@ allow if {
 func TestEngine_PolicyName(t *testing.T) {
 	ctx := context.Background()
 	src := `
-package policy
+package docstore.my_policy
 default allow = true
 `
 	engine, err := policy.NewEngine(ctx, map[string]string{
@@ -197,4 +197,86 @@ default allow = true
 func TestEngine_PolicyResultTypes(t *testing.T) {
 	// Verify that PolicyResult from policy package matches model.PolicyResult fields.
 	var _ = model.PolicyResult{Name: "x", Pass: true, Reason: "y"}
+}
+
+func TestEngine_InputFieldNames(t *testing.T) {
+	// Verify that the corrected field names are accessible and used by policies.
+	ctx := context.Background()
+	src := `
+package docstore.role_check
+
+default allow = false
+
+allow if {
+    input.actor_roles[_] == "maintainer"
+}
+`
+	engine, err := policy.NewEngine(ctx, map[string]string{
+		".docstore/policy/role_check.rego": src,
+	})
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+
+	// Should deny: no roles.
+	results, err := engine.Evaluate(ctx, policy.Input{
+		Actor:      "alice@example.com",
+		ActorRoles: []string{},
+	})
+	if err != nil {
+		t.Fatalf("evaluate error: %v", err)
+	}
+	if results[0].Pass {
+		t.Error("expected deny with no roles")
+	}
+
+	// Should allow: maintainer role present.
+	results, err = engine.Evaluate(ctx, policy.Input{
+		Actor:      "alice@example.com",
+		ActorRoles: []string{"maintainer"},
+	})
+	if err != nil {
+		t.Fatalf("evaluate error: %v", err)
+	}
+	if !results[0].Pass {
+		t.Errorf("expected pass with maintainer role, got deny: %s", results[0].Reason)
+	}
+}
+
+func TestEngine_ChangedPathsField(t *testing.T) {
+	// Verify changed_paths field name is accessible to policies.
+	ctx := context.Background()
+	src := `
+package docstore.path_check
+
+default allow = false
+
+allow if {
+    count(input.changed_paths) == 0
+}
+`
+	engine, err := policy.NewEngine(ctx, map[string]string{
+		".docstore/policy/path_check.rego": src,
+	})
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+
+	// Should allow: no changed paths.
+	results, err := engine.Evaluate(ctx, policy.Input{ChangedPaths: []string{}})
+	if err != nil {
+		t.Fatalf("evaluate error: %v", err)
+	}
+	if !results[0].Pass {
+		t.Errorf("expected pass with no changed paths")
+	}
+
+	// Should deny: has changed paths.
+	results, err = engine.Evaluate(ctx, policy.Input{ChangedPaths: []string{"foo.go"}})
+	if err != nil {
+		t.Fatalf("evaluate error: %v", err)
+	}
+	if results[0].Pass {
+		t.Error("expected deny with changed paths")
+	}
 }

--- a/internal/policy/owners.go
+++ b/internal/policy/owners.go
@@ -32,6 +32,42 @@ func ParseOwners(files map[string][]byte) map[string][]string {
 	return owners
 }
 
+// ResolveOwners returns the owners for a given file path by finding the most
+// specific (longest) directory prefix in ownersMap that is a parent of the path.
+// The ownersMap keys use the format produced by ParseOwners: directory paths
+// without trailing slashes, with root represented by the empty string "".
+//
+// Examples (ownersMap keys: "", "src", "src/pkg"):
+//   - "src/pkg/foo.go" → ownersMap["src/pkg"]  (most specific match)
+//   - "src/bar.go"     → ownersMap["src"]
+//   - "README.md"      → ownersMap[""]           (root fallback)
+//   - If no root entry exists and no prefix matches, returns nil.
+func ResolveOwners(ownersMap map[string][]string, filePath string) []string {
+	bestKey := ""
+	bestMatchLen := -1
+
+	for k := range ownersMap {
+		var matchLen int
+		if k == "" {
+			// Root matches everything.
+			matchLen = 0
+		} else if strings.HasPrefix(filePath, k+"/") {
+			matchLen = len(k)
+		} else {
+			continue
+		}
+		if matchLen > bestMatchLen {
+			bestKey = k
+			bestMatchLen = matchLen
+		}
+	}
+
+	if bestMatchLen < 0 {
+		return nil
+	}
+	return ownersMap[bestKey]
+}
+
 // parseOwnersFile parses a single OWNERS file.
 // Lines starting with '#' are treated as comments.
 // Empty or whitespace-only lines are skipped.

--- a/internal/policy/owners_test.go
+++ b/internal/policy/owners_test.go
@@ -94,3 +94,76 @@ func TestParseOwners_EmptyFile(t *testing.T) {
 		t.Errorf("expected no entry for all-comment OWNERS file, got %v", owners)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// ResolveOwners tests
+// ---------------------------------------------------------------------------
+
+func TestResolveOwners_ExactDirMatch(t *testing.T) {
+	// Most specific match: "src/pkg" is the longest prefix of "src/pkg/foo.go"
+	owners := map[string][]string{
+		"":        {"root@example.com"},
+		"src":     {"src@example.com"},
+		"src/pkg": {"pkg@example.com"},
+	}
+	got := policy.ResolveOwners(owners, "src/pkg/foo.go")
+	if len(got) != 1 || got[0] != "pkg@example.com" {
+		t.Errorf("expected [pkg@example.com], got %v", got)
+	}
+}
+
+func TestResolveOwners_PrefixInheritance(t *testing.T) {
+	// "src/pkg" not in map; fall back to "src"
+	owners := map[string][]string{
+		"":    {"root@example.com"},
+		"src": {"src@example.com"},
+	}
+	got := policy.ResolveOwners(owners, "src/bar.go")
+	if len(got) != 1 || got[0] != "src@example.com" {
+		t.Errorf("expected [src@example.com], got %v", got)
+	}
+}
+
+func TestResolveOwners_RootFallback(t *testing.T) {
+	// No subdirectory entry; root applies.
+	owners := map[string][]string{
+		"":    {"root@example.com"},
+		"src": {"src@example.com"},
+	}
+	got := policy.ResolveOwners(owners, "README.md")
+	if len(got) != 1 || got[0] != "root@example.com" {
+		t.Errorf("expected [root@example.com], got %v", got)
+	}
+}
+
+func TestResolveOwners_NoOwners(t *testing.T) {
+	// Empty map: no owners at all.
+	got := policy.ResolveOwners(map[string][]string{}, "src/foo.go")
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestResolveOwners_NoMatchingPrefix(t *testing.T) {
+	// Map has entries but none match the path, and no root entry.
+	owners := map[string][]string{
+		"docs": {"docs@example.com"},
+	}
+	got := policy.ResolveOwners(owners, "src/foo.go")
+	if got != nil {
+		t.Errorf("expected nil (no root fallback), got %v", got)
+	}
+}
+
+func TestResolveOwners_DeepNesting(t *testing.T) {
+	// Three-level deep: "a/b/c" matches "a/b/c/d/e.go" better than "a/b"
+	owners := map[string][]string{
+		"":      {"root@example.com"},
+		"a/b":   {"ab@example.com"},
+		"a/b/c": {"abc@example.com"},
+	}
+	got := policy.ResolveOwners(owners, "a/b/c/d/e.go")
+	if len(got) != 1 || got[0] != "abc@example.com" {
+		t.Errorf("expected [abc@example.com], got %v", got)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1110,30 +1110,19 @@ func (s *server) handleMerge(w http.ResponseWriter, r *http.Request) {
 // Policy helpers
 // ---------------------------------------------------------------------------
 
-// evaluateMergePolicy evaluates all OPA policies for a pending merge.
-// Returns the failing PolicyResults (non-nil means denied), or nil if allowed.
-// Returns an error only for unexpected infrastructure failures.
-// When readStore or policyCache are nil, or no policies exist, the merge is allowed.
-func (s *server) evaluateMergePolicy(ctx context.Context, repo, branch, actor string) ([]model.PolicyResult, error) {
-	if s.policyCache == nil || s.readStore == nil {
-		return nil, nil
-	}
-
-	engine, owners, err := s.policyCache.Load(ctx, repo, s.readStore)
-	if err != nil {
-		return nil, err
-	}
-	if engine == nil {
-		return nil, nil // bootstrap mode
-	}
-
+// assembleMergeInput gathers all data needed for OPA policy evaluation and
+// returns a populated Input. Returns nil, nil if the branch does not exist
+// (callers should let the merge handler surface the 404). owners is the raw
+// directory→owners map from the policy cache; it is resolved per changed path
+// before being placed on the Input.
+func (s *server) assembleMergeInput(ctx context.Context, repo, branch, actor string, owners map[string][]string) (*policy.Input, error) {
 	// Collect branch info for head/base sequence.
 	branchInfo, err := s.readStore.GetBranch(ctx, repo, branch)
 	if err != nil {
 		return nil, fmt.Errorf("get branch info: %w", err)
 	}
 	if branchInfo == nil {
-		return nil, nil // branch not found — let the merge handler surface the error
+		return nil, nil // branch not found
 	}
 
 	// Collect changed paths.
@@ -1141,14 +1130,14 @@ func (s *server) evaluateMergePolicy(ctx context.Context, repo, branch, actor st
 	if err != nil {
 		return nil, fmt.Errorf("get diff: %w", err)
 	}
-	var paths []string
+	var changedPaths []string
 	if diff != nil {
 		for _, e := range diff.BranchChanges {
-			paths = append(paths, e.Path)
+			changedPaths = append(changedPaths, e.Path)
 		}
 	}
 
-	// Collect reviews and check runs at the current head sequence.
+	// Collect reviews filtered to the current head sequence (stale reviews excluded).
 	reviews, err := s.commitStore.ListReviews(ctx, repo, branch, &branchInfo.HeadSequence)
 	if err != nil {
 		return nil, fmt.Errorf("list reviews: %w", err)
@@ -1158,10 +1147,10 @@ func (s *server) evaluateMergePolicy(ctx context.Context, repo, branch, actor st
 		return nil, fmt.Errorf("list check runs: %w", err)
 	}
 
-	// Look up actor role (empty string if not assigned).
-	roleStr := ""
+	// Look up actor roles (empty slice if not assigned).
+	actorRoles := []string{}
 	if r, err := s.commitStore.GetRole(ctx, repo, actor); err == nil && r != nil {
-		roleStr = string(r.Role)
+		actorRoles = []string{string(r.Role)}
 	}
 
 	// Build OPA input.
@@ -1182,19 +1171,53 @@ func (s *server) evaluateMergePolicy(ctx context.Context, repo, branch, actor st
 		}
 	}
 
-	input := policy.Input{
-		Actor:     actor,
-		Role:      roleStr,
-		Paths:     paths,
-		Reviews:   reviewInputs,
-		CheckRuns: checkInputs,
-		Owners:    owners,
-		Branch:    branch,
-		HeadSeq:   branchInfo.HeadSequence,
-		BaseSeq:   branchInfo.BaseSequence,
+	// Resolve owners per changed path so policies can use input.owners["path"].
+	resolvedOwners := make(map[string][]string)
+	for _, p := range changedPaths {
+		resolvedOwners[p] = policy.ResolveOwners(owners, p)
 	}
 
-	results, err := engine.Evaluate(ctx, input)
+	return &policy.Input{
+		Actor:        actor,
+		ActorRoles:   actorRoles,
+		Action:       "merge",
+		Repo:         repo,
+		Branch:       branch,
+		ChangedPaths: changedPaths,
+		Reviews:      reviewInputs,
+		CheckRuns:    checkInputs,
+		Owners:       resolvedOwners,
+		HeadSeq:      branchInfo.HeadSequence,
+		BaseSeq:      branchInfo.BaseSequence,
+	}, nil
+}
+
+// evaluateMergePolicy evaluates all OPA policies for a pending merge.
+// Returns the failing PolicyResults (non-nil means denied), or nil if allowed.
+// Returns an error only for unexpected infrastructure failures.
+// When readStore or policyCache are nil, or no policies exist, the merge is allowed.
+func (s *server) evaluateMergePolicy(ctx context.Context, repo, branch, actor string) ([]model.PolicyResult, error) {
+	if s.policyCache == nil || s.readStore == nil {
+		return nil, nil
+	}
+
+	engine, owners, err := s.policyCache.Load(ctx, repo, s.readStore)
+	if err != nil {
+		return nil, err
+	}
+	if engine == nil {
+		return nil, nil // bootstrap mode
+	}
+
+	input, err := s.assembleMergeInput(ctx, repo, branch, actor, owners)
+	if err != nil {
+		return nil, err
+	}
+	if input == nil {
+		return nil, nil // branch not found — let the merge handler surface the error
+	}
+
+	results, err := engine.Evaluate(ctx, *input)
 	if err != nil {
 		return nil, fmt.Errorf("evaluate policies: %w", err)
 	}
@@ -1250,78 +1273,18 @@ func (s *server) handleBranchStatus(w http.ResponseWriter, r *http.Request, repo
 		return
 	}
 
-	// Collect branch info.
-	branchInfo, err := s.readStore.GetBranch(r.Context(), repo, branch)
+	input, err := s.assembleMergeInput(r.Context(), repo, branch, actor, owners)
 	if err != nil {
+		slog.Error("assemble merge input error", "op", "branch_status", "repo", repo, "branch", branch, "error", err)
 		writeError(w, http.StatusInternalServerError, "query failed")
 		return
 	}
-	if branchInfo == nil {
+	if input == nil {
 		writeError(w, http.StatusNotFound, "branch not found")
 		return
 	}
 
-	// Collect changed paths.
-	diff, err := s.readStore.GetDiff(r.Context(), repo, branch)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "query failed")
-		return
-	}
-	var paths []string
-	if diff != nil {
-		for _, e := range diff.BranchChanges {
-			paths = append(paths, e.Path)
-		}
-	}
-
-	// Collect reviews and check runs at current head.
-	reviews, err := s.commitStore.ListReviews(r.Context(), repo, branch, &branchInfo.HeadSequence)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "query failed")
-		return
-	}
-	checkRuns, err := s.commitStore.ListCheckRuns(r.Context(), repo, branch, &branchInfo.HeadSequence)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "query failed")
-		return
-	}
-
-	// Actor role.
-	roleStr := ""
-	if role, err := s.commitStore.GetRole(r.Context(), repo, actor); err == nil && role != nil {
-		roleStr = string(role.Role)
-	}
-
-	reviewInputs := make([]policy.ReviewInput, len(reviews))
-	for i, rev := range reviews {
-		reviewInputs[i] = policy.ReviewInput{
-			Reviewer: rev.Reviewer,
-			Status:   string(rev.Status),
-			Sequence: rev.Sequence,
-		}
-	}
-	checkInputs := make([]policy.CheckRunInput, len(checkRuns))
-	for i, cr := range checkRuns {
-		checkInputs[i] = policy.CheckRunInput{
-			CheckName: cr.CheckName,
-			Status:    string(cr.Status),
-			Sequence:  cr.Sequence,
-		}
-	}
-
-	input := policy.Input{
-		Actor:     actor,
-		Role:      roleStr,
-		Paths:     paths,
-		Reviews:   reviewInputs,
-		CheckRuns: checkInputs,
-		Owners:    owners,
-		Branch:    branch,
-		HeadSeq:   branchInfo.HeadSequence,
-		BaseSeq:   branchInfo.BaseSequence,
-	}
-
-	results, err := engine.Evaluate(r.Context(), input)
+	results, err := engine.Evaluate(r.Context(), *input)
 	if err != nil {
 		slog.Error("policy evaluation error", "op", "branch_status", "repo", repo, "branch", branch, "error", err)
 		writeError(w, http.StatusInternalServerError, "policy evaluation error")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,25 @@ import (
 	"github.com/dlorenc/docstore/internal/store"
 )
 
+// readStore is the interface for all read operations used by handlers.
+// *store.Store satisfies this interface.
+type readStore interface {
+	MaterializeTree(ctx context.Context, repo, branch string, atSeq *int64, limit int, afterPath string) ([]store.TreeEntry, error)
+	GetFile(ctx context.Context, repo, branch, path string, atSeq *int64) (*store.FileContent, error)
+	GetFileHistory(ctx context.Context, repo, branch, path string, limit int, afterSeq *int64) ([]store.FileHistoryEntry, error)
+	GetBranch(ctx context.Context, repo, branch string) (*store.BranchInfo, error)
+	ListBranches(ctx context.Context, repo, statusFilter string) ([]store.BranchInfo, error)
+	GetDiff(ctx context.Context, repo, branch string) (*store.DiffResult, error)
+	GetCommit(ctx context.Context, repo string, seq int64) (*store.CommitDetail, error)
+}
+
+// policyCache is the interface for loading and invalidating OPA policy engines.
+// *policy.Cache satisfies this interface.
+type policyCache interface {
+	Load(ctx context.Context, repo string, st policy.ReadStore) (*policy.Engine, map[string][]string, error)
+	Invalidate(repo string)
+}
+
 // WriteStore abstracts the database write, repo management, and role operations.
 type WriteStore interface {
 	// Org management
@@ -66,7 +85,13 @@ func New(writeStore WriteStore, database *sql.DB, devIdentity, bootstrapAdmin st
 	if database != nil {
 		s.readStore = store.New(database)
 	}
+	return s.buildHandler(devIdentity, bootstrapAdmin, writeStore)
+}
 
+// buildHandler wires up all routes and middleware for the given server.
+// Extracted so tests can construct a server with injected dependencies and still
+// get the full middleware stack.
+func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore WriteStore) http.Handler {
 	// Health check is exempt from auth — load balancers and probes call it.
 	outer := http.NewServeMux()
 	outer.HandleFunc("GET /healthz", handleHealth)
@@ -104,8 +129,8 @@ func New(writeStore WriteStore, database *sql.DB, devIdentity, bootstrapAdmin st
 
 type server struct {
 	commitStore CommitStore
-	readStore   *store.Store
-	policyCache *policy.Cache
+	readStore   readStore
+	policyCache policyCache
 }
 
 func (s *server) handleCommit(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/policy"
+	"github.com/dlorenc/docstore/internal/store"
 )
 
 // mockStore implements WriteStore for testing.
@@ -1794,5 +1796,453 @@ func TestHandleFileHistory_InvalidAfter(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mock readStore and policyCache for policy handler tests
+// ---------------------------------------------------------------------------
+
+// mockReadStore implements the readStore interface for testing.
+type mockReadStore struct {
+	getBranchFn      func(ctx context.Context, repo, branch string) (*store.BranchInfo, error)
+	getDiffFn        func(ctx context.Context, repo, branch string) (*store.DiffResult, error)
+	materializeTreeFn func(ctx context.Context, repo, branch string, atSeq *int64, limit int, afterPath string) ([]store.TreeEntry, error)
+	getFileFn         func(ctx context.Context, repo, branch, path string, atSeq *int64) (*store.FileContent, error)
+	getFileHistoryFn  func(ctx context.Context, repo, branch, path string, limit int, afterSeq *int64) ([]store.FileHistoryEntry, error)
+	listBranchesFn    func(ctx context.Context, repo, statusFilter string) ([]store.BranchInfo, error)
+	getCommitFn       func(ctx context.Context, repo string, seq int64) (*store.CommitDetail, error)
+}
+
+func (m *mockReadStore) GetBranch(ctx context.Context, repo, branch string) (*store.BranchInfo, error) {
+	if m.getBranchFn != nil {
+		return m.getBranchFn(ctx, repo, branch)
+	}
+	return &store.BranchInfo{Name: branch, HeadSequence: 1, BaseSequence: 0, Status: "active"}, nil
+}
+
+func (m *mockReadStore) GetDiff(ctx context.Context, repo, branch string) (*store.DiffResult, error) {
+	if m.getDiffFn != nil {
+		return m.getDiffFn(ctx, repo, branch)
+	}
+	return &store.DiffResult{}, nil
+}
+
+func (m *mockReadStore) MaterializeTree(ctx context.Context, repo, branch string, atSeq *int64, limit int, afterPath string) ([]store.TreeEntry, error) {
+	if m.materializeTreeFn != nil {
+		return m.materializeTreeFn(ctx, repo, branch, atSeq, limit, afterPath)
+	}
+	return nil, nil
+}
+
+func (m *mockReadStore) GetFile(ctx context.Context, repo, branch, path string, atSeq *int64) (*store.FileContent, error) {
+	if m.getFileFn != nil {
+		return m.getFileFn(ctx, repo, branch, path, atSeq)
+	}
+	return nil, nil
+}
+
+func (m *mockReadStore) GetFileHistory(ctx context.Context, repo, branch, path string, limit int, afterSeq *int64) ([]store.FileHistoryEntry, error) {
+	if m.getFileHistoryFn != nil {
+		return m.getFileHistoryFn(ctx, repo, branch, path, limit, afterSeq)
+	}
+	return nil, nil
+}
+
+func (m *mockReadStore) ListBranches(ctx context.Context, repo, statusFilter string) ([]store.BranchInfo, error) {
+	if m.listBranchesFn != nil {
+		return m.listBranchesFn(ctx, repo, statusFilter)
+	}
+	return nil, nil
+}
+
+func (m *mockReadStore) GetCommit(ctx context.Context, repo string, seq int64) (*store.CommitDetail, error) {
+	if m.getCommitFn != nil {
+		return m.getCommitFn(ctx, repo, seq)
+	}
+	return nil, nil
+}
+
+// mockPolicyCache implements the policyCache interface for testing.
+type mockPolicyCache struct {
+	loadFn       func(ctx context.Context, repo string, st policy.ReadStore) (*policy.Engine, map[string][]string, error)
+	invalidateFn func(repo string)
+	invalidated  []string
+}
+
+func (m *mockPolicyCache) Load(ctx context.Context, repo string, st policy.ReadStore) (*policy.Engine, map[string][]string, error) {
+	if m.loadFn != nil {
+		return m.loadFn(ctx, repo, st)
+	}
+	return nil, nil, nil
+}
+
+func (m *mockPolicyCache) Invalidate(repo string) {
+	m.invalidated = append(m.invalidated, repo)
+	if m.invalidateFn != nil {
+		m.invalidateFn(repo)
+	}
+}
+
+// newTestHandler creates an http.Handler using injected stores and policy cache.
+// Used for handler-level policy tests that need custom readStore/policyCache.
+func newTestHandler(ws WriteStore, rs readStore, pc policyCache) http.Handler {
+	s := &server{
+		commitStore: ws,
+		readStore:   rs,
+		policyCache: pc,
+	}
+	return s.buildHandler(devID, devID, ws)
+}
+
+// mustBuildEngine compiles a test OPA policy and panics on error.
+func mustBuildEngine(t *testing.T, name, src string) *policy.Engine {
+	t.Helper()
+	engine, err := policy.NewEngine(context.Background(), map[string]string{
+		".docstore/policy/" + name + ".rego": src,
+	})
+	if err != nil {
+		t.Fatalf("compile policy: %v", err)
+	}
+	return engine
+}
+
+// ---------------------------------------------------------------------------
+// Handler policy tests
+// ---------------------------------------------------------------------------
+
+// TestHandleMerge_PolicyDeny verifies that a deny policy results in a 403.
+func TestHandleMerge_PolicyDeny(t *testing.T) {
+	engine := mustBuildEngine(t, "require_review", `
+package docstore.require_review
+default allow = false
+default reason = "a review is required"
+`)
+
+	ms := &mockStore{
+		mergeFn: func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
+			t.Fatal("merge should not be called when policy denies")
+			return nil, nil, nil
+		},
+		listReviewsFn:   func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error) { return nil, nil },
+		listCheckRunsFn: func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error) { return nil, nil },
+	}
+	pc := &mockPolicyCache{
+		loadFn: func(ctx context.Context, repo string, _ policy.ReadStore) (*policy.Engine, map[string][]string, error) {
+			return engine, nil, nil
+		},
+	}
+	rs := &mockReadStore{}
+
+	srv := newTestHandler(ms, rs, pc)
+
+	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/test"})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/merge", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.MergePolicyError
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Policies) != 1 {
+		t.Fatalf("expected 1 policy result, got %d", len(resp.Policies))
+	}
+	if resp.Policies[0].Pass {
+		t.Error("expected policy to fail")
+	}
+}
+
+// TestHandleMerge_PolicyAllow verifies that an allowing policy lets the merge proceed.
+func TestHandleMerge_PolicyAllow(t *testing.T) {
+	engine := mustBuildEngine(t, "always_allow", `
+package docstore.always_allow
+default allow = true
+`)
+
+	ms := &mockStore{
+		mergeFn: func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
+			return &model.MergeResponse{Sequence: 5}, nil, nil
+		},
+		listReviewsFn:   func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error) { return nil, nil },
+		listCheckRunsFn: func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error) { return nil, nil },
+	}
+	pc := &mockPolicyCache{
+		loadFn: func(ctx context.Context, repo string, _ policy.ReadStore) (*policy.Engine, map[string][]string, error) {
+			return engine, nil, nil
+		},
+	}
+	rs := &mockReadStore{}
+
+	srv := newTestHandler(ms, rs, pc)
+
+	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/test"})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/merge", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleMerge_Bootstrap verifies that with no policies (nil engine) the merge proceeds normally.
+func TestHandleMerge_Bootstrap(t *testing.T) {
+	merged := false
+	ms := &mockStore{
+		mergeFn: func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
+			merged = true
+			return &model.MergeResponse{Sequence: 1}, nil, nil
+		},
+	}
+	// policyCache returns nil engine (bootstrap mode — no .rego files)
+	pc := &mockPolicyCache{
+		loadFn: func(ctx context.Context, repo string, _ policy.ReadStore) (*policy.Engine, map[string][]string, error) {
+			return nil, nil, nil
+		},
+	}
+	rs := &mockReadStore{}
+
+	srv := newTestHandler(ms, rs, pc)
+
+	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/test"})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/merge", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	if !merged {
+		t.Error("expected merge to be called in bootstrap mode")
+	}
+}
+
+// TestHandleBranchStatus_NotMergeable verifies that a denying policy gives {mergeable:false}.
+func TestHandleBranchStatus_NotMergeable(t *testing.T) {
+	engine := mustBuildEngine(t, "require_review", `
+package docstore.require_review
+default allow = false
+default reason = "a review is required"
+`)
+
+	ms := &mockStore{
+		listReviewsFn:   func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error) { return nil, nil },
+		listCheckRunsFn: func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error) { return nil, nil },
+	}
+	pc := &mockPolicyCache{
+		loadFn: func(ctx context.Context, repo string, _ policy.ReadStore) (*policy.Engine, map[string][]string, error) {
+			return engine, nil, nil
+		},
+	}
+	rs := &mockReadStore{}
+
+	srv := newTestHandler(ms, rs, pc)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/feature/x/status", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.BranchStatusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Mergeable {
+		t.Error("expected mergeable=false")
+	}
+	if len(resp.Policies) != 1 || resp.Policies[0].Pass {
+		t.Errorf("expected 1 failing policy, got: %+v", resp.Policies)
+	}
+}
+
+// TestHandleBranchStatus_Mergeable verifies that an allowing policy gives {mergeable:true}.
+func TestHandleBranchStatus_Mergeable(t *testing.T) {
+	engine := mustBuildEngine(t, "always_allow", `
+package docstore.always_allow
+default allow = true
+`)
+
+	ms := &mockStore{
+		listReviewsFn:   func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error) { return nil, nil },
+		listCheckRunsFn: func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error) { return nil, nil },
+	}
+	pc := &mockPolicyCache{
+		loadFn: func(ctx context.Context, repo string, _ policy.ReadStore) (*policy.Engine, map[string][]string, error) {
+			return engine, nil, nil
+		},
+	}
+	rs := &mockReadStore{}
+
+	srv := newTestHandler(ms, rs, pc)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/feature/x/status", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.BranchStatusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Mergeable {
+		t.Errorf("expected mergeable=true, policies: %+v", resp.Policies)
+	}
+}
+
+// TestHandleMerge_StaleReview_Excluded verifies that when the handler calls
+// ListReviews with headSeq, only reviews at that sequence are passed to policy.
+// A stale review (seq < headSeq) results in no eligible reviews, so a
+// require-review policy denies the merge.
+func TestHandleMerge_StaleReview_Excluded(t *testing.T) {
+	engine := mustBuildEngine(t, "require_review", `
+package docstore.require_review
+default allow = false
+default reason = "at least one approval required"
+
+allow if {
+    count(input.reviews) > 0
+    input.reviews[_].status == "approved"
+}
+`)
+
+	const headSeq int64 = 5
+	ms := &mockStore{
+		mergeFn: func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
+			t.Fatal("merge should not be called when policy denies")
+			return nil, nil, nil
+		},
+		// ListReviews is called with atSeq=headSeq; the stale review at seq=3
+		// is filtered out by the DB (simulated here by returning empty).
+		listReviewsFn: func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error) {
+			if atSeq == nil || *atSeq != headSeq {
+				t.Errorf("expected ListReviews called with atSeq=%d, got %v", headSeq, atSeq)
+			}
+			// No review at head sequence — the stale review (seq=3) is not returned.
+			return []model.Review{}, nil
+		},
+		listCheckRunsFn: func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error) {
+			return nil, nil
+		},
+	}
+	pc := &mockPolicyCache{
+		loadFn: func(ctx context.Context, repo string, _ policy.ReadStore) (*policy.Engine, map[string][]string, error) {
+			return engine, nil, nil
+		},
+	}
+	rs := &mockReadStore{
+		getBranchFn: func(ctx context.Context, repo, branch string) (*store.BranchInfo, error) {
+			return &store.BranchInfo{Name: branch, HeadSequence: headSeq, BaseSequence: 0, Status: "active"}, nil
+		},
+	}
+
+	srv := newTestHandler(ms, rs, pc)
+
+	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/x"})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/merge", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 (policy deny, no eligible reviews), got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.MergePolicyError
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Policies) == 0 || resp.Policies[0].Pass {
+		t.Errorf("expected policy deny, got: %+v", resp.Policies)
+	}
+}
+
+// TestHandleBranchStatus_NoSideEffects verifies that GET .../status does not
+// write to any DB table.
+func TestHandleBranchStatus_NoSideEffects(t *testing.T) {
+	engine := mustBuildEngine(t, "always_allow", `
+package docstore.always_allow
+default allow = true
+`)
+
+	writeCallCount := 0
+	writeDetector := func() {
+		writeCallCount++
+		t.Errorf("unexpected write operation called during branch status")
+	}
+
+	ms := &mockStore{
+		// Write operations that must NOT be called:
+		commitFn: func(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
+			writeDetector()
+			return nil, nil
+		},
+		createBranchFn: func(ctx context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error) {
+			writeDetector()
+			return nil, nil
+		},
+		mergeFn: func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
+			writeDetector()
+			return nil, nil, nil
+		},
+		deleteBranchFn: func(ctx context.Context, repo, name string) error {
+			writeDetector()
+			return nil
+		},
+		rebaseFn: func(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []db.MergeConflict, error) {
+			writeDetector()
+			return nil, nil, nil
+		},
+		createReviewFn: func(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error) {
+			writeDetector()
+			return nil, nil
+		},
+		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string) (*model.CheckRun, error) {
+			writeDetector()
+			return nil, nil
+		},
+		setRoleFn: func(ctx context.Context, repo, identity string, role model.RoleType) error {
+			writeDetector()
+			return nil
+		},
+		deleteRoleFn: func(ctx context.Context, repo, identity string) error {
+			writeDetector()
+			return nil
+		},
+		purgeFn: func(ctx context.Context, req db.PurgeRequest) (*db.PurgeResult, error) {
+			writeDetector()
+			return nil, nil
+		},
+		// Read operations that may be called:
+		listReviewsFn:   func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error) { return nil, nil },
+		listCheckRunsFn: func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error) { return nil, nil },
+	}
+	pc := &mockPolicyCache{
+		loadFn: func(ctx context.Context, repo string, _ policy.ReadStore) (*policy.Engine, map[string][]string, error) {
+			return engine, nil, nil
+		},
+	}
+	rs := &mockReadStore{}
+
+	srv := newTestHandler(ms, rs, pc)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/feature/x/status", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	if writeCallCount != 0 {
+		t.Errorf("branch status triggered %d write operation(s)", writeCallCount)
 	}
 }


### PR DESCRIPTION
## Summary

- **BUG-1**: Engine now queries `data.<package_path>.allow` per module (parsed from AST) instead of hardcoded `data.policy.allow`. Policies must use `package docstore.<name>`; name is derived from the package path's last segment.
- **BUG-2**: `Input` struct corrected: `Role string` → `ActorRoles []string`, `Paths []string` → `ChangedPaths []string`; added `Action string` ("merge") and `Repo string`. Handlers updated accordingly.
- **BUG-3**: `ResolveOwners(ownersMap, filePath)` added to `owners.go` — longest-prefix match for OWNERS inheritance. `Input.Owners` is now a per-path resolved map (`input.owners["src/api.go"]` returns owners for that file).
- **OPA eval errors**: `evalPrepared` now returns errors instead of converting them to silent denies. Each evaluation is wrapped in a 5-second context timeout.
- **Code dedup**: Extracted `assembleMergeInput` shared helper (was duplicated between `evaluateMergePolicy` and `handleBranchStatus`). Stale review filtering is explicit: `ListReviews` is called with `headSeq`.
- **Missing tests**: All tests from the task spec added including `TestCachePerRepo`, `TestCacheInvalidatedAfterMerge`, `TestHandleMerge_PolicyDeny/Allow/Bootstrap`, `TestHandleBranchStatus_NotMergeable/Mergeable/NoSideEffects`, `TestHandleMerge_StaleReview_Excluded`.

## Test plan

- [x] `go test ./internal/policy/...` — all pass (26 tests including new ones)
- [x] `go test ./internal/server/... -short` — all pass (includes 7 new handler policy tests)
- [x] `go test ./... -short` — all packages pass
- [x] `go build ./...` and `go vet ./...` — clean
- Handler tests use injected `mockReadStore`/`mockPolicyCache` via new `buildHandler` helper; no Docker/DB required

## Internal changes enabling test injection

- `policy.Cache.Load` now accepts `policy.ReadStore` interface instead of `*store.Store`
- `server.readStore` and `server.policyCache` are now interface types
- `server.buildHandler` extracted from `New()` so tests can construct a server with custom stores

## Opportunities noted

- The `action` field is always "merge" for now; could be extended for other operations
- `ActorRoles` is always a single-element slice (wrapping the DB's one-role-per-identity model); the spec allows multiple roles for future flexibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)