### PR TITLE
Add ds orgs get subcommand (issue #81)

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -41,6 +41,7 @@ commands:
 
   orgs                                            List organizations
   orgs create <name>                              Create an organization
+  orgs get <name>                                 Get details for an organization
   orgs delete <name>                              Delete an organization
   orgs repos <name>                               List repos in an organization
 
@@ -305,6 +306,12 @@ func main() {
 					os.Exit(1)
 				}
 				err = app.OrgsCreate(args[2])
+			case "get":
+				if len(args) < 3 {
+					fmt.Fprintln(os.Stderr, "usage: ds orgs get <name>")
+					os.Exit(1)
+				}
+				err = app.OrgsGet(args[2])
 			case "delete":
 				if len(args) < 3 {
 					fmt.Fprintln(os.Stderr, "usage: ds orgs delete <name>")

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1942,6 +1942,33 @@ func (a *App) OrgsCreate(name string) error {
 	return nil
 }
 
+// OrgsGet fetches and prints details for a single organization.
+func (a *App) OrgsGet(name string) error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doGET(remote + "/orgs/" + name)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("org '%s' not found", name)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var org model.Org
+	if err := json.NewDecoder(resp.Body).Decode(&org); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "Name:       %s\n", org.Name)
+	fmt.Fprintf(a.Out, "Created by: %s\n", org.CreatedBy)
+	fmt.Fprintf(a.Out, "Created at: %s\n", org.CreatedAt.Format("2006-01-02"))
+	return nil
+}
+
 // OrgsDelete deletes an organization (fails if it still has repos).
 func (a *App) OrgsDelete(name string) error {
 	remote, err := a.loadRemote()

--- a/internal/cli/e2e_test.go
+++ b/internal/cli/e2e_test.go
@@ -353,6 +353,20 @@ func TestOrgs_EndToEnd(t *testing.T) {
 		t.Errorf("expected 'e2eorg' in listing, got: %s", out.String())
 	}
 
+	// Get org — should return details.
+	out.Reset()
+	if err := app.OrgsGet("e2eorg"); err != nil {
+		t.Fatalf("OrgsGet: %v", err)
+	}
+	if !strings.Contains(out.String(), "e2eorg") {
+		t.Errorf("expected 'e2eorg' in get output, got: %s", out.String())
+	}
+
+	// Get non-existent org — should error.
+	if err := app.OrgsGet("nosuchorg"); err == nil {
+		t.Error("expected error for missing org, got nil")
+	}
+
 	// Delete org.
 	out.Reset()
 	if err := app.OrgsDelete("e2eorg"); err != nil {


### PR DESCRIPTION
## Summary

- The server already had `GET /orgs/{org}` but the CLI was missing a corresponding command
- Adds `App.OrgsGet(name string)` in `internal/cli/app.go` following the same pattern as `OrgsCreate`/`OrgsDelete`
- Adds `ds orgs get <name>` subcommand handling in `cmd/ds/main.go`
- Updates the usage string to document the new subcommand
- Adds E2E test covering successful get and 404-error case for missing org

## Test plan

- [x] `go test ./... -count=1` passes (all packages)
- [x] `go build ./... && go vet ./...` clean
- New `TestOrgs_EndToEnd` test verifies get returns org details and errors on missing org

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)