### PR TITLE
Refactor integration tests to use testcontainers-based buildkitd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build Docker image
         run: docker build -t docstore:ci .
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Run integration tests
+        run: go test -v -count=1 -timeout 300s ./internal/executor/... ./cmd/ci-runner/...

--- a/cmd/ci-runner/integration_test.go
+++ b/cmd/ci-runner/integration_test.go
@@ -1,42 +1,40 @@
-//go:build integration
-
 package main
 
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 
 	"github.com/dlorenc/docstore/internal/executor"
+	"github.com/dlorenc/docstore/internal/testutil"
 )
 
-// buildkitAddr returns the buildkitd address to use for integration tests.
-// If BUILDKIT_ADDR is set, it is used. Otherwise /run/buildkit/buildkitd.sock
-// is checked. If neither is available the test is skipped.
-func buildkitAddr(t *testing.T) string {
-	t.Helper()
-	if addr := os.Getenv("BUILDKIT_ADDR"); addr != "" {
-		return addr
+// pkgBuildkitAddr is the buildkitd address shared across all tests in this package.
+var pkgBuildkitAddr string
+
+func TestMain(m *testing.M) {
+	addr, cleanup, err := testutil.StartBuildkit()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "skipping ci-runner integration tests: could not start buildkit: %v\n", err)
+		os.Exit(0)
 	}
-	const defaultSock = "/run/buildkit/buildkitd.sock"
-	if _, err := os.Stat(defaultSock); err == nil {
-		return "unix://" + defaultSock
-	}
-	t.Skip("buildkitd not available: set BUILDKIT_ADDR or ensure /run/buildkit/buildkitd.sock exists")
-	return ""
+	pkgBuildkitAddr = addr
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
 }
 
 // newIntegrationServer starts a ci-runner HTTP server connected to buildkitd
 // and returns its httptest.Server. Both are closed when the test finishes.
 func newIntegrationServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	addr := buildkitAddr(t)
-	exec, err := executor.New(addr)
+	exec, err := executor.New(pkgBuildkitAddr)
 	if err != nil {
-		t.Skipf("cannot connect to buildkitd at %s: %v", addr, err)
+		t.Fatalf("cannot connect to buildkitd at %s: %v", pkgBuildkitAddr, err)
 	}
 	srv := httptest.NewServer(newMux(exec))
 	t.Cleanup(func() {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -2,37 +2,36 @@ package executor_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/dlorenc/docstore/internal/executor"
+	"github.com/dlorenc/docstore/internal/testutil"
 )
 
-// buildkitAddr returns the buildkitd address to use for tests.
-// If BUILDKIT_ADDR is set, it is used. Otherwise /run/buildkit/buildkitd.sock
-// is checked. If neither is available the test is skipped.
-func buildkitAddr(t *testing.T) string {
-	t.Helper()
-	if addr := os.Getenv("BUILDKIT_ADDR"); addr != "" {
-		return addr
+// pkgBuildkitAddr is the buildkitd address shared across all tests in this package.
+var pkgBuildkitAddr string
+
+func TestMain(m *testing.M) {
+	addr, cleanup, err := testutil.StartBuildkit()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "skipping executor tests: could not start buildkit: %v\n", err)
+		os.Exit(0)
 	}
-	const defaultSock = "/run/buildkit/buildkitd.sock"
-	if _, err := os.Stat(defaultSock); err == nil {
-		return "unix://" + defaultSock
-	}
-	t.Skip("buildkitd not available: set BUILDKIT_ADDR or ensure /run/buildkit/buildkitd.sock exists")
-	return ""
+	pkgBuildkitAddr = addr
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
 }
 
-// newExecutor creates an Executor for tests, skipping if buildkitd is
-// unreachable.
+// newExecutor creates an Executor for tests using the package-level buildkitd address.
 func newExecutor(t *testing.T) *executor.Executor {
 	t.Helper()
-	addr := buildkitAddr(t)
-	exec, err := executor.New(addr)
+	exec, err := executor.New(pkgBuildkitAddr)
 	if err != nil {
-		t.Skipf("cannot connect to buildkitd at %s: %v", addr, err)
+		t.Fatalf("cannot connect to buildkitd at %s: %v", pkgBuildkitAddr, err)
 	}
 	return exec
 }

--- a/internal/testutil/testbuildkit.go
+++ b/internal/testutil/testbuildkit.go
@@ -1,0 +1,51 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	dockercontainer "github.com/moby/moby/api/types/container"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// StartBuildkit starts a buildkitd container for use in tests and returns the
+// BUILDKIT_ADDR (tcp://host:port) and a cleanup function.
+//
+// If BUILDKIT_ADDR is already set in the environment it is returned directly
+// with a no-op cleanup, following the same pattern as StartSharedPostgres.
+func StartBuildkit() (addr string, cleanup func(), err error) {
+	if addr := os.Getenv("BUILDKIT_ADDR"); addr != "" {
+		return addr, func() {}, nil
+	}
+
+	ctx := context.Background()
+
+	ctr, err := testcontainers.Run(ctx, "moby/buildkit:v0.29.0",
+		testcontainers.WithExposedPorts("1234/tcp"),
+		testcontainers.WithCmd("--addr", "tcp://0.0.0.0:1234"),
+		testcontainers.WithHostConfigModifier(func(hc *dockercontainer.HostConfig) {
+			hc.Privileged = true
+		}),
+		testcontainers.WithWaitStrategy(
+			wait.ForListeningPort("1234/tcp").WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		return "", func() {}, fmt.Errorf("start buildkit container: %w", err)
+	}
+
+	bkAddr, err := ctr.PortEndpoint(ctx, "1234/tcp", "tcp")
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		return "", func() {}, fmt.Errorf("get buildkit endpoint: %w", err)
+	}
+
+	return bkAddr, func() {
+		if termErr := ctr.Terminate(ctx); termErr != nil {
+			fmt.Fprintf(os.Stderr, "terminate buildkit container: %v\n", termErr)
+		}
+	}, nil
+}


### PR DESCRIPTION
## Summary

- Adds `internal/testutil/testbuildkit.go` with `StartBuildkit()` that starts `moby/buildkit:v0.29.0` via testcontainers-go, using `WithHostConfigModifier` to set privileged mode, exposing port 1234 TCP, and waiting with `ForListeningPort`. Respects `BUILDKIT_ADDR` env var (no-op cleanup path) following the same pattern as `StartSharedPostgres`.

- Refactors `internal/executor/executor_test.go`: removes the manual `buildkitAddr()` skip helper; adds `TestMain` that calls `testutil.StartBuildkit()` and stores the addr in `pkgBuildkitAddr`; `newExecutor` uses that package-level var.

- Refactors `cmd/ci-runner/integration_test.go`: same `TestMain` pattern; removes the `//go:build integration` build tag so tests always run when Docker is available (testcontainers exits 0 gracefully when Docker is not reachable).

- Adds an `integration` job to `.github/workflows/ci.yml` that runs `go test -v -count=1 -timeout 300s ./internal/executor/... ./cmd/ci-runner/...` on `ubuntu-latest` (which ships with Docker).

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Non-integration unit tests (`go test ./...` excluding executor/ci-runner packages) pass
- [x] Test files compile without errors (`go test -run '^$' ./internal/executor/... ./cmd/ci-runner/...`)
- [ ] Integration tests pass in CI (requires Docker + buildkitd pull)

## Notes for future work

- The `test` job in CI now also reaches the integration tests (since the build tag is removed). If that turns out to be too slow, consider excluding those packages from `./...` in the `test` job and relying solely on the `integration` job.
- The `testbuildkit.go` helper could be extended to support a shared singleton container across packages (analogous to how some suites share a Postgres instance) if parallel CI becomes a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)