### PR TITLE
Remove TestDB: migrate callers to shared-container pattern

### DIFF
--- a/internal/db/bench_test.go
+++ b/internal/db/bench_test.go
@@ -14,7 +14,7 @@ import (
 // verifying the hash chain for a repo with 100 commits on main.
 // The benchmark fails if any commit_hash does not match the recomputed value.
 func BenchmarkChainWalk_100Commits(b *testing.B) {
-	d := testutil.TestDB(b, RunMigrations)
+	d := testutil.TestDBFromShared(b, sharedAdminDSN, RunMigrations)
 	s := NewStore(d)
 	rs := store.New(d)
 	ctx := context.Background()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -73,7 +73,8 @@ func seed(t *testing.T, db *sql.DB) {
 }
 
 func TestMaterializeTree(t *testing.T) {
-	db := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	seed(t, db)
 	s := store.New(db)
 	ctx := context.Background()
@@ -196,7 +197,8 @@ func TestMaterializeTree(t *testing.T) {
 }
 
 func TestGetFile(t *testing.T) {
-	db := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	seed(t, db)
 	s := store.New(db)
 	ctx := context.Background()
@@ -253,7 +255,8 @@ func TestGetFile(t *testing.T) {
 }
 
 func TestGetFileHistory(t *testing.T) {
-	db := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	seed(t, db)
 	s := store.New(db)
 	ctx := context.Background()
@@ -368,7 +371,8 @@ func TestGetFileHistory(t *testing.T) {
 }
 
 func TestGetCommit(t *testing.T) {
-	db := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	seed(t, db)
 	s := store.New(db)
 	ctx := context.Background()
@@ -440,7 +444,8 @@ func TestGetCommit(t *testing.T) {
 }
 
 func TestListBranches(t *testing.T) {
-	db := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	seed(t, db)
 	s := store.New(db)
 	ctx := context.Background()
@@ -495,7 +500,8 @@ func TestListBranches(t *testing.T) {
 }
 
 func TestGetDiff(t *testing.T) {
-	db := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	seed(t, db)
 	s := store.New(db)
 	ctx := context.Background()
@@ -578,7 +584,8 @@ func TestGetDiff(t *testing.T) {
 }
 
 func TestGetDiff_WithConflict(t *testing.T) {
-	db := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	s := store.New(db)
 	ctx := context.Background()
 
@@ -635,7 +642,8 @@ func TestGetDiff_WithConflict(t *testing.T) {
 }
 
 func TestBranchTree(t *testing.T) {
-	db := testutil.TestDB(t, dbpkg.RunMigrations)
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	seed(t, db)
 	s := store.New(db)
 	ctx := context.Background()
@@ -686,7 +694,7 @@ func TestBranchTree(t *testing.T) {
 // BenchmarkGetChain_100 measures the server-side GetChain query cost for a
 // repo with 100 commits on main.
 func BenchmarkGetChain_100(b *testing.B) {
-	db := testutil.TestDB(b, dbpkg.RunMigrations)
+	db := testutil.TestDBFromShared(b, sharedAdminDSN, dbpkg.RunMigrations)
 	ds := dbpkg.NewStore(db)
 	s := store.New(db)
 	ctx := context.Background()

--- a/internal/store/testmain_test.go
+++ b/internal/store/testmain_test.go
@@ -1,0 +1,23 @@
+package store_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/testutil"
+)
+
+var sharedAdminDSN string
+
+func TestMain(m *testing.M) {
+	dsn, cleanup, err := testutil.StartSharedPostgres()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "start shared postgres: %v\n", err)
+		os.Exit(1)
+	}
+	sharedAdminDSN = dsn
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -71,64 +71,6 @@ func TestDBFromShared(t testing.TB, adminDSN string, migrate func(*sql.DB) error
 	return testDBFromDSN(t, adminDSN, migrate)
 }
 
-// TestDB starts a PostgreSQL container via testcontainers-go, creates a fresh
-// database, runs the given migration function, and returns a connected *sql.DB.
-// The container is automatically terminated when the test finishes.
-//
-// If the DOCSTORE_TEST_DSN environment variable is set, it is used instead of
-// starting a container (useful for local development with an existing server).
-func TestDB(t testing.TB, migrate func(*sql.DB) error) *sql.DB {
-	t.Helper()
-
-	// Allow override for local dev.
-	if dsn := os.Getenv("DOCSTORE_TEST_DSN"); dsn != "" {
-		return testDBFromDSN(t, dsn, migrate)
-	}
-
-	ctx := context.Background()
-
-	dbName := fmt.Sprintf("docstore_test_%d", time.Now().UnixNano())
-
-	ctr, err := postgres.Run(ctx,
-		"postgres:16-alpine",
-		postgres.WithDatabase(dbName),
-		postgres.WithUsername("test"),
-		postgres.WithPassword("test"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second),
-		),
-	)
-	if err != nil {
-		t.Fatalf("start postgres container: %v", err)
-	}
-
-	t.Cleanup(func() {
-		if err := ctr.Terminate(ctx); err != nil {
-			t.Logf("terminate postgres container: %v", err)
-		}
-	})
-
-	connStr, err := ctr.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("get connection string: %v", err)
-	}
-
-	testDB, err := sql.Open("postgres", connStr)
-	if err != nil {
-		t.Fatalf("connect to test database: %v", err)
-	}
-	t.Cleanup(func() { testDB.Close() })
-
-	// Run schema migrations.
-	if err := migrate(testDB); err != nil {
-		t.Fatalf("run migrations: %v", err)
-	}
-
-	return testDB
-}
-
 // testDBFromDSN is the legacy path: use a pre-existing PostgreSQL server via DSN.
 // It creates a unique database per test so parallel tests don't interfere.
 func testDBFromDSN(t testing.TB, dsn string, migrate func(*sql.DB) error) *sql.DB {


### PR DESCRIPTION
## Summary

- Migrated `internal/db/bench_test.go` from `testutil.TestDB` to `testutil.TestDBFromShared(b, sharedAdminDSN, ...)`  — `sharedAdminDSN` was already provided by the existing `TestMain` in that package
- Added `internal/store/testmain_test.go` with `TestMain` + `sharedAdminDSN` following the PR #89 pattern
- Migrated all 9 `testutil.TestDB` call sites in `internal/store/store_test.go` to `testutil.TestDBFromShared` and added `t.Parallel()` to the 7 top-level test functions
- Removed `testutil.TestDB` from `internal/testutil/testdb.go` (now has zero callers)
- Retained `testDBFromDSN`, `replaceDBName`, and `splitDSN` — still used by `TestDBFromShared`

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all packages pass

## Notes

No opportunities identified beyond scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)