### PR TITLE
Fix PR #112 review issues: validateRepo, main guard, RBAC, --include-draft

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -32,7 +32,7 @@ commands:
   resolve <path>                                  Resolve a merge/rebase conflict
   verify                                          Verify commit chain integrity
   ready                                           Mark current branch as ready (not draft)
-  branches [--status active|merged|abandoned] [--draft]  List branches
+  branches [--status active|merged|abandoned] [--draft] [--include-draft]  List branches
   reviews [--branch <name>]                       List reviews for a branch
   review --status approved|rejected [--body "…"] [--branch <name>]  Submit a review
   checks [--branch <name>]                        List check runs for a branch
@@ -230,15 +230,18 @@ func main() {
 	case "branches":
 		status := "active"
 		onlyDraft := false
+		includeDraft := false
 		for i := 1; i < len(args); i++ {
 			if args[i] == "--status" && i+1 < len(args) {
 				status = args[i+1]
 				i++
 			} else if args[i] == "--draft" {
 				onlyDraft = true
+			} else if args[i] == "--include-draft" {
+				includeDraft = true
 			}
 		}
-		err = app.Branches(status, onlyDraft)
+		err = app.Branches(status, onlyDraft, includeDraft)
 
 	case "reviews":
 		branch := ""

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1451,7 +1451,7 @@ func (a *App) fetchFileBytesForBranch(cfg *Config, path, branch string) ([]byte,
 }
 
 // Branches lists branches for the current repo, filtered by status (default: active).
-func (a *App) Branches(status string, onlyDraft bool) error {
+func (a *App) Branches(status string, onlyDraft bool, includeDraft bool) error {
 	cfg, err := a.loadConfig()
 	if err != nil {
 		return err
@@ -1464,6 +1464,9 @@ func (a *App) Branches(status string, onlyDraft bool) error {
 	q.Set("status", status)
 	if onlyDraft {
 		q.Set("draft", "true")
+	}
+	if includeDraft {
+		q.Set("include_draft", "true")
 	}
 	resp, err := a.httpGet(cfg, repoBase(cfg)+"/branches?"+q.Encode())
 	if err != nil {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1767,7 +1767,7 @@ func TestBranches_ListsActive(t *testing.T) {
 	app, out := newTestApp(t, srv)
 	initWorkspace(t, app, srv.URL, "main", "alice")
 
-	if err := app.Branches("active", false); err != nil {
+	if err := app.Branches("active", false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1795,9 +1795,33 @@ func TestBranches_DefaultStatusActive(t *testing.T) {
 	app, _ := newTestApp(t, srv)
 	initWorkspace(t, app, srv.URL, "main", "alice")
 
-	app.Branches("", false)
+	app.Branches("", false, false)
 	if gotStatus != "active" {
 		t.Errorf("expected status=active, got %q", gotStatus)
+	}
+}
+
+func TestBranches_IncludeDraft(t *testing.T) {
+	var gotIncludeDraft, gotDraft string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotIncludeDraft = r.URL.Query().Get("include_draft")
+		gotDraft = r.URL.Query().Get("draft")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]model.Branch{})
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initWorkspace(t, app, srv.URL, "main", "alice")
+
+	if err := app.Branches("active", false, true); err != nil {
+		t.Fatal(err)
+	}
+	if gotIncludeDraft != "true" {
+		t.Errorf("expected include_draft=true, got %q", gotIncludeDraft)
+	}
+	if gotDraft != "" {
+		t.Errorf("expected draft param absent, got %q", gotDraft)
 	}
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1227,6 +1227,14 @@ func (s *server) handleUpdateBranch(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
 	bname := r.PathValue("bname")
 
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+	if bname == "main" {
+		writeError(w, http.StatusBadRequest, "cannot modify branch 'main'")
+		return
+	}
+
 	var req model.UpdateBranchRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -253,6 +253,11 @@ func roleAllows(role model.RoleType, method, subPath string, r *http.Request) bo
 		return role == model.RoleMaintainer || role == model.RoleAdmin
 	}
 
+	// PATCH /branch/* (draft promotion) — writer+.
+	if method == http.MethodPatch && strings.HasPrefix(subPath, "branch/") {
+		return role == model.RoleWriter || role == model.RoleMaintainer || role == model.RoleAdmin
+	}
+
 	return false
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -893,6 +893,55 @@ func TestHandleUpdateBranch_NotFound(t *testing.T) {
 	}
 }
 
+func TestHandleUpdateBranch_RepoNotFound(t *testing.T) {
+	store := &mockStore{
+		getRepoFn: func(ctx context.Context, name string) (*model.Repo, error) {
+			return nil, db.ErrRepoNotFound
+		},
+	}
+	srv := New(store, nil, devID, devID)
+
+	body, _ := json.Marshal(model.UpdateBranchRequest{Draft: false})
+	req := httptest.NewRequest(http.MethodPatch, "/repos/default/default/-/branch/feature/x", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleUpdateBranch_CannotPatchMain(t *testing.T) {
+	srv := New(&mockStore{}, nil, devID, devID)
+
+	body, _ := json.Marshal(model.UpdateBranchRequest{Draft: false})
+	req := httptest.NewRequest(http.MethodPatch, "/repos/default/default/-/branch/main", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleUpdateBranch_ReaderForbidden(t *testing.T) {
+	store := &mockStore{
+		getRoleFn: func(ctx context.Context, repo, identity string) (*model.Role, error) {
+			return &model.Role{Identity: identity, Role: model.RoleReader}, nil
+		},
+	}
+	srv := New(store, nil, "reader@example.com", "")
+
+	body, _ := json.Marshal(model.UpdateBranchRequest{Draft: false})
+	req := httptest.NewRequest(http.MethodPatch, "/repos/default/default/-/branch/feature/x", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestHandleBranches_DraftFilter(t *testing.T) {
 	var gotIncludeDraft, gotOnlyDraft bool
 	rs := &mockReadStore{


### PR DESCRIPTION
## Summary

Fixes all review findings from PR #112 (draft branches implementation):

- **[HIGH] Missing validateRepo in handleUpdateBranch**: Added `s.validateRepo(w, r, repo)` as the first check after extracting repo/bname. PATCH on a nonexistent repo now correctly returns 404, consistent with every other write handler.
- **[LOW-MEDIUM] No guard against PATCHing main**: Added `if bname == "main"` check returning 400, consistent with `handleDeleteBranch` and `handleMerge`.
- **[MEDIUM] No authorization check for draft promotion**: Added `PATCH /branch/*` → writer+ rule to `roleAllows` in `middleware.go`. Readers get 403; writers, maintainers, and admins can promote drafts.
- **[MEDIUM] Missing --include-draft CLI flag**: Added `--include-draft` flag to `ds branches` that maps to `?include_draft=true`, complementing the existing `--draft` flag.

## Test plan

- `TestHandleUpdateBranch_RepoNotFound` — PATCH /branch/:name on nonexistent repo → 404
- `TestHandleUpdateBranch_CannotPatchMain` — PATCH /branch/main → 400
- `TestHandleUpdateBranch_ReaderForbidden` — PATCH /branch/:name by a reader → 403
- `TestBranches_IncludeDraft` — CLI `ds branches --include-draft` sends `?include_draft=true`
- Full test suite passes: `go test ./... -count=1` ✓

## Notes for future

The writer+ RBAC rule is enforced at the middleware layer (consistent with how delete/merge/rebase are handled), so no duplicate check is needed in the handler itself.

Reference: PR #112 review findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)