### PR TITLE
Implement release tags (issue #96)

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -71,7 +71,12 @@ commands:
 
   role list                                       List roles for the current repo
   role set <identity> <role>                      Set a role (reader/writer/maintainer/admin)
-  role delete <identity>                          Delete a role assignment`
+  role delete <identity>                          Delete a role assignment
+
+  release create <name> [--sequence N] [--notes 'text']  Create a named release
+  release list                                           List releases
+  release show <name>                                    Show release metadata and tree
+  release delete <name>                                  Delete a release (admin only)`
 
 func main() {
 	if len(os.Args) < 2 {
@@ -616,6 +621,60 @@ func main() {
 			os.Exit(1)
 		}
 		err = app.Purge(olderThan, dryRun)
+
+	case "release":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: ds release <create|list|show|delete> [args]")
+			os.Exit(1)
+		}
+		switch args[1] {
+		case "create":
+			if len(args) < 3 {
+				fmt.Fprintln(os.Stderr, "usage: ds release create <name> [--sequence N] [--notes 'text']")
+				os.Exit(1)
+			}
+			relName := args[2]
+			var sequence int64
+			notes := ""
+			for i := 3; i < len(args); i++ {
+				switch args[i] {
+				case "--sequence":
+					if i+1 < len(args) {
+						n, convErr := strconv.ParseInt(args[i+1], 10, 64)
+						if convErr != nil || n < 0 {
+							fmt.Fprintln(os.Stderr, "usage: ds release create <name> [--sequence N] [--notes 'text']")
+							os.Exit(1)
+						}
+						sequence = n
+						i++
+					}
+				case "--notes":
+					if i+1 < len(args) {
+						notes = args[i+1]
+						i++
+					}
+				}
+			}
+			err = app.ReleaseCreate(relName, sequence, notes)
+		case "list":
+			err = app.ReleaseList()
+		case "show":
+			if len(args) < 3 {
+				fmt.Fprintln(os.Stderr, "usage: ds release show <name>")
+				os.Exit(1)
+			}
+			err = app.ReleaseShow(args[2])
+		case "delete":
+			if len(args) < 3 {
+				fmt.Fprintln(os.Stderr, "usage: ds release delete <name>")
+				os.Exit(1)
+			}
+			err = app.ReleaseDelete(args[2])
+		default:
+			fmt.Fprintf(os.Stderr, "unknown release subcommand: %s\n", args[1])
+			fmt.Fprintln(os.Stderr, usage)
+			os.Exit(1)
+		}
 
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", cmd)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -2418,3 +2418,159 @@ func (a *App) RolesDelete(identity string) error {
 	fmt.Fprintf(a.Out, "Deleted role for '%s'\n", identity)
 	return nil
 }
+
+// ---------------------------------------------------------------------------
+// Release management
+// ---------------------------------------------------------------------------
+
+// releaseEntry is a local type for decoding release API responses.
+type releaseEntry struct {
+	ID        string    `json:"id"`
+	Repo      string    `json:"repo"`
+	Name      string    `json:"name"`
+	Sequence  int64     `json:"sequence"`
+	Body      string    `json:"body,omitempty"`
+	CreatedBy string    `json:"created_by"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type listReleasesResponse struct {
+	Releases []releaseEntry `json:"releases"`
+}
+
+// ReleaseCreate creates a named release. If sequence is 0, the server defaults
+// to the current main head sequence.
+func (a *App) ReleaseCreate(name string, sequence int64, notes string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+
+	body := map[string]interface{}{
+		"name": name,
+	}
+	if sequence != 0 {
+		body["sequence"] = sequence
+	}
+	if notes != "" {
+		body["body"] = notes
+	}
+
+	resp, err := a.postJSON(cfg, repoBase(cfg)+"/releases", body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		return a.readError(resp)
+	}
+	var rel releaseEntry
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "Created release '%s' at sequence %d\n", rel.Name, rel.Sequence)
+	return nil
+}
+
+// ReleaseList lists all releases for the current repository.
+func (a *App) ReleaseList() error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	resp, err := a.httpGet(cfg, repoBase(cfg)+"/releases")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var r listReleasesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "%-20s  %-10s  %-20s  %s\n", "NAME", "SEQUENCE", "CREATED BY", "CREATED AT")
+	for _, rel := range r.Releases {
+		fmt.Fprintf(a.Out, "%-20s  %-10d  %-20s  %s\n", rel.Name, rel.Sequence, rel.CreatedBy, rel.CreatedAt.Format("2006-01-02"))
+	}
+	return nil
+}
+
+// ReleaseShow prints release metadata and then shows the tree at that release's sequence.
+func (a *App) ReleaseShow(name string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	resp, err := a.httpGet(cfg, repoBase(cfg)+"/releases/"+name)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("release '%s' not found", name)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var rel releaseEntry
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "Name:       %s\n", rel.Name)
+	fmt.Fprintf(a.Out, "Sequence:   %d\n", rel.Sequence)
+	fmt.Fprintf(a.Out, "Created by: %s\n", rel.CreatedBy)
+	fmt.Fprintf(a.Out, "Created at: %s\n", rel.CreatedAt.Format("2006-01-02 15:04:05"))
+	if rel.Body != "" {
+		fmt.Fprintf(a.Out, "Notes:\n%s\n", rel.Body)
+	}
+
+	// Show the tree at the release sequence.
+	q := url.Values{}
+	q.Set("at", fmt.Sprintf("%d", rel.Sequence))
+	treeResp, err := a.httpGet(cfg, repoBase(cfg)+"/tree?"+q.Encode())
+	if err != nil {
+		return err
+	}
+	defer treeResp.Body.Close()
+	if treeResp.StatusCode != http.StatusOK {
+		return a.readError(treeResp)
+	}
+
+	type treeEntry struct {
+		Path        string `json:"path"`
+		VersionID   string `json:"version_id"`
+		ContentHash string `json:"content_hash"`
+	}
+	var entries []treeEntry
+	if err := json.NewDecoder(treeResp.Body).Decode(&entries); err != nil {
+		return fmt.Errorf("decoding tree: %w", err)
+	}
+	fmt.Fprintf(a.Out, "\nTree at sequence %d:\n", rel.Sequence)
+	for _, e := range entries {
+		fmt.Fprintf(a.Out, "  %s\n", e.Path)
+	}
+	return nil
+}
+
+// ReleaseDelete deletes a named release (admin only).
+func (a *App) ReleaseDelete(name string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doDELETE(repoBase(cfg) + "/releases/" + name)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("release '%s' not found", name)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Deleted release '%s'\n", name)
+	return nil
+}

--- a/internal/db/migrations/000003_releases.down.sql
+++ b/internal/db/migrations/000003_releases.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE releases;

--- a/internal/db/migrations/000003_releases.up.sql
+++ b/internal/db/migrations/000003_releases.up.sql
@@ -1,0 +1,12 @@
+-- releases: named immutable snapshots tied to a commit sequence.
+
+CREATE TABLE releases (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    repo       TEXT NOT NULL REFERENCES repos(name),
+    name       TEXT NOT NULL,
+    sequence   BIGINT NOT NULL,
+    body       TEXT,
+    created_by TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (repo, name)
+);

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -118,6 +118,8 @@ var (
 	ErrInviteExpired          = errors.New("invite expired")
 	ErrInviteAlreadyAccepted  = errors.New("invite already accepted")
 	ErrEmailMismatch          = errors.New("identity does not match invite email")
+	ErrReleaseNotFound        = errors.New("release not found")
+	ErrReleaseExists          = errors.New("release already exists")
 )
 
 // rebaseFile is one file within a replayed commit group.
@@ -1689,6 +1691,122 @@ func (s *Store) RevokeInvite(ctx context.Context, org, inviteID string) error {
 	}
 	if n == 0 {
 		return ErrInviteNotFound
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Release management
+// ---------------------------------------------------------------------------
+
+// CreateRelease inserts a new release row. Returns ErrReleaseExists if the
+// (repo, name) pair is already taken.
+func (s *Store) CreateRelease(ctx context.Context, repo, name string, sequence int64, body, createdBy string) (*model.Release, error) {
+	var rel model.Release
+	err := s.db.QueryRowContext(ctx,
+		`INSERT INTO releases (repo, name, sequence, body, created_by)
+		 VALUES ($1, $2, $3, NULLIF($4, ''), $5)
+		 RETURNING id, repo, name, sequence, COALESCE(body, ''), created_by, created_at`,
+		repo, name, sequence, body, createdBy,
+	).Scan(&rel.ID, &rel.Repo, &rel.Name, &rel.Sequence, &rel.Body, &rel.CreatedBy, &rel.CreatedAt)
+	if err != nil {
+		if isDuplicateKeyError(err) {
+			return nil, ErrReleaseExists
+		}
+		return nil, fmt.Errorf("insert release: %w", err)
+	}
+	return &rel, nil
+}
+
+// GetRelease returns the named release for a repo, or ErrReleaseNotFound.
+func (s *Store) GetRelease(ctx context.Context, repo, name string) (*model.Release, error) {
+	var rel model.Release
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id, repo, name, sequence, COALESCE(body, ''), created_by, created_at
+		 FROM releases WHERE repo = $1 AND name = $2`,
+		repo, name,
+	).Scan(&rel.ID, &rel.Repo, &rel.Name, &rel.Sequence, &rel.Body, &rel.CreatedBy, &rel.CreatedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrReleaseNotFound
+		}
+		return nil, err
+	}
+	return &rel, nil
+}
+
+// ListReleases returns all releases for a repo ordered newest first.
+// limit controls the page size (0 → no limit); afterID is a cursor (UUID) for
+// keyset pagination (exclusive lower bound on created_at).
+func (s *Store) ListReleases(ctx context.Context, repo string, limit int, afterID string) ([]model.Release, error) {
+	var rows *sql.Rows
+	var err error
+	if afterID == "" {
+		if limit <= 0 {
+			rows, err = s.db.QueryContext(ctx,
+				`SELECT id, repo, name, sequence, COALESCE(body, ''), created_by, created_at
+				 FROM releases WHERE repo = $1 ORDER BY created_at DESC, id DESC`,
+				repo,
+			)
+		} else {
+			rows, err = s.db.QueryContext(ctx,
+				`SELECT id, repo, name, sequence, COALESCE(body, ''), created_by, created_at
+				 FROM releases WHERE repo = $1 ORDER BY created_at DESC, id DESC LIMIT $2`,
+				repo, limit,
+			)
+		}
+	} else {
+		// Use the row with id=afterID as the cursor.
+		if limit <= 0 {
+			rows, err = s.db.QueryContext(ctx,
+				`SELECT id, repo, name, sequence, COALESCE(body, ''), created_by, created_at
+				 FROM releases
+				 WHERE repo = $1
+				   AND (created_at, id) < (SELECT created_at, id FROM releases WHERE id = $2)
+				 ORDER BY created_at DESC, id DESC`,
+				repo, afterID,
+			)
+		} else {
+			rows, err = s.db.QueryContext(ctx,
+				`SELECT id, repo, name, sequence, COALESCE(body, ''), created_by, created_at
+				 FROM releases
+				 WHERE repo = $1
+				   AND (created_at, id) < (SELECT created_at, id FROM releases WHERE id = $2)
+				 ORDER BY created_at DESC, id DESC LIMIT $3`,
+				repo, afterID, limit,
+			)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var releases []model.Release
+	for rows.Next() {
+		var rel model.Release
+		if err := rows.Scan(&rel.ID, &rel.Repo, &rel.Name, &rel.Sequence, &rel.Body, &rel.CreatedBy, &rel.CreatedAt); err != nil {
+			return nil, err
+		}
+		releases = append(releases, rel)
+	}
+	return releases, rows.Err()
+}
+
+// DeleteRelease removes a release by name. Returns ErrReleaseNotFound if not found.
+func (s *Store) DeleteRelease(ctx context.Context, repo, name string) error {
+	result, err := s.db.ExecContext(ctx,
+		"DELETE FROM releases WHERE repo = $1 AND name = $2",
+		repo, name,
+	)
+	if err != nil {
+		return fmt.Errorf("delete release: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return ErrReleaseNotFound
 	}
 	return nil
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -3637,3 +3637,106 @@ func TestGetRole_OrgFallback(t *testing.T) {
 		t.Errorf("expected explicit admin role to win, got %s", role.Role)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Release store tests
+// ---------------------------------------------------------------------------
+
+func TestRelease_CreateListGetDelete(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Create a release.
+	rel, err := s.CreateRelease(ctx, "default/default", "v1.0", 5, "initial release", "alice@example.com")
+	if err != nil {
+		t.Fatalf("CreateRelease: %v", err)
+	}
+	if rel.Name != "v1.0" || rel.Sequence != 5 || rel.Body != "initial release" || rel.CreatedBy != "alice@example.com" {
+		t.Errorf("unexpected release: %+v", rel)
+	}
+	if rel.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+
+	// Create a second release (different name).
+	rel2, err := s.CreateRelease(ctx, "default/default", "v2.0", 10, "", "bob@example.com")
+	if err != nil {
+		t.Fatalf("CreateRelease v2.0: %v", err)
+	}
+	if rel2.Name != "v2.0" || rel2.Sequence != 10 {
+		t.Errorf("unexpected v2.0: %+v", rel2)
+	}
+
+	// Duplicate name returns ErrReleaseExists.
+	_, err = s.CreateRelease(ctx, "default/default", "v1.0", 3, "", "carol@example.com")
+	if !errors.Is(err, ErrReleaseExists) {
+		t.Errorf("expected ErrReleaseExists, got %v", err)
+	}
+
+	// GetRelease returns the correct entry.
+	got, err := s.GetRelease(ctx, "default/default", "v1.0")
+	if err != nil {
+		t.Fatalf("GetRelease: %v", err)
+	}
+	if got.Sequence != 5 || got.Body != "initial release" {
+		t.Errorf("unexpected GetRelease result: %+v", got)
+	}
+
+	// GetRelease for unknown name returns ErrReleaseNotFound.
+	_, err = s.GetRelease(ctx, "default/default", "nonexistent")
+	if !errors.Is(err, ErrReleaseNotFound) {
+		t.Errorf("expected ErrReleaseNotFound, got %v", err)
+	}
+
+	// ListReleases returns both, newest first.
+	list, err := s.ListReleases(ctx, "default/default", 0, "")
+	if err != nil {
+		t.Fatalf("ListReleases: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 releases, got %d", len(list))
+	}
+	// v2.0 was created after v1.0 so should appear first.
+	if list[0].Name != "v2.0" {
+		t.Errorf("expected v2.0 first (newest), got %s", list[0].Name)
+	}
+
+	// ListReleases with limit=1.
+	limited, err := s.ListReleases(ctx, "default/default", 1, "")
+	if err != nil {
+		t.Fatalf("ListReleases limit 1: %v", err)
+	}
+	if len(limited) != 1 {
+		t.Fatalf("expected 1 release, got %d", len(limited))
+	}
+	if limited[0].Name != "v2.0" {
+		t.Errorf("expected v2.0, got %s", limited[0].Name)
+	}
+
+	// ListReleases with afterID cursor (page 2).
+	page2, err := s.ListReleases(ctx, "default/default", 0, limited[0].ID)
+	if err != nil {
+		t.Fatalf("ListReleases page2: %v", err)
+	}
+	if len(page2) != 1 || page2[0].Name != "v1.0" {
+		t.Errorf("expected page2=[v1.0], got %+v", page2)
+	}
+
+	// DeleteRelease removes it.
+	if err := s.DeleteRelease(ctx, "default/default", "v1.0"); err != nil {
+		t.Fatalf("DeleteRelease: %v", err)
+	}
+
+	// Now GetRelease should return ErrReleaseNotFound.
+	_, err = s.GetRelease(ctx, "default/default", "v1.0")
+	if !errors.Is(err, ErrReleaseNotFound) {
+		t.Errorf("expected ErrReleaseNotFound after delete, got %v", err)
+	}
+
+	// DeleteRelease for unknown name returns ErrReleaseNotFound.
+	if err := s.DeleteRelease(ctx, "default/default", "nonexistent"); !errors.Is(err, ErrReleaseNotFound) {
+		t.Errorf("expected ErrReleaseNotFound, got %v", err)
+	}
+}

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -380,6 +380,26 @@ type OrgInvitesResponse struct {
 }
 
 // ---------------------------------------------------------------------------
+// POST /repos/{owner}/{name}/-/releases
+// GET  /repos/{owner}/{name}/-/releases
+// GET  /repos/{owner}/{name}/-/releases/{name}
+// DELETE /repos/{owner}/{name}/-/releases/{name}
+// ---------------------------------------------------------------------------
+
+// CreateReleaseRequest is the body for POST /repos/:name/-/releases.
+// Sequence defaults to the current main head if omitted.
+type CreateReleaseRequest struct {
+	Name     string `json:"name"`
+	Sequence *int64 `json:"sequence,omitempty"`
+	Body     string `json:"body,omitempty"`
+}
+
+// ListReleasesResponse is the response for GET /repos/:name/-/releases.
+type ListReleasesResponse struct {
+	Releases []Release `json:"releases"`
+}
+
+// ---------------------------------------------------------------------------
 // Error
 // ---------------------------------------------------------------------------
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -150,3 +150,14 @@ type CheckRun struct {
 	CreatedAt time.Time      `json:"created_at"`
 }
 
+// Release is a named immutable snapshot tied to a commit sequence.
+type Release struct {
+	ID        string    `json:"id"`
+	Repo      string    `json:"repo"`
+	Name      string    `json:"name"`
+	Sequence  int64     `json:"sequence"`
+	Body      string    `json:"body,omitempty"`
+	CreatedBy string    `json:"created_by"`
+	CreatedAt time.Time `json:"created_at"`
+}
+

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -158,6 +158,28 @@ func (s *server) handleReposPrefix(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		}
 
+	case endpoint == "releases":
+		switch r.Method {
+		case http.MethodGet:
+			s.handleListReleases(w, r)
+		case http.MethodPost:
+			s.handleCreateRelease(w, r)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+
+	case strings.HasPrefix(endpoint, "releases/"):
+		releaseName := strings.TrimPrefix(endpoint, "releases/")
+		r.SetPathValue("release", releaseName)
+		switch r.Method {
+		case http.MethodGet:
+			s.handleGetRelease(w, r)
+		case http.MethodDelete:
+			s.handleDeleteRelease(w, r)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+
 	case strings.HasPrefix(endpoint, "commit/"):
 		if r.Method == http.MethodGet {
 			r.SetPathValue("sequence", strings.TrimPrefix(endpoint, "commit/"))
@@ -942,10 +964,16 @@ func (s *server) handleTree(w http.ResponseWriter, r *http.Request) {
 	if v := r.URL.Query().Get("at"); v != "" {
 		n, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "invalid 'at' parameter")
-			return
+			// Try as release name.
+			rel, relErr := s.commitStore.GetRelease(r.Context(), repo, v)
+			if relErr != nil {
+				writeError(w, http.StatusBadRequest, "invalid 'at' parameter: not a sequence number or release name")
+				return
+			}
+			atSequence = &rel.Sequence
+		} else {
+			atSequence = &n
 		}
-		atSequence = &n
 	}
 
 	limit := 100
@@ -1003,10 +1031,16 @@ func (s *server) handleFileContent(w http.ResponseWriter, r *http.Request, repo,
 	if v := r.URL.Query().Get("at"); v != "" {
 		n, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "invalid 'at' parameter")
-			return
+			// Try as release name.
+			rel, relErr := s.commitStore.GetRelease(r.Context(), repo, v)
+			if relErr != nil {
+				writeError(w, http.StatusBadRequest, "invalid 'at' parameter: not a sequence number or release name")
+				return
+			}
+			atSequence = &rel.Sequence
+		} else {
+			atSequence = &n
 		}
-		atSequence = &n
 	}
 
 	fc, err := s.readStore.GetFile(r.Context(), repo, branch, path, atSequence)
@@ -1610,6 +1644,129 @@ func (s *server) handleBranchStatus(w http.ResponseWriter, r *http.Request, repo
 		Mergeable: mergeable,
 		Policies:  results,
 	})
+}
+
+// ---------------------------------------------------------------------------
+// Release handlers
+// ---------------------------------------------------------------------------
+
+// handleCreateRelease implements POST /repos/:name/-/releases (maintainer+)
+// Body: {name, sequence?, body?}. Sequence defaults to current main head if omitted.
+func (s *server) handleCreateRelease(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	var req model.CreateReleaseRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+
+	// Resolve sequence: default to main head if not provided.
+	var sequence int64
+	if req.Sequence != nil {
+		sequence = *req.Sequence
+	} else {
+		if s.readStore == nil {
+			writeError(w, http.StatusServiceUnavailable, "read store not available")
+			return
+		}
+		branchInfo, err := s.readStore.GetBranch(r.Context(), repo, "main")
+		if err != nil || branchInfo == nil {
+			writeError(w, http.StatusInternalServerError, "could not resolve main head sequence")
+			return
+		}
+		sequence = branchInfo.HeadSequence
+	}
+
+	createdBy := IdentityFromContext(r.Context())
+	rel, err := s.commitStore.CreateRelease(r.Context(), repo, req.Name, sequence, req.Body, createdBy)
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrReleaseExists):
+			writeError(w, http.StatusConflict, "release already exists")
+		default:
+			slog.Error("internal error", "op", "create_release", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	slog.Info("release created", "repo", repo, "release", req.Name, "sequence", sequence, "by", createdBy)
+	writeJSON(w, http.StatusCreated, rel)
+}
+
+// handleListReleases implements GET /repos/:name/-/releases (reader+)
+func (s *server) handleListReleases(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	limit := 100
+	if v := r.URL.Query().Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			writeError(w, http.StatusBadRequest, "invalid 'limit' parameter")
+			return
+		}
+		limit = n
+	}
+	afterID := r.URL.Query().Get("after")
+
+	releases, err := s.commitStore.ListReleases(r.Context(), repo, limit, afterID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if releases == nil {
+		releases = []model.Release{}
+	}
+	writeJSON(w, http.StatusOK, model.ListReleasesResponse{Releases: releases})
+}
+
+// handleGetRelease implements GET /repos/:name/-/releases/:release (reader+)
+func (s *server) handleGetRelease(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	releaseName := r.PathValue("release")
+
+	rel, err := s.commitStore.GetRelease(r.Context(), repo, releaseName)
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrReleaseNotFound):
+			writeError(w, http.StatusNotFound, "release not found")
+		default:
+			writeError(w, http.StatusInternalServerError, "query failed")
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, rel)
+}
+
+// handleDeleteRelease implements DELETE /repos/:name/-/releases/:release (admin only)
+func (s *server) handleDeleteRelease(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	releaseName := r.PathValue("release")
+
+	if err := s.commitStore.DeleteRelease(r.Context(), repo, releaseName); err != nil {
+		switch {
+		case errors.Is(err, db.ErrReleaseNotFound):
+			writeError(w, http.StatusNotFound, "release not found")
+		default:
+			slog.Error("internal error", "op", "delete_release", "repo", repo, "release", releaseName, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	slog.Info("release deleted", "repo", repo, "release", releaseName, "by", IdentityFromContext(r.Context()))
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // handleChain implements GET /repos/:name/-/chain?from=N&to=N

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -1717,3 +1717,198 @@ func TestIntegrationPurge_FullFlow(t *testing.T) {
 		t.Error("merged.txt (from merged branch) must still be present on main")
 	}
 }
+
+// TestIntegrationReleases tests the full lifecycle: create, list, get, ?at= resolution, and delete.
+func TestIntegrationReleases(t *testing.T) {
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seed(t, database)
+	handler := server.New(dbpkg.NewStore(database), database, "test@example.com", "test@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// Helper for authenticated requests.
+	doReq := func(method, url, body string) *http.Response {
+		t.Helper()
+		var reqBody *strings.Reader
+		if body != "" {
+			reqBody = strings.NewReader(body)
+		} else {
+			reqBody = strings.NewReader("")
+		}
+		req, err := http.NewRequest(method, url, reqBody)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", method, url, err)
+		}
+		return resp
+	}
+
+	base := srv.URL + "/repos/default/default/-"
+
+	// CREATE: explicit sequence.
+	resp := doReq(http.MethodPost, base+"/releases", `{"name":"v1.0","sequence":2,"body":"first release"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create release: expected 201, got %d", resp.StatusCode)
+	}
+	var created struct {
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		Sequence int64  `json:"sequence"`
+		Body     string `json:"body"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Name != "v1.0" {
+		t.Errorf("expected name=v1.0, got %s", created.Name)
+	}
+	if created.Sequence != 2 {
+		t.Errorf("expected sequence=2, got %d", created.Sequence)
+	}
+	if created.Body != "first release" {
+		t.Errorf("expected body='first release', got %s", created.Body)
+	}
+
+	// CREATE: duplicate name should conflict.
+	resp2 := doReq(http.MethodPost, base+"/releases", `{"name":"v1.0","sequence":1}`)
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusConflict {
+		t.Errorf("duplicate release: expected 409, got %d", resp2.StatusCode)
+	}
+
+	// CREATE: default sequence (omit sequence → uses main head = 4 from seed).
+	resp3 := doReq(http.MethodPost, base+"/releases", `{"name":"v2.0"}`)
+	defer resp3.Body.Close()
+	if resp3.StatusCode != http.StatusCreated {
+		t.Fatalf("create v2.0: expected 201, got %d", resp3.StatusCode)
+	}
+	var created2 struct {
+		Sequence int64 `json:"sequence"`
+	}
+	if err := json.NewDecoder(resp3.Body).Decode(&created2); err != nil {
+		t.Fatalf("decode v2.0 response: %v", err)
+	}
+	if created2.Sequence != 4 {
+		t.Errorf("expected default sequence=4 (main head), got %d", created2.Sequence)
+	}
+
+	// LIST: should see both releases, newest first.
+	listResp := doReq(http.MethodGet, base+"/releases", "")
+	defer listResp.Body.Close()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("list releases: expected 200, got %d", listResp.StatusCode)
+	}
+	var listBody struct {
+		Releases []struct {
+			Name     string `json:"name"`
+			Sequence int64  `json:"sequence"`
+		} `json:"releases"`
+	}
+	if err := json.NewDecoder(listResp.Body).Decode(&listBody); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listBody.Releases) != 2 {
+		t.Fatalf("expected 2 releases, got %d", len(listBody.Releases))
+	}
+	// Newest first: v2.0 (created later) should come first.
+	if listBody.Releases[0].Name != "v2.0" {
+		t.Errorf("expected newest release first (v2.0), got %s", listBody.Releases[0].Name)
+	}
+
+	// GET: single release.
+	getResp := doReq(http.MethodGet, base+"/releases/v1.0", "")
+	defer getResp.Body.Close()
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("get release: expected 200, got %d", getResp.StatusCode)
+	}
+	var getBody struct {
+		Name     string `json:"name"`
+		Sequence int64  `json:"sequence"`
+	}
+	if err := json.NewDecoder(getResp.Body).Decode(&getBody); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if getBody.Name != "v1.0" || getBody.Sequence != 2 {
+		t.Errorf("unexpected get response: %+v", getBody)
+	}
+
+	// GET: not found.
+	notFound := doReq(http.MethodGet, base+"/releases/nonexistent", "")
+	defer notFound.Body.Close()
+	if notFound.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for nonexistent release, got %d", notFound.StatusCode)
+	}
+
+	// ?at= RESOLUTION: use release name on tree endpoint.
+	treeAtRelease := doReq(http.MethodGet, base+"/tree?at=v1.0", "")
+	defer treeAtRelease.Body.Close()
+	if treeAtRelease.StatusCode != http.StatusOK {
+		t.Fatalf("tree?at=v1.0: expected 200, got %d", treeAtRelease.StatusCode)
+	}
+	var treeEntries []struct {
+		Path string `json:"path"`
+	}
+	if err := json.NewDecoder(treeAtRelease.Body).Decode(&treeEntries); err != nil {
+		t.Fatalf("decode tree at release: %v", err)
+	}
+	// At sequence 2 (v1.0), tree should have hello.txt and world.txt (deleted.txt added at seq=3).
+	treePaths := make(map[string]bool)
+	for _, e := range treeEntries {
+		treePaths[e.Path] = true
+	}
+	if !treePaths["hello.txt"] {
+		t.Error("expected hello.txt in tree at v1.0")
+	}
+	if treePaths["deleted.txt"] {
+		t.Error("deleted.txt should not be present in tree at v1.0 (added at seq=3)")
+	}
+
+	// ?at= RESOLUTION: invalid value returns 400.
+	badAt := doReq(http.MethodGet, base+"/tree?at=nonexistent-release", "")
+	defer badAt.Body.Close()
+	if badAt.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for unknown ?at= value, got %d", badAt.StatusCode)
+	}
+
+	// ?at= RESOLUTION: integer still works.
+	treeAtInt := doReq(http.MethodGet, base+"/tree?at=1", "")
+	defer treeAtInt.Body.Close()
+	if treeAtInt.StatusCode != http.StatusOK {
+		t.Errorf("tree?at=1: expected 200, got %d", treeAtInt.StatusCode)
+	}
+
+	// DELETE: remove v1.0.
+	delResp := doReq(http.MethodDelete, base+"/releases/v1.0", "")
+	defer delResp.Body.Close()
+	if delResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete release: expected 204, got %d", delResp.StatusCode)
+	}
+
+	// GET after delete: should 404.
+	afterDel := doReq(http.MethodGet, base+"/releases/v1.0", "")
+	defer afterDel.Body.Close()
+	if afterDel.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 after delete, got %d", afterDel.StatusCode)
+	}
+
+	// LIST after delete: only v2.0 remains.
+	listResp2 := doReq(http.MethodGet, base+"/releases", "")
+	defer listResp2.Body.Close()
+	var listBody2 struct {
+		Releases []struct{ Name string `json:"name"` } `json:"releases"`
+	}
+	if err := json.NewDecoder(listResp2.Body).Decode(&listBody2); err != nil {
+		t.Fatalf("decode list after delete: %v", err)
+	}
+	if len(listBody2.Releases) != 1 || listBody2.Releases[0].Name != "v2.0" {
+		t.Errorf("expected only v2.0 remaining, got %+v", listBody2.Releases)
+	}
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -216,6 +216,16 @@ func roleAllows(role model.RoleType, method, subPath string, r *http.Request) bo
 		return role == model.RoleAdmin
 	}
 
+	// DELETE /releases/<name> — admin only.
+	if method == http.MethodDelete && strings.HasPrefix(subPath, "releases/") {
+		return role == model.RoleAdmin
+	}
+
+	// POST /releases — maintainer+.
+	if method == http.MethodPost && subPath == "releases" {
+		return role == model.RoleMaintainer || role == model.RoleAdmin
+	}
+
 	// All other GET endpoints — reader+.
 	if method == http.MethodGet {
 		return true

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -766,3 +766,66 @@ func TestRBACMiddleware_ReaderUpgradedToWriter(t *testing.T) {
 	}
 }
 
+func TestRBACMiddleware_ReleasesAccess(t *testing.T) {
+	store := &mockRoleStore{
+		getRoleFn: func(_ context.Context, repo, identity string) (*model.Role, error) {
+			return &model.Role{Identity: identity, Role: model.RoleReader}, nil
+		},
+	}
+	h := rbacTestServer(store, "", "alice@example.com")
+
+	// Reader can GET /releases.
+	rec := rbacDo(t, h, http.MethodGet, "/repos/myrepo/myrepo/-/releases", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("reader GET releases: expected 200, got %d", rec.Code)
+	}
+
+	// Reader can GET /releases/<name>.
+	rec = rbacDo(t, h, http.MethodGet, "/repos/myrepo/myrepo/-/releases/v1.0", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("reader GET release: expected 200, got %d", rec.Code)
+	}
+
+	// Reader cannot POST /releases.
+	rec = rbacDo(t, h, http.MethodPost, "/repos/myrepo/myrepo/-/releases", `{"name":"v1.0","sequence":1}`)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("reader POST release: expected 403, got %d", rec.Code)
+	}
+
+	// Reader cannot DELETE /releases/<name>.
+	rec = rbacDo(t, h, http.MethodDelete, "/repos/myrepo/myrepo/-/releases/v1.0", "")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("reader DELETE release: expected 403, got %d", rec.Code)
+	}
+
+	// Maintainer can create releases.
+	storeM := &mockRoleStore{
+		getRoleFn: func(_ context.Context, repo, identity string) (*model.Role, error) {
+			return &model.Role{Identity: identity, Role: model.RoleMaintainer}, nil
+		},
+	}
+	hM := rbacTestServer(storeM, "", "carol@example.com")
+	rec = rbacDo(t, hM, http.MethodPost, "/repos/myrepo/myrepo/-/releases", `{"name":"v1.0","sequence":1}`)
+	if rec.Code != http.StatusOK {
+		t.Errorf("maintainer POST release: expected 200, got %d", rec.Code)
+	}
+
+	// Maintainer cannot delete releases.
+	rec = rbacDo(t, hM, http.MethodDelete, "/repos/myrepo/myrepo/-/releases/v1.0", "")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("maintainer DELETE release: expected 403, got %d", rec.Code)
+	}
+
+	// Admin can delete releases.
+	storeA := &mockRoleStore{
+		getRoleFn: func(_ context.Context, repo, identity string) (*model.Role, error) {
+			return &model.Role{Identity: identity, Role: model.RoleAdmin}, nil
+		},
+	}
+	hA := rbacTestServer(storeA, "", "admin@example.com")
+	rec = rbacDo(t, hA, http.MethodDelete, "/repos/myrepo/myrepo/-/releases/v1.0", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("admin DELETE release: expected 200, got %d", rec.Code)
+	}
+}
+

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -84,6 +84,12 @@ type WriteStore interface {
 
 	// Purge
 	Purge(ctx context.Context, req db.PurgeRequest) (*db.PurgeResult, error)
+
+	// Release management
+	CreateRelease(ctx context.Context, repo, name string, sequence int64, body, createdBy string) (*model.Release, error)
+	GetRelease(ctx context.Context, repo, name string) (*model.Release, error)
+	ListReleases(ctx context.Context, repo string, limit int, afterID string) ([]model.Release, error)
+	DeleteRelease(ctx context.Context, repo, name string) error
 }
 
 // CommitStore is an alias for backward compatibility with tests.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -51,6 +51,11 @@ type mockStore struct {
 	listInvitesFn     func(ctx context.Context, org string) ([]model.OrgInvite, error)
 	acceptInviteFn    func(ctx context.Context, org, token, identity string) error
 	revokeInviteFn    func(ctx context.Context, org, inviteID string) error
+
+	createReleaseFn func(ctx context.Context, repo, name string, sequence int64, body, createdBy string) (*model.Release, error)
+	getReleaseFn    func(ctx context.Context, repo, name string) (*model.Release, error)
+	listReleasesFn  func(ctx context.Context, repo string, limit int, afterID string) ([]model.Release, error)
+	deleteReleaseFn func(ctx context.Context, repo, name string) error
 }
 
 func (m *mockStore) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
@@ -275,6 +280,34 @@ func (m *mockStore) RevokeInvite(ctx context.Context, org, inviteID string) erro
 		return m.revokeInviteFn(ctx, org, inviteID)
 	}
 	return nil
+}
+
+func (m *mockStore) CreateRelease(ctx context.Context, repo, name string, sequence int64, body, createdBy string) (*model.Release, error) {
+	if m.createReleaseFn != nil {
+		return m.createReleaseFn(ctx, repo, name, sequence, body, createdBy)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockStore) GetRelease(ctx context.Context, repo, name string) (*model.Release, error) {
+	if m.getReleaseFn != nil {
+		return m.getReleaseFn(ctx, repo, name)
+	}
+	return nil, db.ErrReleaseNotFound
+}
+
+func (m *mockStore) ListReleases(ctx context.Context, repo string, limit int, afterID string) ([]model.Release, error) {
+	if m.listReleasesFn != nil {
+		return m.listReleasesFn(ctx, repo, limit, afterID)
+	}
+	return []model.Release{}, nil
+}
+
+func (m *mockStore) DeleteRelease(ctx context.Context, repo, name string) error {
+	if m.deleteReleaseFn != nil {
+		return m.deleteReleaseFn(ctx, repo, name)
+	}
+	return db.ErrReleaseNotFound
 }
 
 func TestHealthEndpoint(t *testing.T) {
@@ -2734,6 +2767,176 @@ func TestHandleRevokeInvite_NotFound(t *testing.T) {
 	h := newTestHandler(ms, nil, nil)
 
 	req := httptest.NewRequest(http.MethodDelete, "/orgs/acme/invites/no-such-id", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Release handler unit tests
+// ---------------------------------------------------------------------------
+
+func TestHandleCreateRelease(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return &model.Repo{Name: name}, nil
+		},
+		createReleaseFn: func(_ context.Context, repo, name string, sequence int64, body, createdBy string) (*model.Release, error) {
+			return &model.Release{ID: "test-id", Repo: repo, Name: name, Sequence: sequence, Body: body, CreatedBy: createdBy}, nil
+		},
+	}
+	h := newTestHandler(ms, nil, nil)
+
+	body := `{"name":"v1.0","sequence":5,"body":"initial"}`
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/releases", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp model.Release
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Name != "v1.0" || resp.Sequence != 5 {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+}
+
+func TestHandleCreateRelease_MissingName(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return &model.Repo{Name: name}, nil
+		},
+	}
+	h := newTestHandler(ms, nil, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/releases", bytes.NewBufferString(`{"sequence":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleCreateRelease_Conflict(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return &model.Repo{Name: name}, nil
+		},
+		createReleaseFn: func(_ context.Context, _, _ string, _ int64, _, _ string) (*model.Release, error) {
+			return nil, db.ErrReleaseExists
+		},
+	}
+	h := newTestHandler(ms, nil, nil)
+
+	body := `{"name":"v1.0","sequence":1}`
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/releases", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+}
+
+func TestHandleListReleases(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return &model.Repo{Name: name}, nil
+		},
+		listReleasesFn: func(_ context.Context, repo string, limit int, afterID string) ([]model.Release, error) {
+			return []model.Release{
+				{ID: "id1", Repo: repo, Name: "v2.0", Sequence: 10},
+				{ID: "id2", Repo: repo, Name: "v1.0", Sequence: 5},
+			}, nil
+		},
+	}
+	h := newTestHandler(ms, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/releases", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp model.ListReleasesResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Releases) != 2 {
+		t.Fatalf("expected 2 releases, got %d", len(resp.Releases))
+	}
+	if resp.Releases[0].Name != "v2.0" {
+		t.Errorf("expected v2.0 first, got %s", resp.Releases[0].Name)
+	}
+}
+
+func TestHandleGetRelease(t *testing.T) {
+	ms := &mockStore{
+		getReleaseFn: func(_ context.Context, repo, name string) (*model.Release, error) {
+			return &model.Release{ID: "id1", Repo: repo, Name: name, Sequence: 7}, nil
+		},
+	}
+	h := newTestHandler(ms, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/releases/v1.0", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp model.Release
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Sequence != 7 {
+		t.Errorf("expected sequence=7, got %d", resp.Sequence)
+	}
+}
+
+func TestHandleGetRelease_NotFound(t *testing.T) {
+	ms := &mockStore{}
+	h := newTestHandler(ms, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/releases/nope", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleDeleteRelease(t *testing.T) {
+	var deleted string
+	ms := &mockStore{
+		deleteReleaseFn: func(_ context.Context, repo, name string) error {
+			deleted = name
+			return nil
+		},
+	}
+	h := newTestHandler(ms, nil, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/repos/default/default/-/releases/v1.0", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	if deleted != "v1.0" {
+		t.Errorf("expected v1.0 to be deleted, got %q", deleted)
+	}
+}
+
+func TestHandleDeleteRelease_NotFound(t *testing.T) {
+	ms := &mockStore{}
+	h := newTestHandler(ms, nil, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/repos/default/default/-/releases/missing", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 	if w.Code != http.StatusNotFound {


### PR DESCRIPTION
## Summary

- **Migration 000003**: `releases` table with `UNIQUE(repo, name)`, referencing `repos(name)`, ordered newest-first
- **Model layer**: `Release` struct + `CreateReleaseRequest` / `ListReleasesResponse` API types
- **DB store**: `CreateRelease`, `GetRelease`, `ListReleases` (paginated, newest first), `DeleteRelease` + sentinel errors `ErrReleaseExists` / `ErrReleaseNotFound`
- **RBAC**: maintainer+ to create, admin to delete, reader+ to list/get (enforced in `roleAllows`)
- **HTTP handlers**: full CRUD on `/repos/{owner}/{name}/-/releases[/{name}]`
- **`?at=` resolution**: try `strconv.ParseInt` first (fully backward-compatible), fall back to release-name lookup from the DB; invalid values return HTTP 400
- **Default sequence**: when `POST /releases` omits `sequence`, the handler reads `main.head_sequence` from the `readStore` and uses that
- **CLI**: `ds release create <name> [--sequence N] [--notes text]`, `ds release list`, `ds release show <name>` (prints metadata + tree), `ds release delete <name>`
- **Tests**: db store CRUD, server unit tests for all handlers, RBAC middleware tests, full integration test (create/list/get/`?at=`-name/`?at=`-int/delete lifecycle)

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all packages pass
- [x] Integration test `TestIntegrationReleases` covers create, conflict, default-sequence, list, get, `?at=` name resolution, `?at=` integer backward compat, delete
- [x] `TestRBACMiddleware_ReleasesAccess` covers reader/maintainer/admin privilege boundaries

## Notes / opportunities

- `?at=` on file endpoint also resolves release names (same as tree) — symmetric behavior
- Keyset pagination for `ListReleases` uses `(created_at, id)` tuple so it's stable even when multiple releases share the same timestamp
- `ds release show` uses integer `?at=` (the sequence from the release) to call the tree endpoint — could be updated to use the release name directly once the server supports it (it does now)

Closes #96