### PR TITLE
Add org membership and invites CLI commands (issue #52)

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -46,6 +46,14 @@ commands:
   orgs delete <name>                              Delete an organization
   orgs repos <name>                               List repos in an organization
 
+  org members add <org> <identity> --role owner|member  Add a member to an org
+  org members remove <org> <identity>                   Remove a member from an org
+  org members list <org>                                List org members
+  org invites create <org> --email <email> --role owner|member  Create an invite (prints token)
+  org invites list <org>                                List pending invites
+  org invites accept <org> <token>                      Accept an invite by token
+  org invites revoke <org> <invite-id>                  Revoke a pending invite
+
   repo list                                       List repositories
   repo create <owner/name>                        Create a repository
   repo get <owner/name>                           Get a repository
@@ -312,6 +320,116 @@ func main() {
 
 	case "tui":
 		err = app.TUI()
+
+	case "org":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: ds org members|invites ...")
+			os.Exit(1)
+		}
+		switch args[1] {
+		case "members":
+			if len(args) < 3 {
+				fmt.Fprintln(os.Stderr, "usage: ds org members add|remove|list ...")
+				os.Exit(1)
+			}
+			switch args[2] {
+			case "add":
+				if len(args) < 5 {
+					fmt.Fprintln(os.Stderr, "usage: ds org members add <org> <identity> --role owner|member")
+					os.Exit(1)
+				}
+				org := args[3]
+				identity := args[4]
+				role := ""
+				for i := 5; i < len(args); i++ {
+					if args[i] == "--role" && i+1 < len(args) {
+						role = args[i+1]
+						i++
+					}
+				}
+				if role == "" {
+					fmt.Fprintln(os.Stderr, "usage: ds org members add <org> <identity> --role owner|member")
+					os.Exit(1)
+				}
+				err = app.OrgMembersAdd(org, identity, role)
+			case "remove":
+				if len(args) < 5 {
+					fmt.Fprintln(os.Stderr, "usage: ds org members remove <org> <identity>")
+					os.Exit(1)
+				}
+				err = app.OrgMembersRemove(args[3], args[4])
+			case "list":
+				if len(args) < 4 {
+					fmt.Fprintln(os.Stderr, "usage: ds org members list <org>")
+					os.Exit(1)
+				}
+				err = app.OrgMembersList(args[3])
+			default:
+				fmt.Fprintf(os.Stderr, "unknown org members subcommand: %s\n", args[2])
+				fmt.Fprintln(os.Stderr, usage)
+				os.Exit(1)
+			}
+		case "invites":
+			if len(args) < 3 {
+				fmt.Fprintln(os.Stderr, "usage: ds org invites create|list|accept|revoke ...")
+				os.Exit(1)
+			}
+			switch args[2] {
+			case "create":
+				if len(args) < 4 {
+					fmt.Fprintln(os.Stderr, "usage: ds org invites create <org> --email <email> --role owner|member")
+					os.Exit(1)
+				}
+				org := args[3]
+				email := ""
+				role := ""
+				for i := 4; i < len(args); i++ {
+					switch args[i] {
+					case "--email":
+						if i+1 < len(args) {
+							email = args[i+1]
+							i++
+						}
+					case "--role":
+						if i+1 < len(args) {
+							role = args[i+1]
+							i++
+						}
+					}
+				}
+				if email == "" || role == "" {
+					fmt.Fprintln(os.Stderr, "usage: ds org invites create <org> --email <email> --role owner|member")
+					os.Exit(1)
+				}
+				err = app.OrgInvitesCreate(org, email, role)
+			case "list":
+				if len(args) < 4 {
+					fmt.Fprintln(os.Stderr, "usage: ds org invites list <org>")
+					os.Exit(1)
+				}
+				err = app.OrgInvitesList(args[3])
+			case "accept":
+				if len(args) < 5 {
+					fmt.Fprintln(os.Stderr, "usage: ds org invites accept <org> <token>")
+					os.Exit(1)
+				}
+				err = app.OrgInvitesAccept(args[3], args[4])
+			case "revoke":
+				if len(args) < 5 {
+					fmt.Fprintln(os.Stderr, "usage: ds org invites revoke <org> <invite-id>")
+					os.Exit(1)
+				}
+				err = app.OrgInvitesRevoke(args[3], args[4])
+			default:
+				fmt.Fprintf(os.Stderr, "unknown org invites subcommand: %s\n", args[2])
+				fmt.Fprintln(os.Stderr, usage)
+				os.Exit(1)
+			}
+		default:
+			fmt.Fprintf(os.Stderr, "unknown org subcommand: %s\n", args[1])
+			fmt.Fprintln(os.Stderr, usage)
+			os.Exit(1)
+		}
 
 	case "orgs":
 		if len(args) < 2 {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -2188,6 +2188,168 @@ func (a *App) Purge(olderThan string, dryRun bool) error {
 }
 
 // ---------------------------------------------------------------------------
+// Org membership management
+// ---------------------------------------------------------------------------
+
+// OrgMembersAdd adds or updates a member in an org with the given role.
+func (a *App) OrgMembersAdd(org, identity, role string) error {
+	switch model.OrgRole(role) {
+	case model.OrgRoleOwner, model.OrgRoleMember:
+	default:
+		return fmt.Errorf("role must be 'owner' or 'member'")
+	}
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doPOSTJSON(remote+"/orgs/"+org+"/members/"+identity, model.AddOrgMemberRequest{Role: model.OrgRole(role)})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Added '%s' to org '%s' as '%s'\n", identity, org, role)
+	return nil
+}
+
+// OrgMembersRemove removes a member from an org.
+func (a *App) OrgMembersRemove(org, identity string) error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doDELETE(remote + "/orgs/" + org + "/members/" + identity)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Removed '%s' from org '%s'\n", identity, org)
+	return nil
+}
+
+// OrgMembersList lists all members of an org.
+func (a *App) OrgMembersList(org string) error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doGET(remote + "/orgs/" + org + "/members")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var r model.OrgMembersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "%-30s  %s\n", "IDENTITY", "ROLE")
+	for _, m := range r.Members {
+		fmt.Fprintf(a.Out, "%-30s  %s\n", m.Identity, string(m.Role))
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Org invite management
+// ---------------------------------------------------------------------------
+
+// OrgInvitesCreate creates an invite for email with the given role and prints the token.
+func (a *App) OrgInvitesCreate(org, email, role string) error {
+	switch model.OrgRole(role) {
+	case model.OrgRoleOwner, model.OrgRoleMember:
+	default:
+		return fmt.Errorf("role must be 'owner' or 'member'")
+	}
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doPOSTJSON(remote+"/orgs/"+org+"/invites", model.CreateInviteRequest{Email: email, Role: model.OrgRole(role)})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var r model.CreateInviteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "Invite created: id=%s token=%s\n", r.ID, r.Token)
+	return nil
+}
+
+// OrgInvitesList lists all pending invites for an org.
+func (a *App) OrgInvitesList(org string) error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doGET(remote + "/orgs/" + org + "/invites")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var r model.OrgInvitesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "%-36s  %-30s  %s\n", "ID", "EMAIL", "ROLE")
+	for _, inv := range r.Invites {
+		fmt.Fprintf(a.Out, "%-36s  %-30s  %s\n", inv.ID, inv.Email, string(inv.Role))
+	}
+	return nil
+}
+
+// OrgInvitesAccept accepts an invite using a token.
+func (a *App) OrgInvitesAccept(org, token string) error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doPOSTJSON(remote+"/orgs/"+org+"/invites/"+token+"/accept", struct{}{})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Accepted invite for org '%s'\n", org)
+	return nil
+}
+
+// OrgInvitesRevoke revokes a pending invite by ID.
+func (a *App) OrgInvitesRevoke(org, inviteID string) error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doDELETE(remote + "/orgs/" + org + "/invites/" + inviteID)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Revoked invite '%s' from org '%s'\n", inviteID, org)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
 // Role management
 // ---------------------------------------------------------------------------
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -3013,3 +3013,214 @@ func TestPull_SkipVerify(t *testing.T) {
 		t.Errorf("state.Sequence = %d, want 2", newSt.Sequence)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Org members
+// ---------------------------------------------------------------------------
+
+func TestOrgMembersAdd(t *testing.T) {
+	var gotBody model.AddOrgMemberRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/orgs/myorg/members/alice" {
+			json.NewDecoder(r.Body).Decode(&gotBody)
+			w.WriteHeader(http.StatusCreated)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	app.DefaultRemote = srv.URL
+
+	if err := app.OrgMembersAdd("myorg", "alice", "member"); err != nil {
+		t.Fatal(err)
+	}
+	if gotBody.Role != model.OrgRoleMember {
+		t.Errorf("role = %q, want %q", gotBody.Role, model.OrgRoleMember)
+	}
+	if !strings.Contains(out.String(), "alice") || !strings.Contains(out.String(), "myorg") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+}
+
+func TestOrgMembersAdd_InvalidRole(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	app.DefaultRemote = "http://example.com"
+	err := app.OrgMembersAdd("myorg", "alice", "reader")
+	if err == nil || !strings.Contains(err.Error(), "role must be") {
+		t.Errorf("expected role error, got: %v", err)
+	}
+}
+
+func TestOrgMembersRemove(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "DELETE" && r.URL.Path == "/orgs/myorg/members/alice" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	app.DefaultRemote = srv.URL
+
+	if err := app.OrgMembersRemove("myorg", "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "alice") || !strings.Contains(out.String(), "myorg") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+}
+
+func TestOrgMembersList(t *testing.T) {
+	members := model.OrgMembersResponse{
+		Members: []model.OrgMember{
+			{Identity: "alice", Role: model.OrgRoleOwner},
+			{Identity: "bob", Role: model.OrgRoleMember},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/orgs/myorg/members" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(members)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	app.DefaultRemote = srv.URL
+
+	if err := app.OrgMembersList("myorg"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "alice") || !strings.Contains(out.String(), "bob") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "owner") {
+		t.Errorf("expected 'owner' in output: %s", out.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Org invites
+// ---------------------------------------------------------------------------
+
+func TestOrgInvitesCreate(t *testing.T) {
+	var gotBody model.CreateInviteRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/orgs/myorg/invites" {
+			json.NewDecoder(r.Body).Decode(&gotBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(model.CreateInviteResponse{ID: "inv-1", Token: "tok-abc"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	app.DefaultRemote = srv.URL
+
+	if err := app.OrgInvitesCreate("myorg", "user@example.com", "member"); err != nil {
+		t.Fatal(err)
+	}
+	if gotBody.Email != "user@example.com" {
+		t.Errorf("email = %q, want %q", gotBody.Email, "user@example.com")
+	}
+	if gotBody.Role != model.OrgRoleMember {
+		t.Errorf("role = %q, want %q", gotBody.Role, model.OrgRoleMember)
+	}
+	if !strings.Contains(out.String(), "tok-abc") {
+		t.Errorf("expected token in output: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "inv-1") {
+		t.Errorf("expected invite ID in output: %s", out.String())
+	}
+}
+
+func TestOrgInvitesCreate_InvalidRole(t *testing.T) {
+	app, _ := newTestApp(t, nil)
+	app.DefaultRemote = "http://example.com"
+	err := app.OrgInvitesCreate("myorg", "user@example.com", "admin")
+	if err == nil || !strings.Contains(err.Error(), "role must be") {
+		t.Errorf("expected role error, got: %v", err)
+	}
+}
+
+func TestOrgInvitesList(t *testing.T) {
+	invites := model.OrgInvitesResponse{
+		Invites: []model.OrgInvite{
+			{ID: "inv-1", Email: "alice@example.com", Role: model.OrgRoleOwner},
+			{ID: "inv-2", Email: "bob@example.com", Role: model.OrgRoleMember},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/orgs/myorg/invites" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(invites)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	app.DefaultRemote = srv.URL
+
+	if err := app.OrgInvitesList("myorg"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "alice@example.com") || !strings.Contains(out.String(), "bob@example.com") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "inv-1") {
+		t.Errorf("expected invite ID in output: %s", out.String())
+	}
+}
+
+func TestOrgInvitesAccept(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/orgs/myorg/invites/tok-abc/accept" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	app.DefaultRemote = srv.URL
+
+	if err := app.OrgInvitesAccept("myorg", "tok-abc"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "myorg") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+}
+
+func TestOrgInvitesRevoke(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "DELETE" && r.URL.Path == "/orgs/myorg/invites/inv-1" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	app.DefaultRemote = srv.URL
+
+	if err := app.OrgInvitesRevoke("myorg", "inv-1"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "inv-1") || !strings.Contains(out.String(), "myorg") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `ds org members add|remove|list` subcommands for managing org membership
- Adds `ds org invites create|list|accept|revoke` subcommands for invitation management
- Adds model types for org members and invites to match the HTTP API defined in issue #52
- 9 new unit tests covering all commands including validation edge cases

## API endpoints consumed

- `POST /orgs/{org}/members/{identity}` — body `{role: 'owner'|'member'}`
- `DELETE /orgs/{org}/members/{identity}`
- `GET /orgs/{org}/members`
- `POST /orgs/{org}/invites` — body `{email, role}` → returns `{id, token}`
- `GET /orgs/{org}/invites`
- `POST /orgs/{org}/invites/{token}/accept`
- `DELETE /orgs/{org}/invites/{id}`

## Test plan

- [x] `go test ./... -count=1` — all packages pass
- [x] `go build ./...` — clean build
- [x] `go vet ./...` — no issues
- [x] 9 new tests: `TestOrgMembersAdd`, `TestOrgMembersAdd_InvalidRole`, `TestOrgMembersRemove`, `TestOrgMembersList`, `TestOrgInvitesCreate`, `TestOrgInvitesCreate_InvalidRole`, `TestOrgInvitesList`, `TestOrgInvitesAccept`, `TestOrgInvitesRevoke`

## Notes for reviewers

- The `org` command is a new top-level command (parallel to `orgs`). It mirrors the pattern of `repo`/`repos` and `role`/`roles` in the codebase.
- All methods use `loadRemote()` (no workspace required), consistent with existing `Orgs*` and `Repos*` commands.
- The `OrgMemberRole` type (`owner`/`member`) is distinct from the repo `RoleType` (`reader`/`writer`/`maintainer`/`admin`).
- Opportunity: `ds org members add` currently returns 200 or 201 from server — both are accepted. Server implementation (parallel worker) may return one or the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)