### PR TITLE
ci-runner: Implement Milestone 2 — webhook trigger, run registry, auto-registration

### DIFF
--- a/cmd/ci-runner/cirunner_test.go
+++ b/cmd/ci-runner/cirunner_test.go
@@ -346,6 +346,26 @@ func TestWebhookHandler_InvalidSignature(t *testing.T) {
 	}
 }
 
+func TestWebhookHandler_MissingSignature(t *testing.T) {
+	const secret = "test-secret"
+	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, secret)
+
+	body := buildWebhookBody(t, "com.docstore.commit.created", map[string]any{
+		"repo":   "default/myrepo",
+		"branch": "feature/x",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/cloudevents+json")
+	// No X-DocStore-Signature header
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
 func TestWebhookHandler_UnknownEventType(t *testing.T) {
 	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, "")
 

--- a/cmd/ci-runner/cirunner_test.go
+++ b/cmd/ci-runner/cirunner_test.go
@@ -155,7 +155,7 @@ func TestPostCheckRun_ServerError(t *testing.T) {
 func TestPostRunHandler_ReturnsRunID(t *testing.T) {
 	// Use a nil executor and logstore (the goroutine won't do anything useful
 	// but the handler itself should return 200 with a run_id immediately).
-	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute)
+	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, "")
 
 	body := `{"repo":"default/myrepo","branch":"feature/x","head_sequence":42}`
 	req := httptest.NewRequest(http.MethodPost, "/run", strings.NewReader(body))
@@ -176,7 +176,7 @@ func TestPostRunHandler_ReturnsRunID(t *testing.T) {
 }
 
 func TestPostRunHandler_MissingRepo(t *testing.T) {
-	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute)
+	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, "")
 
 	req := httptest.NewRequest(http.MethodPost, "/run", strings.NewReader(`{"branch":"feature/x"}`))
 	rec := httptest.NewRecorder()
@@ -188,7 +188,7 @@ func TestPostRunHandler_MissingRepo(t *testing.T) {
 }
 
 func TestPostRunHandler_MissingBranch(t *testing.T) {
-	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute)
+	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, "")
 
 	req := httptest.NewRequest(http.MethodPost, "/run", strings.NewReader(`{"repo":"default/myrepo"}`))
 	rec := httptest.NewRecorder()
@@ -271,3 +271,189 @@ func TestPullBranchSource_DownloadsFiles(t *testing.T) {
 
 // Ensure executor.Config is imported (used in fetchConfig).
 var _ executor.Config
+
+// ---------------------------------------------------------------------------
+// POST /webhook handler tests
+// ---------------------------------------------------------------------------
+
+func buildWebhookBody(t *testing.T, eventType string, data any) []byte {
+	t.Helper()
+	dataJSON, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal data: %v", err)
+	}
+	env := map[string]any{
+		"specversion":     "1.0",
+		"type":            eventType,
+		"source":          "/repos/default/myrepo",
+		"id":              "test-id",
+		"time":            "2024-01-01T00:00:00Z",
+		"datacontenttype": "application/json",
+		"data":            json.RawMessage(dataJSON),
+	}
+	body, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	return body
+}
+
+func signBody(body []byte, secret string) string {
+	return "sha256=" + computeHMACHex(body, secret)
+}
+
+func TestWebhookHandler_ValidSignature(t *testing.T) {
+	const secret = "test-secret"
+	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, secret)
+
+	body := buildWebhookBody(t, "com.docstore.commit.created", map[string]any{
+		"repo":       "default/myrepo",
+		"branch":     "feature/x",
+		"sequence":   int64(42),
+		"author":     "alice",
+		"message":    "add feature",
+		"file_count": 1,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/cloudevents+json")
+	req.Header.Set("X-DocStore-Signature", signBody(body, secret))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestWebhookHandler_InvalidSignature(t *testing.T) {
+	const secret = "test-secret"
+	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, secret)
+
+	body := buildWebhookBody(t, "com.docstore.commit.created", map[string]any{
+		"repo":   "default/myrepo",
+		"branch": "feature/x",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/cloudevents+json")
+	req.Header.Set("X-DocStore-Signature", "sha256=badhash")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestWebhookHandler_UnknownEventType(t *testing.T) {
+	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, "")
+
+	body := buildWebhookBody(t, "com.docstore.branch.created", map[string]any{
+		"repo":   "default/myrepo",
+		"branch": "feature/x",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/cloudevents+json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for unknown event type, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GET /run/{run_id} handler tests
+// ---------------------------------------------------------------------------
+
+func TestGetRunStatus_NotFound(t *testing.T) {
+	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/run/nonexistent-id", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestRunStatus_TracksInFlight(t *testing.T) {
+	reg := newRunRegistry()
+
+	// Start a run.
+	reg.start("run-1", "default/myrepo", "feature/x", 42)
+
+	status, ok := reg.get("run-1")
+	if !ok {
+		t.Fatal("expected run-1 to exist in registry")
+	}
+	if status.State != "running" {
+		t.Errorf("state = %q, want running", status.State)
+	}
+	if status.Repo != "default/myrepo" {
+		t.Errorf("repo = %q, want default/myrepo", status.Repo)
+	}
+	if status.Branch != "feature/x" {
+		t.Errorf("branch = %q, want feature/x", status.Branch)
+	}
+	if status.HeadSeq != 42 {
+		t.Errorf("head_seq = %d, want 42", status.HeadSeq)
+	}
+
+	// Complete the run.
+	reg.complete("run-1", []executor.CheckResult{
+		{Name: "ci/build", Status: "passed", Logs: "ok"},
+	})
+
+	status, ok = reg.get("run-1")
+	if !ok {
+		t.Fatal("expected run-1 to still exist after completion")
+	}
+	if status.State != "done" {
+		t.Errorf("state = %q, want done", status.State)
+	}
+	if len(status.Checks) != 1 {
+		t.Errorf("checks count = %d, want 1", len(status.Checks))
+	}
+}
+
+func TestRunStatus_ViaHTTP(t *testing.T) {
+	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, "")
+
+	// Trigger a run via POST /run to register it in the registry.
+	runBody := `{"repo":"default/myrepo","branch":"feature/x","head_sequence":1}`
+	postReq := httptest.NewRequest(http.MethodPost, "/run", strings.NewReader(runBody))
+	postReq.Header.Set("Content-Type", "application/json")
+	postRec := httptest.NewRecorder()
+	mux.ServeHTTP(postRec, postReq)
+
+	if postRec.Code != http.StatusOK {
+		t.Fatalf("POST /run: expected 200, got %d", postRec.Code)
+	}
+	var runResp runResponse
+	if err := json.NewDecoder(postRec.Body).Decode(&runResp); err != nil {
+		t.Fatalf("decode run response: %v", err)
+	}
+
+	// Poll GET /run/{run_id} — run should be visible immediately (at least as "running").
+	getReq := httptest.NewRequest(http.MethodGet, "/run/"+runResp.RunID, nil)
+	getRec := httptest.NewRecorder()
+	mux.ServeHTTP(getRec, getReq)
+
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET /run/{id}: expected 200, got %d; body: %s", getRec.Code, getRec.Body.String())
+	}
+	var status RunStatus
+	if err := json.NewDecoder(getRec.Body).Decode(&status); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if status.RunID != runResp.RunID {
+		t.Errorf("run_id = %q, want %q", status.RunID, runResp.RunID)
+	}
+	if status.State == "" {
+		t.Error("expected non-empty state")
+	}
+}

--- a/cmd/ci-runner/e2e_test.go
+++ b/cmd/ci-runner/e2e_test.go
@@ -1,0 +1,229 @@
+//go:build e2e
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	dbpkg "github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/events"
+	"github.com/dlorenc/docstore/internal/executor"
+	"github.com/dlorenc/docstore/internal/logstore"
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/server"
+	"github.com/dlorenc/docstore/internal/testutil"
+)
+
+// TestE2E_WebhookTriggersRun is a full end-to-end test that:
+//  1. Starts a real docstore server backed by a testcontainers postgres
+//  2. Starts a real ci-runner backed by a testcontainers buildkitd
+//  3. Creates a repo and commits a .docstore/ci.yaml to main
+//  4. Creates a branch and commits a source file to it
+//  5. Registers a webhook subscription pointing at the ci-runner
+//  6. Posts a commit to trigger a commit.created event via the outbox dispatcher
+//  7. Polls GET /run/{run_id} until the run is done or failed
+//  8. Asserts at least one check run was posted back to docstore
+//
+// Run with: go test ./cmd/ci-runner/ -tags=e2e -v -timeout=5m
+func TestE2E_WebhookTriggersRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	ctx := context.Background()
+
+	// --- 1. Start Postgres and docstore server ---
+	adminDSN, dbCleanup, err := testutil.StartSharedPostgres()
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(dbCleanup)
+
+	db := testutil.TestDBFromShared(t, adminDSN, dbpkg.RunMigrations)
+	store := dbpkg.NewStore(db)
+	broker := events.NewBroker(db)
+
+	const adminIdentity = "admin@test.example.com"
+	docstoreHandler := server.NewWithBroker(store, db, nil, broker, adminIdentity, adminIdentity)
+	docstoreSrv := httptest.NewServer(docstoreHandler)
+	t.Cleanup(docstoreSrv.Close)
+	t.Logf("docstore URL: %s", docstoreSrv.URL)
+
+	// Start the outbox dispatcher so webhook deliveries happen.
+	dispatchCtx, dispatchCancel := context.WithCancel(ctx)
+	t.Cleanup(dispatchCancel)
+	events.StartDispatcher(dispatchCtx, db)
+
+	// Admin HTTP client (sets IAP identity header).
+	adminClient := &http.Client{
+		Transport: &devTransport{base: http.DefaultTransport, identity: adminIdentity},
+	}
+
+	// --- 2. Start buildkitd and ci-runner ---
+	buildkitAddr, buildkitCleanup, err := testutil.StartBuildkit()
+	if err != nil {
+		t.Fatalf("start buildkitd: %v", err)
+	}
+	t.Cleanup(buildkitCleanup)
+
+	exec, err := executor.New(buildkitAddr)
+	if err != nil {
+		t.Fatalf("connect to buildkitd: %v", err)
+	}
+	t.Cleanup(func() { exec.Close() }) //nolint:errcheck
+
+	ls, _ := logstore.NewLocalLogStore(t.TempDir())
+	const webhookSecret = "e2e-test-secret"
+	runnerMux := newMux(ctx, exec, ls, docstoreSrv.URL, adminClient, 10*time.Minute, webhookSecret)
+	runnerSrv := httptest.NewServer(runnerMux)
+	t.Cleanup(runnerSrv.Close)
+	t.Logf("ci-runner URL: %s", runnerSrv.URL)
+
+	// --- 3. Seed docstore: create org, repo, and commit ci.yaml to main ---
+	mustPost(t, adminClient, docstoreSrv.URL+"/orgs",
+		map[string]any{"name": "e2e"})
+
+	mustPost(t, adminClient, docstoreSrv.URL+"/repos",
+		map[string]any{"name": "e2e/myrepo", "owner": "e2e"})
+
+	// Give admin role to adminIdentity on the repo.
+	mustPost(t, adminClient, docstoreSrv.URL+"/repos/e2e/myrepo/-/roles",
+		map[string]any{"identity": adminIdentity, "role": "admin"})
+
+	ciYAML := `checks:
+  - name: ci/hello
+    image: alpine
+    steps:
+      - echo "hello from e2e"
+`
+	mustCommit(t, adminClient, docstoreSrv.URL, "e2e/myrepo", "main",
+		"add ci config", []model.FileChange{
+			{Path: ".docstore/ci.yaml", Content: []byte(ciYAML)},
+		})
+
+	// --- 4. Create branch and commit a source file ---
+	mustPost(t, adminClient, docstoreSrv.URL+"/repos/e2e/myrepo/-/branch",
+		map[string]any{"name": "feature/e2e-test", "base": "main"})
+
+	commitResp := mustCommit(t, adminClient, docstoreSrv.URL, "e2e/myrepo", "feature/e2e-test",
+		"add source file", []model.FileChange{
+			{Path: "hello.txt", Content: []byte("hello world\n")},
+		})
+
+	t.Logf("branch commit sequence: %d", commitResp.Sequence)
+
+	// --- 5. Register webhook subscription pointing at ci-runner ---
+	cfgJSON, _ := json.Marshal(map[string]string{
+		"url":    runnerSrv.URL + "/webhook",
+		"secret": webhookSecret,
+	})
+	subBody, _ := json.Marshal(model.CreateSubscriptionRequest{
+		Backend:    "webhook",
+		EventTypes: []string{"com.docstore.commit.created"},
+		Config:     cfgJSON,
+	})
+	resp, err := adminClient.Post(
+		docstoreSrv.URL+"/subscriptions",
+		"application/json",
+		bytes.NewReader(subBody),
+	)
+	if err != nil {
+		t.Fatalf("create subscription: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create subscription: expected 201, got %d", resp.StatusCode)
+	}
+	t.Log("webhook subscription created")
+
+	// --- 6. Post another commit to trigger commit.created event ---
+	// The outbox dispatcher will deliver the event to the ci-runner webhook.
+	triggerResp := mustCommit(t, adminClient, docstoreSrv.URL, "e2e/myrepo", "feature/e2e-test",
+		"trigger ci run", []model.FileChange{
+			{Path: "trigger.txt", Content: []byte("trigger\n")},
+		})
+	t.Logf("trigger commit sequence: %d", triggerResp.Sequence)
+
+	// --- 7. Poll the docstore checks endpoint until checks appear ---
+	checksURL := fmt.Sprintf("%s/repos/e2e/myrepo/-/branch/feature/e2e-test/checks", docstoreSrv.URL)
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		time.Sleep(2 * time.Second)
+
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, checksURL, nil)
+		cr, err := adminClient.Do(req)
+		if err != nil {
+			t.Logf("poll checks: %v", err)
+			continue
+		}
+		var checksResp struct {
+			Checks []struct {
+				CheckName string `json:"check_name"`
+				Status    string `json:"status"`
+			} `json:"checks"`
+		}
+		_ = json.NewDecoder(cr.Body).Decode(&checksResp)
+		cr.Body.Close()
+
+		for _, c := range checksResp.Checks {
+			if c.CheckName == "ci/hello" && (c.Status == "passed" || c.Status == "failed") {
+				t.Logf("check ci/hello completed with status: %s", c.Status)
+				return // success
+			}
+		}
+		t.Logf("waiting for check run... current checks: %+v", checksResp.Checks)
+	}
+
+	t.Fatal("timed out waiting for check run to appear")
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func mustPost(t *testing.T, client *http.Client, url string, body any) {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	resp, err := client.Post(url, "application/json", bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		t.Logf("POST %s: status %d (may be OK for idempotent calls)", url, resp.StatusCode)
+	}
+}
+
+func mustCommit(t *testing.T, client *http.Client, docstoreURL, repo, branch, message string, files []model.FileChange) model.CommitResponse {
+	t.Helper()
+	commitReq := model.CommitRequest{
+		Branch:  branch,
+		Message: message,
+		Files:   files,
+	}
+	b, _ := json.Marshal(commitReq)
+	resp, err := client.Post(
+		fmt.Sprintf("%s/repos/%s/-/commit", docstoreURL, repo),
+		"application/json",
+		bytes.NewReader(b),
+	)
+	if err != nil {
+		t.Fatalf("commit to %s/%s: %v", repo, branch, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("commit to %s/%s: expected 201, got %d", repo, branch, resp.StatusCode)
+	}
+	var cr model.CommitResponse
+	if err := json.NewDecoder(resp.Body).Decode(&cr); err != nil {
+		t.Fatalf("decode commit response: %v", err)
+	}
+	return cr
+}

--- a/cmd/ci-runner/integration_test.go
+++ b/cmd/ci-runner/integration_test.go
@@ -176,7 +176,7 @@ func newIntegrationServer(t *testing.T, docstoreURL string) *httptest.Server {
 		t.Fatalf("cannot connect to buildkitd at %s: %v", pkgBuildkitAddr, err)
 	}
 	ls, _ := logstore.NewLocalLogStore(t.TempDir())
-	srv := httptest.NewServer(newMux(context.Background(), exec, ls, docstoreURL, &http.Client{}, 30*time.Minute))
+	srv := httptest.NewServer(newMux(context.Background(), exec, ls, docstoreURL, &http.Client{}, 30*time.Minute, ""))
 	t.Cleanup(func() {
 		srv.Close()
 		exec.Close() //nolint:errcheck

--- a/cmd/ci-runner/main.go
+++ b/cmd/ci-runner/main.go
@@ -101,6 +101,16 @@ func (r *runRegistry) fail(runID, errMsg string) {
 	}
 }
 
+func (r *runRegistry) cleanup() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for id, s := range r.runs {
+		if s.State != "running" && time.Since(s.StartedAt) > time.Hour {
+			delete(r.runs, id)
+		}
+	}
+}
+
 func (r *runRegistry) get(runID string) (*RunStatus, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -376,7 +386,11 @@ func registerWebhookSubscription(ctx context.Context, client *http.Client, docst
 		if err := json.NewDecoder(resp.Body).Decode(&listResp); err == nil {
 			for _, sub := range listResp.Subscriptions {
 				var cfg map[string]string
-				if err := json.Unmarshal(sub.Config, &cfg); err == nil && cfg["url"] == webhookURL {
+				if err := json.Unmarshal(sub.Config, &cfg); err != nil {
+					slog.Warn("webhook registration: failed to parse subscription config", "id", sub.ID, "error", err)
+					continue
+				}
+				if cfg["url"] == webhookURL {
 					slog.Info("webhook subscription already registered", "id", sub.ID, "url", webhookURL)
 					return
 				}
@@ -418,6 +432,20 @@ func registerWebhookSubscription(ctx context.Context, client *http.Client, docst
 
 func newMux(serverCtx context.Context, exec *executor.Executor, ls logstore.LogStore, docstoreURL string, client *http.Client, runTimeout time.Duration, webhookSecret string) *http.ServeMux {
 	reg := newRunRegistry()
+
+	go func() {
+		ticker := time.NewTicker(10 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-serverCtx.Done():
+				return
+			case <-ticker.C:
+				reg.cleanup()
+			}
+		}
+	}()
+
 	mux := http.NewServeMux()
 
 	// POST /run — manual trigger (existing endpoint).

--- a/cmd/ci-runner/main.go
+++ b/cmd/ci-runner/main.go
@@ -4,6 +4,9 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -14,6 +17,8 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -37,6 +42,78 @@ type runRequest struct {
 
 type runResponse struct {
 	RunID string `json:"run_id"`
+}
+
+// ---------------------------------------------------------------------------
+// RunStatus tracks an in-progress or completed CI run.
+// ---------------------------------------------------------------------------
+
+// RunStatus is the state record for a single CI run.
+type RunStatus struct {
+	RunID     string                 `json:"run_id"`
+	Repo      string                 `json:"repo"`
+	Branch    string                 `json:"branch"`
+	HeadSeq   int64                  `json:"head_seq,omitempty"`
+	State     string                 `json:"state"` // "running", "done", "failed"
+	StartedAt time.Time              `json:"started_at"`
+	Checks    []executor.CheckResult `json:"checks,omitempty"`
+	Error     string                 `json:"error,omitempty"`
+}
+
+// runRegistry is a thread-safe in-memory store of run statuses.
+type runRegistry struct {
+	mu   sync.RWMutex
+	runs map[string]*RunStatus
+}
+
+func newRunRegistry() *runRegistry {
+	return &runRegistry{runs: make(map[string]*RunStatus)}
+}
+
+func (r *runRegistry) start(runID, repo, branch string, headSeq int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.runs[runID] = &RunStatus{
+		RunID:     runID,
+		Repo:      repo,
+		Branch:    branch,
+		HeadSeq:   headSeq,
+		State:     "running",
+		StartedAt: time.Now(),
+	}
+}
+
+func (r *runRegistry) complete(runID string, checks []executor.CheckResult) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if s, ok := r.runs[runID]; ok {
+		s.State = "done"
+		s.Checks = append([]executor.CheckResult(nil), checks...)
+	}
+}
+
+func (r *runRegistry) fail(runID, errMsg string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if s, ok := r.runs[runID]; ok {
+		s.State = "failed"
+		s.Error = errMsg
+	}
+}
+
+func (r *runRegistry) get(runID string) (*RunStatus, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	s, ok := r.runs[runID]
+	if !ok {
+		return nil, false
+	}
+	// Return a shallow copy to avoid data races.
+	cp := *s
+	if s.Checks != nil {
+		cp.Checks = append([]executor.CheckResult(nil), s.Checks...)
+	}
+	return &cp, true
 }
 
 // ---------------------------------------------------------------------------
@@ -165,14 +242,17 @@ func postCheckRun(ctx context.Context, client *http.Client, docstoreURL, repo st
 // Async run goroutine
 // ---------------------------------------------------------------------------
 
-func runAsync(ctx context.Context, client *http.Client, exec *executor.Executor, ls logstore.LogStore, docstoreURL, repo, branch string, headSeq int64) {
+func runAsync(ctx context.Context, client *http.Client, exec *executor.Executor, ls logstore.LogStore, docstoreURL, repo, branch string, headSeq int64, runID string, reg *runRegistry) {
 	defer func() {
 		if r := recover(); r != nil {
 			slog.Error("runAsync panic", "repo", repo, "branch", branch, "panic", r)
+			if reg != nil {
+				reg.fail(runID, fmt.Sprintf("panic: %v", r))
+			}
 		}
 	}()
 
-	slog.Info("run started", "repo", repo, "branch", branch, "head_seq", headSeq)
+	slog.Info("run started", "repo", repo, "branch", branch, "head_seq", headSeq, "run_id", runID)
 
 	// 1. Fetch config from main branch.
 	cfg, err := fetchConfig(ctx, client, docstoreURL, repo)
@@ -186,6 +266,9 @@ func runAsync(ctx context.Context, client *http.Client, exec *executor.Executor,
 			Status:    model.CheckRunFailed,
 			LogURL:    &msg,
 		})
+		if reg != nil {
+			reg.fail(runID, "config fetch failed: "+err.Error())
+		}
 		return
 	}
 
@@ -196,6 +279,9 @@ func runAsync(ctx context.Context, client *http.Client, exec *executor.Executor,
 	}
 	if err != nil {
 		slog.Error("pull source failed", "repo", repo, "branch", branch, "error", err)
+		if reg != nil {
+			reg.fail(runID, "source pull failed: "+err.Error())
+		}
 		return
 	}
 
@@ -214,6 +300,9 @@ func runAsync(ctx context.Context, client *http.Client, exec *executor.Executor,
 	results, err := exec.Run(ctx, tempDir, *cfg)
 	if err != nil {
 		slog.Error("executor failed", "repo", repo, "branch", branch, "error", err)
+		if reg != nil {
+			reg.fail(runID, "executor failed: "+err.Error())
+		}
 		return
 	}
 
@@ -239,15 +328,99 @@ func runAsync(ctx context.Context, client *http.Client, exec *executor.Executor,
 		}
 	}
 
-	slog.Info("run complete", "repo", repo, "branch", branch, "checks", len(results))
+	if reg != nil {
+		reg.complete(runID, results)
+	}
+	slog.Info("run complete", "repo", repo, "branch", branch, "checks", len(results), "run_id", runID)
+}
+
+// ---------------------------------------------------------------------------
+// HMAC helper
+// ---------------------------------------------------------------------------
+
+// computeHMACHex returns the hex-encoded HMAC-SHA256 of body using secret.
+// The format matches what docstore's outbox dispatcher sends:
+// "sha256=" + hex(hmac-sha256(body, secret))
+func computeHMACHex(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// ---------------------------------------------------------------------------
+// Startup: auto-register webhook subscription with docstore
+// ---------------------------------------------------------------------------
+
+// registerWebhookSubscription checks whether a webhook subscription for
+// runnerURL already exists and creates one if not. Errors are logged as
+// warnings so the runner can still be triggered manually.
+func registerWebhookSubscription(ctx context.Context, client *http.Client, docstoreURL, runnerURL, webhookSecret string) {
+	webhookURL := strings.TrimRight(runnerURL, "/") + "/webhook"
+	subsURL := strings.TrimRight(docstoreURL, "/") + "/subscriptions"
+
+	// List existing subscriptions.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, subsURL, nil)
+	if err != nil {
+		slog.Warn("webhook registration: build list request failed", "error", err)
+		return
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.Warn("webhook registration: list subscriptions failed", "error", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		var listResp model.ListSubscriptionsResponse
+		if err := json.NewDecoder(resp.Body).Decode(&listResp); err == nil {
+			for _, sub := range listResp.Subscriptions {
+				var cfg map[string]string
+				if err := json.Unmarshal(sub.Config, &cfg); err == nil && cfg["url"] == webhookURL {
+					slog.Info("webhook subscription already registered", "id", sub.ID, "url", webhookURL)
+					return
+				}
+			}
+		}
+	}
+
+	// Create subscription.
+	cfgJSON, _ := json.Marshal(map[string]string{"url": webhookURL, "secret": webhookSecret})
+	createBody, _ := json.Marshal(model.CreateSubscriptionRequest{
+		Backend:    "webhook",
+		EventTypes: []string{"com.docstore.commit.created"},
+		Config:     cfgJSON,
+	})
+	createReq, err := http.NewRequestWithContext(ctx, http.MethodPost, subsURL, bytes.NewReader(createBody))
+	if err != nil {
+		slog.Warn("webhook registration: build create request failed", "error", err)
+		return
+	}
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := client.Do(createReq)
+	if err != nil {
+		slog.Warn("webhook registration: create subscription failed", "error", err)
+		return
+	}
+	defer createResp.Body.Close()
+
+	if createResp.StatusCode == http.StatusCreated {
+		slog.Info("webhook subscription registered", "url", webhookURL)
+	} else {
+		slog.Warn("webhook registration: unexpected status (runner will still accept manual POST /run)",
+			"status", createResp.StatusCode, "url", webhookURL)
+	}
 }
 
 // ---------------------------------------------------------------------------
 // HTTP mux
 // ---------------------------------------------------------------------------
 
-func newMux(serverCtx context.Context, exec *executor.Executor, ls logstore.LogStore, docstoreURL string, client *http.Client, runTimeout time.Duration) *http.ServeMux {
+func newMux(serverCtx context.Context, exec *executor.Executor, ls logstore.LogStore, docstoreURL string, client *http.Client, runTimeout time.Duration, webhookSecret string) *http.ServeMux {
+	reg := newRunRegistry()
 	mux := http.NewServeMux()
+
+	// POST /run — manual trigger (existing endpoint).
 	mux.HandleFunc("POST /run", func(w http.ResponseWriter, r *http.Request) {
 		var req runRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -264,15 +437,89 @@ func newMux(serverCtx context.Context, exec *executor.Executor, ls logstore.LogS
 		}
 
 		runID := uuid.New().String()
+		reg.start(runID, req.Repo, req.Branch, req.HeadSequence)
 		go func() {
 			ctx, cancel := context.WithTimeout(serverCtx, runTimeout)
 			defer cancel()
-			runAsync(ctx, client, exec, ls, docstoreURL, req.Repo, req.Branch, req.HeadSequence)
+			runAsync(ctx, client, exec, ls, docstoreURL, req.Repo, req.Branch, req.HeadSequence, runID, reg)
 		}()
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(runResponse{RunID: runID}) //nolint:errcheck
 	})
+
+	// POST /webhook — receives CloudEvents webhook deliveries from docstore.
+	mux.HandleFunc("POST /webhook", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			http.Error(w, "failed to read body", http.StatusBadRequest)
+			return
+		}
+
+		// Verify HMAC signature when a secret is configured.
+		if webhookSecret != "" {
+			sig := r.Header.Get("X-DocStore-Signature")
+			expected := "sha256=" + computeHMACHex(body, webhookSecret)
+			if !hmac.Equal([]byte(sig), []byte(expected)) {
+				http.Error(w, "invalid signature", http.StatusBadRequest)
+				return
+			}
+		}
+
+		// Parse CloudEvents envelope — only need type and data.
+		var env struct {
+			Type string          `json:"type"`
+			Data json.RawMessage `json:"data"`
+		}
+		if err := json.Unmarshal(body, &env); err != nil {
+			http.Error(w, "invalid cloudevent body", http.StatusBadRequest)
+			return
+		}
+
+		// Unknown event types are silently acknowledged (forward-compat).
+		if env.Type != "com.docstore.commit.created" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// Extract commit.created data fields.
+		var data struct {
+			Repo     string `json:"repo"`
+			Branch   string `json:"branch"`
+			Sequence int64  `json:"sequence"`
+		}
+		if err := json.Unmarshal(env.Data, &data); err != nil {
+			http.Error(w, "invalid event data", http.StatusBadRequest)
+			return
+		}
+		if data.Repo == "" || data.Branch == "" {
+			http.Error(w, "missing repo or branch in event data", http.StatusBadRequest)
+			return
+		}
+
+		runID := uuid.New().String()
+		reg.start(runID, data.Repo, data.Branch, data.Sequence)
+		go func() {
+			ctx, cancel := context.WithTimeout(serverCtx, runTimeout)
+			defer cancel()
+			runAsync(ctx, client, exec, ls, docstoreURL, data.Repo, data.Branch, data.Sequence, runID, reg)
+		}()
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// GET /run/{run_id} — polling endpoint for run status.
+	mux.HandleFunc("GET /run/{run_id}", func(w http.ResponseWriter, r *http.Request) {
+		runID := r.PathValue("run_id")
+		status, ok := reg.get(runID)
+		if !ok {
+			http.Error(w, "run not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(status) //nolint:errcheck
+	})
+
 	return mux
 }
 
@@ -286,6 +533,8 @@ func main() {
 	docstoreURL := flag.String("docstore-url", "", "Base URL of the docstore server (required)")
 	devIdentity := flag.String("dev-identity", "", "Identity header to send to docstore (local dev only)")
 	runTimeout := flag.Duration("run-timeout", 30*time.Minute, "Maximum duration for a single CI run")
+	runnerURL := flag.String("runner-url", "", "Public URL of this ci-runner instance (used to register webhook subscription)")
+	webhookSecret := flag.String("webhook-secret", "", "Shared HMAC secret for webhook signature verification")
 	flag.Parse()
 
 	if *docstoreURL == "" {
@@ -329,7 +578,7 @@ func main() {
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 	defer serverCancel()
 
-	mux := newMux(serverCtx, exec, ls, *docstoreURL, httpClient, *runTimeout)
+	mux := newMux(serverCtx, exec, ls, *docstoreURL, httpClient, *runTimeout, *webhookSecret)
 
 	srv := &http.Server{
 		Addr:        ":" + *port,
@@ -346,6 +595,13 @@ func main() {
 			os.Exit(1)
 		}
 	}()
+
+	// Auto-register webhook subscription if runner-url and webhook-secret are provided.
+	if *runnerURL != "" && *webhookSecret != "" {
+		registerCtx, registerCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer registerCancel()
+		registerWebhookSubscription(registerCtx, httpClient, *docstoreURL, *runnerURL, *webhookSecret)
+	}
 
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -12,7 +12,9 @@ In the full production flow (Milestone 1):
 3. The runner calls itself (`POST /run`) with the local source path
 4. Results are written back to docstore as check runs via `POST /-/check`
 
-Milestone 0.5 (what is implemented) covers step 3 only — the executor and HTTP API, with no docstore integration.
+Milestone 1 wires in full docstore integration: fetching `.docstore/ci.yaml` from `main`, pulling branch source, posting check runs back to docstore, and writing logs to a configurable log store.
+
+Milestone 2 (this document) adds webhook-triggered runs, a run status polling endpoint, and auto-registration of the webhook subscription at startup.
 
 ## How It Works
 
@@ -82,6 +84,40 @@ Logs are collected from the `SolveStatus` stream in a goroutine (`executor.go:10
 If `Solve` returns an error and no log bytes were collected, the error message is used as the log value.
 
 ## HTTP API
+
+### `POST /webhook` (Milestone 2)
+
+Receives CloudEvents webhook deliveries from docstore's outbox dispatcher.
+
+**Authentication:** Verified via `X-DocStore-Signature: sha256=<hex>` HMAC header using the `--webhook-secret` flag. If no secret is configured, the header is not checked.
+
+**Supported event types:**
+- `com.docstore.commit.created` — extracts `repo`, `branch`, `sequence` from the data field and calls `POST /run` internally
+- All other types — acknowledged with `200 OK` and ignored (forward-compat)
+
+**Responses:**
+- `200 OK` — event accepted (or ignored)
+- `400 Bad Request` — invalid signature or malformed body
+
+---
+
+### `GET /run/{run_id}` (Milestone 2)
+
+Returns the current status of an async CI run. Runs are tracked in-memory; history is lost on restart.
+
+**Response:**
+```json
+{"run_id": "...", "state": "running", "repo": "...", "branch": "...", "head_seq": 42, "started_at": "..."}
+{"run_id": "...", "state": "done",    "checks": [{"name":"ci/build","status":"passed","logs":"..."}]}
+{"run_id": "...", "state": "failed",  "error": "config fetch failed: ..."}
+```
+
+**States:** `running`, `done`, `failed`
+
+**Error responses:**
+- `404 Not Found` — unknown run_id
+
+---
 
 ### `POST /run`
 
@@ -185,6 +221,11 @@ Flags:
 |---|---|---|
 | `--buildkit-addr` | `unix:///run/buildkit/buildkitd.sock` | buildkitd socket address |
 | `--port` | `8080` | HTTP listen port |
+| `--docstore-url` | (required) | Base URL of the docstore server |
+| `--dev-identity` | `""` | Identity header for local dev (sets X-Goog-IAP-JWT-Assertion) |
+| `--run-timeout` | `30m` | Maximum duration for a single CI run |
+| `--runner-url` | `""` | Public URL of this runner (enables auto-registration with docstore) |
+| `--webhook-secret` | `""` | HMAC secret for verifying incoming webhook deliveries |
 
 Log format defaults to JSON. Set `LOG_FORMAT=text` for human-readable output:
 ```bash
@@ -262,6 +303,24 @@ go test ./... -count=1
 go build ./...
 go vet ./...
 ```
+
+### End-to-End Tests (Milestone 2)
+
+The e2e test (`cmd/ci-runner/e2e_test.go`) requires Docker to start real postgres, docstore, and buildkitd containers. It is tagged `//go:build e2e` and excluded from the default test run.
+
+```bash
+# Run the e2e test (requires Docker)
+go test ./cmd/ci-runner/ -tags=e2e -run TestE2E -v -timeout=5m
+```
+
+The test:
+1. Starts a Postgres container via testcontainers and runs docstore migrations
+2. Starts a real docstore HTTP server wired to the database
+3. Starts a testcontainers buildkitd instance
+4. Creates an org, repo, commits `.docstore/ci.yaml` to `main`, and creates a feature branch
+5. Registers a webhook subscription pointing at the in-process ci-runner
+6. Posts a commit to trigger the `commit.created` event via the outbox dispatcher
+7. Polls docstore `GET /repos/{repo}/-/branch/{branch}/checks` until `ci/hello` completes
 
 ## Architecture Notes
 

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -212,6 +212,7 @@ until [ -S /run/buildkit/buildkitd.sock ]; do sleep 0.1; done
 ```bash
 go run ./cmd/ci-runner \
   --buildkit-addr unix:///run/buildkit/buildkitd.sock \
+  --docstore-url http://localhost:8000 \
   --port 8080
 ```
 
@@ -310,7 +311,7 @@ The e2e test (`cmd/ci-runner/e2e_test.go`) requires Docker to start real postgre
 
 ```bash
 # Run the e2e test (requires Docker)
-go test ./cmd/ci-runner/ -tags=e2e -run TestE2E -v -timeout=5m
+go test ./cmd/ci-runner/ -tags=e2e -run TestE2E_WebhookTriggersRun -v -timeout=5m
 ```
 
 The test:


### PR DESCRIPTION
## Summary

Implements [issue #75](https://github.com/dlorenc/docstore/issues/75) Milestone 2, building on the eventing system from commit `d37f20a`.

### Part 1: `POST /webhook` handler

- Verifies `X-DocStore-Signature: sha256=<hex>` HMAC using `--webhook-secret`
- Parses CloudEvents JSON envelope
- For `com.docstore.commit.created`: extracts `repo`, `branch`, `sequence` and spawns `runAsync`
- Unknown event types: `200 OK` and ignored (forward-compat)
- Invalid signature or malformed body: `400 Bad Request`

### Part 2: Auto-registration on startup

- New flags: `--runner-url`, `--webhook-secret`
- On startup with both flags set: calls `GET /subscriptions`, checks if a subscription for `{runner-url}/webhook` already exists, creates one if not
- Uses existing `--dev-identity` mechanism for admin auth
- Registration failure is logged as a warning — runner still works via manual `POST /run`

### Part 3: `GET /run/{run_id}` polling endpoint

- In-memory `runRegistry` (`sync.RWMutex`-protected `map[string]*RunStatus`)
- `RunStatus`: `{run_id, repo, branch, head_seq, state, started_at, checks, error}`
- States: `"running"` → `"done"` or `"failed"`
- `POST /run` and `POST /webhook` register runs immediately; `runAsync` updates state on completion
- `404` for unknown run_id; history lost on restart (acceptable for M2)

### Part 4: E2E test (`//go:build e2e`)

`cmd/ci-runner/e2e_test.go` — full stack test using testcontainers postgres + real docstore + testcontainers buildkitd. Excluded from default `go test ./...` run. See `docs/ci-runner.md` for how to run.

### Unit tests added

- `TestWebhookHandler_ValidSignature` — valid HMAC → 200
- `TestWebhookHandler_InvalidSignature` — bad HMAC → 400
- `TestWebhookHandler_UnknownEventType` — unknown type → 200 ignored
- `TestGetRunStatus_NotFound` — unknown run_id → 404
- `TestRunStatus_TracksInFlight` — registry populated and transitions correctly
- `TestRunStatus_ViaHTTP` — POST /run then GET /run/{id} via HTTP handlers

## Test plan

- [x] `go test ./... -count=1` — all 16 packages pass
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [ ] E2E: `go test ./cmd/ci-runner/ -tags=e2e -run TestE2E -v -timeout=5m` (requires Docker)

## Notes for reviewers

- The `runAsync` signature gained `runID string` and `reg *runRegistry` params (both were previously implicit/unused). Existing callers (`POST /run`) and the new `POST /webhook` handler both pass these.
- The `newMux` signature gained `webhookSecret string` at the end; all test callers pass `""`.
- Auto-registration is opportunistic: if docstore isn't reachable or returns non-201, the runner logs a warning and continues normally — it can still be triggered via `POST /run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)