### PR TITLE
Add ds role list/set/delete commands (issue #83)

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -50,7 +50,11 @@ commands:
 
   roles                                           List roles for the current repo
   roles set <identity> <role>                     Set a role (reader/writer/maintainer/admin)
-  roles delete <identity>                         Delete a role assignment`
+  roles delete <identity>                         Delete a role assignment
+
+  role list                                       List roles for the current repo
+  role set <identity> <role>                      Set a role (reader/writer/maintainer/admin)
+  role delete <identity>                          Delete a role assignment`
 
 func main() {
 	if len(os.Args) < 2 {
@@ -370,6 +374,32 @@ func main() {
 				fmt.Fprintln(os.Stderr, usage)
 				os.Exit(1)
 			}
+		}
+
+	case "role":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: ds role list|set|delete ...")
+			os.Exit(1)
+		}
+		switch args[1] {
+		case "list":
+			err = app.Roles()
+		case "set":
+			if len(args) < 4 {
+				fmt.Fprintln(os.Stderr, "usage: ds role set <identity> <role>")
+				os.Exit(1)
+			}
+			err = app.RolesSet(args[2], args[3])
+		case "delete":
+			if len(args) < 3 {
+				fmt.Fprintln(os.Stderr, "usage: ds role delete <identity>")
+				os.Exit(1)
+			}
+			err = app.RolesDelete(args[2])
+		default:
+			fmt.Fprintf(os.Stderr, "unknown role subcommand: %s\n", args[1])
+			fmt.Fprintln(os.Stderr, usage)
+			os.Exit(1)
 		}
 
 	default:


### PR DESCRIPTION
## Summary

- Adds `ds role list`, `ds role set <identity> <role>`, and `ds role delete <identity>` CLI commands
- These route to the existing `App.Roles`, `App.RolesSet`, and `App.RolesDelete` methods (added in issue #72)
- No new App/server code needed — purely CLI routing in `cmd/ds/main.go`
- The existing `ds roles` / `ds roles set` / `ds roles delete` commands are preserved for backwards compatibility

## Context

Issue #83 asked for singular `role` subcommands with an explicit `list` subcommand. Issue #72 had already implemented the underlying `roles` (plural) commands. This PR bridges the gap by adding the singular form.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` passes (all 75+ tests in internal/cli, including `TestRoles_EndToEnd` and `TestRolesSet_InvalidRole`)
- [ ] Manual: `ds role list`, `ds role set alice@example.com writer`, `ds role delete alice@example.com`

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)