### PR TITLE
Fix silently swallowed reason eval error; add missing test assertions

### DIFF
--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -155,7 +155,10 @@ func evalPrepared(ctx context.Context, p preparedPolicy, input Input) (model.Pol
 
 	// Denied — try to get the reason string.
 	reason := "policy denied"
-	reasonRs, _ := p.reasonPQ.Eval(ctx, rego.EvalInput(input))
+	reasonRs, err := p.reasonPQ.Eval(ctx, rego.EvalInput(input))
+	if err != nil {
+		return model.PolicyResult{}, fmt.Errorf("reason eval: %w", err)
+	}
 	if len(reasonRs) > 0 && len(reasonRs[0].Expressions) > 0 {
 		if r, ok := reasonRs[0].Expressions[0].Value.(string); ok && r != "" {
 			reason = r

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1988,6 +1988,9 @@ default allow = true
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
 	}
+	if len(pc.invalidated) == 0 || pc.invalidated[0] != "default/default" {
+		t.Errorf("expected policyCache.Invalidate called for repo, got: %v", pc.invalidated)
+	}
 }
 
 // TestHandleMerge_Bootstrap verifies that with no policies (nil engine) the merge proceeds normally.
@@ -2244,5 +2247,8 @@ default allow = true
 	}
 	if writeCallCount != 0 {
 		t.Errorf("branch status triggered %d write operation(s)", writeCallCount)
+	}
+	if len(pc.invalidated) != 0 {
+		t.Errorf("expected no Invalidate calls from branch status, got: %v", pc.invalidated)
 	}
 }


### PR DESCRIPTION
## Summary

- `internal/policy/engine.go`: capture and return the error from `reasonPQ.Eval` instead of silently discarding it with `_`. Consistent with how `allowPQ.Eval` errors are handled.
- `internal/server/server_test.go`: add assertion in `TestHandleMerge_PolicyAllow` that `policyCache.Invalidate` was called with the correct repo after a successful merge.
- `internal/server/server_test.go`: add assertion in `TestHandleBranchStatus_NoSideEffects` that `policyCache.Invalidate` was never called (branch status is read-only).

## Test plan
- [x] `go test ./...` passes (all packages green)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)