### PR TITLE
Add performance benchmarks for hash chain verification (issue #76)

### DIFF
--- a/internal/db/bench_test.go
+++ b/internal/db/bench_test.go
@@ -1,0 +1,60 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/store"
+	"github.com/dlorenc/docstore/internal/testutil"
+)
+
+// BenchmarkChainWalk_100Commits measures the end-to-end cost of fetching and
+// verifying the hash chain for a repo with 100 commits on main.
+// The benchmark fails if any commit_hash does not match the recomputed value.
+func BenchmarkChainWalk_100Commits(b *testing.B) {
+	d := testutil.TestDB(b, RunMigrations)
+	s := NewStore(d)
+	rs := store.New(d)
+	ctx := context.Background()
+
+	const n = 100
+	for i := 1; i <= n; i++ {
+		_, err := s.Commit(ctx, model.CommitRequest{
+			Repo:    "default/default",
+			Branch:  "main",
+			Files:   []model.FileChange{{Path: fmt.Sprintf("file%03d.txt", i), Content: []byte(fmt.Sprintf("content %d", i))}},
+			Message: fmt.Sprintf("commit %d", i),
+			Author:  "bench@example.com",
+		})
+		if err != nil {
+			b.Fatalf("setup commit %d: %v", i, err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		entries, err := rs.GetChain(ctx, "default/default", 1, n)
+		if err != nil {
+			b.Fatalf("GetChain: %v", err)
+		}
+
+		prevHash := genesisHash
+		for _, e := range entries {
+			if e.CommitHash == nil {
+				prevHash = genesisHash
+				continue
+			}
+			files := make([]chainFile, len(e.Files))
+			for j, f := range e.Files {
+				files[j] = chainFile{path: f.Path, contentHash: f.ContentHash}
+			}
+			got := computeCommitHash(prevHash, e.Sequence, "default/default", e.Branch, e.Author, e.Message, e.CreatedAt, files)
+			if got != *e.CommitHash {
+				b.Fatalf("chain integrity error at sequence %d: got %s want %s", e.Sequence, got, *e.CommitHash)
+			}
+			prevHash = *e.CommitHash
+		}
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3,9 +3,11 @@ package store_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 
 	dbpkg "github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/store"
 	"github.com/dlorenc/docstore/internal/testutil"
 )
@@ -677,6 +679,40 @@ func TestBranchTree(t *testing.T) {
 	for _, want := range []string{"hello.txt", "new.txt", "world.txt"} {
 		if !paths[want] {
 			t.Errorf("expected %s in tree", want)
+		}
+	}
+}
+
+// BenchmarkGetChain_100 measures the server-side GetChain query cost for a
+// repo with 100 commits on main.
+func BenchmarkGetChain_100(b *testing.B) {
+	db := testutil.TestDB(b, dbpkg.RunMigrations)
+	ds := dbpkg.NewStore(db)
+	s := store.New(db)
+	ctx := context.Background()
+
+	const n = 100
+	for i := 1; i <= n; i++ {
+		_, err := ds.Commit(ctx, model.CommitRequest{
+			Repo:    "default/default",
+			Branch:  "main",
+			Files:   []model.FileChange{{Path: fmt.Sprintf("file%03d.txt", i), Content: []byte(fmt.Sprintf("content %d", i))}},
+			Message: fmt.Sprintf("commit %d", i),
+			Author:  "bench@example.com",
+		})
+		if err != nil {
+			b.Fatalf("setup commit %d: %v", i, err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		entries, err := s.GetChain(ctx, "default/default", 1, n)
+		if err != nil {
+			b.Fatalf("GetChain: %v", err)
+		}
+		if len(entries) != n {
+			b.Fatalf("expected %d entries, got %d", n, len(entries))
 		}
 	}
 }

--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -20,7 +20,7 @@ import (
 //
 // If the DOCSTORE_TEST_DSN environment variable is set, it is used instead of
 // starting a container (useful for local development with an existing server).
-func TestDB(t *testing.T, migrate func(*sql.DB) error) *sql.DB {
+func TestDB(t testing.TB, migrate func(*sql.DB) error) *sql.DB {
 	t.Helper()
 
 	// Allow override for local dev.
@@ -74,7 +74,7 @@ func TestDB(t *testing.T, migrate func(*sql.DB) error) *sql.DB {
 
 // testDBFromDSN is the legacy path: use a pre-existing PostgreSQL server via DSN.
 // It creates a unique database per test so parallel tests don't interfere.
-func testDBFromDSN(t *testing.T, dsn string, migrate func(*sql.DB) error) *sql.DB {
+func testDBFromDSN(t testing.TB, dsn string, migrate func(*sql.DB) error) *sql.DB {
 	t.Helper()
 
 	// Connect to the server using the provided DSN (admin connection).


### PR DESCRIPTION
## Summary

- **`BenchmarkChainWalk_100Commits`** (`internal/db/bench_test.go`, package `db`): Creates 100 commits via `db.Store.Commit`, then benchmarks a full chain walk — fetching all entries via `store.GetChain` and verifying every `commit_hash` against the SHA256 recomputed value. Mirrors the client-side chain walk in `ds pull`/`ds verify`.

- **`BenchmarkGetChain_100`** (`internal/store/store_test.go`, package `store_test`): Seeds 100 commits and benchmarks only the server-side `store.Store.GetChain` SQL query, isolating DB query cost from CPU hash-verification cost.

- **`testutil.TestDB` signature widened** from `*testing.T` to `testing.TB` so benchmarks can reuse the testcontainers-backed DB helper without duplication.

## Why

Issue #76 Phase 1 added the hash chain but left no performance regression signal. These benchmarks close that gap — `go test -bench=. -benchtime=10s ./internal/db/ ./internal/store/` now shows concrete latency numbers and any future regression will be visible.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all packages pass
- [ ] `go test -bench=BenchmarkChainWalk_100Commits ./internal/db/` — verifies chain walk < 500 ms per iteration
- [ ] `go test -bench=BenchmarkGetChain_100 ./internal/store/` — verifies query-only path

## Notes / opportunities

- Benchmarks currently spin up a fresh testcontainer per run (slow wall-clock). A future improvement could use `DOCSTORE_TEST_DSN` with a persistent instance in CI for faster benchmark runs.
- Could add sub-benchmarks parametrised over chain length (10 / 100 / 1000) to build a scaling curve.

Closes gap noted in issue #76 Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)