### PR TITLE
Fix review issues in release tags (PR #111 followup)

### DIFF
--- a/internal/db/migrations/000006_releases_cascade.down.sql
+++ b/internal/db/migrations/000006_releases_cascade.down.sql
@@ -1,0 +1,5 @@
+-- Revert ON DELETE CASCADE from the releases → repos foreign key.
+
+ALTER TABLE releases DROP CONSTRAINT releases_repo_fkey;
+ALTER TABLE releases ADD CONSTRAINT releases_repo_fkey
+    FOREIGN KEY (repo) REFERENCES repos(name);

--- a/internal/db/migrations/000006_releases_cascade.up.sql
+++ b/internal/db/migrations/000006_releases_cascade.up.sql
@@ -1,0 +1,6 @@
+-- Add ON DELETE CASCADE to the releases → repos foreign key.
+-- Without this, deleting a repo leaves orphaned release rows.
+
+ALTER TABLE releases DROP CONSTRAINT releases_repo_fkey;
+ALTER TABLE releases ADD CONSTRAINT releases_repo_fkey
+    FOREIGN KEY (repo) REFERENCES repos(name) ON DELETE CASCADE;

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -122,6 +122,7 @@ var (
 	ErrEmailMismatch          = errors.New("identity does not match invite email")
 	ErrReleaseNotFound        = errors.New("release not found")
 	ErrReleaseExists          = errors.New("release already exists")
+	ErrInvalidCursor          = errors.New("invalid pagination cursor")
 	ErrBranchDraft            = errors.New("branch is in draft state")
 )
 
@@ -1847,6 +1848,19 @@ func (s *Store) ListReleases(ctx context.Context, repo string, limit int, afterI
 			)
 		}
 	} else {
+		// Validate that the cursor ID actually exists before running the main query.
+		// If it doesn't exist, the subquery returns no rows and the WHERE condition
+		// would be vacuously false, returning all releases instead of an error.
+		var exists bool
+		if err := s.db.QueryRowContext(ctx,
+			`SELECT EXISTS(SELECT 1 FROM releases WHERE id = $1)`, afterID,
+		).Scan(&exists); err != nil {
+			return nil, fmt.Errorf("validate cursor: %w", err)
+		}
+		if !exists {
+			return nil, ErrInvalidCursor
+		}
+
 		// Use the row with id=afterID as the cursor.
 		if limit <= 0 {
 			rows, err = s.db.QueryContext(ctx,
@@ -1900,6 +1914,20 @@ func (s *Store) DeleteRelease(ctx context.Context, repo, name string) error {
 		return ErrReleaseNotFound
 	}
 	return nil
+}
+
+// CommitSequenceExists reports whether the given sequence number exists in the
+// commits table for the given repo.
+func (s *Store) CommitSequenceExists(ctx context.Context, repo string, sequence int64) (bool, error) {
+	var exists bool
+	err := s.db.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM commits WHERE repo = $1 AND sequence = $2)`,
+		repo, sequence,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("check commit sequence: %w", err)
+	}
+	return exists, nil
 }
 
 // isDuplicateKeyError checks if a PostgreSQL error is a unique violation (23505).

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -3740,3 +3740,15 @@ func TestRelease_CreateListGetDelete(t *testing.T) {
 		t.Errorf("expected ErrReleaseNotFound, got %v", err)
 	}
 }
+
+func TestListReleases_InvalidCursor(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.ListReleases(ctx, "default/default", 10, "00000000-0000-0000-0000-000000000000")
+	if !errors.Is(err, ErrInvalidCursor) {
+		t.Errorf("expected ErrInvalidCursor, got %v", err)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1706,6 +1706,17 @@ func (s *server) handleCreateRelease(w http.ResponseWriter, r *http.Request) {
 	var sequence int64
 	if req.Sequence != nil {
 		sequence = *req.Sequence
+		// Validate that the provided sequence actually exists in the commits table.
+		exists, err := s.commitStore.CommitSequenceExists(r.Context(), repo, sequence)
+		if err != nil {
+			slog.Error("internal error", "op", "create_release_seq_check", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+			return
+		}
+		if !exists {
+			writeError(w, http.StatusBadRequest, "sequence not found")
+			return
+		}
 	} else {
 		if s.readStore == nil {
 			writeError(w, http.StatusServiceUnavailable, "read store not available")
@@ -1756,6 +1767,10 @@ func (s *server) handleListReleases(w http.ResponseWriter, r *http.Request) {
 
 	releases, err := s.commitStore.ListReleases(r.Context(), repo, limit, afterID)
 	if err != nil {
+		if errors.Is(err, db.ErrInvalidCursor) {
+			writeError(w, http.StatusBadRequest, "invalid pagination cursor")
+			return
+		}
 		writeError(w, http.StatusInternalServerError, "query failed")
 		return
 	}
@@ -1768,6 +1783,9 @@ func (s *server) handleListReleases(w http.ResponseWriter, r *http.Request) {
 // handleGetRelease implements GET /repos/:name/-/releases/:release (reader+)
 func (s *server) handleGetRelease(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
 	releaseName := r.PathValue("release")
 
 	rel, err := s.commitStore.GetRelease(r.Context(), repo, releaseName)
@@ -1786,6 +1804,9 @@ func (s *server) handleGetRelease(w http.ResponseWriter, r *http.Request) {
 // handleDeleteRelease implements DELETE /repos/:name/-/releases/:release (admin only)
 func (s *server) handleDeleteRelease(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
 	releaseName := r.PathValue("release")
 
 	if err := s.commitStore.DeleteRelease(r.Context(), repo, releaseName); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -92,6 +92,10 @@ type WriteStore interface {
 	GetRelease(ctx context.Context, repo, name string) (*model.Release, error)
 	ListReleases(ctx context.Context, repo string, limit int, afterID string) ([]model.Release, error)
 	DeleteRelease(ctx context.Context, repo, name string) error
+
+	// CommitSequenceExists reports whether the given sequence number exists in
+	// the commits table for repo. Used to validate release sequence references.
+	CommitSequenceExists(ctx context.Context, repo string, sequence int64) (bool, error)
 }
 
 // CommitStore is an alias for backward compatibility with tests.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -53,10 +53,11 @@ type mockStore struct {
 	revokeInviteFn    func(ctx context.Context, org, inviteID string) error
 	updateBranchDraftFn func(ctx context.Context, repo, name string, draft bool) error
 
-	createReleaseFn func(ctx context.Context, repo, name string, sequence int64, body, createdBy string) (*model.Release, error)
-	getReleaseFn    func(ctx context.Context, repo, name string) (*model.Release, error)
-	listReleasesFn  func(ctx context.Context, repo string, limit int, afterID string) ([]model.Release, error)
-	deleteReleaseFn func(ctx context.Context, repo, name string) error
+	createReleaseFn        func(ctx context.Context, repo, name string, sequence int64, body, createdBy string) (*model.Release, error)
+	getReleaseFn           func(ctx context.Context, repo, name string) (*model.Release, error)
+	listReleasesFn         func(ctx context.Context, repo string, limit int, afterID string) ([]model.Release, error)
+	deleteReleaseFn        func(ctx context.Context, repo, name string) error
+	commitSequenceExistsFn func(ctx context.Context, repo string, sequence int64) (bool, error)
 }
 
 func (m *mockStore) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
@@ -316,6 +317,13 @@ func (m *mockStore) DeleteRelease(ctx context.Context, repo, name string) error 
 		return m.deleteReleaseFn(ctx, repo, name)
 	}
 	return db.ErrReleaseNotFound
+}
+
+func (m *mockStore) CommitSequenceExists(ctx context.Context, repo string, sequence int64) (bool, error) {
+	if m.commitSequenceExistsFn != nil {
+		return m.commitSequenceExistsFn(ctx, repo, sequence)
+	}
+	return true, nil
 }
 
 func TestHealthEndpoint(t *testing.T) {
@@ -3088,5 +3096,77 @@ func TestHandleDeleteRelease_NotFound(t *testing.T) {
 	h.ServeHTTP(w, req)
 	if w.Code != http.StatusNotFound {
 		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleGetRelease_RepoNotFound(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return nil, db.ErrRepoNotFound
+		},
+	}
+	h := newTestHandler(ms, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/ghost/ghost/-/releases/v1.0", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleDeleteRelease_RepoNotFound(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return nil, db.ErrRepoNotFound
+		},
+	}
+	h := newTestHandler(ms, nil, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/repos/ghost/ghost/-/releases/v1.0", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleListReleases_InvalidCursor(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return &model.Repo{Name: name}, nil
+		},
+		listReleasesFn: func(_ context.Context, repo string, limit int, afterID string) ([]model.Release, error) {
+			return nil, db.ErrInvalidCursor
+		},
+	}
+	h := newTestHandler(ms, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/releases?after=does-not-exist", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleCreateRelease_InvalidSequence(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return &model.Repo{Name: name}, nil
+		},
+		commitSequenceExistsFn: func(_ context.Context, repo string, sequence int64) (bool, error) {
+			return false, nil
+		},
+	}
+	h := newTestHandler(ms, nil, nil)
+
+	body := `{"name":"v1.0","sequence":9999}`
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/releases", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

Fixes all five issues identified in the PR #111 review for the release tags implementation.

- **[HIGH] Missing validateRepo** in `handleGetRelease` and `handleDeleteRelease` — both now call `s.validateRepo(w, r, repo)` as the first step after extracting the repo name, matching the pattern in `handleListReleases`.

- **[MEDIUM] Pagination cursor validation** in `db.Store.ListReleases` — added `ErrInvalidCursor` sentinel error and a pre-check `SELECT EXISTS` query before the keyset subquery. Without this, a non-existent `afterID` caused the subquery to return no rows, making the `WHERE` condition vacuously false and returning all releases. The handler now returns `400 Bad Request` on `ErrInvalidCursor`.

- **[MEDIUM] Sequence validation** in `handleCreateRelease` — added `CommitSequenceExists(ctx, repo, seq) (bool, error)` to the `WriteStore` interface and `db.Store`. When `sequence` is provided in the request, the handler validates it exists in the commits table and returns `400` if not.

- **[LOW] ON DELETE CASCADE migration** — added `000006_releases_cascade.up.sql` / `000006_releases_cascade.down.sql` to drop and recreate the `releases_repo_fkey` FK with `ON DELETE CASCADE`.

- **Tests** added:
  - `TestHandleGetRelease_RepoNotFound` → 404
  - `TestHandleDeleteRelease_RepoNotFound` → 404
  - `TestHandleListReleases_InvalidCursor` → 400
  - `TestHandleCreateRelease_InvalidSequence` → 400
  - `TestListReleases_InvalidCursor` (db-layer, uses testcontainer)

All tests pass (`go test ./... -count=1`).

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` all pass

Reference: PR #111 review findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)