### PR TITLE
Add structured logging (slog) to post-PR#58 code

### DIFF
--- a/internal/blob/blob.go
+++ b/internal/blob/blob.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 )
@@ -41,11 +42,14 @@ func (s *LocalBlobStore) keyPath(key string) string {
 func (s *LocalBlobStore) Put(_ context.Context, key string, r io.Reader) error {
 	data, err := io.ReadAll(r)
 	if err != nil {
+		slog.Error("blob put failed", "key", key, "backend", "local", "error", err)
 		return fmt.Errorf("read blob data: %w", err)
 	}
 	if err := os.WriteFile(s.keyPath(key), data, 0o644); err != nil {
+		slog.Error("blob put failed", "key", key, "backend", "local", "error", err)
 		return fmt.Errorf("write blob: %w", err)
 	}
+	slog.Debug("blob put", "key", key, "backend", "local")
 	return nil
 }
 
@@ -53,6 +57,9 @@ func (s *LocalBlobStore) Put(_ context.Context, key string, r io.Reader) error {
 func (s *LocalBlobStore) Get(_ context.Context, key string) (io.ReadCloser, error) {
 	f, err := os.Open(s.keyPath(key))
 	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Error("blob get failed", "key", key, "backend", "local", "error", err)
+		}
 		return nil, fmt.Errorf("open blob: %w", err)
 	}
 	return f, nil
@@ -76,5 +83,10 @@ func (s *LocalBlobStore) Delete(_ context.Context, key string) error {
 	if os.IsNotExist(err) {
 		return nil
 	}
-	return err
+	if err != nil {
+		slog.Error("blob delete failed", "key", key, "backend", "local", "error", err)
+		return err
+	}
+	slog.Debug("blob delete", "key", key, "backend", "local")
+	return nil
 }

--- a/internal/blob/gcs.go
+++ b/internal/blob/gcs.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 
 	"cloud.google.com/go/storage"
 )
@@ -30,11 +31,14 @@ func (s *GCSBlobStore) Put(ctx context.Context, key string, r io.Reader) error {
 	w := s.client.Bucket(s.bucket).Object(key).NewWriter(ctx)
 	if _, err := io.Copy(w, r); err != nil {
 		w.Close() //nolint:errcheck
+		slog.Error("blob put failed", "key", key, "backend", "gcs", "error", err)
 		return fmt.Errorf("gcs upload: %w", err)
 	}
 	if err := w.Close(); err != nil {
+		slog.Error("blob put failed", "key", key, "backend", "gcs", "error", err)
 		return fmt.Errorf("gcs close writer: %w", err)
 	}
+	slog.Debug("blob put", "key", key, "backend", "gcs")
 	return nil
 }
 
@@ -42,6 +46,9 @@ func (s *GCSBlobStore) Put(ctx context.Context, key string, r io.Reader) error {
 func (s *GCSBlobStore) Get(ctx context.Context, key string) (io.ReadCloser, error) {
 	r, err := s.client.Bucket(s.bucket).Object(key).NewReader(ctx)
 	if err != nil {
+		if !errors.Is(err, storage.ErrObjectNotExist) {
+			slog.Error("blob get failed", "key", key, "backend", "gcs", "error", err)
+		}
 		return nil, fmt.Errorf("gcs download: %w", err)
 	}
 	return r, nil
@@ -67,7 +74,9 @@ func (s *GCSBlobStore) Delete(ctx context.Context, key string) error {
 		return nil
 	}
 	if err != nil {
+		slog.Error("blob delete failed", "key", key, "backend", "gcs", "error", err)
 		return fmt.Errorf("gcs delete: %w", err)
 	}
+	slog.Debug("blob delete", "key", key, "backend", "gcs")
 	return nil
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -609,6 +609,7 @@ func (s *Store) UpdateBranchDraft(ctx context.Context, repo, name string, draft 
 		draft, repo, name,
 	)
 	if err != nil {
+		slog.Error("update branch draft failed", "repo", repo, "branch", name, "error", err)
 		return fmt.Errorf("update branch draft: %w", err)
 	}
 	n, err := res.RowsAffected()
@@ -618,6 +619,7 @@ func (s *Store) UpdateBranchDraft(ctx context.Context, repo, name string, draft 
 	if n == 0 {
 		return ErrBranchNotFound
 	}
+	slog.Info("branch draft updated", "repo", repo, "branch", name, "draft", draft)
 	return nil
 }
 
@@ -1614,7 +1616,12 @@ func (s *Store) AddOrgMember(ctx context.Context, org, identity string, role mod
 		 ON CONFLICT (org, identity) DO UPDATE SET role = $3, invited_by = $4`,
 		org, identity, string(role), invitedBy,
 	)
-	return err
+	if err != nil {
+		slog.Error("add org member failed", "org", org, "identity", identity, "error", err)
+		return err
+	}
+	slog.Info("org member added", "org", org, "identity", identity, "role", role)
+	return nil
 }
 
 // RemoveOrgMember removes a member from an org. Returns ErrOrgMemberNotFound if not found.
@@ -1624,6 +1631,7 @@ func (s *Store) RemoveOrgMember(ctx context.Context, org, identity string) error
 		org, identity,
 	)
 	if err != nil {
+		slog.Error("remove org member failed", "org", org, "identity", identity, "error", err)
 		return err
 	}
 	n, err := result.RowsAffected()
@@ -1633,6 +1641,7 @@ func (s *Store) RemoveOrgMember(ctx context.Context, org, identity string) error
 	if n == 0 {
 		return ErrOrgMemberNotFound
 	}
+	slog.Info("org member removed", "org", org, "identity", identity)
 	return nil
 }
 
@@ -1675,9 +1684,11 @@ func (s *Store) CreateInvite(ctx context.Context, org, email string, role model.
 		id, org, email, string(role), invitedBy, token, expiresAt,
 	).Scan(&inv.ID, &inv.Org, &inv.Email, &roleStr, &inv.InvitedBy, &inv.Token, &inv.ExpiresAt, &inv.CreatedAt)
 	if err != nil {
+		slog.Error("create invite failed", "org", org, "email", email, "error", err)
 		return nil, fmt.Errorf("insert invite: %w", err)
 	}
 	inv.Role = model.OrgRole(roleStr)
+	slog.Info("invite created", "org", org, "email", email, "role", role)
 	return &inv, nil
 }
 
@@ -1710,8 +1721,10 @@ func (s *Store) ListInvites(ctx context.Context, org string) ([]model.OrgInvite,
 // AcceptInvite accepts a pending invite: verifies the token, checks expiry and email match,
 // sets accepted_at, and upserts the identity into org_members — all in one transaction.
 func (s *Store) AcceptInvite(ctx context.Context, org, token, identity string) error {
+	slog.Debug("accept invite started", "org", org)
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		slog.Error("tx begin failed", "op", "accept_invite", "error", err)
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	defer func() {
@@ -1765,7 +1778,11 @@ func (s *Store) AcceptInvite(ctx context.Context, org, token, identity string) e
 		return fmt.Errorf("add member: %w", err)
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	slog.Info("invite accepted", "org", org, "identity", identity)
+	return nil
 }
 
 // RevokeInvite deletes a pending invite by ID. Returns ErrInviteNotFound if not found.
@@ -1775,6 +1792,7 @@ func (s *Store) RevokeInvite(ctx context.Context, org, inviteID string) error {
 		inviteID, org,
 	)
 	if err != nil {
+		slog.Error("revoke invite failed", "org", org, "invite_id", inviteID, "error", err)
 		return err
 	}
 	n, err := result.RowsAffected()
@@ -1784,6 +1802,7 @@ func (s *Store) RevokeInvite(ctx context.Context, org, inviteID string) error {
 	if n == 0 {
 		return ErrInviteNotFound
 	}
+	slog.Info("invite revoked", "org", org, "invite_id", inviteID)
 	return nil
 }
 
@@ -1805,8 +1824,10 @@ func (s *Store) CreateRelease(ctx context.Context, repo, name string, sequence i
 		if isDuplicateKeyError(err) {
 			return nil, ErrReleaseExists
 		}
+		slog.Error("create release failed", "repo", repo, "name", name, "error", err)
 		return nil, fmt.Errorf("insert release: %w", err)
 	}
+	slog.Info("release created", "repo", repo, "name", name, "sequence", sequence, "by", createdBy)
 	return &rel, nil
 }
 
@@ -1904,6 +1925,7 @@ func (s *Store) DeleteRelease(ctx context.Context, repo, name string) error {
 		repo, name,
 	)
 	if err != nil {
+		slog.Error("delete release failed", "repo", repo, "name", name, "error", err)
 		return fmt.Errorf("delete release: %w", err)
 	}
 	n, err := result.RowsAffected()
@@ -1913,6 +1935,7 @@ func (s *Store) DeleteRelease(ctx context.Context, repo, name string) error {
 	if n == 0 {
 		return ErrReleaseNotFound
 	}
+	slog.Info("release deleted", "repo", repo, "name", name)
 	return nil
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1732,6 +1732,7 @@ func (s *server) handleCreateRelease(w http.ResponseWriter, r *http.Request) {
 		}
 		branchInfo, err := s.readStore.GetBranch(r.Context(), repo, "main")
 		if err != nil || branchInfo == nil {
+			slog.Error("internal error", "op", "create_release_head", "repo", repo, "error", err)
 			writeError(w, http.StatusInternalServerError, "could not resolve main head sequence")
 			return
 		}
@@ -1779,6 +1780,7 @@ func (s *server) handleListReleases(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "invalid pagination cursor")
 			return
 		}
+		slog.Error("internal error", "op", "list_releases", "repo", repo, "error", err)
 		writeError(w, http.StatusInternalServerError, "query failed")
 		return
 	}
@@ -1802,6 +1804,7 @@ func (s *server) handleGetRelease(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, db.ErrReleaseNotFound):
 			writeError(w, http.StatusNotFound, "release not found")
 		default:
+			slog.Error("internal error", "op", "get_release", "repo", repo, "release", releaseName, "error", err)
 			writeError(w, http.StatusInternalServerError, "query failed")
 		}
 		return


### PR DESCRIPTION
## Summary

Fills logging gaps in three features added after slog was introduced in PR #58. No new dependencies — stdlib `log/slog` only.

### internal/blob/blob.go + gcs.go
- `Put`: `slog.Debug` on success; `slog.Error` on failure
- `Get`: `slog.Error` on failure, but **not** for not-found (os.IsNotExist / storage.ErrObjectNotExist) since that is a normal caller condition
- `Delete`: `slog.Debug` on success; `slog.Error` on failure

### internal/db/store.go
- **AcceptInvite** (transactional): added `slog.Debug` at entry, `slog.Error` on tx begin failure, `slog.Info` on commit. Rollback error was already logged.
- **AddOrgMember, RemoveOrgMember, CreateInvite, RevokeInvite, CreateRelease, DeleteRelease, UpdateBranchDraft** (non-transactional): `slog.Error` on DB error, `slog.Info` on success. Invite tokens are never logged per policy.

### internal/server/handlers.go (minor gaps only)
Three 500-returning paths in new release handlers that were missing `slog.Error`:
- `handleCreateRelease`: GetBranch failure path
- `handleListReleases`: ListReleases failure path
- `handleGetRelease`: GetRelease failure path

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all packages pass

## Notes / future opportunities
- Several older handlers (pre-PR#58) also have unlogged 500 paths — out of scope per task spec
- `handleChain` 500 path is also unlogged but was not part of the three specified feature areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)