### PR TITLE
Implement Milestone 1: wire ci-runner into docstore (issue #75)

### DIFF
--- a/Dockerfile.ci-runner
+++ b/Dockerfile.ci-runner
@@ -1,0 +1,12 @@
+FROM moby/buildkit:v0.29.0 AS buildkit
+
+FROM golang:1.25 AS runner-build
+COPY . /src
+RUN go build -o /ci-runner ./cmd/ci-runner
+
+FROM debian:bookworm-slim
+COPY --from=buildkit    /usr/bin/buildkitd /usr/bin/buildkitd
+COPY --from=runner-build /ci-runner         /usr/bin/ci-runner
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/cmd/ci-runner/cirunner_test.go
+++ b/cmd/ci-runner/cirunner_test.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/executor"
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// ---------------------------------------------------------------------------
+// fetchConfig tests
+// ---------------------------------------------------------------------------
+
+func TestFetchConfig_Success(t *testing.T) {
+	yamlContent := []byte(`checks:
+  - name: ci/build
+    image: golang:1.25
+    steps:
+      - go build ./...
+  - name: ci/test
+    image: golang:1.25
+    steps:
+      - go test ./...
+`)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Query().Get("branch") != "main" {
+			t.Errorf("expected branch=main, got %q", r.URL.Query().Get("branch"))
+		}
+		resp := model.FileResponse{
+			Path:    ".docstore/ci.yaml",
+			Content: yamlContent,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	cfg, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "default/myrepo")
+	if err != nil {
+		t.Fatalf("fetchConfig: %v", err)
+	}
+	if len(cfg.Checks) != 2 {
+		t.Fatalf("expected 2 checks, got %d", len(cfg.Checks))
+	}
+	if cfg.Checks[0].Name != "ci/build" {
+		t.Errorf("checks[0].name = %q, want ci/build", cfg.Checks[0].Name)
+	}
+	if cfg.Checks[1].Name != "ci/test" {
+		t.Errorf("checks[1].name = %q, want ci/test", cfg.Checks[1].Name)
+	}
+	if cfg.Checks[0].Image != "golang:1.25" {
+		t.Errorf("checks[0].image = %q, want golang:1.25", cfg.Checks[0].Image)
+	}
+}
+
+func TestFetchConfig_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "default/myrepo")
+	if err == nil {
+		t.Fatal("expected error on 404, got nil")
+	}
+}
+
+func TestFetchConfig_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "default/myrepo")
+	if err == nil {
+		t.Fatal("expected error on 500, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// postCheckRun tests
+// ---------------------------------------------------------------------------
+
+func TestPostCheckRun_Success(t *testing.T) {
+	var received model.CreateCheckRunRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(model.CreateCheckRunResponse{ID: "cr-1", Sequence: 5}) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	logURL := "file:///tmp/ci-logs/ci_build.log"
+	req := model.CreateCheckRunRequest{
+		Branch:    "feature/x",
+		CheckName: "ci/build",
+		Status:    model.CheckRunPassed,
+		LogURL:    &logURL,
+	}
+	if err := postCheckRun(context.Background(), srv.Client(), srv.URL, "default/myrepo", req); err != nil {
+		t.Fatalf("postCheckRun: %v", err)
+	}
+	if received.Branch != "feature/x" {
+		t.Errorf("branch = %q, want feature/x", received.Branch)
+	}
+	if received.CheckName != "ci/build" {
+		t.Errorf("check_name = %q, want ci/build", received.CheckName)
+	}
+	if received.Status != model.CheckRunPassed {
+		t.Errorf("status = %q, want passed", received.Status)
+	}
+	if received.LogURL == nil || *received.LogURL != logURL {
+		t.Errorf("log_url = %v, want %q", received.LogURL, logURL)
+	}
+}
+
+func TestPostCheckRun_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "branch not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	err := postCheckRun(context.Background(), srv.Client(), srv.URL, "default/myrepo", model.CreateCheckRunRequest{
+		Branch:    "feature/x",
+		CheckName: "ci/build",
+		Status:    model.CheckRunPassed,
+	})
+	if err == nil {
+		t.Fatal("expected error on non-201, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// POST /run handler tests
+// ---------------------------------------------------------------------------
+
+func TestPostRunHandler_ReturnsRunID(t *testing.T) {
+	// Use a nil executor and logstore (the goroutine won't do anything useful
+	// but the handler itself should return 200 with a run_id immediately).
+	mux := newMux(nil, nil, "http://localhost:9999", &http.Client{})
+
+	body := `{"repo":"default/myrepo","branch":"feature/x","head_sequence":42}`
+	req := httptest.NewRequest(http.MethodPost, "/run", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp runResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.RunID == "" {
+		t.Error("expected non-empty run_id")
+	}
+}
+
+func TestPostRunHandler_MissingRepo(t *testing.T) {
+	mux := newMux(nil, nil, "http://localhost:9999", &http.Client{})
+
+	req := httptest.NewRequest(http.MethodPost, "/run", strings.NewReader(`{"branch":"feature/x"}`))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestPostRunHandler_MissingBranch(t *testing.T) {
+	mux := newMux(nil, nil, "http://localhost:9999", &http.Client{})
+
+	req := httptest.NewRequest(http.MethodPost, "/run", strings.NewReader(`{"repo":"default/myrepo"}`))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// pullBranchSource tests
+// ---------------------------------------------------------------------------
+
+func TestPullBranchSource_DownloadsFiles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/default/myrepo/-/tree":
+			entries := []treeEntry{
+				{Path: "main.go", VersionID: "v1"},
+				{Path: "sub/util.go", VersionID: "v2"},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(entries) //nolint:errcheck
+
+		case r.URL.Path == "/repos/default/myrepo/-/file/main.go":
+			resp := model.FileResponse{Path: "main.go", Content: []byte("package main")}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp) //nolint:errcheck
+
+		case r.URL.Path == "/repos/default/myrepo/-/file/sub/util.go":
+			resp := model.FileResponse{Path: "sub/util.go", Content: []byte("package sub")}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp) //nolint:errcheck
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	tempDir, err := pullBranchSource(context.Background(), srv.Client(), srv.URL, "default/myrepo", "feature/x")
+	if tempDir != "" {
+		defer os.RemoveAll(tempDir)
+	}
+	if err != nil {
+		t.Fatalf("pullBranchSource: %v", err)
+	}
+
+	mainContent, err := os.ReadFile(filepath.Join(tempDir, "main.go"))
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	if string(mainContent) != "package main" {
+		t.Errorf("main.go content = %q, want \"package main\"", string(mainContent))
+	}
+
+	utilContent, err := os.ReadFile(filepath.Join(tempDir, "sub", "util.go"))
+	if err != nil {
+		t.Fatalf("read sub/util.go: %v", err)
+	}
+	if string(utilContent) != "package sub" {
+		t.Errorf("sub/util.go content = %q, want \"package sub\"", string(utilContent))
+	}
+}
+
+// Ensure executor.Config is imported (used in fetchConfig).
+var _ executor.Config

--- a/cmd/ci-runner/integration_test.go
+++ b/cmd/ci-runner/integration_test.go
@@ -1,15 +1,20 @@
 package main
 
 import (
-	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/dlorenc/docstore/internal/executor"
+	"github.com/dlorenc/docstore/internal/logstore"
+	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/testutil"
 )
 
@@ -28,50 +33,168 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// mockDocstore is an httptest.Server that simulates the docstore API for integration tests.
+// It serves a ci.yaml config, a minimal source tree, and records posted check runs.
+type mockDocstore struct {
+	srv        *httptest.Server
+	mu         sync.Mutex
+	checkRuns  []model.CreateCheckRunRequest
+	sourceDir  string // temp dir with source files to serve
+	ciYAML     []byte
+}
+
+func newMockDocstore(t *testing.T, ciYAML []byte, sourceDir string) *mockDocstore {
+	t.Helper()
+	md := &mockDocstore{
+		ciYAML:    ciYAML,
+		sourceDir: sourceDir,
+	}
+	md.srv = httptest.NewServer(http.HandlerFunc(md.handle))
+	t.Cleanup(md.srv.Close)
+	return md
+}
+
+func (md *mockDocstore) handle(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+
+	switch {
+	case strings.HasSuffix(path, "/-/file/.docstore/ci.yaml") && r.URL.Query().Get("branch") == "main":
+		resp := model.FileResponse{
+			Path:    ".docstore/ci.yaml",
+			Content: md.ciYAML,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+
+	case strings.Contains(path, "/-/tree"):
+		// List source files from the temp dir.
+		entries, _ := listFiles(md.sourceDir)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(entries) //nolint:errcheck
+
+	case strings.Contains(path, "/-/file/"):
+		// Extract relative file path from URL.
+		// URL pattern: /repos/{repo}/-/file/{path}
+		idx := strings.Index(path, "/-/file/")
+		relPath := path[idx+len("/-/file/"):]
+		content, err := os.ReadFile(fmt.Sprintf("%s/%s", md.sourceDir, relPath))
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		resp := model.FileResponse{Path: relPath, Content: content}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+
+	case strings.HasSuffix(path, "/-/check"):
+		var req model.CreateCheckRunRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		md.mu.Lock()
+		md.checkRuns = append(md.checkRuns, req)
+		md.mu.Unlock()
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(model.CreateCheckRunResponse{ID: "cr-1", Sequence: 1}) //nolint:errcheck
+
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (md *mockDocstore) waitForCheckName(t *testing.T, checkName string, timeout time.Duration) *model.CreateCheckRunRequest {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		md.mu.Lock()
+		for _, cr := range md.checkRuns {
+			if cr.CheckName == checkName && cr.Status != model.CheckRunPending {
+				cr := cr // copy
+				md.mu.Unlock()
+				return &cr
+			}
+		}
+		md.mu.Unlock()
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Errorf("timed out waiting for non-pending check run %q", checkName)
+	return nil
+}
+
+// listFiles returns treeEntry objects for all files under dir.
+func listFiles(dir string) ([]treeEntry, error) {
+	var entries []treeEntry
+	err := walkDir(dir, dir, &entries)
+	return entries, err
+}
+
+func walkDir(root, current string, entries *[]treeEntry) error {
+	infos, err := os.ReadDir(current)
+	if err != nil {
+		return err
+	}
+	for _, info := range infos {
+		full := current + "/" + info.Name()
+		if info.IsDir() {
+			if err := walkDir(root, full, entries); err != nil {
+				return err
+			}
+		} else {
+			rel := strings.TrimPrefix(full, root+"/")
+			*entries = append(*entries, treeEntry{Path: rel, VersionID: "v1"})
+		}
+	}
+	return nil
+}
+
 // newIntegrationServer starts a ci-runner HTTP server connected to buildkitd
-// and returns its httptest.Server. Both are closed when the test finishes.
-func newIntegrationServer(t *testing.T) *httptest.Server {
+// and the given mock docstore server. The test server and executor are closed
+// when the test ends.
+func newIntegrationServer(t *testing.T, docstoreURL string) *httptest.Server {
 	t.Helper()
 	exec, err := executor.New(pkgBuildkitAddr)
 	if err != nil {
 		t.Fatalf("cannot connect to buildkitd at %s: %v", pkgBuildkitAddr, err)
 	}
-	srv := httptest.NewServer(newMux(exec))
+	ls, _ := logstore.NewLocalLogStore(t.TempDir())
+	srv := httptest.NewServer(newMux(exec, ls, docstoreURL, &http.Client{}))
 	t.Cleanup(func() {
 		srv.Close()
-		exec.Close()
+		exec.Close() //nolint:errcheck
 	})
 	return srv
 }
 
-// postJSON sends a POST /run with v marshalled as JSON and returns the response.
-func postJSON(t *testing.T, srv *httptest.Server, v any) *http.Response {
-	t.Helper()
-	b, err := json.Marshal(v)
-	if err != nil {
-		t.Fatalf("marshal request: %v", err)
-	}
-	resp, err := http.Post(srv.URL+"/run", "application/json", bytes.NewReader(b))
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestIntegration_PostRun_ReturnsRunID verifies that POST /run returns a
+// run_id immediately and the goroutine runs checks asynchronously.
+func TestIntegration_PostRun_ReturnsRunID(t *testing.T) {
+	ciYAML := []byte(`checks:
+  - name: ci/hello
+    image: alpine
+    steps:
+      - echo hello
+`)
+	srcDir := t.TempDir()
+	// Write a dummy file so the tree is non-empty.
+	os.WriteFile(srcDir+"/README.md", []byte("hello"), 0o644)
+
+	md := newMockDocstore(t, ciYAML, srcDir)
+	srv := newIntegrationServer(t, md.srv.URL)
+
+	body := `{"repo":"default/myrepo","branch":"feature/x","head_sequence":1}`
+	resp, err := http.Post(srv.URL+"/run", "application/json", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("POST /run: %v", err)
 	}
-	return resp
-}
-
-// TestIntegration_ValidRun posts a valid single-check request and expects a 200
-// response with the check marked "passed".
-func TestIntegration_ValidRun(t *testing.T) {
-	srv := newIntegrationServer(t)
-
-	dir := t.TempDir()
-	resp := postJSON(t, srv, runRequest{
-		SourceDir: dir,
-		Config: executor.Config{
-			Checks: []executor.Check{
-				{Name: "ci/hello", Image: "alpine", Steps: []string{"echo hello"}},
-			},
-		},
-	})
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
@@ -79,162 +202,119 @@ func TestIntegration_ValidRun(t *testing.T) {
 	}
 	var result runResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		t.Fatalf("decode response: %v", err)
+		t.Fatalf("decode: %v", err)
 	}
-	if len(result.Checks) != 1 {
-		t.Fatalf("expected 1 check result, got %d", len(result.Checks))
-	}
-	if result.Checks[0].Status != "passed" {
-		t.Errorf("expected passed, got %s (logs: %s)", result.Checks[0].Status, result.Checks[0].Logs)
+	if result.RunID == "" {
+		t.Error("expected non-empty run_id")
 	}
 }
 
-// TestIntegration_MissingSourceDir expects a 400 when source_dir is absent.
-func TestIntegration_MissingSourceDir(t *testing.T) {
-	srv := newIntegrationServer(t)
+// TestIntegration_FullFlow runs a single passing check and verifies that the
+// mock docstore receives both the pending and the final passed check run.
+func TestIntegration_FullFlow(t *testing.T) {
+	ciYAML := []byte(`checks:
+  - name: ci/hello
+    image: alpine
+    steps:
+      - echo hello
+`)
+	srcDir := t.TempDir()
+	os.WriteFile(srcDir+"/README.md", []byte("hello"), 0o644)
 
-	resp := postJSON(t, srv, runRequest{
-		Config: executor.Config{
-			Checks: []executor.Check{
-				{Name: "ci/hello", Image: "alpine", Steps: []string{"echo hello"}},
-			},
-		},
-	})
-	defer resp.Body.Close()
+	md := newMockDocstore(t, ciYAML, srcDir)
+	srv := newIntegrationServer(t, md.srv.URL)
 
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", resp.StatusCode)
+	body := `{"repo":"default/myrepo","branch":"feature/x","head_sequence":1}`
+	resp, err := http.Post(srv.URL+"/run", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /run: %v", err)
+	}
+	resp.Body.Close()
+
+	// Wait for the async check run to complete (up to 60s for image pull).
+	cr := md.waitForCheckName(t, "ci/hello", 60*time.Second)
+	if cr == nil {
+		return // already failed in waitForCheckName
+	}
+	if cr.Status != model.CheckRunPassed {
+		t.Errorf("expected passed, got %q", cr.Status)
 	}
 }
 
-// TestIntegration_RelativeSourceDir expects a 400 when source_dir is not absolute.
-func TestIntegration_RelativeSourceDir(t *testing.T) {
-	srv := newIntegrationServer(t)
+// TestIntegration_FailingCheck verifies a failing check is reported as failed.
+func TestIntegration_FailingCheck(t *testing.T) {
+	ciYAML := []byte(`checks:
+  - name: ci/fail
+    image: alpine
+    steps:
+      - exit 1
+`)
+	srcDir := t.TempDir()
+	os.WriteFile(srcDir+"/README.md", []byte("hello"), 0o644)
 
-	resp := postJSON(t, srv, runRequest{
-		SourceDir: "relative/path",
-		Config: executor.Config{
-			Checks: []executor.Check{
-				{Name: "ci/hello", Image: "alpine", Steps: []string{"echo hello"}},
-			},
-		},
-	})
-	defer resp.Body.Close()
+	md := newMockDocstore(t, ciYAML, srcDir)
+	srv := newIntegrationServer(t, md.srv.URL)
 
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", resp.StatusCode)
+	body := `{"repo":"default/myrepo","branch":"feature/x","head_sequence":2}`
+	resp, err := http.Post(srv.URL+"/run", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /run: %v", err)
 	}
-}
+	resp.Body.Close()
 
-// TestIntegration_NonExistentSourceDir expects a 400 when source_dir does not exist.
-func TestIntegration_NonExistentSourceDir(t *testing.T) {
-	srv := newIntegrationServer(t)
-
-	resp := postJSON(t, srv, runRequest{
-		SourceDir: "/nonexistent/path/that/does/not/exist",
-		Config: executor.Config{
-			Checks: []executor.Check{
-				{Name: "ci/hello", Image: "alpine", Steps: []string{"echo hello"}},
-			},
-		},
-	})
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", resp.StatusCode)
+	cr := md.waitForCheckName(t, "ci/fail", 60*time.Second)
+	if cr == nil {
+		return
 	}
-}
-
-// TestIntegration_MissingImage expects a 400 when a check has no image.
-func TestIntegration_MissingImage(t *testing.T) {
-	srv := newIntegrationServer(t)
-	dir := t.TempDir()
-
-	resp := postJSON(t, srv, runRequest{
-		SourceDir: dir,
-		Config: executor.Config{
-			Checks: []executor.Check{
-				{Name: "ci/hello", Steps: []string{"echo hello"}},
-			},
-		},
-	})
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", resp.StatusCode)
-	}
-}
-
-// TestIntegration_MissingSteps expects a 400 when a check has no steps.
-func TestIntegration_MissingSteps(t *testing.T) {
-	srv := newIntegrationServer(t)
-	dir := t.TempDir()
-
-	resp := postJSON(t, srv, runRequest{
-		SourceDir: dir,
-		Config: executor.Config{
-			Checks: []executor.Check{
-				{Name: "ci/hello", Image: "alpine"},
-			},
-		},
-	})
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", resp.StatusCode)
-	}
-}
-
-// TestIntegration_TwoChecks posts a request with two checks (one pass, one fail)
-// and verifies the correct per-check statuses in the 200 response.
-func TestIntegration_TwoChecks(t *testing.T) {
-	srv := newIntegrationServer(t)
-	dir := t.TempDir()
-
-	resp := postJSON(t, srv, runRequest{
-		SourceDir: dir,
-		Config: executor.Config{
-			Checks: []executor.Check{
-				{Name: "ci/pass", Image: "alpine", Steps: []string{"echo ok"}},
-				{Name: "ci/fail", Image: "alpine", Steps: []string{"exit 1"}},
-			},
-		},
-	})
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
-	var result runResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if len(result.Checks) != 2 {
-		t.Fatalf("expected 2 check results, got %d", len(result.Checks))
-	}
-	byName := make(map[string]executor.CheckResult)
-	for _, c := range result.Checks {
-		byName[c.Name] = c
-	}
-	if byName["ci/pass"].Status != "passed" {
-		t.Errorf("ci/pass: expected passed, got %s", byName["ci/pass"].Status)
-	}
-	if byName["ci/fail"].Status != "failed" {
-		t.Errorf("ci/fail: expected failed, got %s", byName["ci/fail"].Status)
+	if cr.Status != model.CheckRunFailed {
+		t.Errorf("expected failed, got %q", cr.Status)
 	}
 }
 
 // TestIntegration_InvalidJSON expects a 400 when the request body is not valid JSON.
 func TestIntegration_InvalidJSON(t *testing.T) {
-	srv := newIntegrationServer(t)
+	md := newMockDocstore(t, nil, t.TempDir())
+	srv := newIntegrationServer(t, md.srv.URL)
 
-	resp, err := http.Post(srv.URL+"/run", "application/json", bytes.NewReader([]byte("not valid json {")))
+	resp, err := http.Post(srv.URL+"/run", "application/json", strings.NewReader("not valid json {"))
 	if err != nil {
 		t.Fatalf("POST /run: %v", err)
 	}
 	defer resp.Body.Close()
-
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", resp.StatusCode)
 	}
 }
+
+// TestIntegration_MissingRepo expects a 400 when repo is absent.
+func TestIntegration_MissingRepo(t *testing.T) {
+	md := newMockDocstore(t, nil, t.TempDir())
+	srv := newIntegrationServer(t, md.srv.URL)
+
+	resp, err := http.Post(srv.URL+"/run", "application/json", strings.NewReader(`{"branch":"feature/x"}`))
+	if err != nil {
+		t.Fatalf("POST /run: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+// TestIntegration_MissingBranch expects a 400 when branch is absent.
+func TestIntegration_MissingBranch(t *testing.T) {
+	md := newMockDocstore(t, nil, t.TempDir())
+	srv := newIntegrationServer(t, md.srv.URL)
+
+	resp, err := http.Post(srv.URL+"/run", "application/json", strings.NewReader(`{"repo":"default/myrepo"}`))
+	if err != nil {
+		t.Fatalf("POST /run: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+// Ensure context is used (suppress unused import).
+var _ = context.Background

--- a/cmd/ci-runner/main.go
+++ b/cmd/ci-runner/main.go
@@ -1,32 +1,263 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
 	"time"
 
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+
 	"github.com/dlorenc/docstore/internal/executor"
+	"github.com/dlorenc/docstore/internal/logstore"
+	"github.com/dlorenc/docstore/internal/model"
 )
 
+// ---------------------------------------------------------------------------
+// Request / response types for POST /run
+// ---------------------------------------------------------------------------
+
 type runRequest struct {
-	SourceDir string          `json:"source_dir"`
-	Config    executor.Config `json:"config"`
+	Repo         string `json:"repo"`
+	Branch       string `json:"branch"`
+	HeadSequence int64  `json:"head_sequence"`
 }
 
 type runResponse struct {
-	Checks []executor.CheckResult `json:"checks"`
+	RunID string `json:"run_id"`
 }
 
-// newMux returns an http.ServeMux wired to the given executor.
-func newMux(exec *executor.Executor) *http.ServeMux {
+// ---------------------------------------------------------------------------
+// devTransport adds the X-Goog-IAP-JWT-Assertion header to every request
+// so that a docstore server running with --dev-identity can match identities.
+// ---------------------------------------------------------------------------
+
+type devTransport struct {
+	base     http.RoundTripper
+	identity string
+}
+
+func (t *devTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.Header.Set("X-Goog-IAP-JWT-Assertion", t.identity)
+	return t.base.RoundTrip(clone)
+}
+
+// ---------------------------------------------------------------------------
+// Docstore API helpers
+// ---------------------------------------------------------------------------
+
+// fetchConfig retrieves and parses .docstore/ci.yaml from the main branch.
+func fetchConfig(ctx context.Context, client *http.Client, docstoreURL, repo string) (*executor.Config, error) {
+	fileURL := fmt.Sprintf("%s/repos/%s/-/file/.docstore/ci.yaml?branch=main", docstoreURL, repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create config request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch config: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("ci config not found at %s", fileURL)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch config: unexpected status %d", resp.StatusCode)
+	}
+	var fileResp model.FileResponse
+	if err := json.NewDecoder(resp.Body).Decode(&fileResp); err != nil {
+		return nil, fmt.Errorf("decode file response: %w", err)
+	}
+	var cfg executor.Config
+	if err := yaml.Unmarshal(fileResp.Content, &cfg); err != nil {
+		return nil, fmt.Errorf("parse ci.yaml: %w", err)
+	}
+	return &cfg, nil
+}
+
+// treeEntry is a single entry from GET /-/tree.
+type treeEntry struct {
+	Path      string `json:"path"`
+	VersionID string `json:"version_id"`
+}
+
+// pullBranchSource materialises the given branch into a new temp directory
+// and returns its path. The caller is responsible for os.RemoveAll.
+func pullBranchSource(ctx context.Context, client *http.Client, docstoreURL, repo, branch string) (string, error) {
+	tempDir, err := os.MkdirTemp("", "ci-runner-src-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp dir: %w", err)
+	}
+
+	// Paginate through the full tree.
+	var entries []treeEntry
+	afterPath := ""
+	for {
+		treeURL := fmt.Sprintf("%s/repos/%s/-/tree?branch=%s&limit=100",
+			docstoreURL, repo, url.QueryEscape(branch))
+		if afterPath != "" {
+			treeURL += "&after=" + url.QueryEscape(afterPath)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, treeURL, nil)
+		if err != nil {
+			return tempDir, fmt.Errorf("create tree request: %w", err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return tempDir, fmt.Errorf("fetch tree: %w", err)
+		}
+		var page []treeEntry
+		if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+			resp.Body.Close()
+			return tempDir, fmt.Errorf("decode tree: %w", err)
+		}
+		resp.Body.Close()
+
+		entries = append(entries, page...)
+		if len(page) < 100 {
+			break
+		}
+		afterPath = page[len(page)-1].Path
+	}
+
+	// Download each file.
+	for _, e := range entries {
+		fileURL := fmt.Sprintf("%s/repos/%s/-/file/%s?branch=%s",
+			docstoreURL, repo, e.Path, url.QueryEscape(branch))
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
+		if err != nil {
+			return tempDir, fmt.Errorf("create file request for %s: %w", e.Path, err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return tempDir, fmt.Errorf("fetch file %s: %w", e.Path, err)
+		}
+		var fileResp model.FileResponse
+		if err := json.NewDecoder(resp.Body).Decode(&fileResp); err != nil {
+			resp.Body.Close()
+			return tempDir, fmt.Errorf("decode file %s: %w", e.Path, err)
+		}
+		resp.Body.Close()
+
+		destPath := filepath.Join(tempDir, filepath.FromSlash(e.Path))
+		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+			return tempDir, fmt.Errorf("create dir for %s: %w", e.Path, err)
+		}
+		if err := os.WriteFile(destPath, fileResp.Content, 0o644); err != nil {
+			return tempDir, fmt.Errorf("write file %s: %w", e.Path, err)
+		}
+	}
+
+	return tempDir, nil
+}
+
+// postCheckRun posts a single check run result to the docstore server.
+func postCheckRun(ctx context.Context, client *http.Client, docstoreURL, repo string, req model.CreateCheckRunRequest) error {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal check run: %w", err)
+	}
+	checkURL := fmt.Sprintf("%s/repos/%s/-/check", docstoreURL, repo)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, checkURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create check run request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("post check run: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("post check run: unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Async run goroutine
+// ---------------------------------------------------------------------------
+
+func runAsync(ctx context.Context, client *http.Client, exec *executor.Executor, ls logstore.LogStore, docstoreURL, repo, branch string, headSeq int64) {
+	slog.Info("run started", "repo", repo, "branch", branch, "head_seq", headSeq)
+
+	// 1. Fetch config from main branch.
+	cfg, err := fetchConfig(ctx, client, docstoreURL, repo)
+	if err != nil {
+		slog.Error("fetch config failed", "repo", repo, "branch", branch, "error", err)
+		return
+	}
+
+	// 2. Pull branch source into temp dir.
+	tempDir, err := pullBranchSource(ctx, client, docstoreURL, repo, branch)
+	if tempDir != "" {
+		defer os.RemoveAll(tempDir)
+	}
+	if err != nil {
+		slog.Error("pull source failed", "repo", repo, "branch", branch, "error", err)
+		return
+	}
+
+	// 3. Mark each check as pending.
+	for _, check := range cfg.Checks {
+		if err := postCheckRun(ctx, client, docstoreURL, repo, model.CreateCheckRunRequest{
+			Branch:    branch,
+			CheckName: check.Name,
+			Status:    model.CheckRunPending,
+		}); err != nil {
+			slog.Warn("mark pending failed", "check", check.Name, "error", err)
+		}
+	}
+
+	// 4. Execute all checks.
+	results, err := exec.Run(ctx, tempDir, *cfg)
+	if err != nil {
+		slog.Error("executor failed", "repo", repo, "branch", branch, "error", err)
+		return
+	}
+
+	// 5. Upload logs and post results.
+	for _, result := range results {
+		var logURL *string
+		if ls != nil {
+			u, err := ls.Write(ctx, repo, branch, headSeq, result.Name, result.Logs)
+			if err != nil {
+				slog.Warn("log upload failed", "check", result.Name, "error", err)
+			} else {
+				logURL = &u
+			}
+		}
+
+		if err := postCheckRun(ctx, client, docstoreURL, repo, model.CreateCheckRunRequest{
+			Branch:    branch,
+			CheckName: result.Name,
+			Status:    model.CheckRunStatus(result.Status),
+			LogURL:    logURL,
+		}); err != nil {
+			slog.Warn("post result failed", "check", result.Name, "error", err)
+		}
+	}
+
+	slog.Info("run complete", "repo", repo, "branch", branch, "checks", len(results))
+}
+
+// ---------------------------------------------------------------------------
+// HTTP mux
+// ---------------------------------------------------------------------------
+
+func newMux(exec *executor.Executor, ls logstore.LogStore, docstoreURL string, client *http.Client) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /run", func(w http.ResponseWriter, r *http.Request) {
 		var req runRequest
@@ -34,46 +265,39 @@ func newMux(exec *executor.Executor) *http.ServeMux {
 			http.Error(w, "invalid request body", http.StatusBadRequest)
 			return
 		}
-		if req.SourceDir == "" {
-			http.Error(w, "source_dir is required", http.StatusBadRequest)
+		if req.Repo == "" {
+			http.Error(w, "repo is required", http.StatusBadRequest)
 			return
 		}
-		if !filepath.IsAbs(req.SourceDir) {
-			http.Error(w, "source_dir must be an absolute path", http.StatusBadRequest)
+		if req.Branch == "" {
+			http.Error(w, "branch is required", http.StatusBadRequest)
 			return
-		}
-		if _, err := os.Stat(req.SourceDir); err != nil {
-			http.Error(w, fmt.Sprintf("source_dir does not exist: %v", err), http.StatusBadRequest)
-			return
-		}
-		for i, check := range req.Config.Checks {
-			if check.Image == "" {
-				http.Error(w, fmt.Sprintf("check[%d] (%q): image is required", i, check.Name), http.StatusBadRequest)
-				return
-			}
-			if len(check.Steps) == 0 {
-				http.Error(w, fmt.Sprintf("check[%d] (%q): at least one step is required", i, check.Name), http.StatusBadRequest)
-				return
-			}
 		}
 
-		results, err := exec.Run(r.Context(), req.SourceDir, req.Config)
-		if err != nil {
-			slog.Error("run failed", "error", err)
-			http.Error(w, "internal error", http.StatusInternalServerError)
-			return
-		}
+		runID := uuid.New().String()
+		go runAsync(context.Background(), client, exec, ls, docstoreURL, req.Repo, req.Branch, req.HeadSequence)
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(runResponse{Checks: results})
+		json.NewEncoder(w).Encode(runResponse{RunID: runID}) //nolint:errcheck
 	})
 	return mux
 }
 
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
 func main() {
 	buildkitAddr := flag.String("buildkit-addr", "unix:///run/buildkit/buildkitd.sock", "buildkitd socket address")
 	port := flag.String("port", "8080", "HTTP listen port")
+	docstoreURL := flag.String("docstore-url", "", "Base URL of the docstore server (required)")
+	devIdentity := flag.String("dev-identity", "", "Identity header to send to docstore (local dev only)")
 	flag.Parse()
+
+	if *docstoreURL == "" {
+		fmt.Fprintln(os.Stderr, "error: --docstore-url is required")
+		os.Exit(1)
+	}
 
 	var handler slog.Handler
 	if os.Getenv("LOG_FORMAT") == "text" {
@@ -83,35 +307,47 @@ func main() {
 	}
 	slog.SetDefault(slog.New(handler))
 
+	// Build HTTP client; optionally add dev identity header.
+	httpClient := &http.Client{}
+	if *devIdentity != "" {
+		httpClient.Transport = &devTransport{
+			base:     http.DefaultTransport,
+			identity: *devIdentity,
+		}
+	}
+
+	// Build log store from environment.
+	ls, err := logstore.NewFromEnv(context.Background())
+	if err != nil {
+		slog.Error("failed to create log store", "error", err)
+		os.Exit(1)
+	}
+
+	// Build executor.
 	exec, err := executor.New(*buildkitAddr)
 	if err != nil {
 		slog.Error("failed to connect to buildkitd", "addr", *buildkitAddr, "error", err)
 		os.Exit(1)
 	}
 
-	mux := newMux(exec)
+	mux := newMux(exec, ls, *docstoreURL, httpClient)
 
 	srv := &http.Server{
 		Addr:        ":" + *port,
 		Handler:     mux,
 		ReadTimeout: 10 * time.Second,
-		// WriteTimeout is intentionally not set: long-running CI builds stream
-		// responses back over the HTTP connection and must not be cut off by a
-		// server-side write deadline. The execution timeout is controlled by the
-		// request context instead.
+		// WriteTimeout intentionally omitted: async handler returns immediately.
 		IdleTimeout: 60 * time.Second,
 	}
 
-	// Start server in background.
 	go func() {
-		slog.Info("starting ci-runner", "port", *port, "buildkit_addr", *buildkitAddr)
+		slog.Info("starting ci-runner", "port", *port, "buildkit_addr", *buildkitAddr, "docstore_url", *docstoreURL)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("server error", "error", err)
 			os.Exit(1)
 		}
 	}()
 
-	// Wait for interrupt signal, then gracefully shut down.
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+buildkitd --oci-worker-snapshotter=native &
+until [ -S /run/buildkit/buildkitd.sock ]; do sleep 0.1; done
+
+exec ci-runner \
+  --buildkit-addr unix:///run/buildkit/buildkitd.sock \
+  --docstore-url "${DOCSTORE_URL}" \
+  --port "${PORT:-8080}"

--- a/internal/db/migrations/000001_initial_schema.up.sql
+++ b/internal/db/migrations/000001_initial_schema.up.sql
@@ -109,6 +109,7 @@ CREATE TABLE check_runs (
     check_name TEXT NOT NULL,
     status     check_status NOT NULL,
     reporter   TEXT NOT NULL,
+    log_url    TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     CONSTRAINT check_runs_repo_branch_fk FOREIGN KEY (repo, branch) REFERENCES branches (repo, name)
 );

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1196,7 +1196,8 @@ func (s *Store) ListReviews(ctx context.Context, repo, branch string, atSeq *int
 
 // CreateCheckRun records a CI check run for a branch at its current
 // head_sequence. Returns ErrBranchNotFound if the branch doesn't exist.
-func (s *Store) CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string) (*model.CheckRun, error) {
+// logURL is optional (may be nil) and stores a GCS URI or local file path.
+func (s *Store) CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string) (*model.CheckRun, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		slog.Error("tx begin failed", "op", "create_check_run", "error", err)
@@ -1222,11 +1223,15 @@ func (s *Store) CreateCheckRun(ctx context.Context, repo, branch, checkName stri
 
 	id := uuid.New().String()
 	var createdAt time.Time
+	var nullLogURL sql.NullString
+	if logURL != nil {
+		nullLogURL = sql.NullString{String: *logURL, Valid: true}
+	}
 	err = tx.QueryRowContext(ctx,
-		`INSERT INTO check_runs (id, repo, branch, sequence, check_name, status, reporter)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7)
+		`INSERT INTO check_runs (id, repo, branch, sequence, check_name, status, reporter, log_url)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		 RETURNING created_at`,
-		id, repo, branch, headSeq, checkName, string(status), reporter,
+		id, repo, branch, headSeq, checkName, string(status), reporter, nullLogURL,
 	).Scan(&createdAt)
 	if err != nil {
 		return nil, fmt.Errorf("insert check_run: %w", err)
@@ -1243,6 +1248,7 @@ func (s *Store) CreateCheckRun(ctx context.Context, repo, branch, checkName stri
 		CheckName: checkName,
 		Status:    status,
 		Reporter:  reporter,
+		LogURL:    logURL,
 		CreatedAt: createdAt,
 	}, nil
 }
@@ -1251,7 +1257,7 @@ func (s *Store) CreateCheckRun(ctx context.Context, repo, branch, checkName stri
 // created_at DESC. If atSeq is non-nil, only check runs at that sequence are
 // returned.
 func (s *Store) ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error) {
-	q := `SELECT id, sequence, check_name, status, reporter, created_at
+	q := `SELECT id, sequence, check_name, status, reporter, log_url, created_at
 	      FROM check_runs
 	      WHERE repo = $1 AND branch = $2`
 	args := []interface{}{repo, branch}
@@ -1272,10 +1278,14 @@ func (s *Store) ListCheckRuns(ctx context.Context, repo, branch string, atSeq *i
 		var cr model.CheckRun
 		cr.Branch = branch
 		var statusStr string
-		if err := rows.Scan(&cr.ID, &cr.Sequence, &cr.CheckName, &statusStr, &cr.Reporter, &cr.CreatedAt); err != nil {
+		var nullLogURL sql.NullString
+		if err := rows.Scan(&cr.ID, &cr.Sequence, &cr.CheckName, &statusStr, &cr.Reporter, &nullLogURL, &cr.CreatedAt); err != nil {
 			return nil, err
 		}
 		cr.Status = model.CheckRunStatus(statusStr)
+		if nullLogURL.Valid {
+			cr.LogURL = &nullLogURL.String
+		}
 		checkRuns = append(checkRuns, cr)
 	}
 	return checkRuns, rows.Err()

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -1848,7 +1848,7 @@ func TestCreateCheckRun_Success(t *testing.T) {
 	s := NewStore(d)
 	ctx := context.Background()
 
-	cr, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot")
+	cr, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil)
 	if err != nil {
 		t.Fatalf("CreateCheckRun: %v", err)
 	}
@@ -1881,7 +1881,7 @@ func TestCreateCheckRun_RecordedAtHeadSequence(t *testing.T) {
 		t.Fatalf("commit: %v", err)
 	}
 
-	cr, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot")
+	cr, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil)
 	if err != nil {
 		t.Fatalf("CreateCheckRun: %v", err)
 	}
@@ -1896,11 +1896,11 @@ func TestListCheckRuns_ByBranch(t *testing.T) {
 	s := NewStore(d)
 	ctx := context.Background()
 
-	_, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot")
+	_, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil)
 	if err != nil {
 		t.Fatalf("check 1: %v", err)
 	}
-	_, err = s.CreateCheckRun(ctx, "default/default", "main", "ci/lint", model.CheckRunFailed, "ci-bot")
+	_, err = s.CreateCheckRun(ctx, "default/default", "main", "ci/lint", model.CheckRunFailed, "ci-bot", nil)
 	if err != nil {
 		t.Fatalf("check 2: %v", err)
 	}
@@ -1921,12 +1921,12 @@ func TestListCheckRuns_LatestPerName(t *testing.T) {
 	ctx := context.Background()
 
 	// First run: pending
-	_, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPending, "ci-bot")
+	_, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPending, "ci-bot", nil)
 	if err != nil {
 		t.Fatalf("check 1: %v", err)
 	}
 	// Second run: passed (same check_name, more recent)
-	_, err = s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot")
+	_, err = s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil)
 	if err != nil {
 		t.Fatalf("check 2: %v", err)
 	}
@@ -2421,7 +2421,7 @@ func TestPurge_DeletesReviewsAndChecks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create review: %v", err)
 	}
-	_, err = s.CreateCheckRun(ctx, "default/default", "feature/rev", "ci/build", model.CheckRunPassed, "ci-bot")
+	_, err = s.CreateCheckRun(ctx, "default/default", "feature/rev", "ci/build", model.CheckRunPassed, "ci-bot", nil)
 	if err != nil {
 		t.Fatalf("create check_run: %v", err)
 	}

--- a/internal/logstore/logstore.go
+++ b/internal/logstore/logstore.go
@@ -1,0 +1,125 @@
+// Package logstore provides the LogStore interface and implementations for
+// storing CI build logs. Follows the same local/GCS abstraction as internal/blob.
+package logstore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"cloud.google.com/go/storage"
+)
+
+// LogStore writes build logs for a check run and returns a URL reference.
+type LogStore interface {
+	// Write stores the logs for the named check run and returns the URL
+	// (e.g. "file:///tmp/ci-logs/..." or "gs://bucket/...").
+	Write(ctx context.Context, repo, branch string, seq int64, checkName, logs string) (string, error)
+}
+
+// objectKey returns the log object/file key for the given parameters.
+// Check names containing "/" are replaced with "_" so they are safe as path segments.
+func objectKey(repo, branch string, seq int64, checkName string) string {
+	safeName := strings.ReplaceAll(checkName, "/", "_")
+	return fmt.Sprintf("%s/%s/%d/%s.log", repo, branch, seq, safeName)
+}
+
+// ---------------------------------------------------------------------------
+// LocalLogStore
+// ---------------------------------------------------------------------------
+
+// LocalLogStore is a LogStore backed by the local filesystem.
+// Intended for development and testing.
+type LocalLogStore struct {
+	dir string
+}
+
+// NewLocalLogStore creates a LocalLogStore rooted at dir.
+// The directory is created if it does not exist.
+func NewLocalLogStore(dir string) (*LocalLogStore, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create log dir: %w", err)
+	}
+	return &LocalLogStore{dir: dir}, nil
+}
+
+// Write writes logs to a file under dir and returns a file:// URL.
+func (s *LocalLogStore) Write(_ context.Context, repo, branch string, seq int64, checkName, logs string) (string, error) {
+	key := objectKey(repo, branch, seq, checkName)
+	path := filepath.Join(s.dir, filepath.FromSlash(key))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", fmt.Errorf("create log subdir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(logs), 0o644); err != nil {
+		return "", fmt.Errorf("write log: %w", err)
+	}
+	return "file://" + path, nil
+}
+
+// ---------------------------------------------------------------------------
+// GCSLogStore
+// ---------------------------------------------------------------------------
+
+// GCSLogStore is a LogStore backed by Google Cloud Storage.
+// Uses Application Default Credentials (workload identity on Cloud Run).
+type GCSLogStore struct {
+	client *storage.Client
+	bucket string
+}
+
+// NewGCSLogStore creates a GCSLogStore for the given bucket.
+func NewGCSLogStore(ctx context.Context, bucket string) (*GCSLogStore, error) {
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create gcs client: %w", err)
+	}
+	return &GCSLogStore{client: client, bucket: bucket}, nil
+}
+
+// Write uploads logs to GCS and returns a gs:// URI.
+func (s *GCSLogStore) Write(ctx context.Context, repo, branch string, seq int64, checkName, logs string) (string, error) {
+	key := objectKey(repo, branch, seq, checkName)
+	w := s.client.Bucket(s.bucket).Object(key).NewWriter(ctx)
+	if _, err := w.Write([]byte(logs)); err != nil {
+		w.Close() //nolint:errcheck
+		return "", fmt.Errorf("gcs write: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return "", fmt.Errorf("gcs close writer: %w", err)
+	}
+	return fmt.Sprintf("gs://%s/%s", s.bucket, key), nil
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+// NewFromEnv creates a LogStore from environment variables:
+//
+//	LOG_STORE      "local" (default) or "gcs"
+//	LOG_LOCAL_DIR  directory for local store (default /tmp/ci-logs)
+//	LOG_BUCKET     GCS bucket name (required when LOG_STORE=gcs)
+func NewFromEnv(ctx context.Context) (LogStore, error) {
+	storeType := os.Getenv("LOG_STORE")
+	if storeType == "" {
+		storeType = "local"
+	}
+	switch storeType {
+	case "local":
+		dir := os.Getenv("LOG_LOCAL_DIR")
+		if dir == "" {
+			dir = "/tmp/ci-logs"
+		}
+		return NewLocalLogStore(dir)
+	case "gcs":
+		bucket := os.Getenv("LOG_BUCKET")
+		if bucket == "" {
+			return nil, fmt.Errorf("LOG_BUCKET is required when LOG_STORE=gcs")
+		}
+		return NewGCSLogStore(ctx, bucket)
+	default:
+		return nil, fmt.Errorf("unsupported LOG_STORE %q: must be 'local' or 'gcs'", storeType)
+	}
+}

--- a/internal/logstore/logstore_test.go
+++ b/internal/logstore/logstore_test.go
@@ -1,0 +1,140 @@
+package logstore_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/logstore"
+)
+
+func TestLocalLogStore_Write(t *testing.T) {
+	dir := t.TempDir()
+	ls, err := logstore.NewLocalLogStore(dir)
+	if err != nil {
+		t.Fatalf("NewLocalLogStore: %v", err)
+	}
+
+	ctx := context.Background()
+	const logs = "build output here"
+	url, err := ls.Write(ctx, "myorg/myrepo", "feature/x", 42, "ci/build", logs)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// key = "myorg/myrepo/feature/x/42/ci_build.log"
+	expectedPath := filepath.Join(dir, filepath.FromSlash("myorg/myrepo/feature/x/42/ci_build.log"))
+	expectedURL := "file://" + expectedPath
+	if url != expectedURL {
+		t.Errorf("url = %q, want %q", url, expectedURL)
+	}
+
+	content, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	if string(content) != logs {
+		t.Errorf("content = %q, want %q", string(content), logs)
+	}
+}
+
+func TestLocalLogStore_Write_SlashInCheckName(t *testing.T) {
+	dir := t.TempDir()
+	ls, err := logstore.NewLocalLogStore(dir)
+	if err != nil {
+		t.Fatalf("NewLocalLogStore: %v", err)
+	}
+
+	ctx := context.Background()
+	url, err := ls.Write(ctx, "org/repo", "main", 1, "ci/lint/strict", "lint output")
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Slashes in check name replaced with underscores: ci_lint_strict.log
+	expectedPath := filepath.Join(dir, filepath.FromSlash("org/repo/main/1/ci_lint_strict.log"))
+	expectedURL := "file://" + expectedPath
+	if url != expectedURL {
+		t.Errorf("url = %q, want %q", url, expectedURL)
+	}
+
+	content, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	if string(content) != "lint output" {
+		t.Errorf("content = %q, want %q", string(content), "lint output")
+	}
+}
+
+func TestLocalLogStore_Write_OverwritesPreviousLog(t *testing.T) {
+	dir := t.TempDir()
+	ls, err := logstore.NewLocalLogStore(dir)
+	if err != nil {
+		t.Fatalf("NewLocalLogStore: %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := ls.Write(ctx, "o/r", "b", 1, "ci/test", "first"); err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+	if _, err := ls.Write(ctx, "o/r", "b", 1, "ci/test", "second"); err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+
+	path := filepath.Join(dir, filepath.FromSlash("o/r/b/1/ci_test.log"))
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(content) != "second" {
+		t.Errorf("content = %q, want %q", string(content), "second")
+	}
+}
+
+func TestNewFromEnv_Local(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("LOG_STORE", "local")
+	t.Setenv("LOG_LOCAL_DIR", dir)
+
+	ls, err := logstore.NewFromEnv(context.Background())
+	if err != nil {
+		t.Fatalf("NewFromEnv: %v", err)
+	}
+	if ls == nil {
+		t.Fatal("expected non-nil LogStore")
+	}
+}
+
+func TestNewFromEnv_DefaultIsLocal(t *testing.T) {
+	t.Setenv("LOG_STORE", "")
+	t.Setenv("LOG_LOCAL_DIR", t.TempDir())
+
+	ls, err := logstore.NewFromEnv(context.Background())
+	if err != nil {
+		t.Fatalf("NewFromEnv: %v", err)
+	}
+	if ls == nil {
+		t.Fatal("expected non-nil LogStore")
+	}
+}
+
+func TestNewFromEnv_GCS_MissingBucket(t *testing.T) {
+	t.Setenv("LOG_STORE", "gcs")
+	t.Setenv("LOG_BUCKET", "")
+
+	_, err := logstore.NewFromEnv(context.Background())
+	if err == nil {
+		t.Fatal("expected error when LOG_BUCKET is not set")
+	}
+}
+
+func TestNewFromEnv_Invalid(t *testing.T) {
+	t.Setenv("LOG_STORE", "s3")
+
+	_, err := logstore.NewFromEnv(context.Background())
+	if err == nil {
+		t.Fatal("expected error for unsupported LOG_STORE")
+	}
+}

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -267,6 +267,7 @@ type CreateCheckRunRequest struct {
 	Branch    string         `json:"branch"`
 	CheckName string         `json:"check_name"`
 	Status    CheckRunStatus `json:"status"`
+	LogURL    *string        `json:"log_url,omitempty"`
 }
 
 // CreateCheckRunResponse is the response for POST /check.

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -148,6 +148,7 @@ type CheckRun struct {
 	CheckName string         `json:"check_name"`
 	Status    CheckRunStatus `json:"status"`
 	Reporter  string         `json:"reporter"`
+	LogURL    *string        `json:"log_url,omitempty"`
 	CreatedAt time.Time      `json:"created_at"`
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -695,7 +695,7 @@ func (s *server) handleCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cr, err := s.commitStore.CreateCheckRun(r.Context(), repo, req.Branch, req.CheckName, req.Status, reporter)
+	cr, err := s.commitStore.CreateCheckRun(r.Context(), repo, req.Branch, req.CheckName, req.Status, reporter, req.LogURL)
 	if err != nil {
 		switch {
 		case errors.Is(err, db.ErrBranchNotFound):

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -74,7 +74,7 @@ type WriteStore interface {
 	// Review and check-run operations
 	CreateReview(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error)
 	ListReviews(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error)
-	CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string) (*model.CheckRun, error)
+	CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string) (*model.CheckRun, error)
 	ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error)
 
 	// Role management

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -29,7 +29,7 @@ type mockStore struct {
 	getRepoFn       func(ctx context.Context, name string) (*model.Repo, error)
 	createReviewFn  func(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error)
 	listReviewsFn   func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error)
-	createCheckRunFn func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string) (*model.CheckRun, error)
+	createCheckRunFn func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string) (*model.CheckRun, error)
 	listCheckRunsFn  func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error)
 	getRoleFn      func(ctx context.Context, repo, identity string) (*model.Role, error)
 	setRoleFn      func(ctx context.Context, repo, identity string, role model.RoleType) error
@@ -144,9 +144,9 @@ func (m *mockStore) ListReviews(ctx context.Context, repo, branch string, atSeq 
 	return nil, errors.New("not implemented")
 }
 
-func (m *mockStore) CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string) (*model.CheckRun, error) {
+func (m *mockStore) CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string) (*model.CheckRun, error) {
 	if m.createCheckRunFn != nil {
-		return m.createCheckRunFn(ctx, repo, branch, checkName, status, reporter)
+		return m.createCheckRunFn(ctx, repo, branch, checkName, status, reporter, logURL)
 	}
 	return nil, errors.New("not implemented")
 }
@@ -1404,7 +1404,7 @@ func TestHandleReview_BranchNotFound(t *testing.T) {
 func TestHandleCheck_Success(t *testing.T) {
 	const identity = "ci-bot@example.com"
 	store := &mockStore{
-		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string) (*model.CheckRun, error) {
+		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string) (*model.CheckRun, error) {
 			if repo != "default/default" {
 				t.Errorf("expected repo default, got %q", repo)
 			}
@@ -1447,7 +1447,7 @@ func TestHandleCheck_Success(t *testing.T) {
 
 func TestHandleCheck_BranchNotFound(t *testing.T) {
 	store := &mockStore{
-		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string) (*model.CheckRun, error) {
+		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string) (*model.CheckRun, error) {
 			return nil, db.ErrBranchNotFound
 		},
 	}
@@ -2519,7 +2519,7 @@ default allow = true
 			writeDetector()
 			return nil, nil
 		},
-		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string) (*model.CheckRun, error) {
+		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string) (*model.CheckRun, error) {
 			writeDetector()
 			return nil, nil
 		},


### PR DESCRIPTION
## Summary

Implements Milestone 1 of issue #75: wires the ci-runner executor into docstore with async execution, log storage abstraction, and production Dockerfile.

### Part 1: Docstore server changes
- Added `log_url TEXT` (nullable) to `check_runs` in `000001_initial_schema.up.sql` (no new migration file; requires DB teardown/bring-up on deploy)
- Added `LogURL *string` to `CheckRun` model and `CreateCheckRunRequest` API type
- Updated `CreateCheckRun` signature everywhere to accept optional `logURL *string`
- Updated `ListCheckRuns` to scan and return the new `log_url` column

### Part 2: Log store abstraction (`internal/logstore`)
- `LogStore` interface: `Write(ctx, repo, branch string, seq int64, checkName, logs string) (url string, err error)`
- `LocalLogStore`: writes to `LOG_LOCAL_DIR` (default `/tmp/ci-logs`), returns `file://` URL
- `GCSLogStore`: uploads to `LOG_BUCKET` using workload identity, returns `gs://` URL
- `NewFromEnv` factory reading `LOG_STORE` / `LOG_LOCAL_DIR` / `LOG_BUCKET` env vars

### Part 3: POST /run — new async shape
Replaced synchronous `source_dir+config` handler with:
- **Request**: `{"repo":"default/docstore","branch":"feature/x","head_sequence":42}`
- **Response** (immediate): `{"run_id":"<uuid>"}`

Background goroutine: fetch config → pull source → mark pending → execute → upload logs → post results → cleanup.

### Part 4: New binary flags
- `--docstore-url` (required): base URL of the docstore server
- `--dev-identity ""`: sends `X-Goog-IAP-JWT-Assertion` header for local dev

### Part 5: Dockerfile.ci-runner + entrypoint.sh
- Multi-stage Dockerfile: buildkit binary + ci-runner binary on debian:bookworm-slim
- `entrypoint.sh`: starts buildkitd, waits for socket, execs ci-runner

## Test plan
- [x] All existing tests pass: `go test ./... -count=1` — 14 packages, all green
- [x] New `internal/logstore` unit tests (7 tests)
- [x] New `cmd/ci-runner/cirunner_test.go`: fetchConfig, postCheckRun, pullBranchSource, handler validation
- [x] Updated integration tests for new async API shape (input validation + full flow with mock docstore)
- [x] `go vet ./...` clean

## Notes / opportunities
- Polling endpoint for `run_id` status is Milestone 2
- GCS log store test requires real GCS credentials (not covered in unit tests)
- The `--dev-identity` flag causes the ci-runner to send the email as the IAP assertion header; the docstore server in dev mode ignores all headers and uses its own `--dev-identity` flag value

Closes #75 (partial — Milestone 1 only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)