### PR TITLE
Fix flaky internal/db tests under parallel load

### DIFF
--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -40,6 +40,8 @@ func StartSharedPostgres() (adminDSN string, cleanup func(), err error) {
 		postgres.WithDatabase("postgres"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
+		// Raise the connection limit so many parallel tests don't exhaust it.
+		testcontainers.WithCmdArgs("-c", "max_connections=500"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
@@ -77,10 +79,14 @@ func testDBFromDSN(t testing.TB, dsn string, migrate func(*sql.DB) error) *sql.D
 	t.Helper()
 
 	// Connect to the server using the provided DSN (admin connection).
+	// Limit the admin pool to a handful of connections — it only needs one
+	// at a time to run DDL (CREATE/DROP DATABASE).
 	admin, err := sql.Open("postgres", dsn)
 	if err != nil {
 		t.Fatalf("connect to postgres: %v", err)
 	}
+	admin.SetMaxOpenConns(3)
+	admin.SetMaxIdleConns(1)
 	defer admin.Close()
 
 	// Create a unique database for this test. The atomic counter prevents
@@ -89,18 +95,6 @@ func testDBFromDSN(t testing.TB, dsn string, migrate func(*sql.DB) error) *sql.D
 	if _, err := admin.Exec("CREATE DATABASE " + dbName); err != nil {
 		t.Fatalf("create test database %s: %v", dbName, err)
 	}
-	t.Cleanup(func() {
-		// Reconnect as admin to drop the test database.
-		c, err := sql.Open("postgres", dsn)
-		if err != nil {
-			t.Logf("reconnect to drop test db: %v", err)
-			return
-		}
-		defer c.Close()
-		if _, err := c.Exec("DROP DATABASE IF EXISTS " + dbName); err != nil {
-			t.Logf("drop test database %s: %v", dbName, err)
-		}
-	})
 
 	// Build a DSN for the new database by replacing the dbname parameter.
 	testDSN := replaceDBName(dsn, dbName)
@@ -108,7 +102,37 @@ func testDBFromDSN(t testing.TB, dsn string, migrate func(*sql.DB) error) *sql.D
 	if err != nil {
 		t.Fatalf("connect to test database %s: %v", dbName, err)
 	}
-	t.Cleanup(func() { d.Close() })
+	// Cap the per-test pool so many parallel tests don't exhaust Postgres
+	// max_connections. 5 open connections is ample for any single test.
+	d.SetMaxOpenConns(5)
+	d.SetMaxIdleConns(2)
+	d.SetConnMaxLifetime(30 * time.Second)
+
+	// Single cleanup closes the pool first, then terminates any lingering
+	// backend connections before dropping the database. Combining both steps
+	// in one function ensures correct ordering without relying on LIFO
+	// semantics and avoids the "database is being accessed by other users"
+	// error that can occur when pg_backend connections outlive d.Close().
+	t.Cleanup(func() {
+		d.Close()
+		c, err := sql.Open("postgres", dsn)
+		if err != nil {
+			t.Logf("reconnect to drop test db: %v", err)
+			return
+		}
+		defer c.Close()
+		c.SetMaxOpenConns(3)
+		c.SetMaxIdleConns(1)
+		// Terminate any remaining backend connections to the test database so
+		// that DROP DATABASE succeeds even if d.Close() left stragglers.
+		_, _ = c.Exec(
+			"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+			dbName,
+		)
+		if _, err := c.Exec("DROP DATABASE IF EXISTS " + dbName); err != nil {
+			t.Logf("drop test database %s: %v", dbName, err)
+		}
+	})
 
 	if err := migrate(d); err != nil {
 		t.Fatalf("run migrations: %v", err)


### PR DESCRIPTION
## Summary

- **Root cause 1**: Per-test `sql.DB` had unlimited `MaxOpenConns`. With `go test -count=3 -parallel=8`, many tests run simultaneously, collectively exhausting Postgres's default `max_connections=100`, causing connection errors and test hangs.
- **Root cause 2**: `DROP DATABASE` in cleanup occasionally failed with _"database is being accessed by other users"_ — two separate `t.Cleanup` registrations meant Postgres backends could linger between `d.Close()` and the DROP.

## Changes (`internal/testutil/testdb.go`)

1. **`StartSharedPostgres`**: Pass `-c max_connections=500` to the Postgres container via `testcontainers.WithCmdArgs`. Gives a 5× headroom margin above the default.

2. **`testDBFromDSN`**:
   - Cap admin `*sql.DB`: `SetMaxOpenConns(3)`, `SetMaxIdleConns(1)` — it only ever needs one connection for DDL.
   - Cap per-test `*sql.DB`: `SetMaxOpenConns(5)`, `SetMaxIdleConns(2)`, `SetConnMaxLifetime(30s)` — ample for any single test, limits to ~40 total connections under 8-way parallelism.
   - Merge the two `t.Cleanup` registrations into one: close the pool, call `pg_terminate_backend` on any remaining backends, then DROP. This eliminates the "accessed by other users" race entirely.

## Test plan

- [x] `go build ./...` and `go vet ./...` — clean
- [x] `go test -count=3 -parallel=8 ./internal/db/... -timeout 180s` — passes in ~7.5s (was timing out at 127s)
- [x] `go test -count=1 ./... -timeout 120s` — all packages green

## Notes for reviewer

The fix is confined to `internal/testutil/testdb.go` — no production code changes. The `pg_terminate_backend` call is safe because it only targets the specific test database by name and excludes the current backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)