### PR TITLE
Add --skip-verify flag to ds pull (issue #76 Phase 1 gap)

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -23,7 +23,7 @@ commands:
   commit -m "message"                             Commit all changes
   checkout -b <branch>                            Create and switch to a new branch
   checkout <branch>                               Switch to an existing branch
-  pull                                            Sync files from the server
+  pull [--skip-verify]                            Sync files from the server
   merge                                           Merge current branch into main
   diff                                            Show branch diff from server
   log [path] [--limit N]                          Show commit history (default limit 20)
@@ -146,7 +146,13 @@ func main() {
 		}
 
 	case "pull":
-		err = app.Pull()
+		skipVerify := false
+		for i := 1; i < len(args); i++ {
+			if args[i] == "--skip-verify" {
+				skipVerify = true
+			}
+		}
+		err = app.Pull(skipVerify)
 
 	case "merge":
 		err = app.Merge()

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -350,7 +350,7 @@ func (a *App) Init(remote, repo, author string) error {
 	}
 
 	// Fetch files from the server.
-	if err := a.syncTree(cfg, "main"); err != nil {
+	if err := a.syncTree(cfg, "main", false); err != nil {
 		return err
 	}
 
@@ -573,14 +573,15 @@ func (a *App) Checkout(branch string) error {
 		return err
 	}
 
-	return a.syncTree(cfg, branch)
+	return a.syncTree(cfg, branch, false)
 }
 
 // Pull syncs local files from the current branch on the server.
 // If state has a stored CommitHash, it verifies the chain from the stored
 // sequence to the new head before updating state. On first pull (no stored
 // CommitHash), it uses TOFU and stores the tip's commit_hash.
-func (a *App) Pull() error {
+// If skipVerify is true, chain verification is skipped but state is still updated normally.
+func (a *App) Pull(skipVerify bool) error {
 	cfg, err := a.loadConfig()
 	if err != nil {
 		return err
@@ -601,7 +602,7 @@ func (a *App) Pull() error {
 		return err
 	}
 
-	if err := a.syncTree(cfg, cfg.Branch); err != nil {
+	if err := a.syncTree(cfg, cfg.Branch, skipVerify); err != nil {
 		return err
 	}
 
@@ -612,6 +613,9 @@ func (a *App) Pull() error {
 	}
 
 	// Chain verification / TOFU.
+	if skipVerify {
+		return nil
+	}
 	if newState.Sequence == 0 {
 		// No commits yet; nothing to verify.
 		return nil
@@ -763,7 +767,9 @@ func (a *App) Verify() error {
 }
 
 // syncTree fetches the full tree from the server and updates local files.
-func (a *App) syncTree(cfg *Config, branch string) error {
+// skipVerify is accepted for API consistency with Pull but is unused here;
+// verification occurs in Pull after syncTree returns.
+func (a *App) syncTree(cfg *Config, branch string, skipVerify bool) error {
 	st, err := a.loadState()
 	if err != nil {
 		return err
@@ -929,7 +935,7 @@ func (a *App) Merge() error {
 	if err := a.saveConfig(cfg); err != nil {
 		return err
 	}
-	return a.syncTree(cfg, "main")
+	return a.syncTree(cfg, "main", false)
 }
 
 // Diff shows the diff for the current branch relative to its base.

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -799,7 +799,7 @@ func TestPull(t *testing.T) {
 	writeFile(t, app, "updated.txt", oldContent)
 	app.saveState(&State{Branch: "feature/x", Files: map[string]string{"updated.txt": HashBytes([]byte(oldContent))}})
 
-	if err := app.Pull(); err != nil {
+	if err := app.Pull(false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -855,7 +855,7 @@ func TestPullSkipsUnchanged(t *testing.T) {
 	writeFile(t, app, "same.txt", sameContent)
 	app.saveState(&State{Branch: "main", Files: map[string]string{"same.txt": sameHash}})
 
-	if err := app.Pull(); err != nil {
+	if err := app.Pull(false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -875,7 +875,7 @@ func TestPullDirtyTree(t *testing.T) {
 	// Add a new untracked file — makes the tree dirty.
 	writeFile(t, app, "new.txt", "new content")
 
-	err := app.Pull()
+	err := app.Pull(false)
 	if err == nil || !strings.Contains(err.Error(), "uncommitted changes") {
 		t.Errorf("expected 'uncommitted changes' error, got: %v", err)
 	}
@@ -898,7 +898,7 @@ func TestSyncTreeUpdatesSequence(t *testing.T) {
 	app, _ := newTestApp(t, srv)
 	initWorkspace(t, app, srv.URL, "main", "alice")
 
-	if err := app.Pull(); err != nil {
+	if err := app.Pull(false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2579,7 +2579,7 @@ func TestPull_TOFU(t *testing.T) {
 	app, _ := newTestApp(t, srv)
 	initWorkspace(t, app, srv.URL, "main", "alice")
 
-	if err := app.Pull(); err != nil {
+	if err := app.Pull(false); err != nil {
 		t.Fatalf("Pull: %v", err)
 	}
 
@@ -2614,7 +2614,7 @@ func TestPull_VerificationSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := app.Pull(); err != nil {
+	if err := app.Pull(false); err != nil {
 		t.Fatalf("Pull: %v", err)
 	}
 
@@ -2652,7 +2652,7 @@ func TestPull_VerificationFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := app.Pull()
+	err := app.Pull(false)
 	if err == nil {
 		t.Fatal("expected chain integrity error, got nil")
 	}
@@ -2731,7 +2731,7 @@ func TestPull_AnchorTampered(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := app.Pull()
+	err := app.Pull(false)
 	if err == nil {
 		t.Fatal("expected chain integrity error for tampered anchor, got nil")
 	}
@@ -2766,7 +2766,7 @@ func TestPull_TOFU_NullHash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := app.Pull(); err != nil {
+	if err := app.Pull(false); err != nil {
 		t.Fatalf("Pull: unexpected error: %v", err)
 	}
 
@@ -2965,5 +2965,51 @@ func TestPurge_DryRun(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "dry-run") {
 		t.Errorf("expected dry-run note in output, got: %s", out.String())
+	}
+}
+
+// TestPull_SkipVerify verifies that Pull(skipVerify=true) updates state normally
+// but skips chain verification even when the chain would fail.
+func TestPull_SkipVerify(t *testing.T) {
+	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	e1 := newChainEntry(genesisHash, 1, "default/default", "main", "alice", "first", ts)
+
+	// Build a second entry with a deliberately wrong hash.
+	badHash := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	e2Wrong := chainEntry{
+		Sequence:   2,
+		Branch:     "main",
+		Author:     "alice",
+		Message:    "second",
+		CreatedAt:  ts.Add(time.Second),
+		CommitHash: &badHash,
+		Files:      []chainFile{},
+	}
+
+	// The server has a bad chain that would normally cause a verification error.
+	srv := newPullServer(t, "main", 2, []chainEntry{e1, e2Wrong})
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	// Pre-seed state so verification would be triggered (non-empty CommitHash).
+	st := &State{Branch: "main", Sequence: 1, Files: make(map[string]string), CommitHash: *e1.CommitHash}
+	if err := app.saveState(st); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pull with skipVerify=true must succeed despite the bad chain.
+	if err := app.Pull(true); err != nil {
+		t.Fatalf("Pull(skipVerify=true): unexpected error: %v", err)
+	}
+
+	// State should be updated to the new sequence.
+	newSt, err := app.loadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newSt.Sequence != 2 {
+		t.Errorf("state.Sequence = %d, want 2", newSt.Sequence)
 	}
 }

--- a/internal/cli/e2e_test.go
+++ b/internal/cli/e2e_test.go
@@ -171,7 +171,7 @@ func TestFullWorkflow(t *testing.T) {
 
 	// ── Workspace 2: pull to get the merged changes ───────────────────────
 
-	if err := ws2.Pull(); err != nil {
+	if err := ws2.Pull(false); err != nil {
 		t.Fatalf("ws2 Pull: %v", err)
 	}
 

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -49,7 +49,7 @@ func TestIntegrationPull_UpdatesFile(t *testing.T) {
 
 	// ws2: pull should update the file.
 	ws2Out.Reset()
-	if err := ws2.Pull(); err != nil {
+	if err := ws2.Pull(false); err != nil {
 		t.Fatalf("ws2 Pull: %v", err)
 	}
 
@@ -81,7 +81,7 @@ func TestIntegrationPull_NoOp(t *testing.T) {
 
 	// Pull again — nothing changed.
 	wsOut.Reset()
-	if err := ws.Pull(); err != nil {
+	if err := ws.Pull(false); err != nil {
 		t.Fatalf("Pull: %v", err)
 	}
 	if !strings.Contains(wsOut.String(), "0 downloaded") {
@@ -102,7 +102,7 @@ func TestIntegrationPull_DirtyBlocked(t *testing.T) {
 	// Create an uncommitted file — makes the tree dirty.
 	writeFile(t, ws, "uncommitted.txt", "not committed")
 
-	err := ws.Pull()
+	err := ws.Pull(false)
 	if err == nil {
 		t.Fatal("expected error for dirty tree, got nil")
 	}
@@ -144,7 +144,7 @@ func TestIntegrationPull_RemovesDeletedFile(t *testing.T) {
 	}
 
 	// ws2: pull should remove temp.txt from disk.
-	if err := ws2.Pull(); err != nil {
+	if err := ws2.Pull(false); err != nil {
 		t.Fatalf("ws2 Pull: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(ws2.Dir, "temp.txt")); !os.IsNotExist(err) {


### PR DESCRIPTION
## Summary

- **`internal/cli/app.go`**: `Pull()` now accepts `skipVerify bool`; when true, chain verification (TOFU + forward chain check) is skipped but state is updated normally (files downloaded, sequence updated). `syncTree()` signature updated to accept `skipVerify bool` for API consistency (parameter is accepted but unused in syncTree itself, since verification happens in Pull after syncTree returns). All non-Pull callers (`Init`, `Checkout`, `Merge`) pass `false`.
- **`cmd/ds/main.go`**: The `pull` case parses `--skip-verify` flag and passes it to `app.Pull(skipVerify)`. Usage string updated.
- **Tests**: Added `TestPull_SkipVerify` — sets up a deliberately bad chain that would fail normal verification, then asserts `Pull(true)` succeeds and state is updated to the new sequence. All existing `Pull()` call sites updated to `Pull(false)`.

## Test plan

- [x] `go build ./...` — clean build
- [x] `go test ./... -count=1` — all tests pass
- [x] `TestPull_SkipVerify` covers the new flag path
- [x] Existing chain verification tests (`TestPull_VerificationFailure`, `TestPull_AnchorTampered`, etc.) continue to pass with `skipVerify=false`

## Notes for reviewers

The `syncVerify` parameter on `syncTree` is a no-op there but was included per the task spec; if preferred it could be omitted from `syncTree` and kept only on `Pull` to minimize signature churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)