### PR TITLE
Implement Milestone 1: core eventing system (broker, SSE, webhooks)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1165,6 +1165,18 @@ Index: `(repo, branch, sequence, check_name)`.
 
 ---
 
+## SSE Horizontal Scaling Limitation
+
+Server-Sent Events (SSE) fan-out (`GET /repos/{name}/-/events` and `GET /events`) is implemented in-process using an in-memory broker. This works correctly at `--max-instances=1` (e.g. a single Cloud Run instance).
+
+**If you scale beyond one instance**, SSE clients connected to different instances will only receive events emitted by *their* instance. Events emitted by instance A are not forwarded to SSE clients connected to instance B.
+
+To support SSE at multiple instances, replace the in-process `events.Broker` with a Pub/Sub-backed fan-out (Milestone 2 Pub/Sub backend provides the durability primitive; SSE fan-out would require an additional layer such as Redis Pub/Sub or a shared GCP Pub/Sub subscription).
+
+**Webhook delivery is not affected** — webhooks are delivered via the `event_outbox` database table and the dispatcher goroutine correctly uses `FOR UPDATE SKIP LOCKED` to prevent double-delivery across instances.
+
+---
+
 ## Monitoring
 
 ### Health check

--- a/cmd/docstore/main.go
+++ b/cmd/docstore/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/dlorenc/docstore/internal/blob"
 	"github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/events"
 	"github.com/dlorenc/docstore/internal/server"
 )
 
@@ -122,7 +123,13 @@ func main() {
 
 	commitStore.SetBlobStore(bs, blobThreshold)
 
-	srv := server.NewWithBlobStore(commitStore, database, bs, *devIdentity, *bootstrapAdmin)
+	// Create the event broker and start the outbox dispatcher.
+	// The dispatcher runs until dispatchCancel is called on shutdown.
+	broker := events.NewBroker(database)
+	dispatchCtx, dispatchCancel := context.WithCancel(context.Background())
+	events.StartDispatcher(dispatchCtx, database)
+
+	srv := server.NewWithBroker(commitStore, database, bs, broker, *devIdentity, *bootstrapAdmin)
 
 	httpServer := &http.Server{
 		Addr:         ":" + port,
@@ -147,9 +154,12 @@ func main() {
 	<-quit
 	logger.Info("shutting down")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	if err := httpServer.Shutdown(ctx); err != nil {
+	// Stop the outbox dispatcher.
+	dispatchCancel()
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		logger.Error("shutdown error", "error", err)
 		os.Exit(1)
 	}

--- a/internal/db/migrations/000001_initial_schema.up.sql
+++ b/internal/db/migrations/000001_initial_schema.up.sql
@@ -146,6 +146,9 @@ CREATE TABLE event_outbox (
 CREATE INDEX idx_event_outbox_pending ON event_outbox (next_attempt)
     WHERE delivered_at IS NULL AND attempts < 10;
 
+CREATE INDEX idx_event_subscriptions_active_webhook ON event_subscriptions (backend)
+    WHERE suspended_at IS NULL AND backend = 'webhook';
+
 -- Seed the default org, default repo, and main branch
 INSERT INTO orgs (name, created_by) VALUES ('default', 'system');
 INSERT INTO repos (name, owner, created_by) VALUES ('default/default', 'default', 'system');

--- a/internal/db/migrations/000001_initial_schema.up.sql
+++ b/internal/db/migrations/000001_initial_schema.up.sql
@@ -116,6 +116,36 @@ CREATE TABLE check_runs (
 
 CREATE INDEX idx_check_runs_repo_branch_seq_name ON check_runs (repo, branch, sequence, check_name);
 
+-- event_subscriptions: webhook (and future Pub/Sub) delivery targets
+-- repo NULL means all repos; event_types NULL means all event types.
+CREATE TABLE event_subscriptions (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    repo          TEXT REFERENCES repos(name),
+    event_types   TEXT[],
+    backend       TEXT NOT NULL CHECK (backend IN ('webhook', 'pubsub')),
+    config        JSONB NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by    TEXT NOT NULL,
+    suspended_at  TIMESTAMPTZ,
+    failure_count INT NOT NULL DEFAULT 0
+);
+
+-- event_outbox: pending and delivered outbox rows for webhook delivery.
+-- Rows are cleaned up after 7 days.
+CREATE TABLE event_outbox (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event           JSONB NOT NULL,
+    subscription_id UUID REFERENCES event_subscriptions(id) ON DELETE CASCADE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    attempts        INT NOT NULL DEFAULT 0,
+    next_attempt    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    delivered_at    TIMESTAMPTZ,
+    last_error      TEXT
+);
+
+CREATE INDEX idx_event_outbox_pending ON event_outbox (next_attempt)
+    WHERE delivered_at IS NULL AND attempts < 10;
+
 -- Seed the default org, default repo, and main branch
 INSERT INTO orgs (name, created_by) VALUES ('default', 'system');
 INSERT INTO repos (name, owner, created_by) VALUES ('default/default', 'default', 'system');

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -124,6 +125,7 @@ var (
 	ErrReleaseExists          = errors.New("release already exists")
 	ErrInvalidCursor          = errors.New("invalid pagination cursor")
 	ErrBranchDraft            = errors.New("branch is in draft state")
+	ErrSubscriptionNotFound   = errors.New("subscription not found")
 )
 
 // rebaseFile is one file within a replayed commit group.
@@ -1979,4 +1981,118 @@ func isForeignKeyViolation(err error) bool {
 		return pqErr.Code == "23503"
 	}
 	return false
+}
+
+// ---------------------------------------------------------------------------
+// Event subscription store methods
+// ---------------------------------------------------------------------------
+
+// CreateSubscription inserts a new event subscription.
+func (s *Store) CreateSubscription(ctx context.Context, req model.CreateSubscriptionRequest) (*model.EventSubscription, error) {
+	config, err := req.Config.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("marshal config: %w", err)
+	}
+
+	var id string
+	var createdAt time.Time
+	err = s.db.QueryRowContext(ctx, `
+		INSERT INTO event_subscriptions (repo, event_types, backend, config, created_by)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id, created_at`,
+		req.Repo,
+		pq.Array(req.EventTypes),
+		req.Backend,
+		config,
+		req.CreatedBy,
+	).Scan(&id, &createdAt)
+	if err != nil {
+		return nil, fmt.Errorf("create subscription: %w", err)
+	}
+
+	sub := &model.EventSubscription{
+		ID:         id,
+		Repo:       req.Repo,
+		EventTypes: req.EventTypes,
+		Backend:    req.Backend,
+		Config:     req.Config,
+		CreatedAt:  createdAt,
+		CreatedBy:  req.CreatedBy,
+	}
+	return sub, nil
+}
+
+// ListSubscriptions returns all event subscriptions. If repo is non-nil,
+// only subscriptions matching that repo (or global ones) are returned.
+func (s *Store) ListSubscriptions(ctx context.Context) ([]model.EventSubscription, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, repo, event_types, backend, config, created_at, created_by, suspended_at, failure_count
+		FROM event_subscriptions
+		ORDER BY created_at`)
+	if err != nil {
+		return nil, fmt.Errorf("list subscriptions: %w", err)
+	}
+	defer rows.Close()
+
+	var subs []model.EventSubscription
+	for rows.Next() {
+		var sub model.EventSubscription
+		var repo sql.NullString
+		var eventTypes pq.StringArray
+		var suspendedAt sql.NullTime
+		var configBytes []byte
+		if err := rows.Scan(&sub.ID, &repo, &eventTypes, &sub.Backend,
+			&configBytes, &sub.CreatedAt, &sub.CreatedBy, &suspendedAt, &sub.FailureCount); err != nil {
+			return nil, fmt.Errorf("scan subscription: %w", err)
+		}
+		if repo.Valid {
+			sub.Repo = &repo.String
+		}
+		if len(eventTypes) > 0 {
+			sub.EventTypes = []string(eventTypes)
+		}
+		if suspendedAt.Valid {
+			sub.SuspendedAt = &suspendedAt.Time
+		}
+		sub.Config = json.RawMessage(configBytes)
+		subs = append(subs, sub)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate subscriptions: %w", err)
+	}
+	return subs, nil
+}
+
+// DeleteSubscription deletes a subscription by ID.
+func (s *Store) DeleteSubscription(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM event_subscriptions WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete subscription: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrSubscriptionNotFound
+	}
+	return nil
+}
+
+// ResumeSubscription clears the suspended_at on a subscription.
+func (s *Store) ResumeSubscription(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE event_subscriptions SET suspended_at = NULL, failure_count = 0 WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("resume subscription: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrSubscriptionNotFound
+	}
+	return nil
 }

--- a/internal/events/broker.go
+++ b/internal/events/broker.go
@@ -1,0 +1,146 @@
+package events
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"strings"
+	"sync"
+)
+
+// Broker is the in-process event fan-out hub.
+// It fans out emitted events to SSE subscribers and writes outbox rows for
+// webhook subscriptions. SSE delivery is in-memory and best-effort; clients
+// that disconnect miss events. Webhook delivery is durable via the outbox.
+//
+// Horizontal scaling note: SSE fan-out is in-memory. Works correctly at
+// --max-instances=1 only. See OPERATIONS.md for details.
+type Broker struct {
+	db  *sql.DB
+	mu  sync.RWMutex
+	// subs maps "repo/*" or "repo/<full-type>" to subscriber channels.
+	subs map[string][]chan Event
+}
+
+// NewBroker creates a new Broker. db is used for outbox writes on Emit.
+// Pass nil to disable webhook outbox writes (e.g. in tests that only need SSE).
+func NewBroker(db *sql.DB) *Broker {
+	return &Broker{
+		db:   db,
+		subs: make(map[string][]chan Event),
+	}
+}
+
+// Subscribe registers a channel to receive events for the given repo.
+// If types is empty, all events for the repo are received.
+// Otherwise, only events whose Type() matches one of the provided types
+// are received. Types must be the full CloudEvents type, e.g.
+// "com.docstore.commit.created".
+// Returns the channel and an unsubscribe function that must be called
+// when the subscriber is done (e.g. on client disconnect).
+func (b *Broker) Subscribe(repo string, types []string) (<-chan Event, func()) {
+	ch := make(chan Event, 64)
+	keys := subscriberKeys(repo, types)
+
+	b.mu.Lock()
+	for _, k := range keys {
+		b.subs[k] = append(b.subs[k], ch)
+	}
+	b.mu.Unlock()
+
+	unsub := func() {
+		b.mu.Lock()
+		for _, k := range keys {
+			b.subs[k] = removeChannel(b.subs[k], ch)
+		}
+		b.mu.Unlock()
+		// Drain and close so SSE goroutine can exit cleanly.
+		for len(ch) > 0 {
+			<-ch
+		}
+		close(ch)
+	}
+	return ch, unsub
+}
+
+// Emit publishes an event to all matching SSE subscribers and writes outbox
+// rows for each matching webhook subscription. Outbox writes are best-effort;
+// errors are logged but not returned.
+func (b *Broker) Emit(ctx context.Context, e Event) {
+	b.fanOutSSE(e)
+
+	if b.db == nil {
+		return
+	}
+	if err := insertOutboxForEvent(ctx, b.db, e); err != nil {
+		slog.Error("events: outbox insert failed", "type", e.Type(), "source", e.Source(), "error", err)
+	}
+}
+
+// fanOutSSE sends an event to all SSE subscribers whose keys match the event.
+func (b *Broker) fanOutSSE(e Event) {
+	// Derive the repo name from the source URI.
+	repo := repoFromSource(e.Source())
+
+	// Collect the set of matching subscriber keys.
+	wildcardKey := repo + "/*"
+	typeKey := repo + "/" + e.Type()
+
+	b.mu.RLock()
+	// Collect unique channels (a subscriber might appear under both keys theoretically,
+	// but our Subscribe logic ensures each channel is under exactly one set of keys).
+	seen := make(map[chan Event]struct{})
+	var targets []chan Event
+	for _, k := range []string{wildcardKey, typeKey} {
+		for _, ch := range b.subs[k] {
+			if _, ok := seen[ch]; !ok {
+				seen[ch] = struct{}{}
+				targets = append(targets, ch)
+			}
+		}
+	}
+	b.mu.RUnlock()
+
+	for _, ch := range targets {
+		select {
+		case ch <- e:
+		default:
+			// Slow consumer; drop event rather than block.
+			slog.Warn("events: SSE subscriber too slow, dropping event",
+				"type", e.Type(), "repo", repo)
+		}
+	}
+}
+
+// subscriberKeys returns the broker map keys for the given repo and type filter.
+func subscriberKeys(repo string, types []string) []string {
+	if len(types) == 0 {
+		return []string{repo + "/*"}
+	}
+	keys := make([]string, len(types))
+	for i, t := range types {
+		keys[i] = repo + "/" + t
+	}
+	return keys
+}
+
+// repoFromSource extracts the repo name from a CloudEvents source URI.
+// "/repos/acme/myrepo" → "acme/myrepo"
+// Other sources (e.g. "/orgs/acme") return the source as-is.
+func repoFromSource(source string) string {
+	if strings.HasPrefix(source, "/repos/") {
+		return source[len("/repos/"):]
+	}
+	return source
+}
+
+// removeChannel removes ch from slice without preserving order.
+func removeChannel(slice []chan Event, ch chan Event) []chan Event {
+	for i, c := range slice {
+		if c == ch {
+			slice[i] = slice[len(slice)-1]
+			return slice[:len(slice)-1]
+		}
+	}
+	return slice
+}

--- a/internal/events/broker_test.go
+++ b/internal/events/broker_test.go
@@ -1,0 +1,176 @@
+package events_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dlorenc/docstore/internal/events"
+	evtypes "github.com/dlorenc/docstore/internal/events/types"
+)
+
+func TestBroker_PublishAndReceive(t *testing.T) {
+	t.Parallel()
+	b := events.NewBroker(nil)
+
+	ch, unsub := b.Subscribe("acme/myrepo", nil)
+	defer unsub()
+
+	e := evtypes.CommitCreated{
+		Repo:     "acme/myrepo",
+		Branch:   "main",
+		Sequence: 1,
+		Author:   "alice@example.com",
+	}
+	b.Emit(context.Background(), e)
+
+	select {
+	case got := <-ch:
+		if got.Type() != e.Type() {
+			t.Errorf("expected type %q, got %q", e.Type(), got.Type())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+}
+
+func TestBroker_ClientDisconnect(t *testing.T) {
+	t.Parallel()
+	b := events.NewBroker(nil)
+
+	ch, unsub := b.Subscribe("acme/myrepo", nil)
+
+	// Unsubscribe before any events.
+	unsub()
+
+	// Emitting after unsubscribe should not panic or block.
+	b.Emit(context.Background(), evtypes.CommitCreated{
+		Repo:   "acme/myrepo",
+		Branch: "main",
+	})
+
+	// Channel should be closed.
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected channel to be closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out: channel not closed after unsub")
+	}
+}
+
+func TestBroker_FilterByType(t *testing.T) {
+	t.Parallel()
+	b := events.NewBroker(nil)
+
+	// Subscribe to only commit.created events.
+	ch, unsub := b.Subscribe("acme/myrepo", []string{"com.docstore.commit.created"})
+	defer unsub()
+
+	// Emit a non-matching event first.
+	b.Emit(context.Background(), evtypes.BranchCreated{
+		Repo:   "acme/myrepo",
+		Branch: "feature",
+	})
+
+	// Emit a matching event.
+	b.Emit(context.Background(), evtypes.CommitCreated{
+		Repo:     "acme/myrepo",
+		Branch:   "main",
+		Sequence: 42,
+	})
+
+	select {
+	case got := <-ch:
+		if got.Type() != "com.docstore.commit.created" {
+			t.Errorf("expected commit.created, got %q", got.Type())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for filtered event")
+	}
+
+	// Channel should have no more events.
+	select {
+	case unexpected := <-ch:
+		t.Errorf("received unexpected event: %s", unexpected.Type())
+	default:
+		// Good: no extra events.
+	}
+}
+
+func TestBroker_MultipleSubscribers(t *testing.T) {
+	t.Parallel()
+	b := events.NewBroker(nil)
+
+	ch1, unsub1 := b.Subscribe("acme/myrepo", nil)
+	defer unsub1()
+	ch2, unsub2 := b.Subscribe("acme/myrepo", nil)
+	defer unsub2()
+
+	e := evtypes.CommitCreated{Repo: "acme/myrepo", Branch: "main"}
+	b.Emit(context.Background(), e)
+
+	for _, ch := range []<-chan events.Event{ch1, ch2} {
+		select {
+		case got := <-ch:
+			if got.Type() != e.Type() {
+				t.Errorf("expected %q, got %q", e.Type(), got.Type())
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for event on subscriber")
+		}
+	}
+}
+
+func TestCloudEvents_Schema(t *testing.T) {
+	t.Parallel()
+
+	eventTypes := []events.Event{
+		evtypes.CommitCreated{Repo: "acme/r", Branch: "main", Sequence: 1, Author: "a", FileCount: 1},
+		evtypes.BranchCreated{Repo: "acme/r", Branch: "b", BaseSequence: 0, CreatedBy: "a"},
+		evtypes.BranchMerged{Repo: "acme/r", Branch: "b", Sequence: 2, MergedBy: "a"},
+		evtypes.BranchRebased{Repo: "acme/r", Branch: "b"},
+		evtypes.BranchAbandoned{Repo: "acme/r", Branch: "b", AbandonedBy: "a"},
+		evtypes.ReviewSubmitted{Repo: "acme/r", Branch: "b", Reviewer: "a", Status: "approved"},
+		evtypes.CheckReported{Repo: "acme/r", Branch: "b", CheckName: "ci", Status: "passed", Reporter: "bot"},
+		evtypes.MergeBlocked{Repo: "acme/r", Branch: "b", Actor: "a"},
+		evtypes.RoleChanged{Repo: "acme/r", Identity: "a@example.com", Role: "admin", ChangedBy: "b"},
+		evtypes.OrgCreated{Org: "acme", CreatedBy: "a"},
+		evtypes.OrgDeleted{Org: "acme", DeletedBy: "a"},
+		evtypes.RepoCreated{Repo: "acme/r", Owner: "acme", CreatedBy: "a"},
+		evtypes.RepoDeleted{Repo: "acme/r", DeletedBy: "a"},
+	}
+
+	for _, e := range eventTypes {
+		t.Run(e.Type(), func(t *testing.T) {
+			data, err := events.ToCloudEvent(e)
+			if err != nil {
+				t.Fatalf("ToCloudEvent failed: %v", err)
+			}
+			if len(data) == 0 {
+				t.Fatal("empty CloudEvent JSON")
+			}
+			// Basic sanity: contains required fields.
+			s := string(data)
+			for _, field := range []string{`"specversion":"1.0"`, `"type":"` + e.Type() + `"`, `"source":"` + e.Source() + `"`} {
+				if !contains(s, field) {
+					t.Errorf("missing field %q in CloudEvent: %s", field, s)
+				}
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -1,0 +1,46 @@
+// Package events provides the eventing system for DocStore.
+// Events are emitted after successful mutations and delivered via SSE streaming
+// or webhooks using the CloudEvents 1.0 envelope format.
+package events
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Event is implemented by every domain event type.
+type Event interface {
+	// Type returns the CloudEvents type, e.g. "com.docstore.commit.created".
+	Type() string
+	// Source returns the CloudEvents source URI, e.g. "/repos/acme/myrepo".
+	Source() string
+	// Data returns the event payload, which is marshalled as the CloudEvents data field.
+	Data() any
+}
+
+// Envelope is the CloudEvents 1.0 JSON envelope.
+type Envelope struct {
+	SpecVersion     string    `json:"specversion"`
+	Type            string    `json:"type"`
+	Source          string    `json:"source"`
+	ID              string    `json:"id"`
+	Time            time.Time `json:"time"`
+	DataContentType string    `json:"datacontenttype"`
+	Data            any       `json:"data"`
+}
+
+// ToCloudEvent serializes an Event into a CloudEvents 1.0 JSON byte slice.
+func ToCloudEvent(e Event) ([]byte, error) {
+	env := Envelope{
+		SpecVersion:     "1.0",
+		Type:            e.Type(),
+		Source:          e.Source(),
+		ID:              uuid.New().String(),
+		Time:            time.Now().UTC(),
+		DataContentType: "application/json",
+		Data:            e.Data(),
+	}
+	return json.Marshal(env)
+}

--- a/internal/events/outbox.go
+++ b/internal/events/outbox.go
@@ -1,0 +1,293 @@
+package events
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+// outboxRow is a single pending delivery row fetched from event_outbox.
+type outboxRow struct {
+	ID             string
+	Event          []byte
+	SubscriptionID string
+	Attempts       int
+	WebhookURL     string
+	WebhookSecret  string
+}
+
+// StartDispatcher starts the outbox dispatcher goroutine. It polls for pending
+// outbox rows every 5 seconds, delivers webhooks with exponential backoff, and
+// cleans up delivered rows older than 7 days every hour.
+// The goroutine stops when ctx is cancelled (e.g. on SIGTERM).
+func StartDispatcher(ctx context.Context, db *sql.DB) {
+	go func() {
+		pollTicker := time.NewTicker(5 * time.Second)
+		cleanupTicker := time.NewTicker(time.Hour)
+		defer pollTicker.Stop()
+		defer cleanupTicker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-pollTicker.C:
+				processOutboxBatch(ctx, db)
+			case <-cleanupTicker.C:
+				if err := cleanupOutbox(ctx, db); err != nil {
+					slog.Error("outbox: cleanup failed", "error", err)
+				}
+			}
+		}
+	}()
+}
+
+// processOutboxBatch claims and delivers one batch of pending outbox rows.
+func processOutboxBatch(ctx context.Context, db *sql.DB) {
+	rows, err := claimOutboxBatch(ctx, db, 50)
+	if err != nil {
+		slog.Error("outbox: claim batch failed", "error", err)
+		return
+	}
+	for _, row := range rows {
+		deliverWebhook(ctx, db, row)
+	}
+}
+
+// claimOutboxBatch selects up to batchSize pending outbox rows FOR UPDATE SKIP LOCKED,
+// joining with event_subscriptions for the webhook config.
+func claimOutboxBatch(ctx context.Context, db *sql.DB, batchSize int) ([]outboxRow, error) {
+	const q = `
+		SELECT o.id, o.event, o.subscription_id, o.attempts,
+		       s.config->>'url'    AS webhook_url,
+		       s.config->>'secret' AS webhook_secret
+		FROM event_outbox o
+		JOIN event_subscriptions s ON s.id = o.subscription_id
+		WHERE o.delivered_at IS NULL
+		  AND o.next_attempt <= now()
+		  AND o.attempts < 10
+		  AND s.suspended_at IS NULL
+		  AND s.backend = 'webhook'
+		ORDER BY o.next_attempt
+		LIMIT $1
+		FOR UPDATE OF o SKIP LOCKED`
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	sqlRows, err := tx.QueryContext(ctx, q, batchSize)
+	if err != nil {
+		return nil, fmt.Errorf("query outbox: %w", err)
+	}
+	defer sqlRows.Close()
+
+	var batch []outboxRow
+	for sqlRows.Next() {
+		var r outboxRow
+		var webhookURL, webhookSecret sql.NullString
+		if err := sqlRows.Scan(&r.ID, &r.Event, &r.SubscriptionID,
+			&r.Attempts, &webhookURL, &webhookSecret); err != nil {
+			return nil, fmt.Errorf("scan outbox row: %w", err)
+		}
+		r.WebhookURL = webhookURL.String
+		r.WebhookSecret = webhookSecret.String
+		batch = append(batch, r)
+	}
+	if err := sqlRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate outbox rows: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+	return batch, nil
+}
+
+// deliverWebhook attempts to deliver one outbox row via HTTP POST.
+func deliverWebhook(ctx context.Context, db *sql.DB, row outboxRow) {
+	if row.WebhookURL == "" {
+		slog.Warn("outbox: webhook URL is empty, skipping", "id", row.ID)
+		return
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, row.WebhookURL,
+		strings.NewReader(string(row.Event)))
+	if err != nil {
+		markFailed(ctx, db, row, fmt.Sprintf("build request: %v", err))
+		return
+	}
+	req.Header.Set("Content-Type", "application/cloudevents+json")
+	if row.WebhookSecret != "" {
+		sig := computeHMAC(row.Event, row.WebhookSecret)
+		req.Header.Set("X-DocStore-Signature", "sha256="+sig)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		markFailed(ctx, db, row, fmt.Sprintf("http: %v", err))
+		return
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		markFailed(ctx, db, row, fmt.Sprintf("webhook returned status %d", resp.StatusCode))
+		return
+	}
+
+	// Success.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE event_outbox SET delivered_at = now() WHERE id = $1`, row.ID,
+	); err != nil {
+		slog.Error("outbox: mark delivered failed", "id", row.ID, "error", err)
+	}
+}
+
+// markFailed increments attempts, sets next_attempt using exponential backoff,
+// and suspends the subscription when attempts reach 10.
+func markFailed(ctx context.Context, db *sql.DB, row outboxRow, lastErr string) {
+	newAttempts := row.Attempts + 1
+	backoff := time.Duration(1<<uint(row.Attempts)) * time.Second
+	if backoff > time.Hour {
+		backoff = time.Hour
+	}
+	nextAttempt := time.Now().Add(backoff)
+
+	if _, err := db.ExecContext(ctx, `
+		UPDATE event_outbox
+		SET attempts = $1, next_attempt = $2, last_error = $3
+		WHERE id = $4`,
+		newAttempts, nextAttempt, lastErr, row.ID,
+	); err != nil {
+		slog.Error("outbox: mark failed update", "id", row.ID, "error", err)
+	}
+
+	if newAttempts >= 10 {
+		slog.Warn("outbox: max attempts reached, suspending subscription",
+			"subscription_id", row.SubscriptionID, "last_error", lastErr)
+		if _, err := db.ExecContext(ctx, `
+			UPDATE event_subscriptions
+			SET suspended_at = now(), failure_count = failure_count + 1
+			WHERE id = $1`,
+			row.SubscriptionID,
+		); err != nil {
+			slog.Error("outbox: suspend subscription failed",
+				"subscription_id", row.SubscriptionID, "error", err)
+		}
+	}
+}
+
+// cleanupOutbox deletes outbox rows that have been delivered more than 7 days ago.
+func cleanupOutbox(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, `
+		DELETE FROM event_outbox
+		WHERE delivered_at < now() - interval '7 days'`)
+	return err
+}
+
+// RunCleanupOnce runs a single outbox cleanup pass. Exported for testing.
+func RunCleanupOnce(ctx context.Context, db *sql.DB) error {
+	return cleanupOutbox(ctx, db)
+}
+
+// ProcessOnce runs a single outbox delivery pass synchronously. Exported for testing.
+func ProcessOnce(ctx context.Context, db *sql.DB) {
+	processOutboxBatch(ctx, db)
+}
+
+// insertOutboxForEvent finds all webhook subscriptions matching the event and
+// inserts an outbox row for each one.
+func insertOutboxForEvent(ctx context.Context, db *sql.DB, e Event) error {
+	// Serialize the event as a CloudEvents JSON envelope.
+	eventJSON, err := ToCloudEvent(e)
+	if err != nil {
+		return fmt.Errorf("serialize event: %w", err)
+	}
+
+	// Extract repo name from source (nil-safe: org events have no matching repo subscription).
+	repo := repoFromSource(e.Source())
+
+	// Find matching subscriptions.
+	const q = `
+		SELECT id FROM event_subscriptions
+		WHERE backend = 'webhook'
+		  AND suspended_at IS NULL
+		  AND (repo IS NULL OR repo = $1)
+		  AND (event_types IS NULL OR $2 = ANY(event_types))`
+
+	rows, err := db.QueryContext(ctx, q, repo, e.Type())
+	if err != nil {
+		return fmt.Errorf("query subscriptions: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return fmt.Errorf("scan subscription id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate subscriptions: %w", err)
+	}
+
+	for _, subID := range ids {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO event_outbox (event, subscription_id)
+			VALUES ($1, $2)`,
+			eventJSON, subID,
+		); err != nil {
+			slog.Error("outbox: insert row failed", "subscription_id", subID, "error", err)
+		}
+	}
+	return nil
+}
+
+// computeHMAC returns the hex-encoded HMAC-SHA256 of body using secret.
+func computeHMAC(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// InsertOutboxEvent inserts a single outbox row. Used in tests.
+func InsertOutboxEvent(ctx context.Context, db *sql.DB, eventJSON []byte, subscriptionID string) error {
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO event_outbox (event, subscription_id)
+		VALUES ($1, $2)`,
+		eventJSON, subscriptionID,
+	)
+	return err
+}
+
+// subscriptionRow is returned by CreateSubscription for use in the store.
+type subscriptionRow struct {
+	ID           string
+	Repo         *string
+	EventTypes   []string
+	Backend      string
+	Config       json.RawMessage
+	CreatedAt    time.Time
+	CreatedBy    string
+	SuspendedAt  *time.Time
+	FailureCount int
+}
+
+// ensure pq is used (for TEXT[] scanning)
+var _ = pq.Array

--- a/internal/events/outbox.go
+++ b/internal/events/outbox.go
@@ -95,6 +95,7 @@ func claimOutboxBatch(ctx context.Context, db *sql.DB, batchSize int) ([]outboxR
 	defer sqlRows.Close()
 
 	var batch []outboxRow
+	var ids []string
 	for sqlRows.Next() {
 		var r outboxRow
 		var webhookURL, webhookSecret sql.NullString
@@ -105,9 +106,22 @@ func claimOutboxBatch(ctx context.Context, db *sql.DB, batchSize int) ([]outboxR
 		r.WebhookURL = webhookURL.String
 		r.WebhookSecret = webhookSecret.String
 		batch = append(batch, r)
+		ids = append(ids, r.ID)
 	}
 	if err := sqlRows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate outbox rows: %w", err)
+	}
+
+	// Mark claimed rows as in-flight within the same transaction so a slow
+	// delivery cannot be double-processed by a concurrent poller.
+	if len(ids) > 0 {
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE event_outbox SET next_attempt = now() + interval '5 minutes'
+			 WHERE id = ANY($1)`,
+			pq.Array(ids),
+		); err != nil {
+			return nil, fmt.Errorf("mark in-flight: %w", err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/events/outbox_test.go
+++ b/internal/events/outbox_test.go
@@ -1,0 +1,175 @@
+package events_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	dbpkg "github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/events"
+	evtypes "github.com/dlorenc/docstore/internal/events/types"
+	"github.com/dlorenc/docstore/internal/testutil"
+	"github.com/lib/pq"
+)
+
+// insertWebhookSub inserts a webhook subscription and returns its UUID.
+func insertWebhookSub(t *testing.T, d *sql.DB, webhookURL, secret string) string {
+	t.Helper()
+	config, _ := json.Marshal(map[string]string{"url": webhookURL, "secret": secret})
+	var subID string
+	err := d.QueryRowContext(context.Background(), `
+		INSERT INTO event_subscriptions (backend, config, created_by)
+		VALUES ('webhook', $1, 'test')
+		RETURNING id`, config,
+	).Scan(&subID)
+	if err != nil {
+		t.Fatalf("insert subscription: %v", err)
+	}
+	return subID
+}
+
+func TestOutbox_InsertAndDeliver(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+
+	// Start a test webhook server that counts calls.
+	var callCount int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&callCount, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	subID := insertWebhookSub(t, d, srv.URL, "test-secret")
+
+	// Insert an outbox event for this subscription.
+	e := evtypes.CommitCreated{Repo: "default/default", Branch: "main", Sequence: 1, Author: "alice"}
+	eventJSON, err := events.ToCloudEvent(e)
+	if err != nil {
+		t.Fatalf("serialize event: %v", err)
+	}
+	if err := events.InsertOutboxEvent(context.Background(), d, eventJSON, subID); err != nil {
+		t.Fatalf("insert outbox: %v", err)
+	}
+
+	// Process one batch synchronously.
+	events.ProcessOnce(context.Background(), d)
+
+	var deliveredAt *time.Time
+	d.QueryRowContext(context.Background(),
+		`SELECT delivered_at FROM event_outbox WHERE subscription_id = $1`, subID,
+	).Scan(&deliveredAt)
+	if deliveredAt == nil {
+		t.Fatal("outbox row not marked as delivered")
+	}
+	if atomic.LoadInt64(&callCount) == 0 {
+		t.Fatal("webhook was never called")
+	}
+}
+
+func TestOutbox_RetryOnFailure(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+
+	// Failing webhook server.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	subID := insertWebhookSub(t, d, srv.URL, "")
+
+	e := evtypes.CommitCreated{Repo: "default/default", Branch: "main"}
+	eventJSON, _ := events.ToCloudEvent(e)
+	events.InsertOutboxEvent(context.Background(), d, eventJSON, subID)
+
+	// Process one batch synchronously.
+	ctx := context.Background()
+	events.ProcessOnce(ctx, d)
+
+	var attempts int
+	d.QueryRowContext(context.Background(),
+		`SELECT attempts FROM event_outbox WHERE subscription_id = $1`, subID,
+	).Scan(&attempts)
+	if attempts == 0 {
+		t.Error("expected attempts > 0 after failure")
+	}
+}
+
+func TestOutbox_MaxAttemptsAutoSuspends(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	subID := insertWebhookSub(t, d, srv.URL, "")
+
+	e := evtypes.CommitCreated{Repo: "default/default", Branch: "main"}
+	eventJSON, _ := events.ToCloudEvent(e)
+	events.InsertOutboxEvent(context.Background(), d, eventJSON, subID)
+
+	// Pre-set attempts=9 so next failure triggers suspension.
+	d.ExecContext(context.Background(), `
+		UPDATE event_outbox SET attempts = 9, next_attempt = now() - interval '1 second'
+		WHERE subscription_id = $1`, subID)
+
+	// Process one batch synchronously.
+	events.ProcessOnce(context.Background(), d)
+
+	var suspendedAt *time.Time
+	d.QueryRowContext(context.Background(),
+		`SELECT suspended_at FROM event_subscriptions WHERE id = $1`, subID,
+	).Scan(&suspendedAt)
+	if suspendedAt == nil {
+		t.Error("expected subscription to be suspended after 10 failures")
+	}
+}
+
+func TestOutbox_Cleanup(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+
+	subID := insertWebhookSub(t, d, "http://localhost:9999", "")
+
+	// Insert an old delivered row (> 7 days ago).
+	d.ExecContext(context.Background(), `
+		INSERT INTO event_outbox (event, subscription_id, delivered_at, attempts)
+		VALUES ('{}', $1, now() - interval '8 days', 1)`, subID)
+
+	// Insert a recent delivered row.
+	d.ExecContext(context.Background(), `
+		INSERT INTO event_outbox (event, subscription_id, delivered_at, attempts)
+		VALUES ('{}', $1, now() - interval '1 day', 1)`, subID)
+
+	// Both should exist before cleanup.
+	var countBefore int
+	d.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM event_outbox WHERE subscription_id = $1`, subID).Scan(&countBefore)
+	if countBefore != 2 {
+		t.Fatalf("expected 2 rows before cleanup, got %d", countBefore)
+	}
+
+	// Directly invoke cleanup via the exported helper.
+	if err := events.RunCleanupOnce(context.Background(), d); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+
+	// Old row should be deleted.
+	var countAfter int
+	d.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM event_outbox WHERE subscription_id = $1`, subID).Scan(&countAfter)
+	if countAfter != 1 {
+		t.Errorf("expected 1 row after cleanup, got %d", countAfter)
+	}
+}
+
+// ensure pq is used
+var _ = pq.Array

--- a/internal/events/testmain_test.go
+++ b/internal/events/testmain_test.go
@@ -1,0 +1,23 @@
+package events_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/testutil"
+)
+
+var sharedAdminDSN string
+
+func TestMain(m *testing.M) {
+	dsn, cleanup, err := testutil.StartSharedPostgres()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "start shared postgres: %v\n", err)
+		os.Exit(1)
+	}
+	sharedAdminDSN = dsn
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/events/types/branch.go
+++ b/internal/events/types/branch.go
@@ -1,0 +1,50 @@
+package types
+
+// BranchCreated is emitted when a new branch is created.
+type BranchCreated struct {
+	Repo         string `json:"repo"`
+	Branch       string `json:"branch"`
+	BaseSequence int64  `json:"base_sequence"`
+	CreatedBy    string `json:"created_by"`
+}
+
+func (e BranchCreated) Type() string   { return "com.docstore.branch.created" }
+func (e BranchCreated) Source() string { return "/repos/" + e.Repo }
+func (e BranchCreated) Data() any      { return e }
+
+// BranchMerged is emitted when a branch is merged into main.
+type BranchMerged struct {
+	Repo     string `json:"repo"`
+	Branch   string `json:"branch"`
+	Sequence int64  `json:"sequence"`
+	MergedBy string `json:"merged_by"`
+}
+
+func (e BranchMerged) Type() string   { return "com.docstore.branch.merged" }
+func (e BranchMerged) Source() string { return "/repos/" + e.Repo }
+func (e BranchMerged) Data() any      { return e }
+
+// BranchRebased is emitted when a branch is rebased onto main.
+type BranchRebased struct {
+	Repo            string `json:"repo"`
+	Branch          string `json:"branch"`
+	NewBaseSequence int64  `json:"new_base_sequence"`
+	NewHeadSequence int64  `json:"new_head_sequence"`
+	CommitsReplayed int64  `json:"commits_replayed"`
+	RebasedBy       string `json:"rebased_by"`
+}
+
+func (e BranchRebased) Type() string   { return "com.docstore.branch.rebased" }
+func (e BranchRebased) Source() string { return "/repos/" + e.Repo }
+func (e BranchRebased) Data() any      { return e }
+
+// BranchAbandoned is emitted when a branch is deleted (abandoned).
+type BranchAbandoned struct {
+	Repo        string `json:"repo"`
+	Branch      string `json:"branch"`
+	AbandonedBy string `json:"abandoned_by"`
+}
+
+func (e BranchAbandoned) Type() string   { return "com.docstore.branch.abandoned" }
+func (e BranchAbandoned) Source() string { return "/repos/" + e.Repo }
+func (e BranchAbandoned) Data() any      { return e }

--- a/internal/events/types/check.go
+++ b/internal/events/types/check.go
@@ -1,0 +1,15 @@
+package types
+
+// CheckReported is emitted when a CI check run is reported.
+type CheckReported struct {
+	Repo      string `json:"repo"`
+	Branch    string `json:"branch"`
+	Sequence  int64  `json:"sequence"`
+	CheckName string `json:"check_name"`
+	Status    string `json:"status"`
+	Reporter  string `json:"reporter"`
+}
+
+func (e CheckReported) Type() string   { return "com.docstore.check.reported" }
+func (e CheckReported) Source() string { return "/repos/" + e.Repo }
+func (e CheckReported) Data() any      { return e }

--- a/internal/events/types/commit.go
+++ b/internal/events/types/commit.go
@@ -1,0 +1,15 @@
+package types
+
+// CommitCreated is emitted after a successful commit.
+type CommitCreated struct {
+	Repo      string `json:"repo"`
+	Branch    string `json:"branch"`
+	Sequence  int64  `json:"sequence"`
+	Author    string `json:"author"`
+	Message   string `json:"message"`
+	FileCount int    `json:"file_count"`
+}
+
+func (e CommitCreated) Type() string   { return "com.docstore.commit.created" }
+func (e CommitCreated) Source() string { return "/repos/" + e.Repo }
+func (e CommitCreated) Data() any      { return e }

--- a/internal/events/types/merge.go
+++ b/internal/events/types/merge.go
@@ -1,0 +1,13 @@
+package types
+
+// MergeBlocked is emitted when a merge attempt is denied by policy.
+type MergeBlocked struct {
+	Repo     string   `json:"repo"`
+	Branch   string   `json:"branch"`
+	Actor    string   `json:"actor"`
+	Policies []string `json:"policies"`
+}
+
+func (e MergeBlocked) Type() string   { return "com.docstore.merge.blocked" }
+func (e MergeBlocked) Source() string { return "/repos/" + e.Repo }
+func (e MergeBlocked) Data() any      { return e }

--- a/internal/events/types/org.go
+++ b/internal/events/types/org.go
@@ -1,0 +1,21 @@
+package types
+
+// OrgCreated is emitted when a new org is created.
+type OrgCreated struct {
+	Org       string `json:"org"`
+	CreatedBy string `json:"created_by"`
+}
+
+func (e OrgCreated) Type() string   { return "com.docstore.org.created" }
+func (e OrgCreated) Source() string { return "/orgs/" + e.Org }
+func (e OrgCreated) Data() any      { return e }
+
+// OrgDeleted is emitted when an org is deleted.
+type OrgDeleted struct {
+	Org       string `json:"org"`
+	DeletedBy string `json:"deleted_by"`
+}
+
+func (e OrgDeleted) Type() string   { return "com.docstore.org.deleted" }
+func (e OrgDeleted) Source() string { return "/orgs/" + e.Org }
+func (e OrgDeleted) Data() any      { return e }

--- a/internal/events/types/repo.go
+++ b/internal/events/types/repo.go
@@ -1,0 +1,22 @@
+package types
+
+// RepoCreated is emitted when a new repo is created.
+type RepoCreated struct {
+	Repo      string `json:"repo"`
+	Owner     string `json:"owner"`
+	CreatedBy string `json:"created_by"`
+}
+
+func (e RepoCreated) Type() string   { return "com.docstore.repo.created" }
+func (e RepoCreated) Source() string { return "/repos/" + e.Repo }
+func (e RepoCreated) Data() any      { return e }
+
+// RepoDeleted is emitted when a repo is deleted.
+type RepoDeleted struct {
+	Repo      string `json:"repo"`
+	DeletedBy string `json:"deleted_by"`
+}
+
+func (e RepoDeleted) Type() string   { return "com.docstore.repo.deleted" }
+func (e RepoDeleted) Source() string { return "/repos/" + e.Repo }
+func (e RepoDeleted) Data() any      { return e }

--- a/internal/events/types/review.go
+++ b/internal/events/types/review.go
@@ -1,0 +1,14 @@
+package types
+
+// ReviewSubmitted is emitted when a review is submitted.
+type ReviewSubmitted struct {
+	Repo     string `json:"repo"`
+	Branch   string `json:"branch"`
+	Sequence int64  `json:"sequence"`
+	Reviewer string `json:"reviewer"`
+	Status   string `json:"status"`
+}
+
+func (e ReviewSubmitted) Type() string   { return "com.docstore.review.submitted" }
+func (e ReviewSubmitted) Source() string { return "/repos/" + e.Repo }
+func (e ReviewSubmitted) Data() any      { return e }

--- a/internal/events/types/role.go
+++ b/internal/events/types/role.go
@@ -1,0 +1,13 @@
+package types
+
+// RoleChanged is emitted when a role is set or removed.
+type RoleChanged struct {
+	Repo      string `json:"repo"`
+	Identity  string `json:"identity"`
+	Role      string `json:"role"`      // empty string means role was removed
+	ChangedBy string `json:"changed_by"`
+}
+
+func (e RoleChanged) Type() string   { return "com.docstore.role.changed" }
+func (e RoleChanged) Source() string { return "/repos/" + e.Repo }
+func (e RoleChanged) Data() any      { return e }

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -1,6 +1,9 @@
 package model
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // ---------------------------------------------------------------------------
 // Pagination
@@ -412,6 +415,30 @@ type CreateReleaseRequest struct {
 // ListReleasesResponse is the response for GET /repos/:name/-/releases.
 type ListReleasesResponse struct {
 	Releases []Release `json:"releases"`
+}
+
+// ---------------------------------------------------------------------------
+// POST /subscriptions / GET /subscriptions / DELETE /subscriptions/{id}
+// POST /subscriptions/{id}/resume
+// ---------------------------------------------------------------------------
+
+// CreateSubscriptionRequest is the body for POST /subscriptions.
+type CreateSubscriptionRequest struct {
+	// Repo is the repo to subscribe to (optional; nil means all repos).
+	Repo *string `json:"repo,omitempty"`
+	// EventTypes is the list of event types to subscribe to (optional; nil means all types).
+	EventTypes []string `json:"event_types,omitempty"`
+	// Backend must be "webhook" for Milestone 1.
+	Backend string `json:"backend"`
+	// Config is backend-specific: {"url":"https://...","secret":"..."}
+	Config json.RawMessage `json:"config"`
+	// CreatedBy is populated by the server from the IAP identity; not set by clients.
+	CreatedBy string `json:"-"`
+}
+
+// ListSubscriptionsResponse is the response for GET /subscriptions.
+type ListSubscriptionsResponse struct {
+	Subscriptions []EventSubscription `json:"subscriptions"`
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -2,7 +2,10 @@
 // described in DESIGN.md.
 package model
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // OrgRole represents the role of an org member.
 type OrgRole string
@@ -161,5 +164,18 @@ type Release struct {
 	Body      string    `json:"body,omitempty"`
 	CreatedBy string    `json:"created_by"`
 	CreatedAt time.Time `json:"created_at"`
+}
+
+// EventSubscription is a webhook or Pub/Sub delivery target for events.
+type EventSubscription struct {
+	ID           string          `json:"id"`
+	Repo         *string         `json:"repo,omitempty"`
+	EventTypes   []string        `json:"event_types,omitempty"`
+	Backend      string          `json:"backend"`
+	Config       json.RawMessage `json:"config"`
+	CreatedAt    time.Time       `json:"created_at"`
+	CreatedBy    string          `json:"created_by"`
+	SuspendedAt  *time.Time      `json:"suspended_at,omitempty"`
+	FailureCount int             `json:"failure_count"`
 }
 

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -238,13 +238,19 @@ func TestWebhook_HMACSignatureValid(t *testing.T) {
 	db.Exec(`INSERT INTO roles (repo, identity, role) VALUES ('default/default', 'test@example.com', 'admin') ON CONFLICT DO NOTHING`)
 
 	const secret = "my-hmac-secret"
-	var sigHeader string
-	var body []byte
+	type capturedRequest struct {
+		sig  string
+		body []byte
+	}
+	captured := make(chan capturedRequest, 1)
 
 	webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sigHeader = r.Header.Get("X-DocStore-Signature")
-		body = make([]byte, r.ContentLength)
-		r.Body.Read(body)
+		b := make([]byte, r.ContentLength)
+		r.Body.Read(b)
+		select {
+		case captured <- capturedRequest{sig: r.Header.Get("X-DocStore-Signature"), body: b}:
+		default:
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer webhook.Close()
@@ -272,20 +278,19 @@ func TestWebhook_HMACSignatureValid(t *testing.T) {
 	}
 
 	// Wait for webhook.
-	deadline := time.Now().Add(15 * time.Second)
-	for time.Now().Before(deadline) && sigHeader == "" {
-		time.Sleep(100 * time.Millisecond)
-	}
-	if sigHeader == "" {
+	var cap capturedRequest
+	select {
+	case cap = <-captured:
+	case <-time.After(15 * time.Second):
 		t.Fatal("webhook not received within timeout")
 	}
 
 	// Verify HMAC.
 	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write(body)
+	mac.Write(cap.body)
 	expected := "sha256=" + hex.EncodeToString(mac.Sum(nil))
-	if sigHeader != expected {
-		t.Errorf("HMAC mismatch: got %q, expected %q", sigHeader, expected)
+	if cap.sig != expected {
+		t.Errorf("HMAC mismatch: got %q, expected %q", cap.sig, expected)
 	}
 }
 
@@ -296,10 +301,11 @@ func TestWebhook_RetriedOnFailure(t *testing.T) {
 	db.Exec(`INSERT INTO roles (repo, identity, role) VALUES ('default/default', 'test@example.com', 'admin') ON CONFLICT DO NOTHING`)
 
 	var callCount int64
-	fail := true
+	var fail atomic.Bool
+	fail.Store(true)
 	webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&callCount, 1)
-		if fail {
+		if fail.Load() {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -336,7 +342,7 @@ func TestWebhook_RetriedOnFailure(t *testing.T) {
 	}
 
 	// Now succeed.
-	fail = false
+	fail.Store(false)
 
 	// Reset next_attempt so the dispatcher retries immediately.
 	db.ExecContext(context.Background(), `UPDATE event_outbox SET next_attempt = now() - interval '1 second'`)

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -1,0 +1,388 @@
+package server_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	dbpkg "github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/events"
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/server"
+	"github.com/dlorenc/docstore/internal/testutil"
+	"github.com/lib/pq"
+)
+
+// newEventTestServer creates a server with an event broker wired.
+func newEventTestServer(t *testing.T, db *sql.DB) (*httptest.Server, *events.Broker) {
+	t.Helper()
+	store := dbpkg.NewStore(db)
+	broker := events.NewBroker(db)
+	handler := server.NewWithBroker(store, db, nil, broker, "test@example.com", "test@example.com")
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv, broker
+}
+
+// seedForEvents inserts the minimum rows needed for SSE/webhook tests.
+func seedForEvents(t *testing.T, db *sql.DB) {
+	t.Helper()
+	stmts := []string{
+		`INSERT INTO orgs (name) VALUES ('default') ON CONFLICT DO NOTHING`,
+		`INSERT INTO repos (name, owner) VALUES ('default/default', 'default') ON CONFLICT DO NOTHING`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("seed: %v\n%s", err, s)
+		}
+	}
+}
+
+func TestSSE_ReceivesEventsOnCommit(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seedForEvents(t, db)
+	// Give default/default a role for the identity "test@example.com".
+	db.Exec(`INSERT INTO roles (repo, identity, role) VALUES ('default/default', 'test@example.com', 'admin') ON CONFLICT DO NOTHING`)
+
+	srv, _ := newEventTestServer(t, db)
+
+	// Open SSE stream.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
+		srv.URL+"/repos/default/default/-/events", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("SSE connect: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	// In a goroutine, post a commit.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		commitBody, _ := json.Marshal(model.CommitRequest{
+			Branch:  "main",
+			Message: "test commit",
+			Files:   []model.FileChange{{Path: "x.txt", Content: []byte("hello")}},
+		})
+		http.Post(srv.URL+"/repos/default/default/-/commit",
+			"application/json", bytes.NewReader(commitBody))
+	}()
+
+	// Read the SSE stream looking for the commit.created event.
+	scanner := bufio.NewScanner(resp.Body)
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if !scanner.Scan() {
+			break
+		}
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data: ") {
+			data := strings.TrimPrefix(line, "data: ")
+			var env map[string]any
+			if err := json.Unmarshal([]byte(data), &env); err != nil {
+				continue
+			}
+			if env["type"] == "com.docstore.commit.created" {
+				return // success
+			}
+		}
+	}
+	t.Fatal("did not receive commit.created event on SSE stream")
+}
+
+func TestSSE_FilterByType(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seedForEvents(t, db)
+	db.Exec(`INSERT INTO roles (repo, identity, role) VALUES ('default/default', 'test@example.com', 'admin') ON CONFLICT DO NOTHING`)
+
+	srv, broker := newEventTestServer(t, db)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Subscribe only to branch.created.
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
+		srv.URL+"/repos/default/default/-/events?types=com.docstore.branch.created", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("SSE connect: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Emit a commit event (should be filtered out) then a branch event.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		// Emit commit (should not appear in stream).
+		broker.Emit(context.Background(), &commitCreatedStub{repo: "default/default"})
+		time.Sleep(50 * time.Millisecond)
+		// Emit branch.created (should appear).
+		broker.Emit(context.Background(), &branchCreatedStub{repo: "default/default"})
+	}()
+
+	scanner := bufio.NewScanner(resp.Body)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !scanner.Scan() {
+			break
+		}
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data: ") {
+			data := strings.TrimPrefix(line, "data: ")
+			var env map[string]any
+			if err := json.Unmarshal([]byte(data), &env); err != nil {
+				continue
+			}
+			evType, _ := env["type"].(string)
+			if evType == "com.docstore.commit.created" {
+				t.Error("received commit.created event that should have been filtered")
+			}
+			if evType == "com.docstore.branch.created" {
+				return // success
+			}
+		}
+	}
+	t.Fatal("did not receive branch.created event")
+}
+
+// Stub event types for testing.
+type commitCreatedStub struct{ repo string }
+
+func (e *commitCreatedStub) Type() string   { return "com.docstore.commit.created" }
+func (e *commitCreatedStub) Source() string { return "/repos/" + e.repo }
+func (e *commitCreatedStub) Data() any      { return e }
+
+type branchCreatedStub struct{ repo string }
+
+func (e *branchCreatedStub) Type() string   { return "com.docstore.branch.created" }
+func (e *branchCreatedStub) Source() string { return "/repos/" + e.repo }
+func (e *branchCreatedStub) Data() any      { return e }
+
+func TestWebhook_DeliveredAfterMutation(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seedForEvents(t, db)
+	db.Exec(`INSERT INTO roles (repo, identity, role) VALUES ('default/default', 'test@example.com', 'admin') ON CONFLICT DO NOTHING`)
+
+	// Webhook target.
+	var receivedCount int64
+	webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&receivedCount, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer webhook.Close()
+
+	// Insert subscription.
+	config, _ := json.Marshal(map[string]string{"url": webhook.URL, "secret": ""})
+	db.Exec(`
+		INSERT INTO event_subscriptions (backend, config, created_by, event_types)
+		VALUES ('webhook', $1, 'test', $2)`,
+		config, pq.Array([]string{"com.docstore.commit.created"}))
+
+	srv, _ := newEventTestServer(t, db)
+
+	// Start the outbox dispatcher.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events.StartDispatcher(ctx, db)
+
+	// Post a commit.
+	commitBody, _ := json.Marshal(model.CommitRequest{
+		Branch:  "main",
+		Message: "test",
+		Files:   []model.FileChange{{Path: "x.txt", Content: []byte("x")}},
+	})
+	resp, err := http.Post(srv.URL+"/repos/default/default/-/commit",
+		"application/json", bytes.NewReader(commitBody))
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+
+	// Wait for webhook delivery.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt64(&receivedCount) > 0 {
+			return // success
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("webhook was not delivered within timeout; received count = %d", atomic.LoadInt64(&receivedCount))
+}
+
+func TestWebhook_HMACSignatureValid(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seedForEvents(t, db)
+	db.Exec(`INSERT INTO roles (repo, identity, role) VALUES ('default/default', 'test@example.com', 'admin') ON CONFLICT DO NOTHING`)
+
+	const secret = "my-hmac-secret"
+	var sigHeader string
+	var body []byte
+
+	webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sigHeader = r.Header.Get("X-DocStore-Signature")
+		body = make([]byte, r.ContentLength)
+		r.Body.Read(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer webhook.Close()
+
+	config, _ := json.Marshal(map[string]string{"url": webhook.URL, "secret": secret})
+	db.Exec(`
+		INSERT INTO event_subscriptions (backend, config, created_by)
+		VALUES ('webhook', $1, 'test')`, config)
+
+	srv, _ := newEventTestServer(t, db)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events.StartDispatcher(ctx, db)
+
+	commitBody, _ := json.Marshal(model.CommitRequest{
+		Branch:  "main",
+		Message: "test",
+		Files:   []model.FileChange{{Path: "x.txt", Content: []byte("x")}},
+	})
+	resp, _ := http.Post(srv.URL+"/repos/default/default/-/commit",
+		"application/json", bytes.NewReader(commitBody))
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	// Wait for webhook.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) && sigHeader == "" {
+		time.Sleep(100 * time.Millisecond)
+	}
+	if sigHeader == "" {
+		t.Fatal("webhook not received within timeout")
+	}
+
+	// Verify HMAC.
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	expected := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if sigHeader != expected {
+		t.Errorf("HMAC mismatch: got %q, expected %q", sigHeader, expected)
+	}
+}
+
+func TestWebhook_RetriedOnFailure(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seedForEvents(t, db)
+	db.Exec(`INSERT INTO roles (repo, identity, role) VALUES ('default/default', 'test@example.com', 'admin') ON CONFLICT DO NOTHING`)
+
+	var callCount int64
+	fail := true
+	webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&callCount, 1)
+		if fail {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer webhook.Close()
+
+	config, _ := json.Marshal(map[string]string{"url": webhook.URL, "secret": ""})
+	db.Exec(`
+		INSERT INTO event_subscriptions (backend, config, created_by)
+		VALUES ('webhook', $1, 'test')`, config)
+
+	srv, _ := newEventTestServer(t, db)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events.StartDispatcher(ctx, db)
+
+	commitBody, _ := json.Marshal(model.CommitRequest{
+		Branch:  "main",
+		Message: "test",
+		Files:   []model.FileChange{{Path: "x.txt", Content: []byte("x")}},
+	})
+	resp, _ := http.Post(srv.URL+"/repos/default/default/-/commit",
+		"application/json", bytes.NewReader(commitBody))
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	// Wait for first failure.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) && atomic.LoadInt64(&callCount) == 0 {
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Now succeed.
+	fail = false
+
+	// Reset next_attempt so the dispatcher retries immediately.
+	db.ExecContext(context.Background(), `UPDATE event_outbox SET next_attempt = now() - interval '1 second'`)
+
+	// Wait for successful delivery.
+	deadline = time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		var deliveredCount int
+		db.QueryRowContext(context.Background(),
+			`SELECT COUNT(*) FROM event_outbox WHERE delivered_at IS NOT NULL`).Scan(&deliveredCount)
+		if deliveredCount > 0 {
+			return // success
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("webhook was never delivered after retry; call count = %d", atomic.LoadInt64(&callCount))
+}
+
+func TestSubscription_AdminOnly(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seedForEvents(t, db)
+
+	// Create server with no global admin (empty bootstrapAdmin).
+	store := dbpkg.NewStore(db)
+	broker := events.NewBroker(db)
+	handler := server.NewWithBroker(store, db, nil, broker, "test@example.com", "")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	config, _ := json.Marshal(map[string]string{"url": "https://example.com", "secret": ""})
+	body, _ := json.Marshal(map[string]any{
+		"backend": "webhook",
+		"config":  json.RawMessage(config),
+	})
+
+	resp, err := http.Post(srv.URL+"/subscriptions", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /subscriptions: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+// Use pq to silence the import.
+var _ = pq.Array

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/events"
+	evtypes "github.com/dlorenc/docstore/internal/events/types"
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/policy"
 	"github.com/dlorenc/docstore/internal/store"
@@ -237,6 +239,13 @@ func (s *server) handleReposPrefix(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		}
 
+	case endpoint == "events":
+		if r.Method == http.MethodGet {
+			s.handleSSERepoEvents(w, r)
+		} else {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+
 	default:
 		writeError(w, http.StatusNotFound, "not found")
 	}
@@ -273,6 +282,7 @@ func (s *server) handleCreateOrg(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	s.emit(r.Context(), evtypes.OrgCreated{Org: org.Name, CreatedBy: identity})
 	writeJSON(w, http.StatusCreated, org)
 }
 
@@ -320,6 +330,7 @@ func (s *server) handleDeleteOrg(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	s.emit(r.Context(), evtypes.OrgDeleted{Org: name, DeletedBy: IdentityFromContext(r.Context())})
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -673,6 +684,13 @@ func (s *server) handleReview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.emit(r.Context(), evtypes.ReviewSubmitted{
+		Repo:     repo,
+		Branch:   req.Branch,
+		Sequence: review.Sequence,
+		Reviewer: reviewer,
+		Status:   string(req.Status),
+	})
 	slog.Info("review submitted", "repo", repo, "branch", req.Branch, "reviewer", reviewer, "status", req.Status)
 	writeJSON(w, http.StatusCreated, model.CreateReviewResponse{
 		ID:       review.ID,
@@ -715,6 +733,14 @@ func (s *server) handleCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.emit(r.Context(), evtypes.CheckReported{
+		Repo:      repo,
+		Branch:    req.Branch,
+		Sequence:  cr.Sequence,
+		CheckName: req.CheckName,
+		Status:    string(req.Status),
+		Reporter:  reporter,
+	})
 	writeJSON(w, http.StatusCreated, model.CreateCheckRunResponse{
 		ID:       cr.ID,
 		Sequence: cr.Sequence,
@@ -909,7 +935,9 @@ func (s *server) handleCreateRepo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("repo created", "repo", repo.Name, "by", IdentityFromContext(r.Context()))
+	identity := IdentityFromContext(r.Context())
+	s.emit(r.Context(), evtypes.RepoCreated{Repo: repo.Name, Owner: repo.Owner, CreatedBy: identity})
+	slog.Info("repo created", "repo", repo.Name, "by", identity)
 	writeJSON(w, http.StatusCreated, repo)
 }
 
@@ -957,7 +985,9 @@ func (s *server) handleDeleteRepo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("repo deleted", "repo", name, "by", IdentityFromContext(r.Context()))
+	identity := IdentityFromContext(r.Context())
+	s.emit(r.Context(), evtypes.RepoDeleted{Repo: name, DeletedBy: identity})
+	slog.Info("repo deleted", "repo", name, "by", identity)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -1227,7 +1257,14 @@ func (s *server) handleCreateBranch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("branch created", "repo", repo, "branch", req.Name, "by", IdentityFromContext(r.Context()))
+	identity := IdentityFromContext(r.Context())
+	s.emit(r.Context(), evtypes.BranchCreated{
+		Repo:         repo,
+		Branch:       req.Name,
+		BaseSequence: resp.BaseSequence,
+		CreatedBy:    identity,
+	})
+	slog.Info("branch created", "repo", repo, "branch", req.Name, "by", identity)
 	writeJSON(w, http.StatusCreated, resp)
 }
 
@@ -1288,7 +1325,9 @@ func (s *server) handleDeleteBranch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("branch deleted", "repo", repo, "branch", bname, "by", IdentityFromContext(r.Context()))
+	identity := IdentityFromContext(r.Context())
+	s.emit(r.Context(), evtypes.BranchAbandoned{Repo: repo, Branch: bname, AbandonedBy: identity})
+	slog.Info("branch deleted", "repo", repo, "branch", bname, "by", identity)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -1336,7 +1375,14 @@ func (s *server) handleSetRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("role assigned", "repo", repo, "identity", identity, "role", req.Role, "by", IdentityFromContext(r.Context()))
+	by := IdentityFromContext(r.Context())
+	s.emit(r.Context(), evtypes.RoleChanged{
+		Repo:      repo,
+		Identity:  identity,
+		Role:      string(req.Role),
+		ChangedBy: by,
+	})
+	slog.Info("role assigned", "repo", repo, "identity", identity, "role", req.Role, "by", by)
 	writeJSON(w, http.StatusOK, model.Role{Identity: identity, Role: req.Role})
 }
 
@@ -1361,7 +1407,14 @@ func (s *server) handleDeleteRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("role removed", "repo", repo, "identity", identity, "by", IdentityFromContext(r.Context()))
+	by := IdentityFromContext(r.Context())
+	s.emit(r.Context(), evtypes.RoleChanged{
+		Repo:      repo,
+		Identity:  identity,
+		Role:      "", // empty means removed
+		ChangedBy: by,
+	})
+	slog.Info("role removed", "repo", repo, "identity", identity, "by", by)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -1416,6 +1469,14 @@ func (s *server) handleRebase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.emit(r.Context(), evtypes.BranchRebased{
+		Repo:            repo,
+		Branch:          req.Branch,
+		NewBaseSequence: resp.NewBaseSequence,
+		NewHeadSequence: resp.NewHeadSequence,
+		CommitsReplayed: resp.CommitsReplayed,
+		RebasedBy:       req.Author,
+	})
 	slog.Info("branch rebased", "repo", repo, "branch", req.Branch, "by", req.Author, "commits_replayed", resp.CommitsReplayed)
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -1453,6 +1514,17 @@ func (s *server) handleMerge(w http.ResponseWriter, r *http.Request) {
 		return
 	} else if denied != nil {
 		slog.Warn("merge denied by policy", "repo", repo, "branch", req.Branch, "actor", req.Author)
+		// Collect policy names for event.
+		policyNames := make([]string, len(denied))
+		for i, p := range denied {
+			policyNames[i] = p.Name
+		}
+		s.emit(r.Context(), evtypes.MergeBlocked{
+			Repo:     repo,
+			Branch:   req.Branch,
+			Actor:    req.Author,
+			Policies: policyNames,
+		})
 		writeJSON(w, http.StatusForbidden, model.MergePolicyError{Policies: denied})
 		return
 	}
@@ -1490,6 +1562,12 @@ func (s *server) handleMerge(w http.ResponseWriter, r *http.Request) {
 		s.policyCache.Invalidate(repo)
 	}
 
+	s.emit(r.Context(), evtypes.BranchMerged{
+		Repo:     repo,
+		Branch:   req.Branch,
+		Sequence: resp.Sequence,
+		MergedBy: req.Author,
+	})
 	slog.Info("branch merged", "repo", repo, "branch", req.Branch, "by", req.Author, "sequence", resp.Sequence)
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -1952,4 +2030,196 @@ func (s *server) handleChain(w http.ResponseWriter, r *http.Request) {
 		entries = []store.ChainEntry{}
 	}
 	writeJSON(w, http.StatusOK, entries)
+}
+
+// ---------------------------------------------------------------------------
+// Event subscription handlers (admin only)
+// ---------------------------------------------------------------------------
+
+// handleCreateSubscription implements POST /subscriptions
+func (s *server) handleCreateSubscription(w http.ResponseWriter, r *http.Request) {
+	if !s.requireGlobalAdmin(w, r) {
+		return
+	}
+
+	var req model.CreateSubscriptionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Backend == "" {
+		writeError(w, http.StatusBadRequest, "backend is required")
+		return
+	}
+	if req.Backend != "webhook" {
+		writeError(w, http.StatusBadRequest, "only backend='webhook' is supported in Milestone 1")
+		return
+	}
+	if len(req.Config) == 0 {
+		writeError(w, http.StatusBadRequest, "config is required")
+		return
+	}
+	req.CreatedBy = IdentityFromContext(r.Context())
+
+	sub, err := s.commitStore.CreateSubscription(r.Context(), req)
+	if err != nil {
+		slog.Error("internal error", "op", "create_subscription", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	slog.Info("subscription created", "id", sub.ID, "backend", sub.Backend, "by", req.CreatedBy)
+	writeJSON(w, http.StatusCreated, sub)
+}
+
+// handleListSubscriptions implements GET /subscriptions
+func (s *server) handleListSubscriptions(w http.ResponseWriter, r *http.Request) {
+	if !s.requireGlobalAdmin(w, r) {
+		return
+	}
+
+	subs, err := s.commitStore.ListSubscriptions(r.Context())
+	if err != nil {
+		slog.Error("internal error", "op", "list_subscriptions", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	if subs == nil {
+		subs = []model.EventSubscription{}
+	}
+	writeJSON(w, http.StatusOK, model.ListSubscriptionsResponse{Subscriptions: subs})
+}
+
+// handleDeleteSubscription implements DELETE /subscriptions/{id}
+func (s *server) handleDeleteSubscription(w http.ResponseWriter, r *http.Request) {
+	if !s.requireGlobalAdmin(w, r) {
+		return
+	}
+
+	id := r.PathValue("id")
+	if err := s.commitStore.DeleteSubscription(r.Context(), id); err != nil {
+		switch {
+		case errors.Is(err, db.ErrSubscriptionNotFound):
+			writeError(w, http.StatusNotFound, "subscription not found")
+		default:
+			slog.Error("internal error", "op", "delete_subscription", "id", id, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	slog.Info("subscription deleted", "id", id, "by", IdentityFromContext(r.Context()))
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleResumeSubscription implements POST /subscriptions/{id}/resume
+func (s *server) handleResumeSubscription(w http.ResponseWriter, r *http.Request) {
+	if !s.requireGlobalAdmin(w, r) {
+		return
+	}
+
+	id := r.PathValue("id")
+	if err := s.commitStore.ResumeSubscription(r.Context(), id); err != nil {
+		switch {
+		case errors.Is(err, db.ErrSubscriptionNotFound):
+			writeError(w, http.StatusNotFound, "subscription not found")
+		default:
+			slog.Error("internal error", "op", "resume_subscription", "id", id, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	slog.Info("subscription resumed", "id", id, "by", IdentityFromContext(r.Context()))
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ---------------------------------------------------------------------------
+// SSE streaming handlers
+// ---------------------------------------------------------------------------
+
+// handleSSERepoEvents implements GET /repos/{name}/-/events
+// Streams CloudEvents for a specific repo. Optional ?types= comma-separated
+// full event type filter (e.g. "com.docstore.commit.created").
+func (s *server) handleSSERepoEvents(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+	s.streamSSE(w, r, repo)
+}
+
+// handleSSEGlobalEvents implements GET /events (admin only)
+// Streams CloudEvents for all repos or a specific repo via ?repo= filter.
+func (s *server) handleSSEGlobalEvents(w http.ResponseWriter, r *http.Request) {
+	if !s.requireGlobalAdmin(w, r) {
+		return
+	}
+	// Optional repo filter.
+	repo := r.URL.Query().Get("repo")
+	if repo == "" {
+		repo = "*" // wildcard: receive events from all repos
+	}
+	s.streamSSE(w, r, repo)
+}
+
+// streamSSE is the shared SSE streaming implementation.
+// repo is the repo to subscribe to (or "*" for global admin stream).
+func (s *server) streamSSE(w http.ResponseWriter, r *http.Request, repo string) {
+	if s.broker == nil {
+		writeError(w, http.StatusServiceUnavailable, "event streaming not available")
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	// Parse optional type filter.
+	var types []string
+	if q := r.URL.Query().Get("types"); q != "" {
+		for _, t := range strings.Split(q, ",") {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				types = append(types, t)
+			}
+		}
+	}
+
+	ch, unsub := s.broker.Subscribe(repo, types)
+	defer unsub()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	keepAlive := time.NewTicker(15 * time.Second)
+	defer keepAlive.Stop()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-keepAlive.C:
+			fmt.Fprint(w, ": keepalive\n\n")
+			flusher.Flush()
+		case e, ok := <-ch:
+			if !ok {
+				return
+			}
+			data, err := events.ToCloudEvent(e)
+			if err != nil {
+				slog.Error("SSE: serialize event failed", "error", err)
+				continue
+			}
+			fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
+		}
+	}
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -2059,6 +2060,27 @@ func (s *server) handleCreateSubscription(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusBadRequest, "config is required")
 		return
 	}
+
+	// Validate webhook config: url must be present and an http/https URL.
+	var webhookConfig map[string]string
+	if err := json.Unmarshal(req.Config, &webhookConfig); err != nil {
+		writeError(w, http.StatusBadRequest, "config must be a JSON object")
+		return
+	}
+	webhookURL, ok := webhookConfig["url"]
+	if !ok || webhookURL == "" {
+		writeError(w, http.StatusBadRequest, "config.url is required for webhook backend")
+		return
+	}
+	parsedURL, err := url.ParseRequestURI(webhookURL)
+	if err != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
+		writeError(w, http.StatusBadRequest, "config.url must be a valid http or https URL")
+		return
+	}
+	if webhookConfig["secret"] == "" {
+		slog.Warn("subscription created without webhook secret", "url", webhookURL)
+	}
+
 	req.CreatedBy = IdentityFromContext(r.Context())
 
 	sub, err := s.commitStore.CreateSubscription(r.Context(), req)

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -74,6 +74,15 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 	return n, err
 }
 
+// Flush implements http.Flusher by forwarding to the underlying writer if it
+// supports flushing. This is required for SSE streaming to work through the
+// RequestLogger middleware.
+func (rw *responseWriter) Flush() {
+	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // repoFromPath extracts the repo name from any /repos/:name... URL path.
 // Returns "" for non-repo paths.
 func repoFromPath(path string) string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/dlorenc/docstore/internal/blob"
 	"github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/events"
+	evtypes "github.com/dlorenc/docstore/internal/events/types"
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/policy"
 	"github.com/dlorenc/docstore/internal/store"
@@ -96,6 +98,12 @@ type WriteStore interface {
 	// CommitSequenceExists reports whether the given sequence number exists in
 	// the commits table for repo. Used to validate release sequence references.
 	CommitSequenceExists(ctx context.Context, repo string, sequence int64) (bool, error)
+
+	// Event subscription management
+	CreateSubscription(ctx context.Context, req model.CreateSubscriptionRequest) (*model.EventSubscription, error)
+	ListSubscriptions(ctx context.Context) ([]model.EventSubscription, error)
+	DeleteSubscription(ctx context.Context, id string) error
+	ResumeSubscription(ctx context.Context, id string) error
 }
 
 // CommitStore is an alias for backward compatibility with tests.
@@ -107,17 +115,28 @@ type CommitStore = WriteStore
 // writeStore provides write operations; pass nil if only read/health endpoints are needed.
 // database provides read operations; pass nil if only write/health endpoints are needed.
 func New(writeStore WriteStore, database *sql.DB, devIdentity, bootstrapAdmin string) http.Handler {
-	return newServer(writeStore, database, nil, devIdentity, bootstrapAdmin)
+	return newServer(writeStore, database, nil, nil, devIdentity, bootstrapAdmin)
 }
 
 // NewWithBlobStore is like New but also wires a BlobStore into the read store
 // so that files stored externally can be fetched by the file endpoint.
 func NewWithBlobStore(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, devIdentity, bootstrapAdmin string) http.Handler {
-	return newServer(writeStore, database, bs, devIdentity, bootstrapAdmin)
+	return newServer(writeStore, database, bs, nil, devIdentity, bootstrapAdmin)
 }
 
-func newServer(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, devIdentity, bootstrapAdmin string) http.Handler {
-	s := &server{commitStore: writeStore, policyCache: policy.NewCache()}
+// NewWithBroker is like NewWithBlobStore but also wires an event Broker.
+// Use this in production so mutation handlers can emit events.
+func NewWithBroker(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker, devIdentity, bootstrapAdmin string) http.Handler {
+	return newServer(writeStore, database, bs, broker, devIdentity, bootstrapAdmin)
+}
+
+func newServer(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker, devIdentity, bootstrapAdmin string) http.Handler {
+	s := &server{
+		commitStore: writeStore,
+		policyCache: policy.NewCache(),
+		broker:      broker,
+		globalAdmin: bootstrapAdmin,
+	}
 	if database != nil {
 		rs := store.New(database)
 		if bs != nil {
@@ -168,6 +187,15 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 	//   GET  /repos/acme/myrepo          (bare: GET/DELETE a repo)
 	inner.Handle("/repos/", http.HandlerFunc(s.handleReposPrefix))
 
+	// Event subscription management (global, admin only).
+	inner.HandleFunc("POST /subscriptions", s.handleCreateSubscription)
+	inner.HandleFunc("GET /subscriptions", s.handleListSubscriptions)
+	inner.HandleFunc("DELETE /subscriptions/{id}", s.handleDeleteSubscription)
+	inner.HandleFunc("POST /subscriptions/{id}/resume", s.handleResumeSubscription)
+
+	// Global SSE stream (admin only).
+	inner.HandleFunc("GET /events", s.handleSSEGlobalEvents)
+
 	// Chain: IAPMiddleware → RBACMiddleware (when store present) → routes.
 	// IAP must run first to set identity in context before RBAC reads it.
 	var routed http.Handler = inner
@@ -182,6 +210,10 @@ type server struct {
 	commitStore CommitStore
 	readStore   readStore
 	policyCache policyCache
+	broker      *events.Broker
+	// globalAdmin is the identity that may manage global resources like
+	// event subscriptions. Corresponds to the --bootstrap-admin flag.
+	globalAdmin string
 }
 
 func (s *server) handleCommit(w http.ResponseWriter, r *http.Request) {
@@ -239,8 +271,39 @@ func (s *server) handleCommit(w http.ResponseWriter, r *http.Request) {
 		s.policyCache.Invalidate(repo)
 	}
 
+	s.emit(r.Context(), evtypes.CommitCreated{
+		Repo:      repo,
+		Branch:    req.Branch,
+		Sequence:  resp.Sequence,
+		Author:    req.Author,
+		Message:   req.Message,
+		FileCount: len(req.Files),
+	})
+
 	slog.Info("commit created", "repo", repo, "branch", req.Branch, "sequence", resp.Sequence, "files", len(req.Files), "author", req.Author)
 	writeJSON(w, http.StatusCreated, resp)
+}
+
+// emit publishes an event to the broker if one is configured.
+func (s *server) emit(ctx context.Context, e events.Event) {
+	if s.broker != nil {
+		s.broker.Emit(ctx, e)
+	}
+}
+
+// requireGlobalAdmin checks that the current identity is the global admin.
+// Returns false and writes 403 if not.
+func (s *server) requireGlobalAdmin(w http.ResponseWriter, r *http.Request) bool {
+	if s.globalAdmin == "" {
+		writeError(w, http.StatusForbidden, "forbidden: no global admin configured")
+		return false
+	}
+	identity := IdentityFromContext(r.Context())
+	if identity != s.globalAdmin {
+		writeError(w, http.StatusForbidden, "forbidden: global admin required")
+		return false
+	}
+	return true
 }
 
 func handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -60,6 +60,11 @@ type mockStore struct {
 	listReleasesFn         func(ctx context.Context, repo string, limit int, afterID string) ([]model.Release, error)
 	deleteReleaseFn        func(ctx context.Context, repo, name string) error
 	commitSequenceExistsFn func(ctx context.Context, repo string, sequence int64) (bool, error)
+
+	createSubscriptionFn func(ctx context.Context, req model.CreateSubscriptionRequest) (*model.EventSubscription, error)
+	listSubscriptionsFn  func(ctx context.Context) ([]model.EventSubscription, error)
+	deleteSubscriptionFn func(ctx context.Context, id string) error
+	resumeSubscriptionFn func(ctx context.Context, id string) error
 }
 
 func (m *mockStore) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
@@ -326,6 +331,34 @@ func (m *mockStore) CommitSequenceExists(ctx context.Context, repo string, seque
 		return m.commitSequenceExistsFn(ctx, repo, sequence)
 	}
 	return true, nil
+}
+
+func (m *mockStore) CreateSubscription(ctx context.Context, req model.CreateSubscriptionRequest) (*model.EventSubscription, error) {
+	if m.createSubscriptionFn != nil {
+		return m.createSubscriptionFn(ctx, req)
+	}
+	return &model.EventSubscription{ID: "test-sub-id", Backend: req.Backend}, nil
+}
+
+func (m *mockStore) ListSubscriptions(ctx context.Context) ([]model.EventSubscription, error) {
+	if m.listSubscriptionsFn != nil {
+		return m.listSubscriptionsFn(ctx)
+	}
+	return []model.EventSubscription{}, nil
+}
+
+func (m *mockStore) DeleteSubscription(ctx context.Context, id string) error {
+	if m.deleteSubscriptionFn != nil {
+		return m.deleteSubscriptionFn(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockStore) ResumeSubscription(ctx context.Context, id string) error {
+	if m.resumeSubscriptionFn != nil {
+		return m.resumeSubscriptionFn(ctx, id)
+	}
+	return nil
 }
 
 func TestHealthEndpoint(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements issue #41 Milestone 1 — core eventing system with broker, SSE streaming, and webhook delivery.

- **`internal/events` package**: `Event` interface, CloudEvents 1.0 serialization (`ToCloudEvent`), in-process `Broker` for SSE fan-out, outbox dispatcher goroutine for webhook delivery with HMAC-SHA256 signatures and exponential backoff
- **13 event types** across `internal/events/types/`: commit, branch (created/merged/rebased/abandoned), review, check, merge.blocked, role.changed, org (created/deleted), repo (created/deleted)
- **DB schema additions** (appended to `000001_initial_schema.up.sql`): `event_subscriptions` and `event_outbox` tables
- **Subscription management API** (`POST/GET/DELETE /subscriptions`, `POST /subscriptions/{id}/resume`): admin-only, webhook backend only in M1
- **SSE endpoints**: `GET /repos/{name}/-/events` (reader+, optional `?types=` filter), `GET /events` (admin only, optional `?repo=` filter)
- **Broker emits** wired into all 13 mutation handlers
- **`http.Flusher` forwarding** added to `RequestLogger` middleware wrapper (needed for SSE through the middleware chain)
- **Graceful shutdown**: dispatcher goroutine cancelled on SIGTERM via context
- **OPERATIONS.md**: SSE horizontal scaling limitation documented

## Test plan

All tests pass (`go test ./... -count=1`):

- [x] `TestBroker_PublishAndReceive` — events delivered to subscribers
- [x] `TestBroker_ClientDisconnect` — no panic/leak on unsub before emit
- [x] `TestBroker_FilterByType` — type filter works correctly
- [x] `TestOutbox_InsertAndDeliver` — webhook delivered, row marked delivered
- [x] `TestOutbox_RetryOnFailure` — attempts incremented on 500 response
- [x] `TestOutbox_MaxAttemptsAutoSuspends` — subscription suspended after 10 failures
- [x] `TestOutbox_Cleanup` — rows > 7 days deleted
- [x] `TestCloudEvents_Schema` — all 13 types produce valid CloudEvents 1.0 JSON
- [x] `TestSSE_ReceivesEventsOnCommit` — SSE receives event after commit mutation
- [x] `TestSSE_FilterByType` — filtered SSE stream only receives matching types
- [x] `TestWebhook_DeliveredAfterMutation` — webhook received after commit
- [x] `TestWebhook_HMACSignatureValid` — HMAC-SHA256 signature verified
- [x] `TestWebhook_RetriedOnFailure` — webhook retried on initial 500, succeeds on retry
- [x] `TestSubscription_AdminOnly` — 403 when globalAdmin not configured

## Notes for future work

- Milestone 2 (GCP Pub/Sub backend): add `backend='pubsub'` support to `CreateSubscription` handler and dispatcher
- SSE at `--max-instances>1`: replace in-process broker with Pub/Sub-backed fan-out (see OPERATIONS.md)
- The `subscriptionRow` type in `outbox.go` and `createTestSubscription`/`insertSubscription` stubs in `outbox_test.go` can be cleaned up in M2

Closes #41 (Milestone 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)