### PR TITLE
Add CLI commands for repo management (issue #82)

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -38,6 +38,7 @@ commands:
   check --name <n> --status passed|failed [--branch <name>]  Report a CI check
   import-git <path> [--mode squash|replay]        Import a git repo into docstore main
   tui                                             Launch the terminal UI
+  purge --older-than <Nd> [--dry-run]             Purge old merged/abandoned branches
 
   orgs                                            List organizations
   orgs create <name>                              Create an organization
@@ -45,9 +46,16 @@ commands:
   orgs delete <name>                              Delete an organization
   orgs repos <name>                               List repos in an organization
 
+  repo list                                       List repositories
+  repo create <owner/name>                        Create a repository
+  repo get <owner/name>                           Get a repository
+  repo delete <owner/name>                        Delete a repository
+
   repos                                           List repositories
   repos create <owner> <name>                     Create a repository
   repos delete <name>                             Delete a repository (e.g. acme/myrepo)
+
+  branch delete <name>                            Delete a branch from the current repo
 
   roles                                           List roles for the current repo
   roles set <identity> <role>                     Set a role (reader/writer/maintainer/admin)
@@ -408,6 +416,82 @@ func main() {
 			fmt.Fprintln(os.Stderr, usage)
 			os.Exit(1)
 		}
+
+	case "repo":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: ds repo <list|create|get|delete> [args]")
+			os.Exit(1)
+		}
+		switch args[1] {
+		case "list":
+			err = app.Repos()
+		case "create":
+			if len(args) < 3 {
+				fmt.Fprintln(os.Stderr, "usage: ds repo create <owner/name>")
+				os.Exit(1)
+			}
+			fullName := args[2]
+			slash := strings.Index(fullName, "/")
+			if slash <= 0 || slash == len(fullName)-1 {
+				fmt.Fprintln(os.Stderr, "error: repo name must be in owner/name format")
+				os.Exit(1)
+			}
+			err = app.ReposCreate(fullName[:slash], fullName[slash+1:])
+		case "get":
+			if len(args) < 3 {
+				fmt.Fprintln(os.Stderr, "usage: ds repo get <owner/name>")
+				os.Exit(1)
+			}
+			err = app.RepoGet(args[2])
+		case "delete":
+			if len(args) < 3 {
+				fmt.Fprintln(os.Stderr, "usage: ds repo delete <owner/name>")
+				os.Exit(1)
+			}
+			err = app.ReposDelete(args[2])
+		default:
+			fmt.Fprintf(os.Stderr, "unknown repo subcommand: %s\n", args[1])
+			fmt.Fprintln(os.Stderr, usage)
+			os.Exit(1)
+		}
+
+	case "branch":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: ds branch <delete> [args]")
+			os.Exit(1)
+		}
+		switch args[1] {
+		case "delete":
+			if len(args) < 3 {
+				fmt.Fprintln(os.Stderr, "usage: ds branch delete <name>")
+				os.Exit(1)
+			}
+			err = app.BranchDelete(args[2])
+		default:
+			fmt.Fprintf(os.Stderr, "unknown branch subcommand: %s\n", args[1])
+			fmt.Fprintln(os.Stderr, usage)
+			os.Exit(1)
+		}
+
+	case "purge":
+		olderThan := ""
+		dryRun := false
+		for i := 1; i < len(args); i++ {
+			switch args[i] {
+			case "--older-than":
+				if i+1 < len(args) {
+					olderThan = args[i+1]
+					i++
+				}
+			case "--dry-run":
+				dryRun = true
+			}
+		}
+		if olderThan == "" {
+			fmt.Fprintln(os.Stderr, "usage: ds purge --older-than <Nd> [--dry-run]")
+			os.Exit(1)
+		}
+		err = app.Purge(olderThan, dryRun)
 
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", cmd)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -2087,6 +2087,100 @@ func (a *App) ReposDelete(name string) error {
 	return nil
 }
 
+// RepoGet gets a single repository by full name (e.g., "acme/myrepo").
+func (a *App) RepoGet(fullName string) error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doGET(remote + "/repos/" + fullName)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("repo '%s' not found", fullName)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var repo model.Repo
+	if err := json.NewDecoder(resp.Body).Decode(&repo); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "%-30s  %-20s  %-20s  %s\n", "NAME", "OWNER", "CREATED BY", "CREATED AT")
+	fmt.Fprintf(a.Out, "%-30s  %-20s  %-20s  %s\n", repo.Name, repo.Owner, repo.CreatedBy, repo.CreatedAt.Format("2006-01-02"))
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Branch management (CLI-level)
+// ---------------------------------------------------------------------------
+
+// BranchDelete deletes a branch from the current repo by name.
+func (a *App) BranchDelete(branch string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doDELETE(repoBase(cfg) + "/branch/" + url.PathEscape(branch))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("branch '%s' not found", branch)
+	}
+	if resp.StatusCode == http.StatusConflict {
+		return fmt.Errorf("branch '%s' is already merged or abandoned", branch)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Deleted branch '%s'\n", branch)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Purge
+// ---------------------------------------------------------------------------
+
+// Purge removes merged/abandoned branches and their unreachable data from the
+// current repo. olderThan is a duration string like "30d". If dryRun is true
+// the server reports what would be deleted without deleting anything.
+func (a *App) Purge(olderThan string, dryRun bool) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	req := model.PurgeRequest{OlderThan: olderThan, DryRun: dryRun}
+	resp, err := a.postJSON(cfg, repoBase(cfg)+"/purge", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("repo '%s' not found", cfg.Repo)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var result model.PurgeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	if dryRun {
+		fmt.Fprintf(a.Out, "[dry-run] would purge:\n")
+	}
+	fmt.Fprintf(a.Out, "  branches purged:      %d\n", result.BranchesPurged)
+	fmt.Fprintf(a.Out, "  file commits deleted: %d\n", result.FileCommitsDeleted)
+	fmt.Fprintf(a.Out, "  commits deleted:      %d\n", result.CommitsDeleted)
+	fmt.Fprintf(a.Out, "  documents deleted:    %d\n", result.DocumentsDeleted)
+	fmt.Fprintf(a.Out, "  reviews deleted:      %d\n", result.ReviewsDeleted)
+	fmt.Fprintf(a.Out, "  check runs deleted:   %d\n", result.CheckRunsDeleted)
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // Role management
 // ---------------------------------------------------------------------------

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -2784,3 +2784,186 @@ func TestPull_TOFU_NullHash(t *testing.T) {
 		t.Errorf("expected predates-hash-chain note in output, got: %s", out.String())
 	}
 }
+
+// ---------------------------------------------------------------------------
+// RepoGet
+// ---------------------------------------------------------------------------
+
+func TestRepoGet_Success(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/repos/acme/myrepo" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(model.Repo{
+				Name:      "acme/myrepo",
+				Owner:     "acme",
+				CreatedBy: "alice",
+				CreatedAt: now,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	app.DefaultRemote = srv.URL
+
+	if err := app.RepoGet("acme/myrepo"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "acme/myrepo") {
+		t.Errorf("expected repo name in output, got: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "alice") {
+		t.Errorf("expected created_by in output, got: %s", out.String())
+	}
+}
+
+func TestRepoGet_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(model.ErrorResponse{Error: "not found"})
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	app.DefaultRemote = srv.URL
+
+	err := app.RepoGet("acme/nope")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not found error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BranchDelete
+// ---------------------------------------------------------------------------
+
+func TestBranchDelete_Success(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	if err := app.BranchDelete("feature/x"); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotMethod != "DELETE" {
+		t.Errorf("expected DELETE request, got %s", gotMethod)
+	}
+	if !strings.Contains(gotPath, "/branch/") {
+		t.Errorf("expected branch path, got %s", gotPath)
+	}
+	if !strings.Contains(out.String(), "Deleted branch 'feature/x'") {
+		t.Errorf("expected deletion message in output, got: %s", out.String())
+	}
+}
+
+func TestBranchDelete_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(model.ErrorResponse{Error: "branch not found"})
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	err := app.BranchDelete("nonexistent")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not found error, got: %v", err)
+	}
+}
+
+func TestBranchDelete_AlreadyMerged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(model.ErrorResponse{Error: "branch is already merged or abandoned"})
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	err := app.BranchDelete("merged-branch")
+	if err == nil || !strings.Contains(err.Error(), "merged or abandoned") {
+		t.Errorf("expected merged/abandoned error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Purge
+// ---------------------------------------------------------------------------
+
+func TestPurge_Success(t *testing.T) {
+	var gotReq model.PurgeRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/repos/default/default/-/purge" {
+			json.NewDecoder(r.Body).Decode(&gotReq)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(model.PurgeResponse{
+				BranchesPurged:     3,
+				FileCommitsDeleted: 12,
+				CommitsDeleted:     6,
+				DocumentsDeleted:   9,
+				ReviewsDeleted:     2,
+				CheckRunsDeleted:   4,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	if err := app.Purge("30d", false); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotReq.OlderThan != "30d" {
+		t.Errorf("older_than = %q, want %q", gotReq.OlderThan, "30d")
+	}
+	if gotReq.DryRun {
+		t.Error("expected dry_run=false")
+	}
+	if !strings.Contains(out.String(), "branches purged") {
+		t.Errorf("expected purge summary in output, got: %s", out.String())
+	}
+}
+
+func TestPurge_DryRun(t *testing.T) {
+	var gotReq model.PurgeRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&gotReq)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(model.PurgeResponse{BranchesPurged: 1})
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	if err := app.Purge("7d", true); err != nil {
+		t.Fatal(err)
+	}
+
+	if !gotReq.DryRun {
+		t.Error("expected dry_run=true")
+	}
+	if !strings.Contains(out.String(), "dry-run") {
+		t.Errorf("expected dry-run note in output, got: %s", out.String())
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `ds repo list/create/get/delete` subcommand group (new `owner/name` format for create/get/delete)
- Adds `ds branch delete <name>` to expose `DELETE /repos/:name/-/branch/:bname`
- Adds `ds purge --older-than <Nd> [--dry-run]` to expose `POST /repos/:name/-/purge`

Existing `ds repos` subcommand group is preserved for backwards compatibility.

## New methods in `internal/cli/app.go`

- `RepoGet(fullName string) error` — `GET /repos/:name`
- `BranchDelete(branch string) error` — `DELETE /repos/:name/-/branch/:bname` (uses workspace config for repo)
- `Purge(olderThan string, dryRun bool) error` — `POST /repos/:name/-/purge` (uses workspace config for repo)

## Test plan

- [x] 7 new unit tests covering success and error paths: `TestRepoGet_*`, `TestBranchDelete_*`, `TestPurge_*`
- [x] All existing tests pass (`go test ./... -count=1`)
- [x] `go build ./...` and `go vet ./...` are clean

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)