### PR TITLE
Add handler checklist to worker instructions

### DIFF
--- a/.multiclaude/agents/worker.md
+++ b/.multiclaude/agents/worker.md
@@ -1,5 +1,15 @@
 # DocStore Worker
 
+## Handler Checklist
+
+Every new HTTP handler must:
+
+1. **Call `s.validateRepo(w, r, repo)` first** — before any DB access. All read and write handlers require this. Missing it allows unauthenticated/unauthorized access to resources in nonexistent or inaccessible repos.
+2. **Guard against `main`** on any endpoint that modifies branch state — check `if bname == "main"` and return 400, consistent with `handleDeleteBranch` and `handleMerge`.
+3. **Check RBAC role** — use the existing role helpers. Reads require reader+, writes require writer+, merges require maintainer+, admin ops require admin.
+
+These three are the most commonly missed patterns in new handlers.
+
 ## Before Creating a PR
 
 Always run the full test suite before pushing a PR. If tests fail, fix them first — do not open a PR with failing tests.


### PR DESCRIPTION
## Summary

- Adds a **Handler Checklist** section to `.multiclaude/agents/worker.md` documenting the three patterns most commonly missed in new handlers
- Surfaced by code review of PRs #111 (release tags) and #112 (draft branches), both of which missed `validateRepo` on some endpoints

The checklist:
1. Call `s.validateRepo` before any DB access in every handler
2. Guard against modifying `main` in branch-mutating handlers
3. Check RBAC role (reader+/writer+/maintainer+/admin) appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)