### PR TITLE
Refactor test infra: shared Postgres container per package + t.Parallel()

### DIFF
--- a/internal/cli/e2e_test.go
+++ b/internal/cli/e2e_test.go
@@ -16,7 +16,7 @@ import (
 // instance running the full server handler with a real database.
 func newRealServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -30,6 +30,7 @@ func newRealServer(t *testing.T) *httptest.Server {
 //	init → modify file → commit → checkout -b → add file → commit →
 //	diff → checkout main → merge → pull from second workspace → verify files
 func TestFullWorkflow(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	// ── Workspace 1: init against empty server ────────────────────────────
@@ -195,6 +196,7 @@ func TestFullWorkflow(t *testing.T) {
 
 // TestCLILog_EndToEnd verifies that ds log returns commits in newest-first order.
 func TestCLILog_EndToEnd(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, out := newTestApp(t, srv)
@@ -232,6 +234,7 @@ func TestCLILog_EndToEnd(t *testing.T) {
 
 // TestCLIRebase_EndToEnd exercises the full rebase workflow with a real server.
 func TestCLIRebase_EndToEnd(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, _ := newTestApp(t, srv)
@@ -288,6 +291,7 @@ func TestCLIRebase_EndToEnd(t *testing.T) {
 // TestCLIResolve_EndToEnd exercises the resolve workflow: write conflict files,
 // create a resolved version, call Resolve, verify commit and cleanup.
 func TestCLIResolve_EndToEnd(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, _ := newTestApp(t, srv)
@@ -332,6 +336,7 @@ func TestCLIResolve_EndToEnd(t *testing.T) {
 
 // TestOrgs_EndToEnd verifies org creation, listing, and deletion via a real server.
 func TestOrgs_EndToEnd(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 	app, out := newTestApp(t, srv)
 	app.DefaultRemote = srv.URL
@@ -388,6 +393,7 @@ func TestOrgs_EndToEnd(t *testing.T) {
 
 // TestRepos_EndToEnd verifies repo creation, listing (global and per-org), and deletion.
 func TestRepos_EndToEnd(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 	app, out := newTestApp(t, srv)
 	app.DefaultRemote = srv.URL
@@ -445,6 +451,7 @@ func TestRepos_EndToEnd(t *testing.T) {
 
 // TestRoles_EndToEnd verifies role assignment, listing, and deletion via a real server.
 func TestRoles_EndToEnd(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 	app, out := newTestApp(t, srv)
 	app.DefaultRemote = srv.URL
@@ -498,6 +505,7 @@ func TestRoles_EndToEnd(t *testing.T) {
 
 // TestLoadRemote_Fallback verifies that loadRemote() uses DefaultRemote when no config exists.
 func TestLoadRemote_Fallback(t *testing.T) {
+	t.Parallel()
 	app, _ := newTestApp(t, nil)
 	app.DefaultRemote = "https://example.com"
 
@@ -512,6 +520,7 @@ func TestLoadRemote_Fallback(t *testing.T) {
 
 // TestLoadRemote_NoConfig verifies that loadRemote() errors when no config or DefaultRemote.
 func TestLoadRemote_NoConfig(t *testing.T) {
+	t.Parallel()
 	app, _ := newTestApp(t, nil)
 
 	_, err := app.loadRemote()
@@ -525,6 +534,7 @@ func TestLoadRemote_NoConfig(t *testing.T) {
 
 // TestRolesSet_InvalidRole verifies client-side role validation.
 func TestRolesSet_InvalidRole(t *testing.T) {
+	t.Parallel()
 	app, _ := newTestApp(t, nil)
 	initWorkspace(t, app, "http://localhost", "main", "alice")
 

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -14,6 +14,7 @@ import (
 // TestIntegrationPull_UpdatesFile verifies that pull downloads a file committed
 // by another workspace and updates the local working directory.
 func TestIntegrationPull_UpdatesFile(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	// ws1: commit a file to main.
@@ -68,6 +69,7 @@ func TestIntegrationPull_UpdatesFile(t *testing.T) {
 // TestIntegrationPull_NoOp verifies that pull with no remote changes
 // succeeds without downloading any files.
 func TestIntegrationPull_NoOp(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, wsOut := newTestApp(t, srv)
@@ -92,6 +94,7 @@ func TestIntegrationPull_NoOp(t *testing.T) {
 // TestIntegrationPull_DirtyBlocked verifies that pull with uncommitted local
 // changes returns an error.
 func TestIntegrationPull_DirtyBlocked(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, _ := newTestApp(t, srv)
@@ -114,6 +117,7 @@ func TestIntegrationPull_DirtyBlocked(t *testing.T) {
 // TestIntegrationPull_RemovesDeletedFile verifies that pull removes a file
 // that has been deleted on the server (committed with nil content).
 func TestIntegrationPull_RemovesDeletedFile(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	// ws1: commit a file then delete it.
@@ -165,6 +169,7 @@ func TestIntegrationPull_RemovesDeletedFile(t *testing.T) {
 // then switches to the feature branch again — verifying that files are properly
 // restored on each checkout and that branch isolation holds.
 func TestIntegrationCheckout_BranchCycle(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, _ := newTestApp(t, srv)
@@ -228,6 +233,7 @@ func TestIntegrationCheckout_BranchCycle(t *testing.T) {
 // TestIntegrationCheckout_DirtyBlocked verifies that checking out a branch
 // when the working tree is dirty returns an error.
 func TestIntegrationCheckout_DirtyBlocked(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, _ := newTestApp(t, srv)
@@ -258,6 +264,7 @@ func TestIntegrationCheckout_DirtyBlocked(t *testing.T) {
 // TestIntegrationCheckout_BranchIsolation verifies that two branches with
 // different files do not leak files into each other.
 func TestIntegrationCheckout_BranchIsolation(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, _ := newTestApp(t, srv)
@@ -316,6 +323,7 @@ func TestIntegrationCheckout_BranchIsolation(t *testing.T) {
 // TestIntegrationMerge_Success exercises the full branch→commit→merge workflow
 // and verifies that the working directory ends up on main with all files.
 func TestIntegrationMerge_Success(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, wsOut := newTestApp(t, srv)
@@ -372,6 +380,7 @@ func TestIntegrationMerge_Success(t *testing.T) {
 // TestIntegrationMerge_Conflict verifies that merging two branches that both
 // modified the same file reports a conflict error gracefully.
 func TestIntegrationMerge_Conflict(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, wsOut := newTestApp(t, srv)
@@ -427,6 +436,7 @@ func TestIntegrationMerge_Conflict(t *testing.T) {
 // TestIntegrationRebase_Success verifies that rebase replays branch commits
 // onto the current main head and updates the state sequence.
 func TestIntegrationRebase_Success(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, wsOut := newTestApp(t, srv)
@@ -488,6 +498,7 @@ func TestIntegrationRebase_Success(t *testing.T) {
 // TestIntegrationRebase_Conflict verifies that a rebase conflict writes
 // .main and .branch files to disk with the correct content.
 func TestIntegrationRebase_Conflict(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, _ := newTestApp(t, srv)
@@ -552,6 +563,7 @@ func TestIntegrationRebase_Conflict(t *testing.T) {
 // TestIntegrationRebaseAndMerge verifies the full rebase-then-merge workflow:
 // rebase a branch onto advanced main, then merge — all files end up on main.
 func TestIntegrationRebaseAndMerge(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, _ := newTestApp(t, srv)
@@ -616,6 +628,7 @@ func TestIntegrationRebaseAndMerge(t *testing.T) {
 // TestIntegrationLog_MultipleCommits commits three files with distinct messages
 // and verifies all three appear in log output in newest-first order.
 func TestIntegrationLog_MultipleCommits(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, wsOut := newTestApp(t, srv)
@@ -659,6 +672,7 @@ func TestIntegrationLog_MultipleCommits(t *testing.T) {
 // TestIntegrationLog_FilePath verifies that ds log <path> only shows commits
 // that touched the specified file.
 func TestIntegrationLog_FilePath(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, wsOut := newTestApp(t, srv)
@@ -709,6 +723,7 @@ func TestIntegrationLog_FilePath(t *testing.T) {
 // TestIntegrationShow_Sequence commits a file and verifies that Show for that
 // sequence returns the correct commit metadata and file list.
 func TestIntegrationShow_Sequence(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, wsOut := newTestApp(t, srv)
@@ -748,6 +763,7 @@ func TestIntegrationShow_Sequence(t *testing.T) {
 // TestIntegrationShow_FileContent verifies that Show with a path parameter
 // returns the file's content at the given sequence.
 func TestIntegrationShow_FileContent(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, wsOut := newTestApp(t, srv)
@@ -776,6 +792,7 @@ func TestIntegrationShow_FileContent(t *testing.T) {
 // TestIntegrationBinaryFile verifies that committing a binary file succeeds and
 // that ds diff shows [binary] for that file on the branch diff.
 func TestIntegrationBinaryFile(t *testing.T) {
+	t.Parallel()
 	srv := newRealServer(t)
 
 	ws, wsOut := newTestApp(t, srv)

--- a/internal/cli/testmain_test.go
+++ b/internal/cli/testmain_test.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/testutil"
+)
+
+var sharedAdminDSN string
+
+func TestMain(m *testing.M) {
+	dsn, cleanup, err := testutil.StartSharedPostgres()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "start shared postgres: %v\n", err)
+		os.Exit(1)
+	}
+	sharedAdminDSN = dsn
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 func TestCommit_SingleFile(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -55,7 +56,8 @@ func TestCommit_SingleFile(t *testing.T) {
 }
 
 func TestCommit_MultipleFiles(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -93,7 +95,8 @@ func TestCommit_MultipleFiles(t *testing.T) {
 }
 
 func TestCommit_ContentDedup(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -134,7 +137,8 @@ func TestCommit_ContentDedup(t *testing.T) {
 }
 
 func TestCommit_ContentDedupAcrossCommits(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -175,7 +179,8 @@ func TestCommit_ContentDedupAcrossCommits(t *testing.T) {
 }
 
 func TestCommit_SequenceIncrementsPerCommit(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -197,7 +202,8 @@ func TestCommit_SequenceIncrementsPerCommit(t *testing.T) {
 }
 
 func TestCommit_DeleteFile(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -247,7 +253,8 @@ func TestCommit_DeleteFile(t *testing.T) {
 }
 
 func TestCommit_BranchNotFound(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -264,7 +271,8 @@ func TestCommit_BranchNotFound(t *testing.T) {
 }
 
 func TestCommit_BranchNotActive(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -291,7 +299,8 @@ func TestCommit_BranchNotActive(t *testing.T) {
 // --- CreateBranch tests ---
 
 func TestCreateBranch_Success(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -335,7 +344,8 @@ func TestCreateBranch_Success(t *testing.T) {
 }
 
 func TestCreateBranch_Duplicate(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -353,7 +363,8 @@ func TestCreateBranch_Duplicate(t *testing.T) {
 // --- Merge tests ---
 
 func TestMerge_Success(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -447,7 +458,8 @@ func TestMerge_Success(t *testing.T) {
 }
 
 func TestMerge_Conflict(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -525,7 +537,8 @@ func TestMerge_Conflict(t *testing.T) {
 }
 
 func TestMerge_BranchNotFound(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -536,7 +549,8 @@ func TestMerge_BranchNotFound(t *testing.T) {
 }
 
 func TestMerge_BranchNotActive(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -555,7 +569,8 @@ func TestMerge_BranchNotActive(t *testing.T) {
 // --- DeleteBranch tests ---
 
 func TestDeleteBranch_Success(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -579,7 +594,8 @@ func TestDeleteBranch_Success(t *testing.T) {
 }
 
 func TestDeleteBranch_NotFound(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -590,7 +606,8 @@ func TestDeleteBranch_NotFound(t *testing.T) {
 }
 
 func TestDeleteBranch_AlreadyMerged(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -606,7 +623,8 @@ func TestDeleteBranch_AlreadyMerged(t *testing.T) {
 }
 
 func TestDeleteBranch_AlreadyAbandoned(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -622,7 +640,8 @@ func TestDeleteBranch_AlreadyAbandoned(t *testing.T) {
 }
 
 func TestMerge_EmptyBranch(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -657,7 +676,8 @@ func TestMerge_EmptyBranch(t *testing.T) {
 // --- Rebase tests ---
 
 func TestRebase_CleanNoConflict(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -726,7 +746,8 @@ func TestRebase_CleanNoConflict(t *testing.T) {
 }
 
 func TestRebase_UpdatesBaseSequence(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -800,7 +821,8 @@ func TestRebase_UpdatesBaseSequence(t *testing.T) {
 }
 
 func TestRebase_ReplaysAllCommits(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -881,7 +903,8 @@ func TestRebase_ReplaysAllCommits(t *testing.T) {
 }
 
 func TestRebase_EmptyBranch(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -941,7 +964,8 @@ func TestRebase_EmptyBranch(t *testing.T) {
 }
 
 func TestRebase_Conflict(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1009,7 +1033,8 @@ func TestRebase_Conflict(t *testing.T) {
 }
 
 func TestRebase_ConflictIsAtomic(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1096,7 +1121,8 @@ func TestRebase_ConflictIsAtomic(t *testing.T) {
 }
 
 func TestRebase_BranchNotFound(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1107,7 +1133,8 @@ func TestRebase_BranchNotFound(t *testing.T) {
 }
 
 func TestRebase_AlreadyMerged(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1123,7 +1150,8 @@ func TestRebase_AlreadyMerged(t *testing.T) {
 }
 
 func TestRebase_MainBranch(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1134,7 +1162,8 @@ func TestRebase_MainBranch(t *testing.T) {
 }
 
 func TestRebase_ThenMerge(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1220,7 +1249,8 @@ func TestRebase_ThenMerge(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestCreateRepo_Success(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1247,7 +1277,8 @@ func TestCreateRepo_Success(t *testing.T) {
 }
 
 func TestCreateRepo_Duplicate(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1263,7 +1294,8 @@ func TestCreateRepo_Duplicate(t *testing.T) {
 }
 
 func TestDeleteRepo_RemovesAllData(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1334,7 +1366,8 @@ func TestDeleteRepo_RemovesAllData(t *testing.T) {
 }
 
 func TestDeleteRepo_DoesNotAffectOtherRepo(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1373,7 +1406,8 @@ func TestDeleteRepo_DoesNotAffectOtherRepo(t *testing.T) {
 }
 
 func TestDeleteRepo_NotFound(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1389,7 +1423,8 @@ func TestDeleteRepo_NotFound(t *testing.T) {
 // positive invariant: after a successful CreateRepo the repo and its main branch
 // always exist together.
 func TestCreateRepo_IsAtomic(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1419,7 +1454,8 @@ func TestCreateRepo_IsAtomic(t *testing.T) {
 // TestCreateBranch_RepoNotFound verifies that creating a branch for a repo that
 // does not exist returns ErrRepoNotFound rather than an opaque error.
 func TestCreateBranch_RepoNotFound(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1434,7 +1470,8 @@ func TestCreateBranch_RepoNotFound(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRepoIsolation_Branches(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1477,7 +1514,8 @@ func TestRepoIsolation_Branches(t *testing.T) {
 }
 
 func TestRepoIsolation_Commits(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1528,7 +1566,8 @@ func TestRepoIsolation_Commits(t *testing.T) {
 }
 
 func TestRepoIsolation_Merge(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1589,7 +1628,8 @@ func TestRepoIsolation_Merge(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestCreateReview_Success(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1622,7 +1662,8 @@ func TestCreateReview_Success(t *testing.T) {
 }
 
 func TestCreateReview_RecordedAtHeadSequence(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1649,7 +1690,8 @@ func TestCreateReview_RecordedAtHeadSequence(t *testing.T) {
 }
 
 func TestCreateReview_StaleAfterCommit(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1697,7 +1739,8 @@ func TestCreateReview_StaleAfterCommit(t *testing.T) {
 }
 
 func TestListReviews_ByBranch(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1734,7 +1777,8 @@ func TestListReviews_ByBranch(t *testing.T) {
 }
 
 func TestCreateReview_SelfApproval(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1756,7 +1800,8 @@ func TestCreateReview_SelfApproval(t *testing.T) {
 }
 
 func TestReviewRepoIsolation(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1798,7 +1843,8 @@ func TestReviewRepoIsolation(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestCreateCheckRun_Success(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1821,7 +1867,8 @@ func TestCreateCheckRun_Success(t *testing.T) {
 }
 
 func TestCreateCheckRun_RecordedAtHeadSequence(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1844,7 +1891,8 @@ func TestCreateCheckRun_RecordedAtHeadSequence(t *testing.T) {
 }
 
 func TestListCheckRuns_ByBranch(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1867,7 +1915,8 @@ func TestListCheckRuns_ByBranch(t *testing.T) {
 }
 
 func TestListCheckRuns_LatestPerName(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1900,7 +1949,8 @@ func TestListCheckRuns_LatestPerName(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestGetRole_Exists(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1924,7 +1974,8 @@ func TestGetRole_Exists(t *testing.T) {
 }
 
 func TestGetRole_NotFound(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1939,7 +1990,8 @@ func TestGetRole_NotFound(t *testing.T) {
 }
 
 func TestSetRole(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1967,7 +2019,8 @@ func TestSetRole(t *testing.T) {
 }
 
 func TestDeleteRole(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -1995,7 +2048,8 @@ func TestDeleteRole(t *testing.T) {
 }
 
 func TestRoleIsolation(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2053,7 +2107,8 @@ func makeOld(t *testing.T, db *sql.DB, repo, branch string) {
 }
 
 func TestPurge_DeletesMergedBranches(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2112,7 +2167,8 @@ func TestPurge_DeletesMergedBranches(t *testing.T) {
 }
 
 func TestPurge_DeletesAbandonedBranches(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2150,7 +2206,8 @@ func TestPurge_DeletesAbandonedBranches(t *testing.T) {
 }
 
 func TestPurge_RespectsOlderThan(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2181,7 +2238,8 @@ func TestPurge_RespectsOlderThan(t *testing.T) {
 }
 
 func TestPurge_DoesNotTouchActiveBranches(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2202,7 +2260,8 @@ func TestPurge_DoesNotTouchActiveBranches(t *testing.T) {
 }
 
 func TestPurge_DoesNotTouchMain(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2235,7 +2294,8 @@ func TestPurge_DoesNotTouchMain(t *testing.T) {
 }
 
 func TestPurge_OrphanedDocumentsDeleted(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2282,7 +2342,8 @@ func TestPurge_OrphanedDocumentsDeleted(t *testing.T) {
 }
 
 func TestPurge_SharedDocumentRetained(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2337,7 +2398,8 @@ func TestPurge_SharedDocumentRetained(t *testing.T) {
 }
 
 func TestPurge_DeletesReviewsAndChecks(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2382,7 +2444,8 @@ func TestPurge_DeletesReviewsAndChecks(t *testing.T) {
 }
 
 func TestPurge_DryRun(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2435,10 +2498,11 @@ func TestPurge_DryRun(t *testing.T) {
 }
 
 func TestPurge_IsAtomic(t *testing.T) {
+	t.Parallel()
 	// Demonstrates that all deletes are committed together (or not at all).
 	// We use a pre-cancelled context so BeginTx fails before any deletions occur,
 	// verifying that no partial state is left behind.
-	d := testutil.TestDB(t, RunMigrations)
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2490,7 +2554,8 @@ func TestPurge_IsAtomic(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestMerge_MultipleConflicts(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2577,7 +2642,8 @@ func TestMerge_MultipleConflicts(t *testing.T) {
 }
 
 func TestRebase_MultipleConflicts(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2667,7 +2733,8 @@ func TestRebase_MultipleConflicts(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDeleteBranch_MainBranch(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2687,7 +2754,8 @@ func TestDeleteBranch_MainBranch(t *testing.T) {
 }
 
 func TestMerge_AlreadyMergedBranch(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2719,7 +2787,8 @@ func TestMerge_AlreadyMergedBranch(t *testing.T) {
 }
 
 func TestCommit_ToMergedBranch(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2761,7 +2830,8 @@ func TestCommit_ToMergedBranch(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestCreateOrg(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2784,7 +2854,8 @@ func TestCreateOrg(t *testing.T) {
 }
 
 func TestCreateOrg_DefaultCreatedBy(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2798,7 +2869,8 @@ func TestCreateOrg_DefaultCreatedBy(t *testing.T) {
 }
 
 func TestDeleteOrg(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2818,7 +2890,8 @@ func TestDeleteOrg(t *testing.T) {
 }
 
 func TestDeleteOrg_NotFound(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2829,7 +2902,8 @@ func TestDeleteOrg_NotFound(t *testing.T) {
 }
 
 func TestDeleteOrg_HasRepos(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2847,7 +2921,8 @@ func TestDeleteOrg_HasRepos(t *testing.T) {
 }
 
 func TestListOrgRepos(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2884,7 +2959,8 @@ func TestListOrgRepos(t *testing.T) {
 }
 
 func TestListRepos(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2913,7 +2989,8 @@ func TestListRepos(t *testing.T) {
 }
 
 func TestGetRepo(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2938,7 +3015,8 @@ func TestGetRepo(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestListRoles(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -2980,6 +3058,7 @@ func TestListRoles(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestIsForeignKeyViolation_NonPQError(t *testing.T) {
+	t.Parallel()
 	// A plain error should return false.
 	if isForeignKeyViolation(errors.New("some error")) {
 		t.Error("expected false for non-pq error")
@@ -2987,13 +3066,15 @@ func TestIsForeignKeyViolation_NonPQError(t *testing.T) {
 }
 
 func TestIsDuplicateKeyError_NonPQError(t *testing.T) {
+	t.Parallel()
 	if isDuplicateKeyError(errors.New("some error")) {
 		t.Error("expected false for non-pq error")
 	}
 }
 
 func TestIsForeignKeyViolation_FromDB(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -3018,6 +3099,7 @@ const expectedCommitHash = "54662b84dcaca30b108d9b779bec9ad8727f35db9e6742401aaa
 
 // TestComputeCommitHash verifies that computeCommitHash produces a stable SHA256 output.
 func TestComputeCommitHash(t *testing.T) {
+	t.Parallel()
 	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	files := []chainFile{
 		{path: "b.txt", contentHash: "bbb"},
@@ -3088,7 +3170,8 @@ func TestComputeCommitHash(t *testing.T) {
 
 // TestCommit_HashIsSet verifies that Commit stores a non-empty commit_hash.
 func TestCommit_HashIsSet(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -3121,7 +3204,8 @@ func TestCommit_HashIsSet(t *testing.T) {
 
 // TestCommit_ChainLinks verifies that the second commit's hash links to the first.
 func TestCommit_ChainLinks(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 
@@ -3191,7 +3275,8 @@ func TestCommit_ChainLinks(t *testing.T) {
 // TestCommit_PerBranchChain verifies that commits on different branches each
 // start their own chain from genesisHash, independently of each other.
 func TestCommit_PerBranchChain(t *testing.T) {
-	d := testutil.TestDB(t, RunMigrations)
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	ctx := context.Background()
 

--- a/internal/db/testmain_test.go
+++ b/internal/db/testmain_test.go
@@ -1,0 +1,23 @@
+package db
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/testutil"
+)
+
+var sharedAdminDSN string
+
+func TestMain(m *testing.M) {
+	dsn, cleanup, err := testutil.StartSharedPostgres()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "start shared postgres: %v\n", err)
+		os.Exit(1)
+	}
+	sharedAdminDSN = dsn
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -58,7 +58,8 @@ func seed(t *testing.T, db *sql.DB) {
 }
 
 func TestIntegrationTreeEndpoint(t *testing.T) {
-	db := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	seed(t, db)
 	handler := server.New(dbpkg.NewStore(db), db, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -85,7 +86,8 @@ func TestIntegrationTreeEndpoint(t *testing.T) {
 }
 
 func TestIntegrationFileEndpoint(t *testing.T) {
-	db := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	seed(t, db)
 	handler := server.New(dbpkg.NewStore(db), db, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -168,7 +170,8 @@ func TestIntegrationFileEndpoint(t *testing.T) {
 }
 
 func TestIntegrationBranchesEndpoint(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	seed(t, database)
 
 	// Add feature branch.
@@ -224,7 +227,8 @@ func TestIntegrationBranchesEndpoint(t *testing.T) {
 }
 
 func TestIntegrationDiffEndpoint(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	seed(t, database)
 
 	// Create a branch with changes.
@@ -297,7 +301,8 @@ func TestIntegrationDiffEndpoint(t *testing.T) {
 }
 
 func TestIntegrationCommitEndpoint(t *testing.T) {
-	db := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	seed(t, db)
 	handler := server.New(nil, db, "test@example.com", "")
 	srv := httptest.NewServer(handler)
@@ -353,7 +358,8 @@ func TestIntegrationCommitEndpoint(t *testing.T) {
 }
 
 func TestIntegrationDeleteBranch(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	seed(t, database)
 
 	writeStore := dbpkg.NewStore(database)
@@ -431,7 +437,8 @@ func TestIntegrationDeleteBranch(t *testing.T) {
 }
 
 func TestIntegrationRebase_FullFlow(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -541,6 +548,7 @@ func TestIntegrationRebase_FullFlow(t *testing.T) {
 // TestHTTP_AuthRequired verifies that write endpoints return 401 when no IAP JWT
 // is present and the server is not in dev mode.
 func TestHTTP_AuthRequired(t *testing.T) {
+	t.Parallel()
 	// No devIdentity → real IAP auth enforced.
 	handler := server.New(nil, nil, "", "")
 	srv := httptest.NewServer(handler)
@@ -570,8 +578,9 @@ func TestHTTP_AuthRequired(t *testing.T) {
 // TestHTTP_AuthIdentityUsedAsAuthor verifies that the authenticated identity
 // (set via dev mode) is recorded as the commit author, not any value in the body.
 func TestHTTP_AuthIdentityUsedAsAuthor(t *testing.T) {
+	t.Parallel()
 	const identity = "alice@example.com"
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, identity, identity)
 	srv := httptest.NewServer(handler)
@@ -612,7 +621,8 @@ func TestHTTP_AuthIdentityUsedAsAuthor(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestHandleCreateRepo_Success(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -631,7 +641,8 @@ func TestHandleCreateRepo_Success(t *testing.T) {
 }
 
 func TestHandleCreateRepo_Duplicate(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -651,7 +662,8 @@ func TestHandleCreateRepo_Duplicate(t *testing.T) {
 }
 
 func TestHandleDeleteRepo_Success(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -678,7 +690,8 @@ func TestHandleDeleteRepo_Success(t *testing.T) {
 }
 
 func TestHandleDeleteRepo_NotFound(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -696,7 +709,8 @@ func TestHandleDeleteRepo_NotFound(t *testing.T) {
 }
 
 func TestHandleListRepos(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -732,7 +746,8 @@ func TestHandleListRepos(t *testing.T) {
 }
 
 func TestIntegrationMultiRepo_FullIsolation(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -808,7 +823,8 @@ func TestIntegrationMultiRepo_FullIsolation(t *testing.T) {
 }
 
 func TestIntegrationDeleteRepo_CleansUp(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -866,7 +882,8 @@ func TestIntegrationDeleteRepo_CleansUp(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestIntegrationReviewFlow(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "alice@example.com", "alice@example.com")
 	srv := httptest.NewServer(handler)
@@ -973,7 +990,8 @@ func TestIntegrationReviewFlow(t *testing.T) {
 }
 
 func TestIntegrationCheckRunFlow(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "ci-bot@example.com", "ci-bot@example.com")
 	srv := httptest.NewServer(handler)
@@ -1033,7 +1051,8 @@ func TestIntegrationCheckRunFlow(t *testing.T) {
 }
 
 func TestIntegrationReviewRepoIsolation(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	// alice is the reviewer; bob is the committer so alice can approve
 	handler := server.New(writeStore, database, "alice@example.com", "alice@example.com")
@@ -1091,7 +1110,8 @@ func TestIntegrationReviewRepoIsolation(t *testing.T) {
 // TestIntegrationRBAC_FullFlow exercises the complete bootstrap → role assignment
 // → role-constrained operations flow.
 func TestIntegrationRBAC_FullFlow(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 
 	const bootstrapAdmin = "admin@example.com"
@@ -1203,7 +1223,8 @@ func TestIntegrationRBAC_FullFlow(t *testing.T) {
 // TestIntegrationRBAC_CrossRepoIsolation verifies that a role in repo-a
 // grants no access to repo-b.
 func TestIntegrationRBAC_CrossRepoIsolation(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 
 	const bootstrapAdmin = "admin@example.com"
@@ -1276,7 +1297,8 @@ func TestIntegrationRBAC_CrossRepoIsolation(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestIntegrationMerge_ConflictBody(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -1357,7 +1379,8 @@ func TestIntegrationMerge_ConflictBody(t *testing.T) {
 }
 
 func TestIntegrationRebase_ConflictBody(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -1442,7 +1465,8 @@ func TestIntegrationRebase_ConflictBody(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestIntegrationBranchLifecycle_MergeAfterMerge(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -1485,7 +1509,8 @@ func TestIntegrationBranchLifecycle_MergeAfterMerge(t *testing.T) {
 }
 
 func TestIntegrationBranchLifecycle_CommitAfterMerge(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -1526,7 +1551,8 @@ func TestIntegrationBranchLifecycle_CommitAfterMerge(t *testing.T) {
 }
 
 func TestIntegrationBranchLifecycle_RebaseMain(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)
@@ -1544,7 +1570,8 @@ func TestIntegrationBranchLifecycle_RebaseMain(t *testing.T) {
 }
 
 func TestIntegrationPurge_FullFlow(t *testing.T) {
-	database := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	writeStore := dbpkg.NewStore(database)
 	handler := server.New(writeStore, database, "test@example.com", "test@example.com")
 	srv := httptest.NewServer(handler)

--- a/internal/server/testmain_test.go
+++ b/internal/server/testmain_test.go
@@ -1,0 +1,23 @@
+package server_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/testutil"
+)
+
+var sharedAdminDSN string
+
+func TestMain(m *testing.M) {
+	dsn, cleanup, err := testutil.StartSharedPostgres()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "start shared postgres: %v\n", err)
+		os.Exit(1)
+	}
+	sharedAdminDSN = dsn
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,6 +16,60 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
+
+// testDBSeq is a monotonically increasing counter used to generate unique
+// database names within a single test binary, preventing collisions when
+// tests run in parallel.
+var testDBSeq int64
+
+// StartSharedPostgres starts a single PostgreSQL container for use across a
+// test package. Call it from TestMain before m.Run() and store the returned
+// adminDSN in a package-level variable. Pass adminDSN to TestDBFromShared for
+// each individual test. Call cleanup after m.Run() to terminate the container.
+//
+// If DOCSTORE_TEST_DSN is set it is returned directly with a no-op cleanup.
+func StartSharedPostgres() (adminDSN string, cleanup func(), err error) {
+	if dsn := os.Getenv("DOCSTORE_TEST_DSN"); dsn != "" {
+		return dsn, func() {}, nil
+	}
+
+	ctx := context.Background()
+
+	ctr, err := postgres.Run(ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("postgres"),
+		postgres.WithUsername("test"),
+		postgres.WithPassword("test"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(30*time.Second),
+		),
+	)
+	if err != nil {
+		return "", func() {}, fmt.Errorf("start postgres container: %w", err)
+	}
+
+	connStr, err := ctr.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		return "", func() {}, fmt.Errorf("get connection string: %w", err)
+	}
+
+	return connStr, func() {
+		if termErr := ctr.Terminate(ctx); termErr != nil {
+			fmt.Fprintf(os.Stderr, "terminate postgres container: %v\n", termErr)
+		}
+	}, nil
+}
+
+// TestDBFromShared creates an isolated database from a shared admin DSN,
+// runs migrations, and returns a connected *sql.DB. The database is dropped
+// when the test finishes. Use this in combination with StartSharedPostgres.
+func TestDBFromShared(t testing.TB, adminDSN string, migrate func(*sql.DB) error) *sql.DB {
+	t.Helper()
+	return testDBFromDSN(t, adminDSN, migrate)
+}
 
 // TestDB starts a PostgreSQL container via testcontainers-go, creates a fresh
 // database, runs the given migration function, and returns a connected *sql.DB.
@@ -84,8 +141,9 @@ func testDBFromDSN(t testing.TB, dsn string, migrate func(*sql.DB) error) *sql.D
 	}
 	defer admin.Close()
 
-	// Create a unique database for this test.
-	dbName := fmt.Sprintf("docstore_test_%d", time.Now().UnixNano())
+	// Create a unique database for this test. The atomic counter prevents
+	// collisions when many parallel tests call this simultaneously.
+	dbName := fmt.Sprintf("docstore_test_%d_%d", time.Now().UnixNano(), atomic.AddInt64(&testDBSeq, 1))
 	if _, err := admin.Exec("CREATE DATABASE " + dbName); err != nil {
 		t.Fatalf("create test database %s: %v", dbName, err)
 	}
@@ -117,11 +175,18 @@ func testDBFromDSN(t testing.TB, dsn string, migrate func(*sql.DB) error) *sql.D
 	return d
 }
 
-// replaceDBName replaces the dbname in a PostgreSQL DSN (key=value format)
-// or appends it if not present.
+// replaceDBName replaces the database name in a PostgreSQL DSN. It handles
+// both URL format (postgres://...) and key=value format.
 func replaceDBName(dsn, dbName string) string {
+	// Handle URL-format DSNs (postgres:// or postgresql://).
+	if strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://") {
+		u, err := url.Parse(dsn)
+		if err == nil {
+			u.Path = "/" + dbName
+			return u.String()
+		}
+	}
 	// Handle key=value format DSNs.
-	// Try to replace existing dbname parameter.
 	parts := splitDSN(dsn)
 	found := false
 	for i, p := range parts {


### PR DESCRIPTION
## Summary

- **One container per test package** via `TestMain` in `internal/db`, `internal/server`, and `internal/cli`. Previously each `testutil.TestDB` call started a fresh Docker container (~30s startup), making a large test suite with 80+ tests in `internal/db` alone very expensive.
- **Isolated DB per test** from the shared container: `TestDBFromShared(t, sharedAdminDSN, migrate)` creates a unique database per test (CREATE/DROP DATABASE), runs migrations, and cleans up on test finish — same strong isolation as before.
- **`t.Parallel()`** added to all independent top-level test functions across the three packages.
- **Bug fix**: `replaceDBName` now handles URL-format DSNs (`postgres://...`) returned by testcontainers-go, in addition to key=value format. Previously it would append `dbname=xxx` after `?sslmode=disable` producing an invalid DSN.
- **Atomic DB naming**: use an atomic counter + nanosecond timestamp to guarantee unique DB names when parallel tests call `testDBFromDSN` simultaneously.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1 -short` — all pass

## Opportunities noted (not implemented)

- The `TestDB` function (starts one container per call) is kept for backward compatibility but is no longer called. It could be removed in a follow-up.
- The smoke test (`TestDockerSmoke`) was left as-is since it builds a full Docker image and has its own container lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)