### PR TITLE
Update documentation to reflect current codebase state

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,6 +24,7 @@ Eight tables. Documents and file_commits are append-only. Branches are mutable (
 | path | text | e.g. `src/main.py` |
 | content | blob | file contents |
 | content_hash | sha256 | dedup + integrity |
+| content_type | text | MIME type (nullable; set for binary files, omitted for text) |
 | created_at | timestamp | |
 | created_by | text | author |
 
@@ -135,43 +136,87 @@ Three layers control what an authenticated identity can do.
 
 ### Policy Evaluation
 
-Every write endpoint (`/commit`, `/merge`, `/review`, `/check`, `/branch`) assembles an input document and evaluates it before proceeding. The input document schema:
+`POST /merge` assembles an input document and evaluates it against all loaded policies before proceeding. The input document schema:
 
 ```json
 {
   "action": "merge",
   "actor": "alice@example.com",
   "actor_roles": ["maintainer"],
+  "repo": "acme/myrepo",
   "branch": "feature/new-api",
   "changed_paths": ["src/api.go", "src/api_test.go"],
   "reviews": [
     {"reviewer": "bob@example.com", "status": "approved", "sequence": 42}
   ],
   "check_runs": [
-    {"check_name": "ci/build", "status": "passed", "reporter": "ci-bot@project.iam.gserviceaccount.com"}
+    {"check_name": "ci/build", "status": "passed", "sequence": 42}
   ],
   "owners": {
-    "src/": ["bob@example.com", "carol@example.com"]
+    "src/api.go": ["bob@example.com", "carol@example.com"],
+    "src/api_test.go": ["bob@example.com", "carol@example.com"]
   },
-  "head_sequence": 42
+  "head_sequence": 42,
+  "base_sequence": 38
 }
 ```
 
-Fields vary by action — `reviews` and `check_runs` are only populated for `/merge`, `changed_paths` is populated for `/commit` and `/merge`, etc.
+Field notes:
+- `actor_roles` — slice of role strings (e.g. `["maintainer"]`); empty slice if the actor has no role.
+- `reviews` — only reviews matching the current `head_sequence` are included; stale reviews (from before the last commit) are filtered out automatically.
+- `check_runs` — same staleness rule as reviews; each entry has `check_name`, `status`, and `sequence`.
+- `owners` — keyed by **file path** (not directory); each entry is the resolved owner list for that file after inheritance. E.g. `input.owners["src/api.go"]` returns the owners covering that file.
+- `action` — currently always `"merge"`.
+
+Policy evaluation currently only occurs on `POST /merge` and `GET /branch/:name/status`.
+
+### Writing Policies
+
+Policies are Rego files stored at `.docstore/policy/*.rego` on `main`. Every policy **must** declare its package using the `package docstore.<name>` convention (e.g. `package docstore.require_review`). The policy name exposed in API responses is derived from the last segment of the package path.
+
+A minimal policy looks like:
+
+```rego
+package docstore.require_review
+
+import rego.v1
+
+default allow := false
+
+allow if {
+    some rev in input.reviews
+    rev.status == "approved"
+}
+
+reason := "at least one approval required"
+```
+
+- `allow` (bool) — required. Defaults to `false`.
+- `reason` (string) — optional. Returned in the denial message when `allow` is `false`.
+
+OPA v1 syntax is required (use `if` in rule bodies, `import rego.v1`).
 
 ### Policy Storage
 
 Policies live in `.docstore/policy/*.rego` files in the repo on `main`. They are versioned documents like any other file and go through the same branch/review/merge workflow. This means policy changes require review and approval just like code changes.
 
-The server loads policies from the materialized `main` tree and caches them in memory. Policies are reloaded whenever main's `head_sequence` advances (on commit or merge to main). This ensures policies are always fresh with no staleness window, at the cost of a small reload on each main write.
+The server loads policies from the materialized `main` tree into a per-repo in-memory cache. The cache is invalidated whenever main's `head_sequence` advances (on a direct commit to main or a successful merge). This ensures policies stay fresh at the cost of a small reload on each main write.
 
-The bootstrap/fallback policy (used when no `.docstore/policy/*.rego` files exist) is wide open — all authenticated users can perform all actions, subject only to role checks in Layer 2. Policies are purely additive restrictions. This allows initial setup without a chicken-and-egg problem; the first policy commit then locks things down.
+The bootstrap mode (used when no `.docstore/policy/*.rego` files exist on main) allows all merges — only Layer 2 role checks apply. Policies are purely additive restrictions. This avoids the chicken-and-egg problem of needing a policy review to land the first policy.
 
 ### OWNERS Files
 
-`OWNERS` files are regular versioned documents that can exist at any directory level. Each contains a list of identities authorized to approve changes under that path. Ownership is inherited — a file at `src/OWNERS` covers `src/` and all subdirectories unless overridden by a more specific `OWNERS` file.
+`OWNERS` files are regular versioned documents at any directory level. Format: one identity per line; lines starting with `#` are comments; blank lines are ignored.
 
-At policy evaluation time, the engine reads OWNERS from the materialized `main` tree and builds the `owners` map in the input document. Policies can then require that at least one reviewer is a listed owner for each changed path.
+```
+# src/OWNERS
+alice@example.com
+bob@example.com
+```
+
+Ownership is inherited by longest-prefix match. If `src/pkg/OWNERS` exists, it takes precedence over `src/OWNERS` for files under `src/pkg/`. If no `OWNERS` file covers a path, the root `OWNERS` (if any) is used as a fallback; if there is no root `OWNERS`, `input.owners["path"]` is `null` for that file.
+
+At policy evaluation time, the engine reads all OWNERS files from the materialized `main` tree, builds the directory→owners map, then resolves each changed path to its effective owners. The result is placed in `input.owners` keyed by file path (not directory). Policies can then require that at least one reviewer is listed in the owners for each changed path.
 
 ## API
 
@@ -246,11 +291,11 @@ The pattern is `/repos/{full-repo-name}/-/{endpoint}`. The full repo name may co
 
 ### Repo-scoped writes
 
-`POST /repos/{name}/-/commit` — Commit one or more file changes atomically. Body: `{branch, files: [{path, content}], message}`. Policy-evaluated: the engine checks the actor's role and the target branch (e.g., direct commits to `main` can be blocked by policy). Allocates a single sequence number, writes one row to commits and one row per file to file_commits (all referencing that sequence), advances the branch head.
+`POST /repos/{name}/-/commit` — Commit one or more file changes atomically. Body: `{branch, files: [{path, content, content_type?}], message}`. The optional `content_type` field per file stores the MIME type (set automatically by the CLI for binary files; text files omit it). Policy-evaluated: the engine checks the actor's role and the target branch (e.g., direct commits to `main` can be blocked by policy). Allocates a single sequence number, writes one row to commits and one row per file to file_commits (all referencing that sequence), advances the branch head.
 
 `POST /repos/{name}/-/branch` — Create a branch. Body: `{name}`. Policy-evaluated. Sets `base_sequence` to main's current head.
 
-`POST /repos/{name}/-/merge` — Merge a branch into main. Body: `{branch}`. Policy-evaluated: the engine evaluates all merge policies (required reviews, passing checks, OWNERS approval) before proceeding. On policy failure, returns `{policies: [{name, pass, reason}]}` with a 403. **Staleness rule**: the server only includes reviews and check_runs whose `sequence` matches the branch's current `head_sequence` in the policy input. Any new commit to the branch advances `head_sequence`, which automatically invalidates all prior reviews and checks — policies see an empty list until the branch is re-reviewed and re-checked at the new head. The merge uses `base_sequence` from the branches table as the fork point:
+`POST /repos/{name}/-/merge` — Merge a branch into main. Body: `{branch}`. Policy-evaluated: the engine evaluates all merge policies (required reviews, passing checks, OWNERS approval) before proceeding. On policy failure, returns `{"policies": [{name, pass, reason}]}` with a `403`. On merge conflicts, returns `{"conflicts": [...]}` with a `409`. **Staleness rule**: the server only includes reviews and check_runs whose `sequence` matches the branch's current `head_sequence` in the policy input. Any new commit to the branch advances `head_sequence`, which automatically invalidates all prior reviews and checks — policies see an empty list until the branch is re-reviewed and re-checked at the new head. The merge uses `base_sequence` from the branches table as the fork point:
 
 1. **Branch changes**: find the latest version of each path changed on the branch since `base_sequence` (`WHERE branch = :branch AND sequence > :base_sequence`, `DISTINCT ON (path) ... ORDER BY path, sequence DESC`).
 2. **Main changes**: find the latest version of each path changed on main since `base_sequence` (same query shape against `branch = 'main'`).
@@ -272,8 +317,9 @@ The pattern is `/repos/{full-repo-name}/-/{endpoint}`. The full repo name may co
 A CLI that wraps the API. Working directory tracked via a `.docstore` config file containing the remote URL, repo name, and current branch.
 
 ```
-ds init <remote-url>
-ds checkout -b <branch>      # POST /repos/{repo}/-/branch
+# Workspace commands
+ds init [<remote-url>]        # initialize a workspace; URL optional if compiled-in default exists
+ds checkout -b <branch>       # POST /repos/{repo}/-/branch
 ds status                     # diff local fs against GET /repos/{repo}/-/tree
 ds commit -m "message"        # POST /repos/{repo}/-/commit with all changed files atomically
 ds log [path]                 # GET /repos/{repo}/-/file/:path/history or full branch log
@@ -283,9 +329,34 @@ ds rebase                     # POST /repos/{repo}/-/rebase
 ds pull                       # fetch latest tree for current branch, update local files
 ds checkout main              # switch branch, GET /repos/{repo}/-/tree to update local files
 ds show <sequence> [path]     # GET /repos/{repo}/-/commit/:seq or GET /repos/{repo}/-/file/:path?at=N
+
+# Review and CI workflow
+ds branches [--status active|merged|abandoned]         # list branches
+ds reviews [--branch <name>]                           # list reviews with stale indicators
+ds review --status approved|rejected [--body "..."] [--branch <name>]  # submit review
+ds checks [--branch <name>]                            # list check runs with stale indicators
+ds check --name <n> --status passed|failed [--branch <name>]           # report CI result
+
+# Terminal UI
+ds tui                        # Bubble Tea TUI with branch list, diff/review/check panels, inline merge
+
+# Import
+ds import-git <path> [--mode squash|replay]            # import a local git repo into docstore main
+
+# Org/repo/role management (no workspace required)
+ds orgs                       # list orgs
+ds orgs create <name>         # create an org
+ds orgs delete <name>         # delete an org
+ds orgs repos <name>          # list repos in an org
+ds repos                      # list all repos
+ds repos create <owner> <name># create a repo
+ds repos delete <name>        # delete a repo (full name, e.g. acme/myrepo)
+ds roles                      # list roles in current repo
+ds roles set <identity> <role># grant or update a role
+ds roles delete <identity>    # remove a role
 ```
 
-The CLI stores the base server URL and repo name (e.g. `default/default`) separately in `.docstore/config.json`. The `ds init` command accepts the repo name either embedded in the URL (`https://host/repos/acme/myrepo`) or via the `--repo` flag. The default repo is `default/default`.
+The CLI stores the base server URL and repo name (e.g. `default/default`) separately in `.docstore/config.json`. The `ds init` command accepts the repo name either embedded in the URL (`https://host/repos/acme/myrepo`) or via the `--repo` flag. The default repo is `default/default`. When `make build-ds` is used, a default remote URL is compiled in via `-ldflags`, allowing `ds init` to be called with no URL argument.
 
 **`ds pull` flow**:
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -212,6 +212,108 @@ curl -X PUT https://docstore.example.com/repos/acme/myrepo/-/roles/alice@example
 
 ---
 
+## OPA Policy Engine
+
+DocStore embeds [Open Policy Agent](https://www.openpolicyagent.org/) for fine-grained merge access control. Policies are Rego files stored in the repo itself under `.docstore/policy/`.
+
+### Writing Policies
+
+Every policy file must:
+1. Use `package docstore.<name>` (e.g. `package docstore.require_review`)
+2. Define a boolean `allow` rule (defaults to `false`)
+3. Optionally define a `reason` string rule for denial messages
+
+Use OPA v1 syntax (`import rego.v1`; `allow if { ... }`).
+
+**Example — require at least one approval:**
+
+```rego
+package docstore.require_review
+
+import rego.v1
+
+default allow := false
+
+allow if {
+    some rev in input.reviews
+    rev.status == "approved"
+}
+
+reason := "at least one review approval required before merging"
+```
+
+**Example — require a passing CI check:**
+
+```rego
+package docstore.require_ci
+
+import rego.v1
+
+default allow := false
+
+allow if {
+    some cr in input.check_runs
+    cr.check_name == "ci/build"
+    cr.status == "passed"
+}
+
+reason := "ci/build must pass before merging"
+```
+
+### Policy Input Schema
+
+On `POST /merge` (and `GET /branch/:name/status`), the server passes this input to every policy:
+
+```json
+{
+  "action": "merge",
+  "actor": "alice@example.com",
+  "actor_roles": ["maintainer"],
+  "repo": "acme/myrepo",
+  "branch": "feature/new-api",
+  "changed_paths": ["src/api.go", "src/api_test.go"],
+  "reviews": [
+    {"reviewer": "bob@example.com", "status": "approved", "sequence": 42}
+  ],
+  "check_runs": [
+    {"check_name": "ci/build", "status": "passed", "sequence": 42}
+  ],
+  "owners": {
+    "src/api.go": ["bob@example.com", "carol@example.com"],
+    "src/api_test.go": ["bob@example.com", "carol@example.com"]
+  },
+  "head_sequence": 42,
+  "base_sequence": 38
+}
+```
+
+- `reviews` and `check_runs` include **only current-head** entries; stale entries (from before the latest commit) are excluded automatically.
+- `owners` is keyed by file path. The server resolves each changed path to its effective owners via longest-prefix directory matching.
+
+### Bootstrap Mode
+
+When no `.docstore/policy/*.rego` files exist on `main`, all merges are permitted (subject only to role checks). This avoids a chicken-and-egg setup problem. Once the first policy file is committed, it takes effect immediately.
+
+### Cache Invalidation
+
+The server caches compiled policies and OWNERS maps per repo. The cache is invalidated after:
+- A successful `POST /merge` to main
+- A `POST /commit` that targets `main` directly
+
+### OWNERS Files
+
+`OWNERS` files live at any directory level in the repo. Format: one identity per line; `#` starts a comment; blank lines are ignored.
+
+```
+# src/OWNERS
+alice@example.com
+bob@example.com
+```
+
+Inheritance works by longest-prefix match: `src/pkg/OWNERS` takes precedence over `src/OWNERS` for files under `src/pkg/`. The root `OWNERS` (at repo root) is the fallback for all unmatched paths.
+
+---
+
 ## API Reference
 
 All endpoints (except `/healthz`) require authentication. Errors are returned as:
@@ -474,12 +576,14 @@ Commit one or more file changes to a branch.
   "message": "update access control docs",
   "files": [
     {"path": "docs/guide.md", "content": "<base64-encoded bytes>"},
+    {"path": "images/logo.png", "content": "<base64-encoded bytes>", "content_type": "image/png"},
     {"path": "old-file.txt"}
   ]
 }
 ```
 
 - `content` is the raw file bytes encoded as base64 (standard JSON encoding of `[]byte`)
+- `content_type` (optional) — MIME type for the file; omit for plain text files. The CLI sets this automatically for detected binary files.
 - A file entry with no `content` field (or `null`) is a **delete**
 - `author` in the request body is ignored; the server uses the IAP-authenticated identity
 
@@ -563,9 +667,12 @@ Get the content of a file on a branch at an optional sequence.
   "path": "docs/guide.md",
   "version_id": "<uuid>",
   "content_hash": "<sha256-hex>",
-  "content": "<base64-encoded bytes>"
+  "content": "<base64-encoded bytes>",
+  "content_type": "image/png"
 }
 ```
+
+- `content_type` is omitted when the file has no stored MIME type (i.e. plain text files).
 
 **Errors:** `404 Not Found`.
 
@@ -609,6 +716,7 @@ Compare a branch against its base sequence on `main`, showing what changed on ea
 {
   "branch_changes": [
     {"path": "docs/guide.md", "version_id": "<uuid>"},
+    {"path": "images/logo.png", "version_id": "<uuid>", "binary": true},
     {"path": "old-file.txt", "version_id": null}
   ],
   "main_changes": [
@@ -625,6 +733,7 @@ Compare a branch against its base sequence on `main`, showing what changed on ea
 ```
 
 - `version_id: null` means the file was deleted on that side
+- `binary: true` is set for files that have a stored `content_type` (omitted for text files)
 - `conflicts` is omitted when empty
 
 **Errors:** `400 Bad Request` (missing branch); `404 Not Found` (branch).
@@ -649,6 +758,15 @@ Merge a branch into `main`. Cannot merge `main` into itself.
 {"sequence": 46}
 ```
 
+**Response `403 Forbidden` (policy denied):**
+```json
+{
+  "policies": [
+    {"name": "require_review", "pass": false, "reason": "at least one approval required"}
+  ]
+}
+```
+
 **Response `409 Conflict` (merge conflicts):**
 ```json
 {
@@ -662,7 +780,7 @@ Merge a branch into `main`. Cannot merge `main` into itself.
 }
 ```
 
-**Errors:** `404 Not Found` (branch); `409 Conflict` (branch not active, or conflicts).
+**Errors:** `404 Not Found` (branch); `403 Forbidden` (policy denied); `409 Conflict` (branch not active, or conflicts).
 
 **RBAC:** maintainer or admin.
 
@@ -866,11 +984,28 @@ Remove an identity's role from the repo.
 
 ---
 
-### Branch Status (Not Implemented)
+### Branch Status
 
 #### `GET /repos/{name}/-/branch/{bname}/status`
 
-Returns `501 Not Implemented`. Intended for future policy evaluation (OPA integration).
+Evaluate all merge policies for a branch without actually merging. Useful for CI gates and UI indicators.
+
+**Response `200 OK`:**
+```json
+{
+  "mergeable": true,
+  "policies": [
+    {"name": "require_review", "pass": true, "reason": ""},
+    {"name": "require_ci",     "pass": true, "reason": ""}
+  ]
+}
+```
+
+- `mergeable` — `true` if all policies pass (or no policies are defined)
+- `policies` — one entry per loaded policy; empty array when in bootstrap mode
+- `reason` — human-readable denial reason when `pass` is `false`; empty string otherwise
+
+**RBAC:** reader or above.
 
 ---
 
@@ -950,6 +1085,7 @@ Immutable, content-addressed file versions. Identical content is stored once per
 | `path`         | `TEXT`       | File path (as stored in the commit)            |
 | `content`      | `BYTEA`      | Raw file bytes                                 |
 | `content_hash` | `TEXT`       | SHA256 hex digest of `content`                 |
+| `content_type` | `TEXT`       | MIME type (nullable; set for binary files)     |
 | `created_at`   | `TIMESTAMPTZ`|                                                |
 | `created_by`   | `TEXT`       | Identity                                       |
 | `repo`         | `TEXT`       | FK → `repos.name`                             |
@@ -1072,3 +1208,99 @@ The server uses the standard `log/slog` package for structured JSON logging. All
      -d '{"role": "admin"}'
    ```
 10. Initialize a local workspace: `ds init https://<url>/repos/acme/myrepo`
+
+---
+
+## CLI Reference
+
+The `ds` CLI wraps the DocStore API. All workspace commands require a `.docstore/` directory (created by `ds init`). Org, repo, and role management commands work without a workspace when a default remote URL is compiled in.
+
+### Building the CLI
+
+```bash
+make build-ds   # produces bin/ds with the default Cloud Run URL baked in
+```
+
+To override the compiled-in URL:
+
+```bash
+DEFAULT_REMOTE=https://your-server.example.com make build-ds
+```
+
+### Workspace Commands
+
+| Command | Description |
+|---|---|
+| `ds init [<url>]` | Initialize a workspace. URL optional if compiled-in default exists. |
+| `ds status` | Show local changes vs last synced state. |
+| `ds commit -m "msg"` | Commit all local changes; binary files detected automatically. |
+| `ds checkout <branch>` | Switch to an existing branch (requires clean working tree). |
+| `ds checkout -b <branch>` | Create and switch to a new branch. |
+| `ds pull` | Sync local files from the current branch on the server. |
+| `ds merge` | Merge current branch into main. |
+| `ds rebase` | Rebase current branch onto latest main. |
+| `ds resolve <path>` | Mark a rebase conflict as resolved. |
+| `ds diff` | Show branch diff; binary files shown as `[binary]`. |
+| `ds log [path] [--limit N]` | Show commit history. |
+| `ds show <seq> [path]` | Inspect a commit or file at a sequence. |
+
+### Review and CI Workflow
+
+| Command | Description |
+|---|---|
+| `ds branches [--status active\|merged\|abandoned]` | List branches with head/base sequences. |
+| `ds reviews [--branch <name>]` | List reviews; stale reviews (before latest commit) shown with `[stale]`. |
+| `ds review --status approved\|rejected [--body "..."] [--branch <name>]` | Submit a review. |
+| `ds checks [--branch <name>]` | List CI check runs; stale checks shown with `[stale]`. |
+| `ds check --name <name> --status passed\|failed [--branch <name>]` | Report a CI check result. |
+
+### Terminal UI
+
+```bash
+ds tui
+```
+
+A Bubble Tea terminal UI with:
+- **Branch list view** — active branches with review and CI summary; `j`/`k` to navigate
+- **Branch detail view** — Diff / Reviews / Checks panels; cycle with `Tab`
+  - Diff panel: `+`/`~`/`-` file list; expand inline with `Enter`; binary files shown as `[binary]`
+  - Reviews panel: one-per-reviewer with stale indicators; approval summary
+  - Checks panel: check runs with stale indicators
+- **Review overlay** — Approve / Reject toggle + optional body; `Esc` to cancel
+- **Inline merge** — `y`/`N` prompt; surfaces conflicts on failure
+- `R` to refresh; `q` to go back / quit
+
+### Importing a Git Repository
+
+```bash
+ds import-git <path-to-local-git-repo> [--mode squash|replay]
+```
+
+Imports the default branch of a local git repository into the docstore `main` branch.
+
+- `replay` (default) — one docstore commit per git commit (merge commits skipped); original author embedded in the message as `[git-author: email]`
+- `squash` — single commit with all files at HEAD; message prefixed with `[git-import]`
+
+Binary files are detected automatically. Deleted files are handled correctly.
+
+### Org / Repo / Role Management
+
+These commands work without a local workspace. They read the compiled-in default remote or accept `--remote <url>`.
+
+```bash
+# Orgs
+ds orgs                           # list all orgs
+ds orgs create <name>             # create an org
+ds orgs delete <name>             # delete an org (fails if org has repos)
+ds orgs repos <name>              # list repos in an org
+
+# Repos
+ds repos                          # list all repos
+ds repos create <owner> <name>    # create a repo (owner = org name)
+ds repos delete <owner>/<name>    # delete a repo
+
+# Roles (require a workspace or --remote)
+ds roles                          # list roles in current repo
+ds roles set <identity> <role>    # set role (reader|writer|maintainer|admin)
+ds roles delete <identity>        # remove a role
+```

--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ ds init https://docstore.example.com/repos/myrepo --author alice@example.com
 
 ## CLI Reference
 
-### `ds init <remote-url> [--author <name>] [--repo <name>]`
+### `ds init [<remote-url>] [--author <name>] [--repo <name>]`
 
 Initialize a docstore workspace in the current directory.
 
-- `<remote-url>` — base server URL, optionally including the repo path (`https://host/repos/acme/myrepo`)
+- `<remote-url>` — base server URL, optionally including the repo path (`https://host/repos/acme/myrepo`). **Optional** when `make build-ds` was used — the default Cloud Run URL is compiled in.
 - `--author <name>` — identity to use for commits (defaults to OS username)
 - `--repo <name>` — full repo name `owner/name` (overrides any name embedded in the URL; defaults to `default/default`)
 
@@ -102,6 +102,9 @@ Creates `.docstore/config.json` and `.docstore/state.json`, then syncs files fro
 
 ```bash
 ds init https://docstore.example.com/repos/acme/docs --author jane@example.com
+
+# If built with make build-ds, the URL can be omitted:
+ds init --repo acme/docs
 ```
 
 ---
@@ -132,6 +135,8 @@ ds commit -m "update access control docs"
 ```
 
 The server assigns a monotonically increasing sequence number. The local state is updated after a successful commit so `ds status` shows clean.
+
+Binary files (images, PDFs, compiled assets, etc.) are detected automatically and committed with the appropriate `content_type` MIME type.
 
 ---
 
@@ -185,11 +190,12 @@ On success, switches the local workspace to `main` and syncs files. On conflict,
 
 ### `ds diff`
 
-Show what files changed on the current branch relative to its base, and what changed on `main` in the same window (potentially conflicting).
+Show what files changed on the current branch relative to its base, and what changed on `main` in the same window (potentially conflicting). Binary files are shown with a `[binary]` label instead of content.
 
 ```
 Changed files on 'feature/my-change':
   changed: docs/guide.md
+  changed: images/logo.png [binary]
   deleted: old-file.txt
 
 Changed files on main:
@@ -278,6 +284,104 @@ Repeat for each conflicting file, then continue with `ds rebase` or `ds merge`.
 
 ---
 
+### `ds branches [--status active|merged|abandoned]`
+
+List all branches with their head and base sequences.
+
+```bash
+ds branches
+ds branches --status active
+```
+
+---
+
+### `ds reviews [--branch <name>]`
+
+List reviews for the current branch (or `--branch <name>`). Stale reviews (before the latest commit) are marked `[stale]`.
+
+---
+
+### `ds review --status approved|rejected [--body "..."] [--branch <name>]`
+
+Submit a review for the current branch (or `--branch <name>`).
+
+```bash
+ds review --status approved
+ds review --status rejected --body "needs more tests"
+```
+
+A reviewer cannot approve their own commits.
+
+---
+
+### `ds checks [--branch <name>]`
+
+List CI check runs for the current branch. Stale checks are marked `[stale]`.
+
+---
+
+### `ds check --name <name> --status passed|failed [--branch <name>]`
+
+Report a CI check result.
+
+```bash
+ds check --name ci/build --status passed
+```
+
+---
+
+### `ds tui`
+
+Launch the Bubble Tea terminal UI for reviewing branches without leaving the terminal.
+
+- Branch list with review/CI summary columns; `j`/`k` to navigate
+- Branch detail panels: Diff / Reviews / Checks — cycle with `Tab`
+- Review overlay with Approve/Reject toggle; `Esc` to cancel
+- Inline merge prompt (`y`/`N`)
+- `R` to refresh; `q` to quit
+
+---
+
+### `ds import-git <path> [--mode squash|replay]`
+
+Import a local git repository's default branch into docstore `main`.
+
+- `replay` (default) — one docstore commit per git commit; original author embedded in message as `[git-author: email]`
+- `squash` — single commit with all files at HEAD
+
+```bash
+ds import-git /path/to/my-git-repo
+ds import-git /path/to/my-git-repo --mode squash
+```
+
+---
+
+### `ds orgs` / `ds repos` / `ds roles`
+
+Manage orgs, repos, and roles without a workspace. These commands use the compiled-in default remote or accept `--remote <url>`.
+
+```bash
+# Orgs
+ds orgs                          # list orgs
+ds orgs create acme              # create an org
+ds orgs delete acme              # delete an org
+ds orgs repos acme               # list repos in acme
+
+# Repos
+ds repos                         # list all repos
+ds repos create acme myrepo      # create acme/myrepo
+ds repos delete acme/myrepo      # delete acme/myrepo
+
+# Roles (require --remote or workspace context)
+ds roles                         # list roles in current repo
+ds roles set alice@example.com admin    # grant admin
+ds roles delete alice@example.com       # revoke role
+```
+
+Valid roles: `reader`, `writer`, `maintainer`, `admin`.
+
+---
+
 ## Branching and Merging
 
 DocStore uses a simple, linear branching model:
@@ -338,12 +442,15 @@ ds merge
 Repos live under orgs. An org must be created before a repo can be created in it.
 
 ```bash
-# Create an org
+# Using the CLI (recommended)
+ds orgs create acme
+ds repos create acme myrepo
+
+# Or via the API
 curl -X POST https://docstore.example.com/orgs \
   -H "Content-Type: application/json" \
   -d '{"name": "acme"}'
 
-# Create a repo in that org
 curl -X POST https://docstore.example.com/repos \
   -H "Content-Type: application/json" \
   -d '{"owner": "acme", "name": "myrepo"}'

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,9 +23,9 @@ Depends on P0 server being functional.
 - [x] **Roles table & RBAC middleware**: Role lookup, coarse-grained permission checks (reader/writer/maintainer/admin)
 - [x] **Review system**: `POST /repos/{repo}/-/review`, review storage, sequence-scoped approval tracking
 - [x] **Check runs**: `POST /repos/{repo}/-/check`, check status storage, reporter authorization
-- [ ] **OPA policy engine integration**: Embed OPA, load policies from `.docstore/policy/*.rego`, evaluate on all write endpoints
-- [ ] **OWNERS files**: Parse OWNERS from materialized main tree, build owners map for policy input
-- [ ] **Branch status endpoint**: `GET /repos/{repo}/-/branch/{name}/status` — evaluate merge policies without merging (currently returns 501)
+- [x] **OPA policy engine integration**: Embed OPA, load policies from `.docstore/policy/*.rego`, evaluate on `POST /merge`; package naming convention `package docstore.<name>`; bootstrap mode when no policies exist; cache invalidation on main writes
+- [x] **OWNERS files**: Parse OWNERS from materialized main tree, longest-prefix inheritance, per-path resolved owners in policy input
+- [x] **Branch status endpoint**: `GET /repos/{repo}/-/branch/{name}/status` — evaluate merge policies without merging; returns `{mergeable, policies[]}`
 
 ## P2 — CLI Client
 
@@ -36,3 +36,9 @@ Can be developed in parallel with P1.
 - [x] **Merge & rebase commands**: `merge`, `rebase`
 - [x] **Conflict resolution**: Write conflict files, `ds resolve` command
 - [x] **Local state management**: `.docstore/state.json`, local hash tracking for offline status
+- [x] **Review & CI workflow commands**: `ds branches`, `ds reviews`, `ds review`, `ds checks`, `ds check`
+- [x] **Terminal UI**: `ds tui` — Bubble Tea TUI with branch list, diff/review/check panels, inline merge
+- [x] **Binary file support**: Auto-detect binary files on commit; `content_type` stored; `[binary]` shown in diff; `binary` flag in diff API response
+- [x] **Git import**: `ds import-git <path> [--mode squash|replay]`
+- [x] **Org/repo/role CLI**: `ds orgs`, `ds repos`, `ds roles` subcommand groups with full CRUD
+- [x] **Default remote URL**: `make build-ds` bakes in Cloud Run URL via `-ldflags`; `ds init` works with no URL argument


### PR DESCRIPTION
## Summary

Documentation-only PR — no code changes. Updates all four main docs to reflect everything added since commit da20f38 (PR #50, the last doc update).

### What changed

**DESIGN.md**
- Corrected policy engine input schema: `actor_roles []string`, `changed_paths []string`, `action`, `repo`, `base_sequence`; `owners` keyed by file path (resolved per changed path); `check_runs` uses `{check_name, status, sequence}` not `reporter`
- Added "Writing Policies" section with `package docstore.<name>` convention and OPA v1 syntax examples
- Expanded policy storage section with cache invalidation details
- Expanded OWNERS section with format and longest-prefix inheritance rules
- `documents` table: added `content_type` column
- `POST /commit`: documented optional `content_type` field
- `POST /merge`: documented 403 `MergePolicyError` response shape
- Client section: added all new CLI commands (review/CI workflow, TUI, import-git, org/repo/role management, default remote)

**OPERATIONS.md**
- Fixed "Branch Status (Not Implemented)" — endpoint is fully implemented; documented real response shape (`{mergeable, policies[]}`)
- `POST /commit`: added `content_type` optional field per file
- `GET /file/:path` response: added `content_type` field (omitted for text)
- `GET /diff` response: added `binary` field on diff entries
- `POST /merge`: added 403 policy denial response shape
- `documents` schema: added `content_type` column
- New "OPA Policy Engine" section: policy writing guide, input schema table, bootstrap mode, cache invalidation, OWNERS format
- New "CLI Reference" section: all commands including `branches`, `reviews`, `review`, `checks`, `check`, `tui`, `import-git`, `orgs`, `repos`, `roles`, and default remote URL

**README.md**
- `ds init`: URL is now optional when built with `make build-ds`
- `ds commit`: noted binary file auto-detection
- `ds diff`: added `[binary]` label to example output
- Added CLI reference sections for all new commands
- Orgs and Repos section: added CLI alternative to curl

**ROADMAP.md**
- P1: marked OPA policy engine, OWNERS files, and branch status endpoint as complete
- P2: marked all new CLI features as complete (review/CI, TUI, binary support, import-git, org/repo/role, default remote)

### Features documented (PRs #63–#77)

| PR | Feature |
|---|---|
| #63 | TUI + review/CI CLI commands (`ds branches`, `ds reviews`, `ds review`, `ds checks`, `ds check`, `ds tui`) |
| #66, #67 | Binary file support (`content_type` in commit/file/diff) |
| #69, #70 | `ds import-git` |
| #71 | Default remote URL baked into `ds` via `-ldflags` |
| #73 | Org/repo/role CLI commands |
| #74, #77 | OPA policy engine, OWNERS files, branch status endpoint |

🤖 Generated with [Claude Code](https://claude.com/claude-code)