### PR TITLE
Fix ci-runner: remove WriteTimeout, add input validation, graceful shutdown

### DIFF
--- a/cmd/ci-runner/main.go
+++ b/cmd/ci-runner/main.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/dlorenc/docstore/internal/executor"
@@ -50,6 +55,24 @@ func main() {
 			http.Error(w, "source_dir is required", http.StatusBadRequest)
 			return
 		}
+		if !filepath.IsAbs(req.SourceDir) {
+			http.Error(w, "source_dir must be an absolute path", http.StatusBadRequest)
+			return
+		}
+		if _, err := os.Stat(req.SourceDir); err != nil {
+			http.Error(w, fmt.Sprintf("source_dir does not exist: %v", err), http.StatusBadRequest)
+			return
+		}
+		for i, check := range req.Config.Checks {
+			if check.Image == "" {
+				http.Error(w, fmt.Sprintf("check[%d] (%q): image is required", i, check.Name), http.StatusBadRequest)
+				return
+			}
+			if len(check.Steps) == 0 {
+				http.Error(w, fmt.Sprintf("check[%d] (%q): at least one step is required", i, check.Name), http.StatusBadRequest)
+				return
+			}
+		}
 
 		results, err := exec.Run(r.Context(), req.SourceDir, req.Config)
 		if err != nil {
@@ -63,16 +86,39 @@ func main() {
 	})
 
 	srv := &http.Server{
-		Addr:         ":" + *port,
-		Handler:      mux,
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 300 * time.Second,
-		IdleTimeout:  60 * time.Second,
+		Addr:        ":" + *port,
+		Handler:     mux,
+		ReadTimeout: 10 * time.Second,
+		// WriteTimeout is intentionally not set: long-running CI builds stream
+		// responses back over the HTTP connection and must not be cut off by a
+		// server-side write deadline. The execution timeout is controlled by the
+		// request context instead.
+		IdleTimeout: 60 * time.Second,
 	}
 
-	slog.Info("starting ci-runner", "port", *port, "buildkit_addr", *buildkitAddr)
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		slog.Error("server error", "error", err)
+	// Start server in background.
+	go func() {
+		slog.Info("starting ci-runner", "port", *port, "buildkit_addr", *buildkitAddr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("server error", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	// Wait for interrupt signal, then gracefully shut down.
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+	slog.Info("shutting down")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		slog.Error("shutdown error", "error", err)
 		os.Exit(1)
 	}
+	if err := exec.Close(); err != nil {
+		slog.Error("executor close error", "error", err)
+	}
+	slog.Info("stopped")
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -53,6 +53,15 @@ func (e *Executor) Run(ctx context.Context, sourceDir string, cfg Config) ([]Che
 		wg.Add(1)
 		go func(i int, check Check) {
 			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					results[i] = CheckResult{
+						Name:   check.Name,
+						Status: "failed",
+						Logs:   fmt.Sprintf("panic: %v", r),
+					}
+				}
+			}()
 			results[i] = e.runCheck(ctx, sourceDir, check)
 		}(i, check)
 	}
@@ -60,17 +69,25 @@ func (e *Executor) Run(ctx context.Context, sourceDir string, cfg Config) ([]Che
 	return results, nil
 }
 
+// Close closes the underlying buildkit client.
+func (e *Executor) Close() error {
+	return e.client.Close()
+}
+
 // runCheck executes a single check and returns its result.
 func (e *Executor) runCheck(ctx context.Context, sourceDir string, check Check) CheckResult {
 	source := llb.Local("src")
 	state := llb.Image(check.Image).Dir("/src")
+	srcMount := source
 
 	for _, step := range check.Steps {
-		state = state.Run(
+		exec := state.Run(
 			llb.Args([]string{"sh", "-c", step}),
 			llb.WithCustomName(check.Name+": "+step),
-			llb.AddMount("/src", source),
-		).Root()
+			llb.AddMount("/src", srcMount),
+		)
+		state = exec.Root()
+		srcMount = exec.GetMount("/src")
 	}
 
 	def, err := state.Marshal(ctx, llb.LinuxAmd64)


### PR DESCRIPTION
## Summary

- **Remove WriteTimeout**: The 300s write deadline was cut off long-running CI builds. WriteTimeout is now 0 (unset); execution timeout comes from the request context instead.
- **Input validation**: Before calling `exec.Run()`, validate that `source_dir` is an absolute path, that it exists on disk, and that each check has a non-empty `Image` and at least one `Step`. Returns 400 with a descriptive error for each case.
- **Graceful shutdown**: Handle SIGINT/SIGTERM — server starts in a goroutine, waits for in-flight requests to finish (`srv.Shutdown` with 10s timeout), then closes the buildkit executor client. Matches the pattern in `cmd/docstore/main.go`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)