### PR TITLE
Add integration tests for ci-runner HTTP server

### DIFF
--- a/cmd/ci-runner/integration_test.go
+++ b/cmd/ci-runner/integration_test.go
@@ -1,0 +1,242 @@
+//go:build integration
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/executor"
+)
+
+// buildkitAddr returns the buildkitd address to use for integration tests.
+// If BUILDKIT_ADDR is set, it is used. Otherwise /run/buildkit/buildkitd.sock
+// is checked. If neither is available the test is skipped.
+func buildkitAddr(t *testing.T) string {
+	t.Helper()
+	if addr := os.Getenv("BUILDKIT_ADDR"); addr != "" {
+		return addr
+	}
+	const defaultSock = "/run/buildkit/buildkitd.sock"
+	if _, err := os.Stat(defaultSock); err == nil {
+		return "unix://" + defaultSock
+	}
+	t.Skip("buildkitd not available: set BUILDKIT_ADDR or ensure /run/buildkit/buildkitd.sock exists")
+	return ""
+}
+
+// newIntegrationServer starts a ci-runner HTTP server connected to buildkitd
+// and returns its httptest.Server. Both are closed when the test finishes.
+func newIntegrationServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	addr := buildkitAddr(t)
+	exec, err := executor.New(addr)
+	if err != nil {
+		t.Skipf("cannot connect to buildkitd at %s: %v", addr, err)
+	}
+	srv := httptest.NewServer(newMux(exec))
+	t.Cleanup(func() {
+		srv.Close()
+		exec.Close()
+	})
+	return srv
+}
+
+// postJSON sends a POST /run with v marshalled as JSON and returns the response.
+func postJSON(t *testing.T, srv *httptest.Server, v any) *http.Response {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	resp, err := http.Post(srv.URL+"/run", "application/json", bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("POST /run: %v", err)
+	}
+	return resp
+}
+
+// TestIntegration_ValidRun posts a valid single-check request and expects a 200
+// response with the check marked "passed".
+func TestIntegration_ValidRun(t *testing.T) {
+	srv := newIntegrationServer(t)
+
+	dir := t.TempDir()
+	resp := postJSON(t, srv, runRequest{
+		SourceDir: dir,
+		Config: executor.Config{
+			Checks: []executor.Check{
+				{Name: "ci/hello", Image: "alpine", Steps: []string{"echo hello"}},
+			},
+		},
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var result runResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(result.Checks) != 1 {
+		t.Fatalf("expected 1 check result, got %d", len(result.Checks))
+	}
+	if result.Checks[0].Status != "passed" {
+		t.Errorf("expected passed, got %s (logs: %s)", result.Checks[0].Status, result.Checks[0].Logs)
+	}
+}
+
+// TestIntegration_MissingSourceDir expects a 400 when source_dir is absent.
+func TestIntegration_MissingSourceDir(t *testing.T) {
+	srv := newIntegrationServer(t)
+
+	resp := postJSON(t, srv, runRequest{
+		Config: executor.Config{
+			Checks: []executor.Check{
+				{Name: "ci/hello", Image: "alpine", Steps: []string{"echo hello"}},
+			},
+		},
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+// TestIntegration_RelativeSourceDir expects a 400 when source_dir is not absolute.
+func TestIntegration_RelativeSourceDir(t *testing.T) {
+	srv := newIntegrationServer(t)
+
+	resp := postJSON(t, srv, runRequest{
+		SourceDir: "relative/path",
+		Config: executor.Config{
+			Checks: []executor.Check{
+				{Name: "ci/hello", Image: "alpine", Steps: []string{"echo hello"}},
+			},
+		},
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+// TestIntegration_NonExistentSourceDir expects a 400 when source_dir does not exist.
+func TestIntegration_NonExistentSourceDir(t *testing.T) {
+	srv := newIntegrationServer(t)
+
+	resp := postJSON(t, srv, runRequest{
+		SourceDir: "/nonexistent/path/that/does/not/exist",
+		Config: executor.Config{
+			Checks: []executor.Check{
+				{Name: "ci/hello", Image: "alpine", Steps: []string{"echo hello"}},
+			},
+		},
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+// TestIntegration_MissingImage expects a 400 when a check has no image.
+func TestIntegration_MissingImage(t *testing.T) {
+	srv := newIntegrationServer(t)
+	dir := t.TempDir()
+
+	resp := postJSON(t, srv, runRequest{
+		SourceDir: dir,
+		Config: executor.Config{
+			Checks: []executor.Check{
+				{Name: "ci/hello", Steps: []string{"echo hello"}},
+			},
+		},
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+// TestIntegration_MissingSteps expects a 400 when a check has no steps.
+func TestIntegration_MissingSteps(t *testing.T) {
+	srv := newIntegrationServer(t)
+	dir := t.TempDir()
+
+	resp := postJSON(t, srv, runRequest{
+		SourceDir: dir,
+		Config: executor.Config{
+			Checks: []executor.Check{
+				{Name: "ci/hello", Image: "alpine"},
+			},
+		},
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+// TestIntegration_TwoChecks posts a request with two checks (one pass, one fail)
+// and verifies the correct per-check statuses in the 200 response.
+func TestIntegration_TwoChecks(t *testing.T) {
+	srv := newIntegrationServer(t)
+	dir := t.TempDir()
+
+	resp := postJSON(t, srv, runRequest{
+		SourceDir: dir,
+		Config: executor.Config{
+			Checks: []executor.Check{
+				{Name: "ci/pass", Image: "alpine", Steps: []string{"echo ok"}},
+				{Name: "ci/fail", Image: "alpine", Steps: []string{"exit 1"}},
+			},
+		},
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var result runResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(result.Checks) != 2 {
+		t.Fatalf("expected 2 check results, got %d", len(result.Checks))
+	}
+	byName := make(map[string]executor.CheckResult)
+	for _, c := range result.Checks {
+		byName[c.Name] = c
+	}
+	if byName["ci/pass"].Status != "passed" {
+		t.Errorf("ci/pass: expected passed, got %s", byName["ci/pass"].Status)
+	}
+	if byName["ci/fail"].Status != "failed" {
+		t.Errorf("ci/fail: expected failed, got %s", byName["ci/fail"].Status)
+	}
+}
+
+// TestIntegration_InvalidJSON expects a 400 when the request body is not valid JSON.
+func TestIntegration_InvalidJSON(t *testing.T) {
+	srv := newIntegrationServer(t)
+
+	resp, err := http.Post(srv.URL+"/run", "application/json", bytes.NewReader([]byte("not valid json {")))
+	if err != nil {
+		t.Fatalf("POST /run: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}

--- a/cmd/ci-runner/main.go
+++ b/cmd/ci-runner/main.go
@@ -25,25 +25,8 @@ type runResponse struct {
 	Checks []executor.CheckResult `json:"checks"`
 }
 
-func main() {
-	buildkitAddr := flag.String("buildkit-addr", "unix:///run/buildkit/buildkitd.sock", "buildkitd socket address")
-	port := flag.String("port", "8080", "HTTP listen port")
-	flag.Parse()
-
-	var handler slog.Handler
-	if os.Getenv("LOG_FORMAT") == "text" {
-		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
-	} else {
-		handler = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
-	}
-	slog.SetDefault(slog.New(handler))
-
-	exec, err := executor.New(*buildkitAddr)
-	if err != nil {
-		slog.Error("failed to connect to buildkitd", "addr", *buildkitAddr, "error", err)
-		os.Exit(1)
-	}
-
+// newMux returns an http.ServeMux wired to the given executor.
+func newMux(exec *executor.Executor) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /run", func(w http.ResponseWriter, r *http.Request) {
 		var req runRequest
@@ -84,6 +67,29 @@ func main() {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(runResponse{Checks: results})
 	})
+	return mux
+}
+
+func main() {
+	buildkitAddr := flag.String("buildkit-addr", "unix:///run/buildkit/buildkitd.sock", "buildkitd socket address")
+	port := flag.String("port", "8080", "HTTP listen port")
+	flag.Parse()
+
+	var handler slog.Handler
+	if os.Getenv("LOG_FORMAT") == "text" {
+		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
+	} else {
+		handler = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
+	}
+	slog.SetDefault(slog.New(handler))
+
+	exec, err := executor.New(*buildkitAddr)
+	if err != nil {
+		slog.Error("failed to connect to buildkitd", "addr", *buildkitAddr, "error", err)
+		os.Exit(1)
+	}
+
+	mux := newMux(exec)
 
 	srv := &http.Server{
 		Addr:        ":" + *port,


### PR DESCRIPTION
## Summary

- Extracts `newMux(exec *executor.Executor) *http.ServeMux` from `main()` in `cmd/ci-runner/main.go` so tests can reuse the same handler wiring without duplicating logic
- Adds `cmd/ci-runner/integration_test.go` (`//go:build integration`) with 8 test cases that spin up a real `httptest.Server` connected to buildkitd via `POST /run`

## Test cases

| Test | Expected |
|------|----------|
| Valid config + temp source dir | 200, check status "passed" |
| Missing `source_dir` | 400 |
| Relative `source_dir` | 400 |
| Non-existent `source_dir` | 400 |
| Check missing `image` | 400 |
| Check missing `steps` | 400 |
| Two checks (one pass, one fail) | 200, correct per-check statuses |
| Invalid JSON body | 400 |

## Test plan

- [ ] `go build ./cmd/ci-runner/...` — passes
- [ ] `go vet ./cmd/ci-runner/...` — passes
- [ ] `go test ./... -count=1` — all existing tests pass (integration tests skipped without buildkitd)
- [ ] `go test -tags integration ./cmd/ci-runner/...` — run manually with buildkitd available

## Notes

- Skips automatically when buildkitd is unavailable (same pattern as `internal/executor/executor_test.go`)
- Uses `alpine` image for all buildkitd-exercising tests, consistent with executor unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)