### PR TITLE
Add Phase 1 hash chain + client verification (issue #76)

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -30,6 +30,7 @@ commands:
   show <sequence> [path]                          Show commit or file at a sequence
   rebase                                          Rebase current branch onto main
   resolve <path>                                  Resolve a merge/rebase conflict
+  verify                                          Verify commit chain integrity
   branches [--status active|merged|abandoned]     List branches
   reviews [--branch <name>]                       List reviews for a branch
   review --status approved|rejected [--body "…"] [--branch <name>]  Submit a review
@@ -176,6 +177,9 @@ func main() {
 
 	case "rebase":
 		err = app.Rebase()
+
+	case "verify":
+		err = app.Verify()
 
 	case "resolve":
 		if len(args) < 2 {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -494,13 +494,12 @@ func (a *App) Commit(message string) error {
 	st.Sequence = commitResp.Sequence
 	st.Branch = cfg.Branch
 
-	// Fetch and store the commit_hash for this new commit.
-	if chainEntries, err := a.fetchChain(cfg, commitResp.Sequence, commitResp.Sequence); err == nil {
-		if len(chainEntries) > 0 && chainEntries[0].CommitHash != nil {
-			st.CommitHash = *chainEntries[0].CommitHash
-		}
+	// Store the commit_hash returned directly in the response (FIX-1).
+	if commitResp.CommitHash != "" {
+		st.CommitHash = commitResp.CommitHash
+	} else {
+		fmt.Fprintf(a.Out, "warning: server did not return commit_hash, chain verification may be incomplete\n")
 	}
-	// Non-fatal if chain fetch fails (e.g. server doesn't support endpoint yet).
 
 	if err := a.saveState(st); err != nil {
 		return err
@@ -630,6 +629,11 @@ func (a *App) Pull() error {
 			newState.CommitHash = *entries[0].CommitHash
 			return a.saveState(newState)
 		}
+		// Tip has NULL commit_hash (pre-feature commit); keep CommitHash empty
+		// so we retry TOFU on the next pull until a hashed tip is available.
+		if len(entries) > 0 {
+			fmt.Fprintf(a.Out, "note: current tip (seq %d) predates hash chain feature; chain verification will begin on next commit\n", entries[0].Sequence)
+		}
 		return nil
 	}
 
@@ -661,12 +665,17 @@ func (a *App) Pull() error {
 	}
 
 	// Verify chain linkage for entries after the anchor.
+	// Only process entries on the current branch (per-branch chain semantics).
 	prevHash := oldState.CommitHash
 	if anchor.CommitHash == nil {
 		prevHash = genesisHash
 	}
 	skippedBoundary := false
 	for _, e := range entries[1:] {
+		if e.Branch != cfg.Branch {
+			// Skip commits on other branches; each branch has its own independent chain.
+			continue
+		}
 		if e.CommitHash == nil {
 			if !skippedBoundary {
 				fmt.Fprintf(a.Out, "note: skipping pre-feature commit at sequence %d (no commit_hash)\n", e.Sequence)
@@ -686,25 +695,27 @@ func (a *App) Pull() error {
 	return a.saveState(newState)
 }
 
-// Verify walks the commit chain from the first non-NULL commit_hash to the current
-// head and prints per-commit verification status to a.Out.
+// Verify walks the commit chain from the first non-NULL commit_hash on the current
+// branch to the server's current head and prints per-commit verification status to a.Out.
 func (a *App) Verify() error {
 	cfg, err := a.loadConfig()
 	if err != nil {
 		return err
 	}
-	st, err := a.loadState()
-	if err != nil {
-		return err
-	}
 
-	if st.Sequence == 0 {
+	// Fetch the current branch head from the server (not from local state) so
+	// we don't miss commits made after the last pull (FIX-3).
+	headSeq, err := a.branchHeadSequence(cfg, cfg.Branch)
+	if err != nil {
+		return fmt.Errorf("fetching branch head: %w", err)
+	}
+	if headSeq == 0 {
 		fmt.Fprintf(a.Out, "No commits to verify.\n")
 		return nil
 	}
 
-	// Fetch the full chain from sequence 1 to head.
-	entries, err := a.fetchChain(cfg, 1, st.Sequence)
+	// Fetch the full chain from sequence 1 to server head.
+	entries, err := a.fetchChain(cfg, 1, headSeq)
 	if err != nil {
 		return fmt.Errorf("fetching chain: %w", err)
 	}
@@ -718,6 +729,10 @@ func (a *App) Verify() error {
 	foundFirst := false
 	var verifyErr error
 	for _, e := range entries {
+		// Skip commits on other branches; each branch has its own independent chain.
+		if e.Branch != cfg.Branch {
+			continue
+		}
 		if e.CommitHash == nil {
 			fmt.Fprintf(a.Out, "seq %-4d  SKIP  (no commit_hash)  %s\n", e.Sequence, e.Message)
 			// Reset prevHash so the next hashed commit starts a new chain segment.
@@ -725,7 +740,7 @@ func (a *App) Verify() error {
 			continue
 		}
 		if !foundFirst {
-			// The first non-NULL commit is the chain anchor; accept its hash as-is.
+			// The first non-NULL commit on this branch is the chain anchor; accept its hash as-is.
 			foundFirst = true
 			prevHash = *e.CommitHash
 			fmt.Fprintf(a.Out, "seq %-4d  OK    %.16s  %s\n", e.Sequence, *e.CommitHash, e.Message)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dlorenc/docstore/internal/tui"
 )
 
+
 // commitInfo is a local type for decoding GET /commit/:seq server responses.
 type commitInfo struct {
 	Sequence  int64            `json:"sequence"`
@@ -52,6 +53,66 @@ const configDir = ".docstore"
 const configFile = "config.json"
 const stateFile = "state.json"
 
+// chainEntry is the JSON shape returned by GET /-/chain.
+type chainEntry struct {
+	Sequence   int64       `json:"sequence"`
+	Branch     string      `json:"branch"`
+	Author     string      `json:"author"`
+	Message    string      `json:"message"`
+	CreatedAt  time.Time   `json:"created_at"`
+	CommitHash *string     `json:"commit_hash"`
+	Files      []chainFile `json:"files"`
+}
+
+// chainFile is one file in a chainEntry.
+type chainFile struct {
+	Path        string `json:"path"`
+	ContentHash string `json:"content_hash"`
+}
+
+// genesisHash is the all-zeros hash used as the previous-hash for the first chain entry.
+const genesisHash = "0000000000000000000000000000000000000000000000000000000000000000"
+
+// computeChainHash recomputes the SHA256 chain hash for a commit entry.
+// This must exactly match the server-side formula in internal/db/store.go.
+func computeChainHash(prevHash string, seq int64, repo, branch, author, message string, createdAt time.Time, files []chainFile) string {
+	h := sha256.New()
+	h.Write([]byte(prevHash + "\n"))
+	h.Write([]byte(fmt.Sprintf("%d\n", seq)))
+	h.Write([]byte(repo + "\n"))
+	h.Write([]byte(branch + "\n"))
+	h.Write([]byte(author + "\n"))
+	h.Write([]byte(message + "\n"))
+	h.Write([]byte(createdAt.UTC().Format(time.RFC3339Nano) + "\n"))
+	sorted := make([]chainFile, len(files))
+	copy(sorted, files)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Path < sorted[j].Path })
+	for _, f := range sorted {
+		h.Write([]byte(f.Path + ":" + f.ContentHash + "\n"))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// fetchChain calls GET /-/chain?from=N&to=M and returns the decoded entries.
+func (a *App) fetchChain(cfg *Config, from, to int64) ([]chainEntry, error) {
+	q := url.Values{}
+	q.Set("from", fmt.Sprintf("%d", from))
+	q.Set("to", fmt.Sprintf("%d", to))
+	resp, err := a.httpGet(cfg, repoBase(cfg)+"/chain?"+q.Encode())
+	if err != nil {
+		return nil, fmt.Errorf("fetching chain: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, a.readError(resp)
+	}
+	var entries []chainEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		return nil, fmt.Errorf("decoding chain: %w", err)
+	}
+	return entries, nil
+}
+
 // Config is the persistent CLI configuration stored in .docstore/config.json.
 type Config struct {
 	Remote string `json:"remote"`
@@ -62,9 +123,10 @@ type Config struct {
 
 // State tracks the last-synced tree for offline status.
 type State struct {
-	Branch   string            `json:"branch"`
-	Sequence int64             `json:"sequence"`
-	Files    map[string]string `json:"files"` // path -> content_hash
+	Branch     string            `json:"branch"`
+	Sequence   int64             `json:"sequence"`
+	Files      map[string]string `json:"files"`      // path -> content_hash
+	CommitHash string            `json:"commit_hash"` // tip commit_hash for chain verification; empty = not yet set
 }
 
 // App is the CLI application. All fields are injectable for testing.
@@ -432,6 +494,14 @@ func (a *App) Commit(message string) error {
 	st.Sequence = commitResp.Sequence
 	st.Branch = cfg.Branch
 
+	// Fetch and store the commit_hash for this new commit.
+	if chainEntries, err := a.fetchChain(cfg, commitResp.Sequence, commitResp.Sequence); err == nil {
+		if len(chainEntries) > 0 && chainEntries[0].CommitHash != nil {
+			st.CommitHash = *chainEntries[0].CommitHash
+		}
+	}
+	// Non-fatal if chain fetch fails (e.g. server doesn't support endpoint yet).
+
 	if err := a.saveState(st); err != nil {
 		return err
 	}
@@ -508,6 +578,9 @@ func (a *App) Checkout(branch string) error {
 }
 
 // Pull syncs local files from the current branch on the server.
+// If state has a stored CommitHash, it verifies the chain from the stored
+// sequence to the new head before updating state. On first pull (no stored
+// CommitHash), it uses TOFU and stores the tip's commit_hash.
 func (a *App) Pull() error {
 	cfg, err := a.loadConfig()
 	if err != nil {
@@ -523,7 +596,155 @@ func (a *App) Pull() error {
 		return fmt.Errorf("uncommitted changes -- commit or discard first")
 	}
 
-	return a.syncTree(cfg, cfg.Branch)
+	// Save old state before sync (for chain verification).
+	oldState, err := a.loadState()
+	if err != nil {
+		return err
+	}
+
+	if err := a.syncTree(cfg, cfg.Branch); err != nil {
+		return err
+	}
+
+	// Load updated state (syncTree saved it).
+	newState, err := a.loadState()
+	if err != nil {
+		return err
+	}
+
+	// Chain verification / TOFU.
+	if newState.Sequence == 0 {
+		// No commits yet; nothing to verify.
+		return nil
+	}
+
+	if oldState.CommitHash == "" {
+		// TOFU: fetch the tip commit's hash and store it.
+		entries, err := a.fetchChain(cfg, newState.Sequence, newState.Sequence)
+		if err != nil {
+			// Non-fatal: chain endpoint may not be available on older servers.
+			fmt.Fprintf(a.Out, "warning: could not fetch chain for TOFU: %v\n", err)
+			return nil
+		}
+		if len(entries) > 0 && entries[0].CommitHash != nil {
+			newState.CommitHash = *entries[0].CommitHash
+			return a.saveState(newState)
+		}
+		return nil
+	}
+
+	// Verification: old state has a known commit hash; verify the chain forward.
+	if oldState.Sequence == newState.Sequence {
+		// Nothing changed; no verification needed.
+		return nil
+	}
+
+	// Fetch from oldState.Sequence (inclusive) to newState.Sequence.
+	// The first entry is our anchor: its stored commit_hash must match oldState.CommitHash.
+	entries, err := a.fetchChain(cfg, oldState.Sequence, newState.Sequence)
+	if err != nil {
+		return fmt.Errorf("chain fetch for verification: %w", err)
+	}
+
+	if len(entries) == 0 {
+		return nil
+	}
+
+	// Anchor check: the server's hash for oldState.Sequence must match what we stored.
+	anchor := entries[0]
+	if anchor.CommitHash == nil {
+		// Pre-feature commit at anchor; treat as reset.
+		fmt.Fprintf(a.Out, "note: skipping pre-feature commit at sequence %d (no commit_hash)\n", anchor.Sequence)
+	} else if *anchor.CommitHash != oldState.CommitHash {
+		return fmt.Errorf("chain integrity error at sequence %d: anchor hash changed (stored %s, server %s)",
+			anchor.Sequence, oldState.CommitHash, *anchor.CommitHash)
+	}
+
+	// Verify chain linkage for entries after the anchor.
+	prevHash := oldState.CommitHash
+	if anchor.CommitHash == nil {
+		prevHash = genesisHash
+	}
+	skippedBoundary := false
+	for _, e := range entries[1:] {
+		if e.CommitHash == nil {
+			if !skippedBoundary {
+				fmt.Fprintf(a.Out, "note: skipping pre-feature commit at sequence %d (no commit_hash)\n", e.Sequence)
+				skippedBoundary = true
+			}
+			prevHash = genesisHash
+			continue
+		}
+		computed := computeChainHash(prevHash, e.Sequence, cfg.Repo, e.Branch, e.Author, e.Message, e.CreatedAt, e.Files)
+		if computed != *e.CommitHash {
+			return fmt.Errorf("chain integrity error at sequence %d: expected %s got %s", e.Sequence, computed, *e.CommitHash)
+		}
+		prevHash = *e.CommitHash
+	}
+
+	newState.CommitHash = prevHash
+	return a.saveState(newState)
+}
+
+// Verify walks the commit chain from the first non-NULL commit_hash to the current
+// head and prints per-commit verification status to a.Out.
+func (a *App) Verify() error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	st, err := a.loadState()
+	if err != nil {
+		return err
+	}
+
+	if st.Sequence == 0 {
+		fmt.Fprintf(a.Out, "No commits to verify.\n")
+		return nil
+	}
+
+	// Fetch the full chain from sequence 1 to head.
+	entries, err := a.fetchChain(cfg, 1, st.Sequence)
+	if err != nil {
+		return fmt.Errorf("fetching chain: %w", err)
+	}
+
+	if len(entries) == 0 {
+		fmt.Fprintf(a.Out, "No commits to verify.\n")
+		return nil
+	}
+
+	prevHash := genesisHash
+	foundFirst := false
+	var verifyErr error
+	for _, e := range entries {
+		if e.CommitHash == nil {
+			fmt.Fprintf(a.Out, "seq %-4d  SKIP  (no commit_hash)  %s\n", e.Sequence, e.Message)
+			// Reset prevHash so the next hashed commit starts a new chain segment.
+			prevHash = genesisHash
+			continue
+		}
+		if !foundFirst {
+			// The first non-NULL commit is the chain anchor; accept its hash as-is.
+			foundFirst = true
+			prevHash = *e.CommitHash
+			fmt.Fprintf(a.Out, "seq %-4d  OK    %.16s  %s\n", e.Sequence, *e.CommitHash, e.Message)
+			continue
+		}
+		computed := computeChainHash(prevHash, e.Sequence, cfg.Repo, e.Branch, e.Author, e.Message, e.CreatedAt, e.Files)
+		if computed == *e.CommitHash {
+			prevHash = *e.CommitHash
+			fmt.Fprintf(a.Out, "seq %-4d  OK    %.16s  %s\n", e.Sequence, *e.CommitHash, e.Message)
+		} else {
+			fmt.Fprintf(a.Out, "seq %-4d  FAIL  (expected %.16s got %.16s)  %s\n",
+				e.Sequence, computed, *e.CommitHash, e.Message)
+			prevHash = *e.CommitHash // continue verifying remaining chain
+			if verifyErr == nil {
+				verifyErr = fmt.Errorf("chain integrity error at sequence %d", e.Sequence)
+			}
+		}
+	}
+	return verifyErr
 }
 
 // syncTree fetches the full tree from the server and updates local files.

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -2671,6 +2671,9 @@ func TestVerify_HappyPath(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
+		case r.Method == "GET" && r.URL.Path == "/repos/default/default/-/branches":
+			// Verify() now fetches the server head instead of using st.Sequence (FIX-3).
+			json.NewEncoder(w).Encode([]model.Branch{{Name: "main", HeadSequence: 2}})
 		case r.Method == "GET" && r.URL.Path == "/repos/default/default/-/chain":
 			json.NewEncoder(w).Encode([]chainEntry{e1, e2})
 		default:
@@ -2681,6 +2684,7 @@ func TestVerify_HappyPath(t *testing.T) {
 
 	app, out := newTestApp(t, srv)
 	initWorkspace(t, app, srv.URL, "main", "alice")
+	// st.Sequence is no longer used by Verify() (FIX-3), but still saved for completeness.
 	st := &State{Branch: "main", Sequence: 2, Files: make(map[string]string)}
 	if err := app.saveState(st); err != nil {
 		t.Fatal(err)
@@ -2693,5 +2697,90 @@ func TestVerify_HappyPath(t *testing.T) {
 	// First entry is the anchor (no recomputation); second is verified.
 	if !strings.Contains(output, "OK") {
 		t.Errorf("expected OK in output: %s", output)
+	}
+}
+
+// TestPull_AnchorTampered verifies that Pull() returns a chain integrity error
+// when the server reports a different commit_hash for the anchor sequence than
+// what the client has stored in state (FIX-7).
+func TestPull_AnchorTampered(t *testing.T) {
+	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	e1 := newChainEntry(genesisHash, 1, "default/default", "main", "alice", "first", ts)
+
+	// Server returns a tampered hash for the anchor sequence.
+	tamperedHash := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	e1Tampered := chainEntry{
+		Sequence:   1,
+		Branch:     "main",
+		Author:     "alice",
+		Message:    "first",
+		CreatedAt:  ts,
+		CommitHash: &tamperedHash,
+		Files:      []chainFile{},
+	}
+
+	srv := newPullServer(t, "main", 2, []chainEntry{e1Tampered})
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	// Pre-seed state with the legitimate hash from e1.
+	st := &State{Branch: "main", Sequence: 1, Files: make(map[string]string), CommitHash: *e1.CommitHash}
+	if err := app.saveState(st); err != nil {
+		t.Fatal(err)
+	}
+
+	err := app.Pull()
+	if err == nil {
+		t.Fatal("expected chain integrity error for tampered anchor, got nil")
+	}
+	if !strings.Contains(err.Error(), "chain integrity error") {
+		t.Errorf("expected 'chain integrity error' in error, got: %v", err)
+	}
+}
+
+// TestPull_TOFU_NullHash verifies that the TOFU path prints a note and keeps
+// CommitHash empty when the tip commit has a NULL commit_hash (pre-feature commit).
+// This ensures the client retries TOFU on subsequent pulls rather than silently
+// skipping verification forever (FIX-4).
+func TestPull_TOFU_NullHash(t *testing.T) {
+	// Entry with nil CommitHash (simulates a pre-feature commit).
+	nullEntry := chainEntry{
+		Sequence:   1,
+		Branch:     "main",
+		Author:     "alice",
+		Message:    "legacy commit",
+		CreatedAt:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		CommitHash: nil,
+		Files:      []chainFile{},
+	}
+
+	srv := newPullServer(t, "main", 1, []chainEntry{nullEntry})
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+	// No stored CommitHash — TOFU path.
+	if err := app.saveState(&State{Branch: "main", Sequence: 0, Files: make(map[string]string)}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.Pull(); err != nil {
+		t.Fatalf("Pull: unexpected error: %v", err)
+	}
+
+	// CommitHash must remain empty so TOFU is retried next pull.
+	st, err := app.loadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.CommitHash != "" {
+		t.Errorf("expected CommitHash to remain empty, got %q", st.CommitHash)
+	}
+
+	// A note explaining the situation should have been printed.
+	if !strings.Contains(out.String(), "predates hash chain feature") {
+		t.Errorf("expected predates-hash-chain note in output, got: %s", out.String())
 	}
 }

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -2525,3 +2525,173 @@ func TestImportGitDefaultMode(t *testing.T) {
 		t.Fatalf("expected 1 commit request, got %d", len(capturedReqs))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Chain verification / pull tests
+// ---------------------------------------------------------------------------
+
+// buildChainHash replicates the server-side hash formula for tests.
+func buildChainHash(prevHash string, seq int64, repo, branch, author, message string, createdAt time.Time, files []chainFile) string {
+	return computeChainHash(prevHash, seq, repo, branch, author, message, createdAt, files)
+}
+
+// newChainEntry builds a minimal chainEntry with a correct commit_hash for testing.
+func newChainEntry(prevHash string, seq int64, repo, branch, author, msg string, ts time.Time) chainEntry {
+	hash := buildChainHash(prevHash, seq, repo, branch, author, msg, ts, nil)
+	return chainEntry{
+		Sequence:   seq,
+		Branch:     branch,
+		Author:     author,
+		Message:    msg,
+		CreatedAt:  ts,
+		CommitHash: &hash,
+		Files:      []chainFile{},
+	}
+}
+
+// newPullServer builds a mock HTTP server that handles the standard pull flow:
+// tree listing, branches (with headSeq), and a chain endpoint returning entries.
+func newPullServer(t *testing.T, branch string, headSeq int64, chainEntries []chainEntry) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/repos/default/default/-/tree":
+			json.NewEncoder(w).Encode([]treeEntry{})
+		case r.Method == "GET" && r.URL.Path == "/repos/default/default/-/branches":
+			json.NewEncoder(w).Encode([]model.Branch{{Name: branch, HeadSequence: headSeq}})
+		case r.Method == "GET" && r.URL.Path == "/repos/default/default/-/chain":
+			json.NewEncoder(w).Encode(chainEntries)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// TestPull_TOFU verifies that the first pull (no stored CommitHash) stores the tip hash.
+func TestPull_TOFU(t *testing.T) {
+	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	e1 := newChainEntry(genesisHash, 1, "default/default", "main", "alice", "first", ts)
+
+	srv := newPullServer(t, "main", 1, []chainEntry{e1})
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	if err := app.Pull(); err != nil {
+		t.Fatalf("Pull: %v", err)
+	}
+
+	st, err := app.loadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.CommitHash == "" {
+		t.Fatal("expected CommitHash to be set after TOFU pull")
+	}
+	if st.CommitHash != *e1.CommitHash {
+		t.Errorf("expected CommitHash %q, got %q", *e1.CommitHash, st.CommitHash)
+	}
+}
+
+// TestPull_VerificationSuccess verifies that a subsequent pull with a valid chain passes.
+func TestPull_VerificationSuccess(t *testing.T) {
+	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	e1 := newChainEntry(genesisHash, 1, "default/default", "main", "alice", "first", ts)
+	ts2 := ts.Add(time.Second)
+	e2 := newChainEntry(*e1.CommitHash, 2, "default/default", "main", "alice", "second", ts2)
+
+	srv := newPullServer(t, "main", 2, []chainEntry{e1, e2})
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	// Pre-seed state as if we already did a TOFU pull at seq 1.
+	st := &State{Branch: "main", Sequence: 1, Files: make(map[string]string), CommitHash: *e1.CommitHash}
+	if err := app.saveState(st); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.Pull(); err != nil {
+		t.Fatalf("Pull: %v", err)
+	}
+
+	st2, _ := app.loadState()
+	if st2.CommitHash != *e2.CommitHash {
+		t.Errorf("expected updated CommitHash %q, got %q", *e2.CommitHash, st2.CommitHash)
+	}
+}
+
+// TestPull_VerificationFailure verifies that a wrong hash causes an error.
+func TestPull_VerificationFailure(t *testing.T) {
+	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	e1 := newChainEntry(genesisHash, 1, "default/default", "main", "alice", "first", ts)
+	ts2 := ts.Add(time.Second)
+	// Build a second entry with a wrong hash.
+	badHash := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	e2Wrong := chainEntry{
+		Sequence:   2,
+		Branch:     "main",
+		Author:     "alice",
+		Message:    "second",
+		CreatedAt:  ts2,
+		CommitHash: &badHash,
+		Files:      []chainFile{},
+	}
+
+	srv := newPullServer(t, "main", 2, []chainEntry{e1, e2Wrong})
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	st := &State{Branch: "main", Sequence: 1, Files: make(map[string]string), CommitHash: *e1.CommitHash}
+	if err := app.saveState(st); err != nil {
+		t.Fatal(err)
+	}
+
+	err := app.Pull()
+	if err == nil {
+		t.Fatal("expected chain integrity error, got nil")
+	}
+	if !strings.Contains(err.Error(), "chain integrity error") {
+		t.Errorf("expected 'chain integrity error' in error, got: %v", err)
+	}
+}
+
+// TestVerify_HappyPath verifies ds verify prints OK for a valid chain.
+func TestVerify_HappyPath(t *testing.T) {
+	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	e1 := newChainEntry(genesisHash, 1, "default/default", "main", "alice", "first", ts)
+	ts2 := ts.Add(time.Second)
+	e2 := newChainEntry(*e1.CommitHash, 2, "default/default", "main", "alice", "second", ts2)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/repos/default/default/-/chain":
+			json.NewEncoder(w).Encode([]chainEntry{e1, e2})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+	st := &State{Branch: "main", Sequence: 2, Files: make(map[string]string)}
+	if err := app.saveState(st); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.Verify(); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	output := out.String()
+	// First entry is the anchor (no recomputation); second is verified.
+	if !strings.Contains(output, "OK") {
+		t.Errorf("expected OK in output: %s", output)
+	}
+}

--- a/internal/db/migrations/000001_initial_schema.up.sql
+++ b/internal/db/migrations/000001_initial_schema.up.sql
@@ -53,12 +53,15 @@ CREATE TABLE branches (
 
 -- commits: global monotonic sequence allocation, one row per atomic commit
 CREATE TABLE commits (
-    sequence   BIGSERIAL PRIMARY KEY,
-    branch     TEXT NOT NULL,
-    message    TEXT NOT NULL,
-    author     TEXT NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    repo       TEXT NOT NULL DEFAULT 'default/default' REFERENCES repos (name)
+    sequence         BIGSERIAL PRIMARY KEY,
+    branch           TEXT NOT NULL,
+    message          TEXT NOT NULL,
+    author           TEXT NOT NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    repo             TEXT NOT NULL DEFAULT 'default/default' REFERENCES repos (name),
+    commit_hash      TEXT,
+    rekor_uuid       TEXT,
+    signature_bundle JSONB
 );
 
 -- file_commits: core event log, one row per file change within a commit

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -8,12 +8,94 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
+	"strconv"
 	"time"
 
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 )
+
+// genesisHash is the all-zeros hash used as the previous hash for the first commit.
+const genesisHash = "0000000000000000000000000000000000000000000000000000000000000000"
+
+// chainFile holds a path and content_hash for commit hash computation.
+type chainFile struct {
+	path        string
+	contentHash string
+}
+
+// computeCommitHash computes the SHA256 chain hash for a commit.
+// prevHash is the hex-encoded hash of the previous commit (or genesisHash for the first commit).
+// files are sorted by path internally, so caller order does not matter.
+func computeCommitHash(prevHash string, seq int64, repo, branch, author, message string, createdAt time.Time, files []chainFile) string {
+	// Sort a copy so the hash is always canonical regardless of input order.
+	sorted := make([]chainFile, len(files))
+	copy(sorted, files)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].path < sorted[j].path })
+
+	h := sha256.New()
+	h.Write([]byte(prevHash + "\n"))
+	h.Write([]byte(strconv.FormatInt(seq, 10) + "\n"))
+	h.Write([]byte(repo + "\n"))
+	h.Write([]byte(branch + "\n"))
+	h.Write([]byte(author + "\n"))
+	h.Write([]byte(message + "\n"))
+	h.Write([]byte(createdAt.UTC().Format(time.RFC3339Nano) + "\n"))
+	for _, f := range sorted {
+		h.Write([]byte(f.path + ":" + f.contentHash + "\n"))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// fetchPrevCommitHash fetches the commit_hash of the most recent commit before seq
+// in the given repo. Returns genesisHash if no previous commit exists or if the
+// previous commit has a NULL commit_hash (pre-feature commit).
+func fetchPrevCommitHash(ctx context.Context, tx *sql.Tx, repo string, seq int64) (string, error) {
+	var prevNull sql.NullString
+	err := tx.QueryRowContext(ctx,
+		`SELECT commit_hash FROM commits
+		 WHERE repo = $1 AND sequence = (SELECT MAX(sequence) FROM commits WHERE repo = $1 AND sequence < $2)`,
+		repo, seq,
+	).Scan(&prevNull)
+	if errors.Is(err, sql.ErrNoRows) {
+		return genesisHash, nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("fetch prev commit hash: %w", err)
+	}
+	if !prevNull.Valid || prevNull.String == "" {
+		return genesisHash, nil
+	}
+	return prevNull.String, nil
+}
+
+// fetchVersionContentHash fetches the content_hash for a version_id from documents.
+// Returns empty string for nil version_id (deleted files).
+func fetchVersionContentHash(ctx context.Context, tx *sql.Tx, versionID *string) (string, error) {
+	if versionID == nil {
+		return "", nil
+	}
+	var hash string
+	err := tx.QueryRowContext(ctx,
+		"SELECT content_hash FROM documents WHERE version_id = $1",
+		*versionID,
+	).Scan(&hash)
+	if err != nil {
+		return "", fmt.Errorf("fetch content hash for version %s: %w", *versionID, err)
+	}
+	return hash, nil
+}
+
+// updateCommitHash stores the given hash on the commits row identified by repo+seq.
+func updateCommitHash(ctx context.Context, tx *sql.Tx, repo string, seq int64, hash string) error {
+	_, err := tx.ExecContext(ctx,
+		"UPDATE commits SET commit_hash = $1 WHERE repo = $2 AND sequence = $3",
+		hash, repo, seq,
+	)
+	return err
+}
 
 var (
 	ErrBranchNotFound  = errors.New("branch not found")
@@ -323,24 +405,29 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 	}
 
 	// Allocate a globally monotonic sequence by inserting into commits.
+	// RETURNING created_at so we can include it in the hash computation.
 	var newSeq int64
+	var commitCreatedAt time.Time
 	err = tx.QueryRowContext(ctx,
-		`INSERT INTO commits (repo, branch, message, author) VALUES ($1, $2, $3, $4) RETURNING sequence`,
+		`INSERT INTO commits (repo, branch, message, author) VALUES ($1, $2, $3, $4) RETURNING sequence, created_at`,
 		req.Repo, req.Branch, req.Message, req.Author,
-	).Scan(&newSeq)
+	).Scan(&newSeq, &commitCreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("insert commit: %w", err)
 	}
 
 	results := make([]model.CommitFileResult, 0, len(req.Files))
+	hashFiles := make([]chainFile, 0, len(req.Files))
 
 	for _, f := range req.Files {
 		var versionIDPtr *string
+		fileContentHash := ""
 
 		if f.Content != nil {
 			// Hash content for per-repo dedup.
 			h := sha256.Sum256(f.Content)
 			contentHash := hex.EncodeToString(h[:])
+			fileContentHash = contentHash
 
 			// Check for existing document with the same hash in this repo.
 			var existingID string
@@ -370,7 +457,7 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 
 			versionIDPtr = &existingID
 		}
-		// nil Content → delete: versionIDPtr stays nil.
+		// nil Content → delete: versionIDPtr stays nil, fileContentHash stays "".
 
 		commitID := uuid.New().String()
 		_, err = tx.ExecContext(ctx,
@@ -386,6 +473,7 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 			Path:      f.Path,
 			VersionID: versionIDPtr,
 		})
+		hashFiles = append(hashFiles, chainFile{path: f.Path, contentHash: fileContentHash})
 	}
 
 	// Advance branch head.
@@ -395,6 +483,17 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 	)
 	if err != nil {
 		return nil, fmt.Errorf("update branch head: %w", err)
+	}
+
+	// Compute and store commit_hash.
+	prevHash, err := fetchPrevCommitHash(ctx, tx, req.Repo, newSeq)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(hashFiles, func(i, j int) bool { return hashFiles[i].path < hashFiles[j].path })
+	commitHash := computeCommitHash(prevHash, newSeq, req.Repo, req.Branch, req.Author, req.Message, commitCreatedAt, hashFiles)
+	if err := updateCommitHash(ctx, tx, req.Repo, newSeq, commitHash); err != nil {
+		return nil, fmt.Errorf("store commit hash: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -551,11 +650,13 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 
 	// Step 4: No conflicts — allocate a global sequence for the merge commit,
 	// then insert file_commits rows on main for each branch-changed path.
+	mergeMsg := fmt.Sprintf("merge branch '%s'", req.Branch)
 	var newSeq int64
+	var mergeCreatedAt time.Time
 	err = tx.QueryRowContext(ctx,
-		`INSERT INTO commits (repo, branch, message, author) VALUES ($1, 'main', $2, $3) RETURNING sequence`,
-		req.Repo, fmt.Sprintf("merge branch '%s'", req.Branch), req.Author,
-	).Scan(&newSeq)
+		`INSERT INTO commits (repo, branch, message, author) VALUES ($1, 'main', $2, $3) RETURNING sequence, created_at`,
+		req.Repo, mergeMsg, req.Author,
+	).Scan(&newSeq, &mergeCreatedAt)
 	if err != nil {
 		return nil, nil, fmt.Errorf("insert merge commit: %w", err)
 	}
@@ -588,6 +689,25 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("update branch status: %w", err)
+	}
+
+	// Compute and store commit_hash for the merge commit.
+	prevHash, err := fetchPrevCommitHash(ctx, tx, req.Repo, newSeq)
+	if err != nil {
+		return nil, nil, err
+	}
+	hashFiles := make([]chainFile, 0, len(branchChanges))
+	for path, versionID := range branchChanges {
+		contentHash, err := fetchVersionContentHash(ctx, tx, versionID)
+		if err != nil {
+			return nil, nil, err
+		}
+		hashFiles = append(hashFiles, chainFile{path: path, contentHash: contentHash})
+	}
+	sort.Slice(hashFiles, func(i, j int) bool { return hashFiles[i].path < hashFiles[j].path })
+	mergeHash := computeCommitHash(prevHash, newSeq, req.Repo, "main", req.Author, mergeMsg, mergeCreatedAt, hashFiles)
+	if err := updateCommitHash(ctx, tx, req.Repo, newSeq, mergeHash); err != nil {
+		return nil, nil, fmt.Errorf("store merge commit hash: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -706,11 +826,13 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 	}
 	var lastSeq int64
 	for _, g := range groups {
+		rebaseMsg := fmt.Sprintf("rebase: replay sequence %d", g.seq)
 		var newSeq int64
+		var rebaseCreatedAt time.Time
 		err = tx.QueryRowContext(ctx,
-			`INSERT INTO commits (repo, branch, message, author) VALUES ($1, $2, $3, $4) RETURNING sequence`,
-			req.Repo, req.Branch, fmt.Sprintf("rebase: replay sequence %d", g.seq), author,
-		).Scan(&newSeq)
+			`INSERT INTO commits (repo, branch, message, author) VALUES ($1, $2, $3, $4) RETURNING sequence, created_at`,
+			req.Repo, req.Branch, rebaseMsg, author,
+		).Scan(&newSeq, &rebaseCreatedAt)
 		if err != nil {
 			return nil, nil, fmt.Errorf("insert rebase commit: %w", err)
 		}
@@ -726,6 +848,26 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 				return nil, nil, fmt.Errorf("insert file_commit: %w", err)
 			}
 		}
+
+		// Compute and store commit_hash for this replayed commit.
+		prevHash, err := fetchPrevCommitHash(ctx, tx, req.Repo, newSeq)
+		if err != nil {
+			return nil, nil, err
+		}
+		hashFiles := make([]chainFile, 0, len(g.files))
+		for _, f := range g.files {
+			contentHash, err := fetchVersionContentHash(ctx, tx, f.versionID)
+			if err != nil {
+				return nil, nil, err
+			}
+			hashFiles = append(hashFiles, chainFile{path: f.path, contentHash: contentHash})
+		}
+		sort.Slice(hashFiles, func(i, j int) bool { return hashFiles[i].path < hashFiles[j].path })
+		rebaseHash := computeCommitHash(prevHash, newSeq, req.Repo, req.Branch, author, rebaseMsg, rebaseCreatedAt, hashFiles)
+		if err := updateCommitHash(ctx, tx, req.Repo, newSeq, rebaseHash); err != nil {
+			return nil, nil, fmt.Errorf("store rebase commit hash: %w", err)
+		}
+
 		lastSeq = newSeq
 	}
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -50,14 +50,17 @@ func computeCommitHash(prevHash string, seq int64, repo, branch, author, message
 }
 
 // fetchPrevCommitHash fetches the commit_hash of the most recent commit before seq
-// in the given repo. Returns genesisHash if no previous commit exists or if the
-// previous commit has a NULL commit_hash (pre-feature commit).
-func fetchPrevCommitHash(ctx context.Context, tx *sql.Tx, repo string, seq int64) (string, error) {
+// on the same branch. Returns genesisHash if no previous commit exists on this branch
+// or if the previous commit has a NULL commit_hash (pre-feature commit).
+// Using per-branch lookup ensures same-branch commits form a coherent linear chain;
+// different branches have independent chains and are not subject to cross-branch races.
+func fetchPrevCommitHash(ctx context.Context, tx *sql.Tx, repo, branch string, seq int64) (string, error) {
 	var prevNull sql.NullString
 	err := tx.QueryRowContext(ctx,
 		`SELECT commit_hash FROM commits
-		 WHERE repo = $1 AND sequence = (SELECT MAX(sequence) FROM commits WHERE repo = $1 AND sequence < $2)`,
-		repo, seq,
+		 WHERE repo = $1 AND branch = $2
+		   AND sequence = (SELECT MAX(sequence) FROM commits WHERE repo = $1 AND branch = $2 AND sequence < $3)`,
+		repo, branch, seq,
 	).Scan(&prevNull)
 	if errors.Is(err, sql.ErrNoRows) {
 		return genesisHash, nil
@@ -485,12 +488,12 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 		return nil, fmt.Errorf("update branch head: %w", err)
 	}
 
-	// Compute and store commit_hash.
-	prevHash, err := fetchPrevCommitHash(ctx, tx, req.Repo, newSeq)
+	// Compute and store commit_hash (per-branch chain).
+	prevHash, err := fetchPrevCommitHash(ctx, tx, req.Repo, req.Branch, newSeq)
 	if err != nil {
 		return nil, err
 	}
-	sort.Slice(hashFiles, func(i, j int) bool { return hashFiles[i].path < hashFiles[j].path })
+	// computeCommitHash sorts files internally; no pre-sort needed.
 	commitHash := computeCommitHash(prevHash, newSeq, req.Repo, req.Branch, req.Author, req.Message, commitCreatedAt, hashFiles)
 	if err := updateCommitHash(ctx, tx, req.Repo, newSeq, commitHash); err != nil {
 		return nil, fmt.Errorf("store commit hash: %w", err)
@@ -501,8 +504,9 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 	}
 
 	return &model.CommitResponse{
-		Sequence: newSeq,
-		Files:    results,
+		Sequence:   newSeq,
+		Files:      results,
+		CommitHash: commitHash,
 	}, nil
 }
 
@@ -691,8 +695,8 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 		return nil, nil, fmt.Errorf("update branch status: %w", err)
 	}
 
-	// Compute and store commit_hash for the merge commit.
-	prevHash, err := fetchPrevCommitHash(ctx, tx, req.Repo, newSeq)
+	// Compute and store commit_hash for the merge commit (per-branch: main chain).
+	prevHash, err := fetchPrevCommitHash(ctx, tx, req.Repo, "main", newSeq)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -704,7 +708,7 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 		}
 		hashFiles = append(hashFiles, chainFile{path: path, contentHash: contentHash})
 	}
-	sort.Slice(hashFiles, func(i, j int) bool { return hashFiles[i].path < hashFiles[j].path })
+	// computeCommitHash sorts files internally; no pre-sort needed.
 	mergeHash := computeCommitHash(prevHash, newSeq, req.Repo, "main", req.Author, mergeMsg, mergeCreatedAt, hashFiles)
 	if err := updateCommitHash(ctx, tx, req.Repo, newSeq, mergeHash); err != nil {
 		return nil, nil, fmt.Errorf("store merge commit hash: %w", err)
@@ -849,8 +853,8 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 			}
 		}
 
-		// Compute and store commit_hash for this replayed commit.
-		prevHash, err := fetchPrevCommitHash(ctx, tx, req.Repo, newSeq)
+		// Compute and store commit_hash for this replayed commit (per-branch chain).
+		prevHash, err := fetchPrevCommitHash(ctx, tx, req.Repo, req.Branch, newSeq)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -862,7 +866,7 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 			}
 			hashFiles = append(hashFiles, chainFile{path: f.path, contentHash: contentHash})
 		}
-		sort.Slice(hashFiles, func(i, j int) bool { return hashFiles[i].path < hashFiles[j].path })
+		// computeCommitHash sorts files internally; no pre-sort needed.
 		rebaseHash := computeCommitHash(prevHash, newSeq, req.Repo, req.Branch, author, rebaseMsg, rebaseCreatedAt, hashFiles)
 		if err := updateCommitHash(ctx, tx, req.Repo, newSeq, rebaseHash); err != nil {
 			return nil, nil, fmt.Errorf("store rebase commit hash: %w", err)

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -3008,6 +3008,14 @@ func TestIsForeignKeyViolation_FromDB(t *testing.T) {
 // Hash chain tests
 // ---------------------------------------------------------------------------
 
+// expectedCommitHash is a regression sentinel: the known SHA256 for the fixed
+// test inputs used in TestComputeCommitHash. If the hash formula changes, this
+// constant must be updated deliberately (it catches accidental formula drift).
+// Inputs: prevHash=genesisHash, seq=1, repo="myorg/repo", branch="main",
+// author="alice", message="first commit", ts=2024-01-01T00:00:00Z,
+// files=[{a.txt:aaa},{b.txt:bbb}] (sorted alphabetically by path).
+const expectedCommitHash = "54662b84dcaca30b108d9b779bec9ad8727f35db9e6742401aaa5d09a5a5b987"
+
 // TestComputeCommitHash verifies that computeCommitHash produces a stable SHA256 output.
 func TestComputeCommitHash(t *testing.T) {
 	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -3019,6 +3027,11 @@ func TestComputeCommitHash(t *testing.T) {
 	got := computeCommitHash(genesisHash, 1, "myorg/repo", "main", "alice", "first commit", ts, files)
 	if len(got) != 64 {
 		t.Fatalf("expected 64-char hex string, got %q (len=%d)", got, len(got))
+	}
+
+	// Regression sentinel: any formula change will break this even if both sides are updated.
+	if got != expectedCommitHash {
+		t.Errorf("hash formula changed: got %s, want %s", got, expectedCommitHash)
 	}
 
 	// Recomputing with the same inputs must produce the same hash.
@@ -3146,5 +3159,131 @@ func TestCommit_ChainLinks(t *testing.T) {
 	}
 	if hash1.String == hash2.String {
 		t.Error("expected different hashes for different commits")
+	}
+
+	// Verify actual chain linkage: recompute hash2 using hash1 as prevHash and
+	// compare to the stored value. This proves the chain links correctly, not just
+	// that the two hashes differ.
+	var author2, message2 string
+	var createdAt2 time.Time
+	if err := d.QueryRowContext(ctx,
+		"SELECT author, message, created_at FROM commits WHERE sequence = $1", resp2.Sequence,
+	).Scan(&author2, &message2, &createdAt2); err != nil {
+		t.Fatalf("query commit2 metadata: %v", err)
+	}
+	// Get content hash for a.txt at seq2 (b.txt is the new file, but we need the files committed in resp2).
+	// resp2 committed b.txt; get its content hash from documents.
+	var contentHash2 sql.NullString
+	if err := d.QueryRowContext(ctx,
+		`SELECT d.content_hash FROM file_commits fc
+		 JOIN documents d ON d.version_id = fc.version_id AND d.repo = fc.repo
+		 WHERE fc.sequence = $1 AND fc.path = 'b.txt'`, resp2.Sequence,
+	).Scan(&contentHash2); err != nil {
+		t.Fatalf("query content hash for b.txt: %v", err)
+	}
+	hashFiles2 := []chainFile{{path: "b.txt", contentHash: contentHash2.String}}
+	recomputed2 := computeCommitHash(hash1.String, resp2.Sequence, "default/default", "main", author2, message2, createdAt2, hashFiles2)
+	if recomputed2 != hash2.String {
+		t.Errorf("chain linkage broken: recomputed hash2=%s, stored hash2=%s", recomputed2, hash2.String)
+	}
+}
+
+// TestCommit_PerBranchChain verifies that commits on different branches each
+// start their own chain from genesisHash, independently of each other.
+func TestCommit_PerBranchChain(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Commit to main.
+	mainResp, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default/default",
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "base.txt", Content: []byte("base")}},
+		Message: "main first",
+		Author:  "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("main commit: %v", err)
+	}
+
+	// Create a feature branch and commit to it.
+	if _, err = s.CreateBranch(ctx, model.CreateBranchRequest{Repo: "default/default", Name: "feature/x"}); err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	featureResp, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default/default",
+		Branch:  "feature/x",
+		Files:   []model.FileChange{{Path: "feat.txt", Content: []byte("feat")}},
+		Message: "feature first",
+		Author:  "bob@example.com",
+	})
+	if err != nil {
+		t.Fatalf("feature commit: %v", err)
+	}
+
+	// Retrieve both commit hashes from the DB.
+	var mainHash, featureHash sql.NullString
+	if err := d.QueryRowContext(ctx, "SELECT commit_hash FROM commits WHERE sequence = $1", mainResp.Sequence).Scan(&mainHash); err != nil {
+		t.Fatalf("query main hash: %v", err)
+	}
+	if err := d.QueryRowContext(ctx, "SELECT commit_hash FROM commits WHERE sequence = $1", featureResp.Sequence).Scan(&featureHash); err != nil {
+		t.Fatalf("query feature hash: %v", err)
+	}
+	if !mainHash.Valid || !featureHash.Valid {
+		t.Fatal("expected both hashes to be set")
+	}
+
+	// Both commits should be the first on their respective branches, so both
+	// prevHash values should be genesisHash. Retrieve metadata to recompute.
+	type commitMeta struct {
+		author, message string
+		createdAt       time.Time
+	}
+	getMeta := func(seq int64) commitMeta {
+		t.Helper()
+		var m commitMeta
+		if err := d.QueryRowContext(ctx,
+			"SELECT author, message, created_at FROM commits WHERE sequence = $1", seq,
+		).Scan(&m.author, &m.message, &m.createdAt); err != nil {
+			t.Fatalf("query meta seq=%d: %v", seq, err)
+		}
+		return m
+	}
+	getContentHash := func(seq int64, path string) string {
+		t.Helper()
+		var h sql.NullString
+		if err := d.QueryRowContext(ctx,
+			`SELECT d.content_hash FROM file_commits fc
+			 JOIN documents d ON d.version_id = fc.version_id AND d.repo = fc.repo
+			 WHERE fc.sequence = $1 AND fc.path = $2`, seq, path,
+		).Scan(&h); err != nil {
+			t.Fatalf("query content hash seq=%d path=%s: %v", seq, path, err)
+		}
+		return h.String
+	}
+
+	mainMeta := getMeta(mainResp.Sequence)
+	featureMeta := getMeta(featureResp.Sequence)
+
+	// Main commit: prevHash must be genesisHash (first on main).
+	expectedMain := computeCommitHash(genesisHash, mainResp.Sequence, "default/default", "main",
+		mainMeta.author, mainMeta.message, mainMeta.createdAt,
+		[]chainFile{{path: "base.txt", contentHash: getContentHash(mainResp.Sequence, "base.txt")}})
+	if expectedMain != mainHash.String {
+		t.Errorf("main chain: expected %s, got %s", expectedMain, mainHash.String)
+	}
+
+	// Feature commit: prevHash must be genesisHash (first on feature/x, independent of main).
+	expectedFeature := computeCommitHash(genesisHash, featureResp.Sequence, "default/default", "feature/x",
+		featureMeta.author, featureMeta.message, featureMeta.createdAt,
+		[]chainFile{{path: "feat.txt", contentHash: getContentHash(featureResp.Sequence, "feat.txt")}})
+	if expectedFeature != featureHash.String {
+		t.Errorf("feature chain: expected %s, got %s", expectedFeature, featureHash.String)
+	}
+
+	// The two branch chains are independent — their hashes should differ.
+	if mainHash.String == featureHash.String {
+		t.Error("expected different hashes for commits on different branches")
 	}
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -3003,3 +3003,148 @@ func TestIsForeignKeyViolation_FromDB(t *testing.T) {
 		t.Errorf("expected ErrOrgNotFound (wrapping FK violation), got %v", err)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Hash chain tests
+// ---------------------------------------------------------------------------
+
+// TestComputeCommitHash verifies that computeCommitHash produces a stable SHA256 output.
+func TestComputeCommitHash(t *testing.T) {
+	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	files := []chainFile{
+		{path: "b.txt", contentHash: "bbb"},
+		{path: "a.txt", contentHash: "aaa"},
+	}
+	// Files are sorted inside computeCommitHash, so order of input shouldn't matter.
+	got := computeCommitHash(genesisHash, 1, "myorg/repo", "main", "alice", "first commit", ts, files)
+	if len(got) != 64 {
+		t.Fatalf("expected 64-char hex string, got %q (len=%d)", got, len(got))
+	}
+
+	// Recomputing with the same inputs must produce the same hash.
+	got2 := computeCommitHash(genesisHash, 1, "myorg/repo", "main", "alice", "first commit", ts, files)
+	if got != got2 {
+		t.Errorf("hash not deterministic: got %q vs %q", got, got2)
+	}
+
+	// Changing any field must produce a different hash.
+	for _, tc := range []struct {
+		name string
+		fn   func() string
+	}{
+		{"author", func() string {
+			return computeCommitHash(genesisHash, 1, "myorg/repo", "main", "bob", "first commit", ts, files)
+		}},
+		{"message", func() string {
+			return computeCommitHash(genesisHash, 1, "myorg/repo", "main", "alice", "other msg", ts, files)
+		}},
+		{"sequence", func() string {
+			return computeCommitHash(genesisHash, 2, "myorg/repo", "main", "alice", "first commit", ts, files)
+		}},
+		{"repo", func() string {
+			return computeCommitHash(genesisHash, 1, "other/repo", "main", "alice", "first commit", ts, files)
+		}},
+		{"prevHash", func() string {
+			return computeCommitHash("aaaa"+genesisHash[4:], 1, "myorg/repo", "main", "alice", "first commit", ts, files)
+		}},
+	} {
+		if diff := tc.fn(); diff == got {
+			t.Errorf("changing %s should change the hash", tc.name)
+		}
+	}
+
+	// Verify expected value by building the same hash inline.
+	// computeCommitHash sorts files internally, so feed them sorted.
+	h := sha256.New()
+	h.Write([]byte(genesisHash + "\n"))
+	h.Write([]byte("1\n"))
+	h.Write([]byte("myorg/repo\n"))
+	h.Write([]byte("main\n"))
+	h.Write([]byte("alice\n"))
+	h.Write([]byte("first commit\n"))
+	// Use the same format string as the production code.
+	h.Write([]byte(ts.UTC().Format(time.RFC3339Nano) + "\n"))
+	// Sorted alphabetically by path: a.txt then b.txt.
+	h.Write([]byte("a.txt:aaa\n"))
+	h.Write([]byte("b.txt:bbb\n"))
+	expected := hex.EncodeToString(h.Sum(nil))
+	if got != expected {
+		t.Errorf("hash mismatch: got %s, want %s", got, expected)
+	}
+}
+
+// TestCommit_HashIsSet verifies that Commit stores a non-empty commit_hash.
+func TestCommit_HashIsSet(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	resp, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default/default",
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "hello.txt", Content: []byte("hello")}},
+		Message: "first commit",
+		Author:  "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	var commitHash sql.NullString
+	err = d.QueryRowContext(ctx,
+		"SELECT commit_hash FROM commits WHERE sequence = $1",
+		resp.Sequence,
+	).Scan(&commitHash)
+	if err != nil {
+		t.Fatalf("query commit_hash: %v", err)
+	}
+	if !commitHash.Valid || commitHash.String == "" {
+		t.Fatal("expected commit_hash to be set, got NULL or empty")
+	}
+	if len(commitHash.String) != 64 {
+		t.Errorf("expected 64-char hex commit_hash, got %q", commitHash.String)
+	}
+}
+
+// TestCommit_ChainLinks verifies that the second commit's hash links to the first.
+func TestCommit_ChainLinks(t *testing.T) {
+	d := testutil.TestDB(t, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	resp1, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default/default",
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "a.txt", Content: []byte("alpha")}},
+		Message: "first",
+		Author:  "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit 1: %v", err)
+	}
+
+	resp2, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default/default",
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "b.txt", Content: []byte("beta")}},
+		Message: "second",
+		Author:  "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit 2: %v", err)
+	}
+
+	var hash1, hash2 sql.NullString
+	if err := d.QueryRowContext(ctx, "SELECT commit_hash FROM commits WHERE sequence = $1", resp1.Sequence).Scan(&hash1); err != nil {
+		t.Fatalf("query hash1: %v", err)
+	}
+	if err := d.QueryRowContext(ctx, "SELECT commit_hash FROM commits WHERE sequence = $1", resp2.Sequence).Scan(&hash2); err != nil {
+		t.Fatalf("query hash2: %v", err)
+	}
+	if !hash1.Valid || !hash2.Valid {
+		t.Fatal("expected both hashes to be set")
+	}
+	if hash1.String == hash2.String {
+		t.Error("expected different hashes for different commits")
+	}
+}

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -158,8 +158,9 @@ type CommitFileResult struct {
 
 // CommitResponse is the response for POST /commit.
 type CommitResponse struct {
-	Sequence int64              `json:"sequence"`
-	Files    []CommitFileResult `json:"files"`
+	Sequence   int64              `json:"sequence"`
+	Files      []CommitFileResult `json:"files"`
+	CommitHash string             `json:"commit_hash,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -149,6 +149,13 @@ func (s *server) handleReposPrefix(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		}
 
+	case endpoint == "chain":
+		if r.Method == http.MethodGet {
+			s.handleChain(w, r)
+		} else {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+
 	case strings.HasPrefix(endpoint, "commit/"):
 		if r.Method == http.MethodGet {
 			r.SetPathValue("sequence", strings.TrimPrefix(endpoint, "commit/"))
@@ -1306,4 +1313,48 @@ func (s *server) handleBranchStatus(w http.ResponseWriter, r *http.Request, repo
 		Mergeable: mergeable,
 		Policies:  results,
 	})
+}
+
+// handleChain implements GET /repos/:name/-/chain?from=N&to=N
+// Returns commit metadata for sequences in [from, to] with commit hashes and file content hashes.
+func (s *server) handleChain(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+	if s.readStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "read store not available")
+		return
+	}
+
+	fromStr := r.URL.Query().Get("from")
+	toStr := r.URL.Query().Get("to")
+	if fromStr == "" || toStr == "" {
+		writeError(w, http.StatusBadRequest, "from and to query parameters are required")
+		return
+	}
+	from, err := strconv.ParseInt(fromStr, 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid 'from' parameter")
+		return
+	}
+	to, err := strconv.ParseInt(toStr, 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid 'to' parameter")
+		return
+	}
+	if from > to {
+		writeError(w, http.StatusBadRequest, "'from' must be <= 'to'")
+		return
+	}
+
+	entries, err := s.readStore.GetChain(r.Context(), repo, from, to)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if entries == nil {
+		entries = []store.ChainEntry{}
+	}
+	writeJSON(w, http.StatusOK, entries)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,6 +24,7 @@ type readStore interface {
 	ListBranches(ctx context.Context, repo, statusFilter string) ([]store.BranchInfo, error)
 	GetDiff(ctx context.Context, repo, branch string) (*store.DiffResult, error)
 	GetCommit(ctx context.Context, repo string, seq int64) (*store.CommitDetail, error)
+	GetChain(ctx context.Context, repo string, from, to int64) ([]store.ChainEntry, error)
 }
 
 // policyCache is the interface for loading and invalidating OPA policy engines.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1805,13 +1805,14 @@ func TestHandleFileHistory_InvalidAfter(t *testing.T) {
 
 // mockReadStore implements the readStore interface for testing.
 type mockReadStore struct {
-	getBranchFn      func(ctx context.Context, repo, branch string) (*store.BranchInfo, error)
-	getDiffFn        func(ctx context.Context, repo, branch string) (*store.DiffResult, error)
+	getBranchFn       func(ctx context.Context, repo, branch string) (*store.BranchInfo, error)
+	getDiffFn         func(ctx context.Context, repo, branch string) (*store.DiffResult, error)
 	materializeTreeFn func(ctx context.Context, repo, branch string, atSeq *int64, limit int, afterPath string) ([]store.TreeEntry, error)
 	getFileFn         func(ctx context.Context, repo, branch, path string, atSeq *int64) (*store.FileContent, error)
 	getFileHistoryFn  func(ctx context.Context, repo, branch, path string, limit int, afterSeq *int64) ([]store.FileHistoryEntry, error)
 	listBranchesFn    func(ctx context.Context, repo, statusFilter string) ([]store.BranchInfo, error)
 	getCommitFn       func(ctx context.Context, repo string, seq int64) (*store.CommitDetail, error)
+	getChainFn        func(ctx context.Context, repo string, from, to int64) ([]store.ChainEntry, error)
 }
 
 func (m *mockReadStore) GetBranch(ctx context.Context, repo, branch string) (*store.BranchInfo, error) {
@@ -1861,6 +1862,13 @@ func (m *mockReadStore) GetCommit(ctx context.Context, repo string, seq int64) (
 		return m.getCommitFn(ctx, repo, seq)
 	}
 	return nil, nil
+}
+
+func (m *mockReadStore) GetChain(ctx context.Context, repo string, from, to int64) ([]store.ChainEntry, error) {
+	if m.getChainFn != nil {
+		return m.getChainFn(ctx, repo, from, to)
+	}
+	return []store.ChainEntry{}, nil
 }
 
 // mockPolicyCache implements the policyCache interface for testing.
@@ -2250,5 +2258,76 @@ default allow = true
 	}
 	if len(pc.invalidated) != 0 {
 		t.Errorf("expected no Invalidate calls from branch status, got: %v", pc.invalidated)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Chain endpoint tests
+// ---------------------------------------------------------------------------
+
+func TestHandleChain_Success(t *testing.T) {
+	hash := "abc123"
+	rs := &mockReadStore{
+		getChainFn: func(ctx context.Context, repo string, from, to int64) ([]store.ChainEntry, error) {
+			if repo != "default/default" || from != 1 || to != 2 {
+				t.Errorf("unexpected args: repo=%s from=%d to=%d", repo, from, to)
+			}
+			return []store.ChainEntry{
+				{
+					Sequence:   1,
+					Branch:     "main",
+					Author:     "alice",
+					Message:    "first",
+					CreatedAt:  time.Now(),
+					CommitHash: &hash,
+					Files:      []store.ChainFile{{Path: "a.txt", ContentHash: "aaa"}},
+				},
+			}, nil
+		},
+	}
+	h := newTestHandler(&mockStore{}, rs, nil)
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/chain?from=1&to=2", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var entries []store.ChainEntry
+	if err := json.NewDecoder(w.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Sequence != 1 {
+		t.Errorf("expected sequence 1, got %d", entries[0].Sequence)
+	}
+	if entries[0].CommitHash == nil || *entries[0].CommitHash != "abc123" {
+		t.Errorf("unexpected commit_hash: %v", entries[0].CommitHash)
+	}
+}
+
+func TestHandleChain_MissingParams(t *testing.T) {
+	rs := &mockReadStore{}
+	h := newTestHandler(&mockStore{}, rs, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/chain", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing params, got %d", w.Code)
+	}
+}
+
+func TestHandleChain_InvalidFrom(t *testing.T) {
+	rs := &mockReadStore{}
+	h := newTestHandler(&mockStore{}, rs, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/chain?from=abc&to=5", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid from, got %d", w.Code)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -413,6 +413,89 @@ func isBinaryContentType(ct string) bool {
 	return ct != "" && !strings.HasPrefix(ct, "text/")
 }
 
+// ChainEntry is one commit in the hash chain response.
+type ChainEntry struct {
+	Sequence   int64       `json:"sequence"`
+	Branch     string      `json:"branch"`
+	Author     string      `json:"author"`
+	Message    string      `json:"message"`
+	CreatedAt  time.Time   `json:"created_at"`
+	CommitHash *string     `json:"commit_hash"`
+	Files      []ChainFile `json:"files"`
+}
+
+// ChainFile is one file change within a ChainEntry.
+type ChainFile struct {
+	Path        string `json:"path"`
+	ContentHash string `json:"content_hash"`
+}
+
+// GetChain returns commit metadata for sequences in [from, to] inclusive,
+// ordered by sequence ascending. Each entry includes the commit_hash (if set)
+// and the files changed in that commit with their content hashes.
+func (s *Store) GetChain(ctx context.Context, repo string, from, to int64) ([]ChainEntry, error) {
+	const q = `
+SELECT c.sequence, c.branch, c.author, c.message, c.created_at, c.commit_hash,
+       fc.path, d.content_hash
+FROM commits c
+LEFT JOIN file_commits fc ON fc.sequence = c.sequence AND fc.repo = c.repo
+LEFT JOIN documents d ON d.version_id = fc.version_id AND d.repo = c.repo
+WHERE c.repo = $1 AND c.sequence >= $2 AND c.sequence <= $3
+ORDER BY c.sequence ASC, fc.path ASC`
+
+	rows, err := s.db.QueryContext(ctx, q, repo, from, to)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var entries []ChainEntry
+	var cur *ChainEntry
+	for rows.Next() {
+		var seq int64
+		var branch, author, message string
+		var createdAt time.Time
+		var commitHash sql.NullString
+		var path sql.NullString
+		var contentHash sql.NullString
+
+		if err := rows.Scan(&seq, &branch, &author, &message, &createdAt, &commitHash, &path, &contentHash); err != nil {
+			return nil, err
+		}
+
+		if cur == nil || cur.Sequence != seq {
+			if cur != nil {
+				entries = append(entries, *cur)
+			}
+			var chPtr *string
+			if commitHash.Valid {
+				v := commitHash.String
+				chPtr = &v
+			}
+			cur = &ChainEntry{
+				Sequence:   seq,
+				Branch:     branch,
+				Author:     author,
+				Message:    message,
+				CreatedAt:  createdAt,
+				CommitHash: chPtr,
+				Files:      []ChainFile{},
+			}
+		}
+
+		if path.Valid {
+			cur.Files = append(cur.Files, ChainFile{
+				Path:        path.String,
+				ContentHash: contentHash.String, // empty string for deletes (NULL content_hash)
+			})
+		}
+	}
+	if cur != nil {
+		entries = append(entries, *cur)
+	}
+	return entries, rows.Err()
+}
+
 // GetCommit returns all file changes in a single atomic commit (by sequence) within a repo.
 // Returns nil, nil if no commit exists with that sequence in the repo.
 func (s *Store) GetCommit(ctx context.Context, repo string, sequence int64) (*CommitDetail, error) {


### PR DESCRIPTION
## Summary

- **Schema**: Adds `commit_hash`, `rekor_uuid`, `signature_bundle` columns to `commits` table (all three added per spec; only `commit_hash` used in Phase 1)
- **Server hash computation**: On every `Commit()`, `Merge()`, and `Rebase()`, computes `SHA256(prevHash || seq || repo || branch || author || message || created_at || sorted_file_changes)` and stores it via `UPDATE commits SET commit_hash=...` within the same transaction
- **Chain endpoint**: `GET /repos/{name}/-/chain?from=N&to=M` returns commit metadata + file content hashes for client-side verification
- **Client state**: Adds `CommitHash` to `state.json`; populated after every pull and commit
- **Pull verification**: TOFU on first pull (stores tip hash); subsequent pulls fetch chain, do anchor check + linkage verification; aborts on mismatch
- **`ds verify` command**: Walks chain from first non-NULL commit to head, prints OK/SKIP/FAIL per commit

## Test plan

- [x] `TestComputeCommitHash` — fixed input → deterministic known SHA256 output
- [x] `TestCommit_HashIsSet` — commit_hash is persisted in DB after commit
- [x] `TestCommit_ChainLinks` — two commits have different, linked hashes
- [x] `TestHandleChain_Success` — handler returns chain data correctly
- [x] `TestHandleChain_MissingParams` / `TestHandleChain_InvalidFrom` — handler validates params
- [x] `TestPull_TOFU` — first pull with no stored hash stores the tip hash
- [x] `TestPull_VerificationSuccess` — valid chain passes without error
- [x] `TestPull_VerificationFailure` — tampered hash → "chain integrity error"
- [x] `TestVerify_HappyPath` — `ds verify` prints OK for valid chain
- [x] All existing tests continue to pass (`go test ./...`)

## ⚠️ Deployment note

**DB reset required before merging**: The schema adds new columns to `commits` (which has existing data on any running instance). Fresh schema only.

```
DATABASE_URL=... make db-reset
```

## Notes for follow-on work

- Phase 2 (server-side Sigstore signing): `rekor_uuid` and `signature_bundle` columns already present; signing logic hooks into the same hash computation
- Phase 3 (client-side signing): client bundle would be included in POST /commit; server verifies against IAP identity
- Consider performance: for repos with many commits, the chain endpoint could be paginated

Closes part of #76 (Phase 1 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)