### PR TITLE
Go SDK (sdk/go/docstore) and public api package

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -1,0 +1,580 @@
+// Package api defines the request, response, and domain types that cross the
+// HTTP wire between the docstore server and its clients.
+//
+// This package is intentionally dependency-free (only the standard library)
+// so it can be imported by external SDK modules without pulling in server
+// internals. Types here are the canonical JSON schema for the docstore API;
+// the server and the in-tree CLI consume them via re-export aliases in
+// internal/model, and external SDKs (e.g. sdk/go/docstore) import this
+// package directly.
+package api
+
+import "time"
+
+// ---------------------------------------------------------------------------
+// Enumerations
+// ---------------------------------------------------------------------------
+
+// OrgRole represents the role of an org member.
+type OrgRole string
+
+const (
+	OrgRoleOwner  OrgRole = "owner"
+	OrgRoleMember OrgRole = "member"
+)
+
+// BranchStatus represents the lifecycle state of a branch.
+type BranchStatus string
+
+const (
+	BranchStatusActive    BranchStatus = "active"
+	BranchStatusMerged    BranchStatus = "merged"
+	BranchStatusAbandoned BranchStatus = "abandoned"
+)
+
+// RoleType represents coarse-grained permission levels on a repo.
+type RoleType string
+
+const (
+	RoleReader     RoleType = "reader"
+	RoleWriter     RoleType = "writer"
+	RoleMaintainer RoleType = "maintainer"
+	RoleAdmin      RoleType = "admin"
+)
+
+// ReviewStatus represents the outcome of a review.
+type ReviewStatus string
+
+const (
+	ReviewApproved  ReviewStatus = "approved"
+	ReviewRejected  ReviewStatus = "rejected"
+	ReviewDismissed ReviewStatus = "dismissed"
+)
+
+// CheckRunStatus represents the state of a CI check run.
+type CheckRunStatus string
+
+const (
+	CheckRunPending CheckRunStatus = "pending"
+	CheckRunPassed  CheckRunStatus = "passed"
+	CheckRunFailed  CheckRunStatus = "failed"
+)
+
+// ---------------------------------------------------------------------------
+// Domain entities
+// ---------------------------------------------------------------------------
+
+// Org is a top-level namespace that owns one or more repos.
+type Org struct {
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+	CreatedBy string    `json:"created_by"`
+}
+
+// OrgMember is a member of an org with a specific role.
+type OrgMember struct {
+	Org       string    `json:"org"`
+	Identity  string    `json:"identity"`
+	Role      OrgRole   `json:"role"`
+	InvitedBy string    `json:"invited_by"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// OrgInvite is a pending or accepted invitation to join an org.
+type OrgInvite struct {
+	ID         string     `json:"id"`
+	Org        string     `json:"org"`
+	Email      string     `json:"email"`
+	Role       OrgRole    `json:"role"`
+	InvitedBy  string     `json:"invited_by"`
+	Token      string     `json:"token,omitempty"`
+	ExpiresAt  time.Time  `json:"expires_at"`
+	AcceptedAt *time.Time `json:"accepted_at,omitempty"`
+	CreatedAt  time.Time  `json:"created_at"`
+}
+
+// Repo is a named tenant that owns its own isolated set of branches and commits.
+// Name is the full path (e.g. "acme/myrepo" or "acme/team/subrepo").
+// Owner is the first path segment, i.e. the org name.
+type Repo struct {
+	Name      string    `json:"name"`
+	Owner     string    `json:"owner"`
+	CreatedAt time.Time `json:"created_at"`
+	CreatedBy string    `json:"created_by"`
+}
+
+// Branch is a named pointer to a sequence.
+type Branch struct {
+	Name         string       `json:"name"`
+	HeadSequence int64        `json:"head_sequence"`
+	BaseSequence int64        `json:"base_sequence"`
+	Status       BranchStatus `json:"status"`
+	Draft        bool         `json:"draft"`
+}
+
+// Role maps an identity to a coarse-grained permission level on a repo.
+type Role struct {
+	Identity string   `json:"identity"`
+	Role     RoleType `json:"role"`
+}
+
+// Review records an approval or rejection scoped to a branch at a specific
+// head sequence.
+type Review struct {
+	ID        string       `json:"id"`
+	Branch    string       `json:"branch"`
+	Reviewer  string       `json:"reviewer"`
+	Sequence  int64        `json:"sequence"`
+	Status    ReviewStatus `json:"status"`
+	Body      string       `json:"body,omitempty"`
+	CreatedAt time.Time    `json:"created_at"`
+}
+
+// CheckRun stores an external CI status report for a branch at a specific
+// head sequence.
+type CheckRun struct {
+	ID        string         `json:"id"`
+	Branch    string         `json:"branch"`
+	Sequence  int64          `json:"sequence"`
+	CheckName string         `json:"check_name"`
+	Status    CheckRunStatus `json:"status"`
+	Reporter  string         `json:"reporter"`
+	LogURL    *string        `json:"log_url,omitempty"`
+	CreatedAt time.Time      `json:"created_at"`
+}
+
+// Release is a named immutable snapshot tied to a commit sequence.
+type Release struct {
+	ID        string    `json:"id"`
+	Repo      string    `json:"repo"`
+	Name      string    `json:"name"`
+	Sequence  int64     `json:"sequence"`
+	Body      string    `json:"body,omitempty"`
+	CreatedBy string    `json:"created_by"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// ---------------------------------------------------------------------------
+// Pagination
+// ---------------------------------------------------------------------------
+
+// PaginationParams are the common query parameters for list endpoints.
+type PaginationParams struct {
+	Limit int    `json:"limit,omitempty"`
+	After string `json:"after,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// GET /tree
+// ---------------------------------------------------------------------------
+
+// TreeEntry is one file in a materialized tree.
+type TreeEntry struct {
+	Path        string `json:"path"`
+	VersionID   string `json:"version_id"`
+	ContentHash string `json:"content_hash"`
+}
+
+// TreeResponse is the response for GET /tree.
+type TreeResponse struct {
+	Entries []TreeEntry `json:"entries"`
+}
+
+// ---------------------------------------------------------------------------
+// GET /file/:path/history
+// ---------------------------------------------------------------------------
+
+// FileHistoryEntry is one row in a file's history.
+type FileHistoryEntry struct {
+	Sequence  int64     `json:"sequence"`
+	VersionID string    `json:"version_id"`
+	Message   string    `json:"message"`
+	Author    string    `json:"author"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// FileHistoryResponse is the response for GET /file/:path/history.
+type FileHistoryResponse struct {
+	Entries []FileHistoryEntry `json:"entries"`
+}
+
+// ---------------------------------------------------------------------------
+// GET /file/:path
+// ---------------------------------------------------------------------------
+
+// FileResponse is the response for GET /file/:path.
+type FileResponse struct {
+	Path        string `json:"path"`
+	VersionID   string `json:"version_id"`
+	ContentHash string `json:"content_hash"`
+	Content     []byte `json:"content"`
+	ContentType string `json:"content_type,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// GET /diff
+// ---------------------------------------------------------------------------
+
+// DiffEntry represents a single file change in a diff.
+type DiffEntry struct {
+	Path      string  `json:"path"`
+	VersionID *string `json:"version_id"` // nil means deleted
+	Binary    bool    `json:"binary,omitempty"`
+}
+
+// ConflictEntry represents a file that was changed on both main and the branch.
+type ConflictEntry struct {
+	Path            string `json:"path"`
+	MainVersionID   string `json:"main_version_id"`
+	BranchVersionID string `json:"branch_version_id"`
+}
+
+// DiffResponse is the response for GET /diff.
+type DiffResponse struct {
+	BranchChanges []DiffEntry     `json:"branch_changes"`
+	MainChanges   []DiffEntry     `json:"main_changes"`
+	Conflicts     []ConflictEntry `json:"conflicts,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// GET /commit/:sequence
+// ---------------------------------------------------------------------------
+
+// CommitDetail represents one file change within a commit.
+type CommitDetail struct {
+	Path      string  `json:"path"`
+	VersionID *string `json:"version_id"` // nil means delete
+}
+
+// GetCommitResponse is the response for GET /commit/:sequence.
+type GetCommitResponse struct {
+	Sequence  int64          `json:"sequence"`
+	Message   string         `json:"message"`
+	Author    string         `json:"author"`
+	CreatedAt time.Time      `json:"created_at"`
+	Files     []CommitDetail `json:"files"`
+}
+
+// ---------------------------------------------------------------------------
+// GET /branches
+// ---------------------------------------------------------------------------
+
+// BranchesResponse is the response for GET /branches.
+type BranchesResponse struct {
+	Branches []Branch `json:"branches"`
+}
+
+// ---------------------------------------------------------------------------
+// GET /branch/:name/status
+// ---------------------------------------------------------------------------
+
+// PolicyResult is one policy evaluation outcome.
+type PolicyResult struct {
+	Name   string `json:"name"`
+	Pass   bool   `json:"pass"`
+	Reason string `json:"reason"`
+}
+
+// BranchStatusResponse is the response for GET /branch/:name/status.
+type BranchStatusResponse struct {
+	Mergeable bool           `json:"mergeable"`
+	Policies  []PolicyResult `json:"policies"`
+}
+
+// ---------------------------------------------------------------------------
+// POST /commit
+// ---------------------------------------------------------------------------
+
+// FileChange is one file in a commit request. A nil Content means delete.
+type FileChange struct {
+	Path        string `json:"path"`
+	Content     []byte `json:"content,omitempty"`
+	ContentType string `json:"content_type,omitempty"`
+}
+
+// CommitRequest is the body for POST /repos/:name/commit.
+type CommitRequest struct {
+	Repo    string       `json:"repo,omitempty"`
+	Branch  string       `json:"branch"`
+	Files   []FileChange `json:"files"`
+	Message string       `json:"message"`
+	Author  string       `json:"author"`
+}
+
+// CommitFileResult describes one file outcome in a commit response.
+type CommitFileResult struct {
+	Path      string  `json:"path"`
+	VersionID *string `json:"version_id"` // nil for deletes
+}
+
+// CommitResponse is the response for POST /commit.
+type CommitResponse struct {
+	Sequence   int64              `json:"sequence"`
+	Files      []CommitFileResult `json:"files"`
+	CommitHash string             `json:"commit_hash,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// POST /branch, PATCH /branch/:name, DELETE /branch/:name
+// ---------------------------------------------------------------------------
+
+// CreateBranchRequest is the body for POST /repos/:name/branch.
+type CreateBranchRequest struct {
+	Repo  string `json:"repo,omitempty"`
+	Name  string `json:"name"`
+	Draft bool   `json:"draft,omitempty"`
+}
+
+// CreateBranchResponse is the response for POST /branch.
+type CreateBranchResponse struct {
+	Name         string `json:"name"`
+	BaseSequence int64  `json:"base_sequence"`
+	Draft        bool   `json:"draft,omitempty"`
+}
+
+// UpdateBranchRequest is the body for PATCH /repos/:name/branch/:name.
+type UpdateBranchRequest struct {
+	Draft bool `json:"draft"`
+}
+
+// UpdateBranchResponse is the response for PATCH /repos/:name/branch/:name.
+type UpdateBranchResponse struct {
+	Name  string `json:"name"`
+	Draft bool   `json:"draft"`
+}
+
+// DeleteBranchResponse is the response for DELETE /branch/:name.
+type DeleteBranchResponse struct {
+	Name   string       `json:"name"`
+	Status BranchStatus `json:"status"`
+}
+
+// ---------------------------------------------------------------------------
+// POST /merge
+// ---------------------------------------------------------------------------
+
+// MergeRequest is the body for POST /repos/:name/merge.
+type MergeRequest struct {
+	Repo   string `json:"repo,omitempty"`
+	Branch string `json:"branch"`
+	Author string `json:"author,omitempty"`
+}
+
+// MergeResponse is the response for a successful POST /merge.
+type MergeResponse struct {
+	Sequence int64 `json:"sequence"`
+}
+
+// MergeConflictError is the error response when merge has conflicts.
+type MergeConflictError struct {
+	Conflicts []ConflictEntry `json:"conflicts"`
+}
+
+// MergePolicyError is the error response when merge policies fail.
+type MergePolicyError struct {
+	Policies []PolicyResult `json:"policies"`
+}
+
+// ---------------------------------------------------------------------------
+// POST /rebase
+// ---------------------------------------------------------------------------
+
+// RebaseRequest is the body for POST /repos/:name/rebase.
+type RebaseRequest struct {
+	Repo   string `json:"repo,omitempty"`
+	Branch string `json:"branch"`
+	Author string `json:"author,omitempty"`
+}
+
+// RebaseResponse is the response for a successful POST /rebase.
+type RebaseResponse struct {
+	NewBaseSequence int64 `json:"base_sequence"`
+	NewHeadSequence int64 `json:"head_sequence"`
+	CommitsReplayed int64 `json:"commits_replayed"`
+}
+
+// RebaseConflictError is the error response when rebase has conflicts.
+type RebaseConflictError struct {
+	Conflicts []ConflictEntry `json:"conflicts"`
+}
+
+// ---------------------------------------------------------------------------
+// POST /review
+// ---------------------------------------------------------------------------
+
+// CreateReviewRequest is the body for POST /review.
+type CreateReviewRequest struct {
+	Branch string       `json:"branch"`
+	Status ReviewStatus `json:"status"`
+	Body   string       `json:"body,omitempty"`
+}
+
+// CreateReviewResponse is the response for POST /review.
+type CreateReviewResponse struct {
+	ID       string `json:"id"`
+	Sequence int64  `json:"sequence"`
+}
+
+// ---------------------------------------------------------------------------
+// POST /check
+// ---------------------------------------------------------------------------
+
+// CreateCheckRunRequest is the body for POST /check.
+type CreateCheckRunRequest struct {
+	Branch    string         `json:"branch"`
+	CheckName string         `json:"check_name"`
+	Status    CheckRunStatus `json:"status"`
+	LogURL    *string        `json:"log_url,omitempty"`
+}
+
+// CreateCheckRunResponse is the response for POST /check.
+type CreateCheckRunResponse struct {
+	ID       string `json:"id"`
+	Sequence int64  `json:"sequence"`
+}
+
+// ---------------------------------------------------------------------------
+// Orgs
+// ---------------------------------------------------------------------------
+
+// CreateOrgRequest is the body for POST /orgs.
+type CreateOrgRequest struct {
+	Name string `json:"name"`
+}
+
+// CreateOrgResponse is the response for POST /orgs (same fields as Org).
+type CreateOrgResponse = Org
+
+// ListOrgsResponse is the response for GET /orgs.
+type ListOrgsResponse struct {
+	Orgs []Org `json:"orgs"`
+}
+
+// AddOrgMemberRequest is the body for POST /orgs/{org}/members/{identity}.
+type AddOrgMemberRequest struct {
+	Role OrgRole `json:"role"`
+}
+
+// OrgMembersResponse is the response for GET /orgs/{org}/members.
+type OrgMembersResponse struct {
+	Members []OrgMember `json:"members"`
+}
+
+// CreateInviteRequest is the body for POST /orgs/{org}/invites.
+type CreateInviteRequest struct {
+	Email string  `json:"email"`
+	Role  OrgRole `json:"role"`
+}
+
+// CreateInviteResponse is the response for POST /orgs/{org}/invites.
+type CreateInviteResponse struct {
+	ID    string `json:"id"`
+	Token string `json:"token"`
+}
+
+// OrgInvitesResponse is the response for GET /orgs/{org}/invites.
+type OrgInvitesResponse struct {
+	Invites []OrgInvite `json:"invites"`
+}
+
+// ---------------------------------------------------------------------------
+// Repos
+// ---------------------------------------------------------------------------
+
+// CreateRepoRequest is the body for POST /repos.
+// Owner is the org name; Name is the repo path within the org (may contain slashes).
+// The full repo identifier is Owner + "/" + Name.
+type CreateRepoRequest struct {
+	Owner     string `json:"owner"`
+	Name      string `json:"name"`
+	CreatedBy string `json:"created_by,omitempty"`
+}
+
+// FullName returns the full repo path: owner + "/" + name.
+func (r CreateRepoRequest) FullName() string { return r.Owner + "/" + r.Name }
+
+// ReposResponse is the response for GET /repos.
+type ReposResponse struct {
+	Repos []Repo `json:"repos"`
+}
+
+// ---------------------------------------------------------------------------
+// Roles
+// ---------------------------------------------------------------------------
+
+// SetRoleRequest is the body for PUT /repos/:name/roles/:identity.
+type SetRoleRequest struct {
+	Role RoleType `json:"role"`
+}
+
+// RolesResponse is the response for GET /repos/:name/roles.
+type RolesResponse struct {
+	Roles []Role `json:"roles"`
+}
+
+// ---------------------------------------------------------------------------
+// Purge
+// ---------------------------------------------------------------------------
+
+// PurgeRequest is the body for POST /repos/:name/purge.
+type PurgeRequest struct {
+	OlderThan string `json:"older_than"`
+	DryRun    bool   `json:"dry_run,omitempty"`
+}
+
+// PurgeResponse is the response for POST /repos/:name/purge.
+type PurgeResponse struct {
+	BranchesPurged     int64 `json:"branches_purged"`
+	FileCommitsDeleted int64 `json:"file_commits_deleted"`
+	CommitsDeleted     int64 `json:"commits_deleted"`
+	DocumentsDeleted   int64 `json:"documents_deleted"`
+	ReviewsDeleted     int64 `json:"reviews_deleted"`
+	CheckRunsDeleted   int64 `json:"check_runs_deleted"`
+}
+
+// ---------------------------------------------------------------------------
+// Releases
+// ---------------------------------------------------------------------------
+
+// CreateReleaseRequest is the body for POST /repos/:name/-/releases.
+// Sequence defaults to the current main head if omitted.
+type CreateReleaseRequest struct {
+	Name     string `json:"name"`
+	Sequence *int64 `json:"sequence,omitempty"`
+	Body     string `json:"body,omitempty"`
+}
+
+// ListReleasesResponse is the response for GET /repos/:name/-/releases.
+type ListReleasesResponse struct {
+	Releases []Release `json:"releases"`
+}
+
+// ---------------------------------------------------------------------------
+// Commit chain
+// ---------------------------------------------------------------------------
+
+// ChainEntry is one commit in the hash-chain response from GET /chain.
+type ChainEntry struct {
+	Sequence   int64       `json:"sequence"`
+	Branch     string      `json:"branch"`
+	Author     string      `json:"author"`
+	Message    string      `json:"message"`
+	CreatedAt  time.Time   `json:"created_at"`
+	CommitHash *string     `json:"commit_hash"`
+	Files      []ChainFile `json:"files"`
+}
+
+// ChainFile is one file change within a ChainEntry.
+type ChainFile struct {
+	Path        string `json:"path"`
+	ContentHash string `json:"content_hash"`
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+// ErrorResponse is the generic API error envelope.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -1,423 +1,80 @@
 package model
 
-import "time"
-
-// ---------------------------------------------------------------------------
-// Pagination
-// ---------------------------------------------------------------------------
-
-// PaginationParams are the common query parameters for list endpoints.
-type PaginationParams struct {
-	Limit int    `json:"limit,omitempty"`
-	After string `json:"after,omitempty"`
-}
-
-// ---------------------------------------------------------------------------
-// GET /tree
-// ---------------------------------------------------------------------------
-
-// TreeEntry is one file in a materialized tree.
-type TreeEntry struct {
-	Path        string `json:"path"`
-	VersionID   string `json:"version_id"`
-	ContentHash string `json:"content_hash"`
-}
-
-// TreeResponse is the response for GET /tree.
-type TreeResponse struct {
-	Entries []TreeEntry `json:"entries"`
-}
-
-// ---------------------------------------------------------------------------
-// GET /file/:path/history
-// ---------------------------------------------------------------------------
-
-// FileHistoryEntry is one row in a file's history.
-type FileHistoryEntry struct {
-	Sequence  int64     `json:"sequence"`
-	VersionID string    `json:"version_id"`
-	Message   string    `json:"message"`
-	Author    string    `json:"author"`
-	CreatedAt time.Time `json:"created_at"`
-}
-
-// FileHistoryResponse is the response for GET /file/:path/history.
-type FileHistoryResponse struct {
-	Entries []FileHistoryEntry `json:"entries"`
-}
-
-// ---------------------------------------------------------------------------
-// GET /file/:path
-// ---------------------------------------------------------------------------
-
-// FileResponse is the response for GET /file/:path.
-type FileResponse struct {
-	Path        string `json:"path"`
-	VersionID   string `json:"version_id"`
-	ContentHash string `json:"content_hash"`
-	Content     []byte `json:"content"`
-	ContentType string `json:"content_type,omitempty"`
-}
-
-// ---------------------------------------------------------------------------
-// GET /diff
-// ---------------------------------------------------------------------------
-
-// DiffEntry represents a single file change in a diff.
-type DiffEntry struct {
-	Path      string  `json:"path"`
-	VersionID *string `json:"version_id"` // nil means deleted
-	Binary    bool    `json:"binary,omitempty"`
-}
-
-// ConflictEntry represents a file that was changed on both main and the branch.
-type ConflictEntry struct {
-	Path            string `json:"path"`
-	MainVersionID   string `json:"main_version_id"`
-	BranchVersionID string `json:"branch_version_id"`
-}
-
-// DiffResponse is the response for GET /diff.
-type DiffResponse struct {
-	BranchChanges []DiffEntry     `json:"branch_changes"`
-	MainChanges   []DiffEntry     `json:"main_changes"`
-	Conflicts     []ConflictEntry `json:"conflicts,omitempty"`
-}
-
-// ---------------------------------------------------------------------------
-// GET /commit/:sequence
-// ---------------------------------------------------------------------------
-
-// CommitDetail represents one file change within a commit.
-type CommitDetail struct {
-	Path      string  `json:"path"`
-	VersionID *string `json:"version_id"` // nil means delete
-}
-
-// GetCommitResponse is the response for GET /commit/:sequence.
-type GetCommitResponse struct {
-	Sequence  int64          `json:"sequence"`
-	Message   string         `json:"message"`
-	Author    string         `json:"author"`
-	CreatedAt time.Time      `json:"created_at"`
-	Files     []CommitDetail `json:"files"`
-}
-
-// ---------------------------------------------------------------------------
-// GET /branches
-// ---------------------------------------------------------------------------
-
-// BranchesResponse is the response for GET /branches.
-type BranchesResponse struct {
-	Branches []Branch `json:"branches"`
-}
-
-// ---------------------------------------------------------------------------
-// GET /branch/:name/status
-// ---------------------------------------------------------------------------
-
-// PolicyResult is one policy evaluation outcome.
-type PolicyResult struct {
-	Name   string `json:"name"`
-	Pass   bool   `json:"pass"`
-	Reason string `json:"reason"`
-}
-
-// BranchStatusResponse is the response for GET /branch/:name/status.
-type BranchStatusResponse struct {
-	Mergeable bool           `json:"mergeable"`
-	Policies  []PolicyResult `json:"policies"`
-}
-
-// ---------------------------------------------------------------------------
-// POST /commit
-// ---------------------------------------------------------------------------
-
-// FileChange is one file in a commit request.
-// A nil Content means delete.
-type FileChange struct {
-	Path        string `json:"path"`
-	Content     []byte `json:"content,omitempty"`
-	ContentType string `json:"content_type,omitempty"`
-}
-
-// CommitRequest is the body for POST /repos/:name/commit.
-type CommitRequest struct {
-	Repo    string       `json:"repo,omitempty"`
-	Branch  string       `json:"branch"`
-	Files   []FileChange `json:"files"`
-	Message string       `json:"message"`
-	Author  string       `json:"author"`
-}
-
-// CommitFileResult describes one file outcome in a commit response.
-type CommitFileResult struct {
-	Path      string  `json:"path"`
-	VersionID *string `json:"version_id"` // nil for deletes
-}
-
-// CommitResponse is the response for POST /commit.
-type CommitResponse struct {
-	Sequence   int64              `json:"sequence"`
-	Files      []CommitFileResult `json:"files"`
-	CommitHash string             `json:"commit_hash,omitempty"`
-}
-
-// ---------------------------------------------------------------------------
-// POST /branch
-// ---------------------------------------------------------------------------
-
-// CreateBranchRequest is the body for POST /repos/:name/branch.
-type CreateBranchRequest struct {
-	Repo  string `json:"repo,omitempty"`
-	Name  string `json:"name"`
-	Draft bool   `json:"draft,omitempty"`
-}
-
-// CreateBranchResponse is the response for POST /branch.
-type CreateBranchResponse struct {
-	Name         string `json:"name"`
-	BaseSequence int64  `json:"base_sequence"`
-	Draft        bool   `json:"draft,omitempty"`
-}
-
-// UpdateBranchRequest is the body for PATCH /repos/:name/branch/:name.
-type UpdateBranchRequest struct {
-	Draft bool `json:"draft"`
-}
-
-// UpdateBranchResponse is the response for PATCH /repos/:name/branch/:name.
-type UpdateBranchResponse struct {
-	Name  string `json:"name"`
-	Draft bool   `json:"draft"`
-}
-
-// ---------------------------------------------------------------------------
-// POST /merge
-// ---------------------------------------------------------------------------
-
-// MergeRequest is the body for POST /repos/:name/merge.
-type MergeRequest struct {
-	Repo   string `json:"repo,omitempty"`
-	Branch string `json:"branch"`
-	Author string `json:"author,omitempty"`
-}
-
-// MergeResponse is the response for a successful POST /merge.
-type MergeResponse struct {
-	Sequence int64 `json:"sequence"`
-}
-
-// MergeConflictError is the error response when merge has conflicts.
-type MergeConflictError struct {
-	Conflicts []ConflictEntry `json:"conflicts"`
-}
-
-// MergePolicyError is the error response when merge policies fail.
-type MergePolicyError struct {
-	Policies []PolicyResult `json:"policies"`
-}
-
-// ---------------------------------------------------------------------------
-// POST /rebase
-// ---------------------------------------------------------------------------
-
-// RebaseRequest is the body for POST /repos/:name/rebase.
-type RebaseRequest struct {
-	Repo   string `json:"repo,omitempty"`
-	Branch string `json:"branch"`
-	Author string `json:"author,omitempty"`
-}
-
-// RebaseResponse is the response for a successful POST /rebase.
-type RebaseResponse struct {
-	NewBaseSequence int64 `json:"base_sequence"`
-	NewHeadSequence int64 `json:"head_sequence"`
-	CommitsReplayed int64 `json:"commits_replayed"`
-}
-
-// RebaseConflictError is the error response when rebase has conflicts.
-type RebaseConflictError struct {
-	Conflicts []ConflictEntry `json:"conflicts"`
-}
-
-// ---------------------------------------------------------------------------
-// POST /review
-// ---------------------------------------------------------------------------
-
-// CreateReviewRequest is the body for POST /review.
-type CreateReviewRequest struct {
-	Branch string       `json:"branch"`
-	Status ReviewStatus `json:"status"`
-	Body   string       `json:"body,omitempty"`
-}
-
-// CreateReviewResponse is the response for POST /review.
-type CreateReviewResponse struct {
-	ID       string `json:"id"`
-	Sequence int64  `json:"sequence"`
-}
-
-// ---------------------------------------------------------------------------
-// POST /check
-// ---------------------------------------------------------------------------
-
-// CreateCheckRunRequest is the body for POST /check.
-type CreateCheckRunRequest struct {
-	Branch    string         `json:"branch"`
-	CheckName string         `json:"check_name"`
-	Status    CheckRunStatus `json:"status"`
-	LogURL    *string        `json:"log_url,omitempty"`
-}
-
-// CreateCheckRunResponse is the response for POST /check.
-type CreateCheckRunResponse struct {
-	ID       string `json:"id"`
-	Sequence int64  `json:"sequence"`
-}
-
-// ---------------------------------------------------------------------------
-// DELETE /branch/:name
-// ---------------------------------------------------------------------------
-
-// DeleteBranchResponse is the response for DELETE /branch/:name.
-type DeleteBranchResponse struct {
-	Name   string       `json:"name"`
-	Status BranchStatus `json:"status"`
-}
-
-// ---------------------------------------------------------------------------
-// POST /orgs / GET /orgs / GET /orgs/:name / DELETE /orgs/:name
-// ---------------------------------------------------------------------------
-
-// CreateOrgRequest is the body for POST /orgs.
-type CreateOrgRequest struct {
-	Name string `json:"name"`
-}
-
-// CreateOrgResponse is the response for POST /orgs (same fields as Org).
-type CreateOrgResponse = Org
-
-// ListOrgsResponse is the response for GET /orgs.
-type ListOrgsResponse struct {
-	Orgs []Org `json:"orgs"`
-}
-
-// ---------------------------------------------------------------------------
-// POST /repos / GET /repos / GET /repos/:name / DELETE /repos/:name
-// ---------------------------------------------------------------------------
-
-// CreateRepoRequest is the body for POST /repos.
-// Owner is the org name; Name is the repo path within the org (may contain slashes).
-// The full repo identifier is Owner + "/" + Name.
-type CreateRepoRequest struct {
-	Owner     string `json:"owner"`
-	Name      string `json:"name"`
-	CreatedBy string `json:"created_by,omitempty"`
-}
-
-// FullName returns the full repo path: owner + "/" + name.
-func (r CreateRepoRequest) FullName() string { return r.Owner + "/" + r.Name }
-
-// ReposResponse is the response for GET /repos.
-type ReposResponse struct {
-	Repos []Repo `json:"repos"`
-}
-
-// ---------------------------------------------------------------------------
-// GET /repos/:name/roles / PUT /repos/:name/roles/:identity / DELETE /repos/:name/roles/:identity
-// ---------------------------------------------------------------------------
-
-// SetRoleRequest is the body for PUT /repos/:name/roles/:identity.
-type SetRoleRequest struct {
-	Role RoleType `json:"role"`
-}
-
-// RolesResponse is the response for GET /repos/:name/roles.
-type RolesResponse struct {
-	Roles []Role `json:"roles"`
-}
-
-// ---------------------------------------------------------------------------
-// POST /repos/:name/purge
-// ---------------------------------------------------------------------------
-
-// PurgeRequest is the body for POST /repos/:name/purge.
-type PurgeRequest struct {
-	OlderThan string `json:"older_than"`
-	DryRun    bool   `json:"dry_run,omitempty"`
-}
-
-// PurgeResponse is the response for POST /repos/:name/purge.
-type PurgeResponse struct {
-	BranchesPurged     int64 `json:"branches_purged"`
-	FileCommitsDeleted int64 `json:"file_commits_deleted"`
-	CommitsDeleted     int64 `json:"commits_deleted"`
-	DocumentsDeleted   int64 `json:"documents_deleted"`
-	ReviewsDeleted     int64 `json:"reviews_deleted"`
-	CheckRunsDeleted   int64 `json:"check_runs_deleted"`
-}
-
-// ---------------------------------------------------------------------------
-// POST /orgs/{org}/members/{identity} / DELETE /orgs/{org}/members/{identity} / GET /orgs/{org}/members
-// ---------------------------------------------------------------------------
-
-// AddOrgMemberRequest is the body for POST /orgs/{org}/members/{identity}.
-type AddOrgMemberRequest struct {
-	Role OrgRole `json:"role"`
-}
-
-// OrgMembersResponse is the response for GET /orgs/{org}/members.
-type OrgMembersResponse struct {
-	Members []OrgMember `json:"members"`
-}
-
-// ---------------------------------------------------------------------------
-// POST /orgs/{org}/invites / GET /orgs/{org}/invites / DELETE /orgs/{org}/invites/{id}
-// ---------------------------------------------------------------------------
-
-// CreateInviteRequest is the body for POST /orgs/{org}/invites.
-type CreateInviteRequest struct {
-	Email string  `json:"email"`
-	Role  OrgRole `json:"role"`
-}
-
-// CreateInviteResponse is the response for POST /orgs/{org}/invites.
-type CreateInviteResponse struct {
-	ID    string `json:"id"`
-	Token string `json:"token"`
-}
-
-// OrgInvitesResponse is the response for GET /orgs/{org}/invites.
-type OrgInvitesResponse struct {
-	Invites []OrgInvite `json:"invites"`
-}
-
-// ---------------------------------------------------------------------------
-// POST /repos/{owner}/{name}/-/releases
-// GET  /repos/{owner}/{name}/-/releases
-// GET  /repos/{owner}/{name}/-/releases/{name}
-// DELETE /repos/{owner}/{name}/-/releases/{name}
-// ---------------------------------------------------------------------------
-
-// CreateReleaseRequest is the body for POST /repos/:name/-/releases.
-// Sequence defaults to the current main head if omitted.
-type CreateReleaseRequest struct {
-	Name     string `json:"name"`
-	Sequence *int64 `json:"sequence,omitempty"`
-	Body     string `json:"body,omitempty"`
-}
-
-// ListReleasesResponse is the response for GET /repos/:name/-/releases.
-type ListReleasesResponse struct {
-	Releases []Release `json:"releases"`
-}
-
-// ---------------------------------------------------------------------------
-// Error
-// ---------------------------------------------------------------------------
-
-// ErrorResponse is a generic API error envelope.
-type ErrorResponse struct {
-	Error string `json:"error"`
-}
+import "github.com/dlorenc/docstore/api"
+
+// HTTP request/response wire types are defined in github.com/dlorenc/docstore/api
+// and re-exported here as aliases for backward compatibility with existing
+// server and CLI code. New code should import the api package directly.
+
+type PaginationParams = api.PaginationParams
+
+type TreeEntry = api.TreeEntry
+type TreeResponse = api.TreeResponse
+
+type FileHistoryEntry = api.FileHistoryEntry
+type FileHistoryResponse = api.FileHistoryResponse
+
+type FileResponse = api.FileResponse
+
+type DiffEntry = api.DiffEntry
+type ConflictEntry = api.ConflictEntry
+type DiffResponse = api.DiffResponse
+
+type CommitDetail = api.CommitDetail
+type GetCommitResponse = api.GetCommitResponse
+
+type BranchesResponse = api.BranchesResponse
+
+type PolicyResult = api.PolicyResult
+type BranchStatusResponse = api.BranchStatusResponse
+
+type FileChange = api.FileChange
+type CommitRequest = api.CommitRequest
+type CommitFileResult = api.CommitFileResult
+type CommitResponse = api.CommitResponse
+
+type CreateBranchRequest = api.CreateBranchRequest
+type CreateBranchResponse = api.CreateBranchResponse
+type UpdateBranchRequest = api.UpdateBranchRequest
+type UpdateBranchResponse = api.UpdateBranchResponse
+type DeleteBranchResponse = api.DeleteBranchResponse
+
+type MergeRequest = api.MergeRequest
+type MergeResponse = api.MergeResponse
+type MergeConflictError = api.MergeConflictError
+type MergePolicyError = api.MergePolicyError
+
+type RebaseRequest = api.RebaseRequest
+type RebaseResponse = api.RebaseResponse
+type RebaseConflictError = api.RebaseConflictError
+
+type CreateReviewRequest = api.CreateReviewRequest
+type CreateReviewResponse = api.CreateReviewResponse
+
+type CreateCheckRunRequest = api.CreateCheckRunRequest
+type CreateCheckRunResponse = api.CreateCheckRunResponse
+
+type CreateOrgRequest = api.CreateOrgRequest
+type CreateOrgResponse = api.CreateOrgResponse
+type ListOrgsResponse = api.ListOrgsResponse
+
+type CreateRepoRequest = api.CreateRepoRequest
+type ReposResponse = api.ReposResponse
+
+type SetRoleRequest = api.SetRoleRequest
+type RolesResponse = api.RolesResponse
+
+type PurgeRequest = api.PurgeRequest
+type PurgeResponse = api.PurgeResponse
+
+type AddOrgMemberRequest = api.AddOrgMemberRequest
+type OrgMembersResponse = api.OrgMembersResponse
+
+type CreateInviteRequest = api.CreateInviteRequest
+type CreateInviteResponse = api.CreateInviteResponse
+type OrgInvitesResponse = api.OrgInvitesResponse
+
+type CreateReleaseRequest = api.CreateReleaseRequest
+type ListReleasesResponse = api.ListReleasesResponse
+
+type ErrorResponse = api.ErrorResponse

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1,92 +1,76 @@
-// Package model defines the data types for all six database tables
-// described in DESIGN.md.
+// Package model defines data types for the docstore server.
+//
+// Wire-facing types (anything that crosses the HTTP boundary) live in the
+// public github.com/dlorenc/docstore/api package and are re-exported here as
+// type aliases so existing server/CLI code that imports this package keeps
+// working. Internal-only types (storage-layer rows that never appear on the
+// wire) remain defined here.
 package model
 
-import "time"
+import (
+	"time"
 
-// OrgRole represents the role of an org member.
-type OrgRole string
-
-const (
-	OrgRoleOwner  OrgRole = "owner"
-	OrgRoleMember OrgRole = "member"
+	"github.com/dlorenc/docstore/api"
 )
 
-// OrgMember is a member of an org with a specific role.
-type OrgMember struct {
-	Org       string    `json:"org"`
-	Identity  string    `json:"identity"`
-	Role      OrgRole   `json:"role"`
-	InvitedBy string    `json:"invited_by"`
-	CreatedAt time.Time `json:"created_at"`
-}
+// ---------------------------------------------------------------------------
+// Wire-type aliases — canonical definitions in github.com/dlorenc/docstore/api.
+// ---------------------------------------------------------------------------
 
-// OrgInvite is a pending or accepted invitation to join an org.
-type OrgInvite struct {
-	ID         string     `json:"id"`
-	Org        string     `json:"org"`
-	Email      string     `json:"email"`
-	Role       OrgRole    `json:"role"`
-	InvitedBy  string     `json:"invited_by"`
-	Token      string     `json:"token,omitempty"`
-	ExpiresAt  time.Time  `json:"expires_at"`
-	AcceptedAt *time.Time `json:"accepted_at,omitempty"`
-	CreatedAt  time.Time  `json:"created_at"`
-}
-
-// Org is a top-level namespace that owns one or more repos.
-type Org struct {
-	Name      string    `json:"name"`
-	CreatedAt time.Time `json:"created_at"`
-	CreatedBy string    `json:"created_by"`
-}
-
-// Repo is a named tenant that owns its own isolated set of branches and commits.
-// Name is the full path (e.g. "acme/myrepo" or "acme/team/subrepo").
-// Owner is the first path segment, i.e. the org name.
-type Repo struct {
-	Name      string    `json:"name"`
-	Owner     string    `json:"owner"`
-	CreatedAt time.Time `json:"created_at"`
-	CreatedBy string    `json:"created_by"`
-}
-
-// BranchStatus represents the lifecycle state of a branch.
-type BranchStatus string
+type OrgRole = api.OrgRole
 
 const (
-	BranchStatusActive    BranchStatus = "active"
-	BranchStatusMerged    BranchStatus = "merged"
-	BranchStatusAbandoned BranchStatus = "abandoned"
+	OrgRoleOwner  = api.OrgRoleOwner
+	OrgRoleMember = api.OrgRoleMember
 )
 
-// RoleType represents coarse-grained permission levels.
-type RoleType string
+type OrgMember = api.OrgMember
+type OrgInvite = api.OrgInvite
+type Org = api.Org
+type Repo = api.Repo
+
+type BranchStatus = api.BranchStatus
 
 const (
-	RoleReader     RoleType = "reader"
-	RoleWriter     RoleType = "writer"
-	RoleMaintainer RoleType = "maintainer"
-	RoleAdmin      RoleType = "admin"
+	BranchStatusActive    = api.BranchStatusActive
+	BranchStatusMerged    = api.BranchStatusMerged
+	BranchStatusAbandoned = api.BranchStatusAbandoned
 )
 
-// ReviewStatus represents the outcome of a review.
-type ReviewStatus string
+type RoleType = api.RoleType
 
 const (
-	ReviewApproved  ReviewStatus = "approved"
-	ReviewRejected  ReviewStatus = "rejected"
-	ReviewDismissed ReviewStatus = "dismissed"
+	RoleReader     = api.RoleReader
+	RoleWriter     = api.RoleWriter
+	RoleMaintainer = api.RoleMaintainer
+	RoleAdmin      = api.RoleAdmin
 )
 
-// CheckRunStatus represents the state of a CI check run.
-type CheckRunStatus string
+type ReviewStatus = api.ReviewStatus
 
 const (
-	CheckRunPending CheckRunStatus = "pending"
-	CheckRunPassed  CheckRunStatus = "passed"
-	CheckRunFailed  CheckRunStatus = "failed"
+	ReviewApproved  = api.ReviewApproved
+	ReviewRejected  = api.ReviewRejected
+	ReviewDismissed = api.ReviewDismissed
 )
+
+type CheckRunStatus = api.CheckRunStatus
+
+const (
+	CheckRunPending = api.CheckRunPending
+	CheckRunPassed  = api.CheckRunPassed
+	CheckRunFailed  = api.CheckRunFailed
+)
+
+type Branch = api.Branch
+type Role = api.Role
+type Review = api.Review
+type CheckRun = api.CheckRun
+type Release = api.Release
+
+// ---------------------------------------------------------------------------
+// Internal-only types — not part of the HTTP wire surface.
+// ---------------------------------------------------------------------------
 
 // Document stores an immutable file version. Every save creates a new row.
 type Document struct {
@@ -111,55 +95,3 @@ type FileCommit struct {
 	Author    string    `json:"author"`
 	CreatedAt time.Time `json:"created_at"`
 }
-
-// Branch is a named pointer to a sequence.
-type Branch struct {
-	Name         string       `json:"name"`
-	HeadSequence int64        `json:"head_sequence"`
-	BaseSequence int64        `json:"base_sequence"`
-	Status       BranchStatus `json:"status"`
-	Draft        bool         `json:"draft"`
-}
-
-// Role maps an identity to a coarse-grained permission level.
-type Role struct {
-	Identity string   `json:"identity"`
-	Role     RoleType `json:"role"`
-}
-
-// Review records an approval or rejection scoped to a branch at a
-// specific head sequence.
-type Review struct {
-	ID        string       `json:"id"`
-	Branch    string       `json:"branch"`
-	Reviewer  string       `json:"reviewer"`
-	Sequence  int64        `json:"sequence"`
-	Status    ReviewStatus `json:"status"`
-	Body      string       `json:"body,omitempty"`
-	CreatedAt time.Time    `json:"created_at"`
-}
-
-// CheckRun stores an external CI status report for a branch at a
-// specific head sequence.
-type CheckRun struct {
-	ID        string         `json:"id"`
-	Branch    string         `json:"branch"`
-	Sequence  int64          `json:"sequence"`
-	CheckName string         `json:"check_name"`
-	Status    CheckRunStatus `json:"status"`
-	Reporter  string         `json:"reporter"`
-	LogURL    *string        `json:"log_url,omitempty"`
-	CreatedAt time.Time      `json:"created_at"`
-}
-
-// Release is a named immutable snapshot tied to a commit sequence.
-type Release struct {
-	ID        string    `json:"id"`
-	Repo      string    `json:"repo"`
-	Name      string    `json:"name"`
-	Sequence  int64     `json:"sequence"`
-	Body      string    `json:"body,omitempty"`
-	CreatedBy string    `json:"created_by"`
-	CreatedAt time.Time `json:"created_at"`
-}
-

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dlorenc/docstore/api"
 	"github.com/dlorenc/docstore/internal/blob"
 )
 
@@ -448,21 +449,11 @@ func isBinaryContentType(ct string) bool {
 }
 
 // ChainEntry is one commit in the hash chain response.
-type ChainEntry struct {
-	Sequence   int64       `json:"sequence"`
-	Branch     string      `json:"branch"`
-	Author     string      `json:"author"`
-	Message    string      `json:"message"`
-	CreatedAt  time.Time   `json:"created_at"`
-	CommitHash *string     `json:"commit_hash"`
-	Files      []ChainFile `json:"files"`
-}
+// Aliased to api.ChainEntry so the public SDK and server agree on shape.
+type ChainEntry = api.ChainEntry
 
 // ChainFile is one file change within a ChainEntry.
-type ChainFile struct {
-	Path        string `json:"path"`
-	ContentHash string `json:"content_hash"`
-}
+type ChainFile = api.ChainFile
 
 // GetChain returns commit metadata for sequences in [from, to] inclusive,
 // ordered by sequence ascending. Each entry includes the commit_hash (if set)

--- a/sdk/go/docstore/client.go
+++ b/sdk/go/docstore/client.go
@@ -1,0 +1,89 @@
+package docstore
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// DefaultUserAgent is sent on every request unless overridden via
+// WithUserAgent.
+const DefaultUserAgent = "docstore-go-sdk/0.1"
+
+// Client is the entry point for all API calls. It is safe for concurrent use.
+type Client struct {
+	baseURL   string
+	http      *http.Client
+	userAgent string
+
+	bearerToken string
+	identity    string
+}
+
+// ClientOption configures a Client constructed with NewClient.
+type ClientOption func(*Client)
+
+// NewClient returns a Client targeting the docstore server at baseURL. The
+// URL may include a path prefix (e.g. "https://api.example.com/docstore");
+// trailing slashes are stripped.
+func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, errors.New("docstore: base URL is required")
+	}
+	c := &Client{
+		baseURL:   strings.TrimRight(baseURL, "/"),
+		http:      http.DefaultClient,
+		userAgent: DefaultUserAgent,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c, nil
+}
+
+// WithBearerToken sets the Authorization header to "Bearer <token>" on every
+// request. Forward-compatible with API tokens tracked in server issue #101.
+func WithBearerToken(token string) ClientOption {
+	return func(c *Client) { c.bearerToken = token }
+}
+
+// WithIdentity sets the X-DocStore-Identity header on every request. The
+// server only honours this header in dev mode (no IAP); use it for local
+// development and tests.
+func WithIdentity(identity string) ClientOption {
+	return func(c *Client) { c.identity = identity }
+}
+
+// WithHTTPClient replaces the *http.Client used for all requests. Use it to
+// inject timeouts, proxies, or an IAP-authenticated transport.
+func WithHTTPClient(h *http.Client) ClientOption {
+	return func(c *Client) {
+		if h != nil {
+			c.http = h
+		}
+	}
+}
+
+// WithUserAgent overrides the User-Agent header. The default is
+// DefaultUserAgent.
+func WithUserAgent(ua string) ClientOption {
+	return func(c *Client) {
+		if ua != "" {
+			c.userAgent = ua
+		}
+	}
+}
+
+// Repo returns a handle scoped to the repo with full path "owner/name" (e.g.
+// "acme/platform"). The handle is cheap to construct; reuse it or create new
+// ones as convenient.
+func (c *Client) Repo(name string) *RepoClient {
+	return &RepoClient{client: c, repo: strings.Trim(name, "/")}
+}
+
+// Orgs returns the service for organisation-level endpoints.
+func (c *Client) Orgs() *OrgsService { return &OrgsService{client: c} }
+
+// Repos returns the service for repo-CRUD endpoints (distinct from the
+// repo-scoped operations exposed by Client.Repo).
+func (c *Client) Repos() *ReposService { return &ReposService{client: c} }

--- a/sdk/go/docstore/client_test.go
+++ b/sdk/go/docstore/client_test.go
@@ -1,0 +1,411 @@
+package docstore_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dlorenc/docstore/api"
+	"github.com/dlorenc/docstore/sdk/go/docstore"
+)
+
+// recordingHandler records the last request it handled and returns a scripted
+// response. Tests assert on both directions.
+type recordingHandler struct {
+	t        *testing.T
+	status   int
+	respBody any
+
+	// captured
+	method    string
+	path      string
+	rawQuery  string
+	headers   http.Header
+	reqBody   []byte
+	reqCount  int
+	reqBodyFn func([]byte)
+}
+
+func (h *recordingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.reqCount++
+	h.method = r.Method
+	h.path = r.URL.Path
+	h.rawQuery = r.URL.RawQuery
+	h.headers = r.Header.Clone()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		h.t.Fatalf("read body: %v", err)
+	}
+	h.reqBody = body
+	if h.reqBodyFn != nil {
+		h.reqBodyFn(body)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if h.status == 0 {
+		h.status = http.StatusOK
+	}
+	w.WriteHeader(h.status)
+	if h.respBody != nil && h.status != http.StatusNoContent {
+		if err := json.NewEncoder(w).Encode(h.respBody); err != nil {
+			h.t.Fatalf("encode resp: %v", err)
+		}
+	}
+}
+
+func newServer(t *testing.T, h *recordingHandler) (string, func()) {
+	t.Helper()
+	h.t = t
+	srv := httptest.NewServer(h)
+	return srv.URL, srv.Close
+}
+
+func newClient(t *testing.T, base string, opts ...docstore.ClientOption) *docstore.Client {
+	t.Helper()
+	c, err := docstore.NewClient(base, opts...)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+func TestNewClient_Validation(t *testing.T) {
+	if _, err := docstore.NewClient(""); err == nil {
+		t.Fatal("expected error for empty base URL")
+	}
+	if _, err := docstore.NewClient("   "); err == nil {
+		t.Fatal("expected error for whitespace base URL")
+	}
+}
+
+func TestFile_SendsExpectedRequest(t *testing.T) {
+	h := &recordingHandler{respBody: api.FileResponse{
+		Path: "config.yaml", VersionID: "v1", ContentHash: "h1",
+		Content: []byte("hello"),
+	}}
+	base, stop := newServer(t, h)
+	defer stop()
+
+	c := newClient(t, base,
+		docstore.WithBearerToken("tok"),
+		docstore.WithIdentity("alice@example.com"),
+		docstore.WithUserAgent("sdk-test/1.0"),
+	)
+
+	got, err := c.Repo("acme/platform").File(context.Background(),
+		"config.yaml", docstore.AtHead("main"))
+	if err != nil {
+		t.Fatalf("File: %v", err)
+	}
+	if got.Path != "config.yaml" || string(got.Content) != "hello" {
+		t.Errorf("unexpected response: %+v", got)
+	}
+
+	if h.method != "GET" {
+		t.Errorf("method = %q, want GET", h.method)
+	}
+	if h.path != "/repos/acme/platform/-/file/config.yaml" {
+		t.Errorf("path = %q", h.path)
+	}
+	if h.rawQuery != "branch=main" {
+		t.Errorf("query = %q", h.rawQuery)
+	}
+	if got, want := h.headers.Get("Authorization"), "Bearer tok"; got != want {
+		t.Errorf("Authorization = %q, want %q", got, want)
+	}
+	if got, want := h.headers.Get("X-DocStore-Identity"), "alice@example.com"; got != want {
+		t.Errorf("X-DocStore-Identity = %q, want %q", got, want)
+	}
+	if got := h.headers.Get("User-Agent"); got != "sdk-test/1.0" {
+		t.Errorf("User-Agent = %q", got)
+	}
+}
+
+func TestFile_NestedPathIsEscaped(t *testing.T) {
+	h := &recordingHandler{respBody: api.FileResponse{Path: "a/b c/d.yaml"}}
+	base, stop := newServer(t, h)
+	defer stop()
+
+	c := newClient(t, base)
+	if _, err := c.Repo("acme/platform").File(context.Background(), "a/b c/d.yaml"); err != nil {
+		t.Fatalf("File: %v", err)
+	}
+	// "b c" must round-trip as %20 or +. Go decodes r.URL.Path already, so the
+	// server sees the escaped form in RawPath. Here we check RawPath via the
+	// captured path.
+	if !strings.HasPrefix(h.path, "/repos/acme/platform/-/file/a/b") {
+		t.Errorf("path = %q", h.path)
+	}
+}
+
+func TestCommit_PostsJSONBody(t *testing.T) {
+	h := &recordingHandler{
+		status:   http.StatusCreated,
+		respBody: api.CommitResponse{Sequence: 42},
+	}
+	base, stop := newServer(t, h)
+	defer stop()
+
+	c := newClient(t, base)
+	_, err := c.Repo("acme/platform").Commit(context.Background(), api.CommitRequest{
+		Branch:  "main",
+		Message: "test",
+		Files:   []api.FileChange{{Path: "a.txt", Content: []byte("x")}},
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	if h.method != "POST" || h.path != "/repos/acme/platform/-/commit" {
+		t.Errorf("method/path = %s %s", h.method, h.path)
+	}
+	if ct := h.headers.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q", ct)
+	}
+	var got api.CommitRequest
+	if err := json.Unmarshal(h.reqBody, &got); err != nil {
+		t.Fatalf("unmarshal req: %v", err)
+	}
+	if got.Branch != "main" || len(got.Files) != 1 || got.Files[0].Path != "a.txt" {
+		t.Errorf("req body = %+v", got)
+	}
+}
+
+func TestErrors_SentinelsMatchViaIs(t *testing.T) {
+	cases := []struct {
+		status int
+		want   error
+	}{
+		{http.StatusUnauthorized, docstore.ErrUnauthorized},
+		{http.StatusForbidden, docstore.ErrForbidden},
+		{http.StatusNotFound, docstore.ErrNotFound},
+		{http.StatusConflict, docstore.ErrConflict},
+	}
+	for _, tc := range cases {
+		h := &recordingHandler{
+			status:   tc.status,
+			respBody: api.ErrorResponse{Error: "boom"},
+		}
+		base, stop := newServer(t, h)
+
+		c := newClient(t, base)
+		_, err := c.Repo("x/y").File(context.Background(), "z")
+		stop()
+		if err == nil {
+			t.Fatalf("status %d: expected error", tc.status)
+		}
+		if !errors.Is(err, tc.want) {
+			t.Errorf("status %d: errors.Is returned false for %v", tc.status, tc.want)
+		}
+		var se *docstore.Error
+		if !errors.As(err, &se) {
+			t.Errorf("status %d: errors.As to *docstore.Error failed", tc.status)
+		} else if se.Message != "boom" {
+			t.Errorf("status %d: message = %q", tc.status, se.Message)
+		}
+	}
+}
+
+func TestMerge_ConflictErrorCarriesPayload(t *testing.T) {
+	conflicts := []api.ConflictEntry{
+		{Path: "a.txt", MainVersionID: "v1", BranchVersionID: "v2"},
+	}
+	h := &recordingHandler{
+		status:   http.StatusConflict,
+		respBody: api.MergeConflictError{Conflicts: conflicts},
+	}
+	base, stop := newServer(t, h)
+	defer stop()
+
+	c := newClient(t, base)
+	_, err := c.Repo("a/b").Merge(context.Background(), api.MergeRequest{Branch: "feat"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var ce *docstore.ConflictError
+	if !errors.As(err, &ce) {
+		t.Fatalf("errors.As *ConflictError failed for %T", err)
+	}
+	if len(ce.Conflicts) != 1 || ce.Conflicts[0].Path != "a.txt" {
+		t.Errorf("conflicts = %+v", ce.Conflicts)
+	}
+	if !errors.Is(err, docstore.ErrConflict) {
+		t.Error("expected errors.Is ErrConflict")
+	}
+}
+
+func TestMerge_PolicyErrorCarriesPayload(t *testing.T) {
+	policies := []api.PolicyResult{
+		{Name: "two-approvals", Pass: false, Reason: "only 1 approval"},
+	}
+	h := &recordingHandler{
+		status:   http.StatusForbidden,
+		respBody: api.MergePolicyError{Policies: policies},
+	}
+	base, stop := newServer(t, h)
+	defer stop()
+
+	c := newClient(t, base)
+	_, err := c.Repo("a/b").Merge(context.Background(), api.MergeRequest{Branch: "feat"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var pe *docstore.PolicyError
+	if !errors.As(err, &pe) {
+		t.Fatalf("errors.As *PolicyError failed for %T", err)
+	}
+	if len(pe.Policies) != 1 || pe.Policies[0].Name != "two-approvals" {
+		t.Errorf("policies = %+v", pe.Policies)
+	}
+}
+
+func TestBranches_QueryParamsFromOptions(t *testing.T) {
+	h := &recordingHandler{respBody: api.BranchesResponse{}}
+	base, stop := newServer(t, h)
+	defer stop()
+
+	c := newClient(t, base)
+	_, err := c.Repo("a/b").Branches(context.Background(),
+		docstore.BranchStatusFilter(api.BranchStatusActive),
+		docstore.BranchIncludeDraft(),
+	)
+	if err != nil {
+		t.Fatalf("Branches: %v", err)
+	}
+	// Order within a url.Values is stable by key alphabetically, since
+	// net/url encodes keys sorted.
+	if h.rawQuery != "include_draft=true&status=active" {
+		t.Errorf("query = %q", h.rawQuery)
+	}
+}
+
+func TestTree_PaginationOptions(t *testing.T) {
+	h := &recordingHandler{respBody: api.TreeResponse{}}
+	base, stop := newServer(t, h)
+	defer stop()
+
+	c := newClient(t, base)
+	_, err := c.Repo("a/b").Tree(context.Background(),
+		docstore.TreeAtHead("main"),
+		docstore.TreeLimit(50),
+		docstore.TreeAfter("configs/"),
+	)
+	if err != nil {
+		t.Fatalf("Tree: %v", err)
+	}
+	// Sorted alphabetical: after, branch, limit.
+	if h.rawQuery != "after=configs%2F&branch=main&limit=50" {
+		t.Errorf("query = %q", h.rawQuery)
+	}
+}
+
+func TestRoles_PutAndDelete(t *testing.T) {
+	h := &recordingHandler{}
+	base, stop := newServer(t, h)
+	defer stop()
+
+	c := newClient(t, base)
+	if err := c.Repo("a/b").SetRole(context.Background(), "user@example.com", api.RoleMaintainer); err != nil {
+		t.Fatalf("SetRole: %v", err)
+	}
+	if h.method != "PUT" || h.path != "/repos/a/b/-/roles/user@example.com" {
+		t.Errorf("PUT got %s %s", h.method, h.path)
+	}
+	var req api.SetRoleRequest
+	if err := json.Unmarshal(h.reqBody, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.Role != api.RoleMaintainer {
+		t.Errorf("role = %q", req.Role)
+	}
+
+	h.status = http.StatusNoContent
+	if err := c.Repo("a/b").DeleteRole(context.Background(), "user@example.com"); err != nil {
+		t.Fatalf("DeleteRole: %v", err)
+	}
+	if h.method != "DELETE" {
+		t.Errorf("DELETE method = %q", h.method)
+	}
+}
+
+func TestOrgs_CreateAndMembers(t *testing.T) {
+	h := &recordingHandler{
+		status:   http.StatusCreated,
+		respBody: api.Org{Name: "acme"},
+	}
+	base, stop := newServer(t, h)
+	defer stop()
+
+	c := newClient(t, base)
+	if _, err := c.Orgs().Create(context.Background(), api.CreateOrgRequest{Name: "acme"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if h.method != "POST" || h.path != "/orgs" {
+		t.Errorf("got %s %s", h.method, h.path)
+	}
+
+	h.status = http.StatusOK
+	h.respBody = api.OrgMember{Org: "acme", Identity: "u@example.com", Role: api.OrgRoleMember}
+	if _, err := c.Orgs().AddMember(context.Background(), "acme", "u@example.com", api.OrgRoleMember); err != nil {
+		t.Fatalf("AddMember: %v", err)
+	}
+	if h.path != "/orgs/acme/members/u@example.com" {
+		t.Errorf("path = %q", h.path)
+	}
+}
+
+func TestRepos_CRUD(t *testing.T) {
+	h := &recordingHandler{
+		status:   http.StatusCreated,
+		respBody: api.Repo{Owner: "acme", Name: "acme/platform"},
+	}
+	base, stop := newServer(t, h)
+	defer stop()
+
+	c := newClient(t, base)
+	if _, err := c.Repos().Create(context.Background(), api.CreateRepoRequest{Owner: "acme", Name: "platform"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if h.path != "/repos" {
+		t.Errorf("create path = %q", h.path)
+	}
+
+	h.status = http.StatusOK
+	h.respBody = api.Repo{Owner: "acme", Name: "acme/platform"}
+	if _, err := c.Repos().Get(context.Background(), "acme/platform"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if h.path != "/repos/acme/platform" {
+		t.Errorf("get path = %q", h.path)
+	}
+
+	h.status = http.StatusNoContent
+	if err := c.Repos().Delete(context.Background(), "acme/platform"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if h.method != "DELETE" {
+		t.Errorf("delete method = %q", h.method)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	c := newClient(t, srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := c.Repo("a/b").File(ctx, "x")
+	if err == nil {
+		t.Fatal("expected context error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("got %v, want context.Canceled", err)
+	}
+}

--- a/sdk/go/docstore/doc.go
+++ b/sdk/go/docstore/doc.go
@@ -1,0 +1,51 @@
+// Package docstore is the official Go client library for the docstore server.
+//
+// # Usage
+//
+// Construct a client with the base URL of a docstore server and one or more
+// authentication options, then use the resource-scoped handles to call the
+// API:
+//
+//	client, err := docstore.NewClient("https://api.example.com",
+//	    docstore.WithBearerToken(os.Getenv("DOCSTORE_TOKEN")),
+//	)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Commit files on a branch.
+//	_, err = client.Repo("acme/platform").Commit(ctx, api.CommitRequest{
+//	    Branch:  "main",
+//	    Message: "update config",
+//	    Files: []api.FileChange{
+//	        {Path: "config.yaml", Content: []byte("version: 2\n")},
+//	    },
+//	})
+//
+//	// Read a file at the head of main.
+//	file, err := client.Repo("acme/platform").File(ctx, "config.yaml",
+//	    docstore.AtHead("main"))
+//
+// # Authentication
+//
+// WithBearerToken sets Authorization: Bearer <token>. This is forward-
+// compatible with the API-token feature tracked in issue #101 of the server
+// repo; today the server validates GCP IAP JWTs via the
+// X-Goog-IAP-JWT-Assertion header, which is typically terminated by a
+// reverse proxy. When calling the server directly (for example from within
+// the same VPC behind IAP), provide an IAP-authenticated *http.Client via
+// WithHTTPClient.
+//
+// WithIdentity sets the X-DocStore-Identity header, which the server
+// honours when running in dev mode (no IAP). Use it for local development
+// and test fixtures.
+//
+// # Errors
+//
+// All non-2xx responses are decoded into a *Error value that carries the
+// HTTP status code and the server's error message. Common status codes also
+// match sentinel errors (ErrNotFound, ErrUnauthorized, ErrForbidden) via
+// errors.Is. Merge and rebase responses that fail with 409 Conflict or with
+// a policy denial are wrapped into *ConflictError or *PolicyError values
+// that expose the structured payload; unwrap them with errors.As.
+package docstore

--- a/sdk/go/docstore/errors.go
+++ b/sdk/go/docstore/errors.go
@@ -1,0 +1,104 @@
+package docstore
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/dlorenc/docstore/api"
+)
+
+// Sentinel errors for common HTTP failure modes. Match with errors.Is; the
+// underlying *Error still carries the full response context.
+var (
+	ErrUnauthorized = errors.New("docstore: unauthorized")
+	ErrForbidden    = errors.New("docstore: forbidden")
+	ErrNotFound     = errors.New("docstore: not found")
+	ErrConflict     = errors.New("docstore: conflict")
+)
+
+// Error is the structured form of a non-2xx HTTP response from the server.
+type Error struct {
+	StatusCode int    // HTTP status code
+	Message    string // server's ErrorResponse.Error field, if present
+	Body       []byte // raw response body for diagnostics
+}
+
+func (e *Error) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("docstore: %s (status %d)", e.Message, e.StatusCode)
+	}
+	return fmt.Sprintf("docstore: HTTP %d", e.StatusCode)
+}
+
+// Is lets errors.Is(err, ErrNotFound) etc. match on status code.
+func (e *Error) Is(target error) bool {
+	switch target {
+	case ErrUnauthorized:
+		return e.StatusCode == http.StatusUnauthorized
+	case ErrForbidden:
+		return e.StatusCode == http.StatusForbidden
+	case ErrNotFound:
+		return e.StatusCode == http.StatusNotFound
+	case ErrConflict:
+		return e.StatusCode == http.StatusConflict
+	}
+	return false
+}
+
+// ConflictError wraps a 409 response from /merge or /rebase that carries a
+// structured list of file conflicts. Unwrap with errors.As; the HTTP status
+// and raw body remain accessible via the embedded Base.
+type ConflictError struct {
+	Base      *Error
+	Conflicts []api.ConflictEntry
+}
+
+func (e *ConflictError) Error() string {
+	return fmt.Sprintf("docstore: %d conflict(s) (status %d)", len(e.Conflicts), e.Base.StatusCode)
+}
+
+func (e *ConflictError) Unwrap() error { return e.Base }
+
+// PolicyError wraps a 403 response from /merge that carries failing policy
+// evaluation results. Unwrap with errors.As.
+type PolicyError struct {
+	Base     *Error
+	Policies []api.PolicyResult
+}
+
+func (e *PolicyError) Error() string {
+	return fmt.Sprintf("docstore: merge blocked by %d policy result(s) (status %d)", len(e.Policies), e.Base.StatusCode)
+}
+
+func (e *PolicyError) Unwrap() error { return e.Base }
+
+// decodeError reads a non-2xx response body and returns the richest typed
+// error it can reconstruct. The caller is responsible for closing the body.
+func decodeError(resp *http.Response) error {
+	body, _ := io.ReadAll(resp.Body)
+	base := &Error{StatusCode: resp.StatusCode, Body: body}
+
+	// First try policy-denial (503/403): wraps a non-empty Policies slice.
+	if len(body) > 0 {
+		var pe api.MergePolicyError
+		if err := json.Unmarshal(body, &pe); err == nil && len(pe.Policies) > 0 {
+			base.Message = "merge policy denial"
+			return &PolicyError{Base: base, Policies: pe.Policies}
+		}
+		// Then conflicts (409 from merge/rebase).
+		var ce api.MergeConflictError
+		if err := json.Unmarshal(body, &ce); err == nil && len(ce.Conflicts) > 0 {
+			base.Message = "merge conflict"
+			return &ConflictError{Base: base, Conflicts: ce.Conflicts}
+		}
+		// Fallback: generic {"error": "..."}.
+		var er api.ErrorResponse
+		if err := json.Unmarshal(body, &er); err == nil && er.Error != "" {
+			base.Message = er.Error
+		}
+	}
+	return base
+}

--- a/sdk/go/docstore/examples_test.go
+++ b/sdk/go/docstore/examples_test.go
@@ -1,0 +1,72 @@
+package docstore_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/dlorenc/docstore/api"
+	"github.com/dlorenc/docstore/sdk/go/docstore"
+)
+
+// stubServer is used by the examples below so they can run as standard
+// go-test examples (with expected output) without requiring a live
+// docstore server.
+func stubServer(respStatus int, body any) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(respStatus)
+		if body != nil && respStatus != http.StatusNoContent {
+			_ = json.NewEncoder(w).Encode(body)
+		}
+	}))
+}
+
+// ExampleNewClient shows the minimal client construction pattern from the
+// issue that requested this SDK.
+func ExampleNewClient() {
+	srv := stubServer(http.StatusOK, api.FileResponse{
+		Path: "config.yaml", Content: []byte("version: 2\n"),
+	})
+	defer srv.Close()
+
+	client, err := docstore.NewClient(srv.URL,
+		docstore.WithBearerToken("token-from-env"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	file, err := client.Repo("acme/platform").File(context.Background(),
+		"config.yaml", docstore.AtHead("main"))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%s: %s", file.Path, string(file.Content))
+	// Output: config.yaml: version: 2
+}
+
+// ExampleRepoClient_Commit shows committing files on a branch.
+func ExampleRepoClient_Commit() {
+	srv := stubServer(http.StatusCreated, api.CommitResponse{Sequence: 7})
+	defer srv.Close()
+
+	client, _ := docstore.NewClient(srv.URL,
+		docstore.WithIdentity("alice@example.com"))
+
+	resp, err := client.Repo("acme/platform").Commit(context.Background(),
+		api.CommitRequest{
+			Branch:  "main",
+			Message: "update config",
+			Files: []api.FileChange{
+				{Path: "config.yaml", Content: []byte("version: 2\n")},
+			},
+		})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("committed as sequence", resp.Sequence)
+	// Output: committed as sequence 7
+}

--- a/sdk/go/docstore/go.mod
+++ b/sdk/go/docstore/go.mod
@@ -1,0 +1,11 @@
+module github.com/dlorenc/docstore/sdk/go/docstore
+
+go 1.25.5
+
+require github.com/dlorenc/docstore v0.0.0
+
+// The SDK is versioned separately from the server module but needs the public
+// api package from the server tree. While this lives in the monorepo and the
+// server hasn't been tagged yet, resolve it via replace. Drop when the server
+// publishes a tag and this module is tagged for the first time.
+replace github.com/dlorenc/docstore => ../../..

--- a/sdk/go/docstore/options.go
+++ b/sdk/go/docstore/options.go
@@ -1,0 +1,125 @@
+package docstore
+
+import (
+	"strconv"
+
+	"github.com/dlorenc/docstore/api"
+)
+
+// FileOption narrows a file read to a specific branch head, sequence, or
+// named release.
+type FileOption func(*reqParams)
+
+// AtHead reads the file at the head of the given branch. Passing "" selects
+// the server default ("main").
+func AtHead(branch string) FileOption {
+	return func(p *reqParams) {
+		if branch != "" {
+			p.set("branch", branch)
+		}
+	}
+}
+
+// AtSequence reads the file as of a specific commit sequence.
+func AtSequence(seq int64) FileOption {
+	return func(p *reqParams) { p.set("at", strconv.FormatInt(seq, 10)) }
+}
+
+// AtRelease reads the file at the sequence that was pinned by the named
+// release.
+func AtRelease(name string) FileOption {
+	return func(p *reqParams) { p.set("at", name) }
+}
+
+// TreeOption narrows a tree materialisation.
+type TreeOption func(*reqParams)
+
+func TreeAtHead(branch string) TreeOption {
+	return func(p *reqParams) {
+		if branch != "" {
+			p.set("branch", branch)
+		}
+	}
+}
+func TreeAtSequence(seq int64) TreeOption {
+	return func(p *reqParams) { p.set("at", strconv.FormatInt(seq, 10)) }
+}
+func TreeAtRelease(name string) TreeOption {
+	return func(p *reqParams) { p.set("at", name) }
+}
+func TreeLimit(n int) TreeOption {
+	return func(p *reqParams) { p.set("limit", strconv.Itoa(n)) }
+}
+func TreeAfter(path string) TreeOption {
+	return func(p *reqParams) { p.set("after", path) }
+}
+
+// HistoryOption narrows a file-history listing.
+type HistoryOption func(*reqParams)
+
+func HistoryOnBranch(branch string) HistoryOption {
+	return func(p *reqParams) {
+		if branch != "" {
+			p.set("branch", branch)
+		}
+	}
+}
+func HistoryLimit(n int) HistoryOption {
+	return func(p *reqParams) { p.set("limit", strconv.Itoa(n)) }
+}
+func HistoryAfter(seq int64) HistoryOption {
+	return func(p *reqParams) { p.set("after", strconv.FormatInt(seq, 10)) }
+}
+
+// BranchListOption filters a branch listing.
+type BranchListOption func(*reqParams)
+
+// BranchStatusFilter restricts to branches in a given status.
+func BranchStatusFilter(s api.BranchStatus) BranchListOption {
+	return func(p *reqParams) { p.set("status", string(s)) }
+}
+
+// BranchDraftOnly returns only draft branches.
+func BranchDraftOnly() BranchListOption {
+	return func(p *reqParams) { p.set("draft", "true") }
+}
+
+// BranchIncludeDraft includes draft branches in the listing (in addition to
+// non-draft).
+func BranchIncludeDraft() BranchListOption {
+	return func(p *reqParams) { p.set("include_draft", "true") }
+}
+
+// ReviewListOption narrows a review listing.
+type ReviewListOption func(*reqParams)
+
+func ReviewsAt(seq int64) ReviewListOption {
+	return func(p *reqParams) { p.set("at", strconv.FormatInt(seq, 10)) }
+}
+
+// CheckListOption narrows a check-run listing.
+type CheckListOption func(*reqParams)
+
+func ChecksAt(seq int64) CheckListOption {
+	return func(p *reqParams) { p.set("at", strconv.FormatInt(seq, 10)) }
+}
+
+// ReleaseListOption narrows a release listing.
+type ReleaseListOption func(*reqParams)
+
+func ReleasesLimit(n int) ReleaseListOption {
+	return func(p *reqParams) { p.set("limit", strconv.Itoa(n)) }
+}
+func ReleasesAfter(id string) ReleaseListOption {
+	return func(p *reqParams) { p.set("after", id) }
+}
+
+// buildParams applies the option functions to a fresh params struct and
+// returns the resulting url.Values.
+func buildParams[F ~func(*reqParams)](opts []F) *reqParams {
+	p := &reqParams{}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}

--- a/sdk/go/docstore/orgs.go
+++ b/sdk/go/docstore/orgs.go
@@ -1,0 +1,121 @@
+package docstore
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/dlorenc/docstore/api"
+)
+
+// OrgsService groups organisation-level endpoints. Access it via
+// Client.Orgs.
+type OrgsService struct {
+	client *Client
+}
+
+// Create creates a new organisation.
+func (s *OrgsService) Create(ctx context.Context, req api.CreateOrgRequest) (*api.Org, error) {
+	var out api.Org
+	if err := s.client.doJSON(ctx, "POST", "/orgs", nil, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// List returns every organisation the caller can see.
+func (s *OrgsService) List(ctx context.Context) (*api.ListOrgsResponse, error) {
+	var out api.ListOrgsResponse
+	if err := s.client.doJSON(ctx, "GET", "/orgs", nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Get fetches one organisation by name.
+func (s *OrgsService) Get(ctx context.Context, name string) (*api.Org, error) {
+	var out api.Org
+	if err := s.client.doJSON(ctx, "GET", "/orgs/"+url.PathEscape(name), nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Delete removes an organisation.
+func (s *OrgsService) Delete(ctx context.Context, name string) error {
+	return s.client.doJSON(ctx, "DELETE", "/orgs/"+url.PathEscape(name), nil, nil, nil)
+}
+
+// Repos lists repos belonging to the organisation.
+func (s *OrgsService) Repos(ctx context.Context, org string) (*api.ReposResponse, error) {
+	var out api.ReposResponse
+	if err := s.client.doJSON(ctx, "GET", "/orgs/"+url.PathEscape(org)+"/repos", nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Members
+// ---------------------------------------------------------------------------
+
+// Members lists members of an organisation.
+func (s *OrgsService) Members(ctx context.Context, org string) (*api.OrgMembersResponse, error) {
+	var out api.OrgMembersResponse
+	if err := s.client.doJSON(ctx, "GET", "/orgs/"+url.PathEscape(org)+"/members", nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// AddMember adds identity to an organisation with the given role. Org
+// owner only.
+func (s *OrgsService) AddMember(ctx context.Context, org, identity string, role api.OrgRole) (*api.OrgMember, error) {
+	path := "/orgs/" + url.PathEscape(org) + "/members/" + url.PathEscape(identity)
+	var out api.OrgMember
+	if err := s.client.doJSON(ctx, "POST", path, nil, api.AddOrgMemberRequest{Role: role}, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// RemoveMember removes identity from an organisation. Org owner only.
+func (s *OrgsService) RemoveMember(ctx context.Context, org, identity string) error {
+	path := "/orgs/" + url.PathEscape(org) + "/members/" + url.PathEscape(identity)
+	return s.client.doJSON(ctx, "DELETE", path, nil, nil, nil)
+}
+
+// ---------------------------------------------------------------------------
+// Invites
+// ---------------------------------------------------------------------------
+
+// CreateInvite issues an invitation to join an organisation.
+func (s *OrgsService) CreateInvite(ctx context.Context, org string, req api.CreateInviteRequest) (*api.CreateInviteResponse, error) {
+	path := "/orgs/" + url.PathEscape(org) + "/invites"
+	var out api.CreateInviteResponse
+	if err := s.client.doJSON(ctx, "POST", path, nil, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ListInvites returns pending invitations on an organisation.
+func (s *OrgsService) ListInvites(ctx context.Context, org string) (*api.OrgInvitesResponse, error) {
+	path := "/orgs/" + url.PathEscape(org) + "/invites"
+	var out api.OrgInvitesResponse
+	if err := s.client.doJSON(ctx, "GET", path, nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// AcceptInvite accepts an invitation using its token.
+func (s *OrgsService) AcceptInvite(ctx context.Context, org, token string) error {
+	path := "/orgs/" + url.PathEscape(org) + "/invites/" + url.PathEscape(token) + "/accept"
+	return s.client.doJSON(ctx, "POST", path, nil, nil, nil)
+}
+
+// RevokeInvite revokes a pending invitation by ID. Org owner only.
+func (s *OrgsService) RevokeInvite(ctx context.Context, org, id string) error {
+	path := "/orgs/" + url.PathEscape(org) + "/invites/" + url.PathEscape(id)
+	return s.client.doJSON(ctx, "DELETE", path, nil, nil, nil)
+}

--- a/sdk/go/docstore/repo.go
+++ b/sdk/go/docstore/repo.go
@@ -1,0 +1,331 @@
+package docstore
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/dlorenc/docstore/api"
+)
+
+// RepoClient exposes the repo-scoped endpoints for a single repository. It
+// is created by Client.Repo and is cheap to construct.
+type RepoClient struct {
+	client *Client
+	repo   string // full "owner/name" path
+}
+
+// Name returns the repo path this client is bound to.
+func (r *RepoClient) Name() string { return r.repo }
+
+// filePath builds the URL suffix for a file endpoint, escaping each slash-
+// separated segment so arbitrary paths ("configs/prod/app.yaml") survive.
+func filePath(path string) string {
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return ""
+	}
+	parts := strings.Split(path, "/")
+	for i, p := range parts {
+		parts[i] = url.PathEscape(p)
+	}
+	return strings.Join(parts, "/")
+}
+
+// ---------------------------------------------------------------------------
+// Files and trees
+// ---------------------------------------------------------------------------
+
+// File retrieves the contents of a file. Use AtHead, AtSequence, or AtRelease
+// to control which version is returned; by default the server returns the
+// head of main.
+func (r *RepoClient) File(ctx context.Context, path string, opts ...FileOption) (*api.FileResponse, error) {
+	params := buildParams(opts)
+	suffix := "/file/" + filePath(path)
+	var out api.FileResponse
+	if err := r.client.doJSON(ctx, "GET", repoPath(r.repo, suffix), params.query, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// FileHistory lists commits that touched path in reverse-chronological order.
+func (r *RepoClient) FileHistory(ctx context.Context, path string, opts ...HistoryOption) (*api.FileHistoryResponse, error) {
+	params := buildParams(opts)
+	suffix := "/file/" + filePath(path) + "/history"
+	var out api.FileHistoryResponse
+	if err := r.client.doJSON(ctx, "GET", repoPath(r.repo, suffix), params.query, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Tree materialises the directory tree of a branch or sequence.
+func (r *RepoClient) Tree(ctx context.Context, opts ...TreeOption) (*api.TreeResponse, error) {
+	params := buildParams(opts)
+	var out api.TreeResponse
+	if err := r.client.doJSON(ctx, "GET", repoPath(r.repo, "/tree"), params.query, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Commits
+// ---------------------------------------------------------------------------
+
+// Commit creates one atomic commit containing the files in req. A FileChange
+// with nil Content is a delete.
+func (r *RepoClient) Commit(ctx context.Context, req api.CommitRequest) (*api.CommitResponse, error) {
+	var out api.CommitResponse
+	if err := r.client.doJSON(ctx, "POST", repoPath(r.repo, "/commit"), nil, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetCommit returns metadata and the file change set for a specific commit
+// sequence.
+func (r *RepoClient) GetCommit(ctx context.Context, sequence int64) (*api.GetCommitResponse, error) {
+	suffix := "/commit/" + strconv.FormatInt(sequence, 10)
+	var out api.GetCommitResponse
+	if err := r.client.doJSON(ctx, "GET", repoPath(r.repo, suffix), nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Branches
+// ---------------------------------------------------------------------------
+
+// Branches lists branches in the repo.
+func (r *RepoClient) Branches(ctx context.Context, opts ...BranchListOption) (*api.BranchesResponse, error) {
+	params := buildParams(opts)
+	var out api.BranchesResponse
+	if err := r.client.doJSON(ctx, "GET", repoPath(r.repo, "/branches"), params.query, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CreateBranch creates a new branch rooted at the current head of main.
+func (r *RepoClient) CreateBranch(ctx context.Context, req api.CreateBranchRequest) (*api.CreateBranchResponse, error) {
+	var out api.CreateBranchResponse
+	if err := r.client.doJSON(ctx, "POST", repoPath(r.repo, "/branch"), nil, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Branch returns the current pointer and status for one branch.
+func (r *RepoClient) Branch(ctx context.Context, name string) (*api.Branch, error) {
+	suffix := "/branch/" + url.PathEscape(name)
+	var out api.Branch
+	if err := r.client.doJSON(ctx, "GET", repoPath(r.repo, suffix), nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UpdateBranch mutates branch flags (currently only draft).
+func (r *RepoClient) UpdateBranch(ctx context.Context, name string, req api.UpdateBranchRequest) (*api.UpdateBranchResponse, error) {
+	suffix := "/branch/" + url.PathEscape(name)
+	var out api.UpdateBranchResponse
+	if err := r.client.doJSON(ctx, "PATCH", repoPath(r.repo, suffix), nil, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// DeleteBranch marks a branch merged or abandoned.
+func (r *RepoClient) DeleteBranch(ctx context.Context, name string) (*api.DeleteBranchResponse, error) {
+	suffix := "/branch/" + url.PathEscape(name)
+	var out api.DeleteBranchResponse
+	if err := r.client.doJSON(ctx, "DELETE", repoPath(r.repo, suffix), nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// BranchStatus reports mergeability and policy evaluation for a branch.
+func (r *RepoClient) BranchStatus(ctx context.Context, name string) (*api.BranchStatusResponse, error) {
+	suffix := "/branch/" + url.PathEscape(name) + "/status"
+	var out api.BranchStatusResponse
+	if err := r.client.doJSON(ctx, "GET", repoPath(r.repo, suffix), nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Merge, rebase, diff
+// ---------------------------------------------------------------------------
+
+// Merge fast-forwards or three-way-merges a branch into main. On conflicts
+// the returned error is a *ConflictError; on policy failure a *PolicyError.
+func (r *RepoClient) Merge(ctx context.Context, req api.MergeRequest) (*api.MergeResponse, error) {
+	var out api.MergeResponse
+	if err := r.client.doJSON(ctx, "POST", repoPath(r.repo, "/merge"), nil, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Rebase replays a branch onto the current head of main. On conflicts the
+// returned error is a *ConflictError.
+func (r *RepoClient) Rebase(ctx context.Context, req api.RebaseRequest) (*api.RebaseResponse, error) {
+	var out api.RebaseResponse
+	if err := r.client.doJSON(ctx, "POST", repoPath(r.repo, "/rebase"), nil, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Diff returns the set of file changes between a branch and main, plus any
+// conflicts.
+func (r *RepoClient) Diff(ctx context.Context, branch string) (*api.DiffResponse, error) {
+	q := url.Values{"branch": []string{branch}}
+	var out api.DiffResponse
+	if err := r.client.doJSON(ctx, "GET", repoPath(r.repo, "/diff"), q, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Reviews and checks
+// ---------------------------------------------------------------------------
+
+// SubmitReview records a review on a branch.
+func (r *RepoClient) SubmitReview(ctx context.Context, req api.CreateReviewRequest) (*api.CreateReviewResponse, error) {
+	var out api.CreateReviewResponse
+	if err := r.client.doJSON(ctx, "POST", repoPath(r.repo, "/review"), nil, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Reviews lists reviews for a branch.
+func (r *RepoClient) Reviews(ctx context.Context, branch string, opts ...ReviewListOption) ([]api.Review, error) {
+	params := buildParams(opts)
+	suffix := "/branch/" + url.PathEscape(branch) + "/reviews"
+	var out []api.Review
+	if err := r.client.doJSON(ctx, "GET", repoPath(r.repo, suffix), params.query, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ReportCheck records a CI check result on a branch.
+func (r *RepoClient) ReportCheck(ctx context.Context, req api.CreateCheckRunRequest) (*api.CreateCheckRunResponse, error) {
+	var out api.CreateCheckRunResponse
+	if err := r.client.doJSON(ctx, "POST", repoPath(r.repo, "/check"), nil, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Checks lists check runs for a branch.
+func (r *RepoClient) Checks(ctx context.Context, branch string, opts ...CheckListOption) ([]api.CheckRun, error) {
+	params := buildParams(opts)
+	suffix := "/branch/" + url.PathEscape(branch) + "/checks"
+	var out []api.CheckRun
+	if err := r.client.doJSON(ctx, "GET", repoPath(r.repo, suffix), params.query, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Roles
+// ---------------------------------------------------------------------------
+
+// Roles lists the role assignments on this repo.
+func (r *RepoClient) Roles(ctx context.Context) (*api.RolesResponse, error) {
+	var out api.RolesResponse
+	if err := r.client.doJSON(ctx, "GET", repoPath(r.repo, "/roles"), nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// SetRole assigns a role to an identity. Admin-only.
+func (r *RepoClient) SetRole(ctx context.Context, identity string, role api.RoleType) error {
+	suffix := "/roles/" + url.PathEscape(identity)
+	return r.client.doJSON(ctx, "PUT", repoPath(r.repo, suffix), nil, api.SetRoleRequest{Role: role}, nil)
+}
+
+// DeleteRole removes an identity's role. Admin-only.
+func (r *RepoClient) DeleteRole(ctx context.Context, identity string) error {
+	suffix := "/roles/" + url.PathEscape(identity)
+	return r.client.doJSON(ctx, "DELETE", repoPath(r.repo, suffix), nil, nil, nil)
+}
+
+// ---------------------------------------------------------------------------
+// Releases
+// ---------------------------------------------------------------------------
+
+// CreateRelease pins a sequence under a named release.
+func (r *RepoClient) CreateRelease(ctx context.Context, req api.CreateReleaseRequest) (*api.Release, error) {
+	var out api.Release
+	if err := r.client.doJSON(ctx, "POST", repoPath(r.repo, "/releases"), nil, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ListReleases returns releases in reverse-chronological order.
+func (r *RepoClient) ListReleases(ctx context.Context, opts ...ReleaseListOption) (*api.ListReleasesResponse, error) {
+	params := buildParams(opts)
+	var out api.ListReleasesResponse
+	if err := r.client.doJSON(ctx, "GET", repoPath(r.repo, "/releases"), params.query, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetRelease returns a named release.
+func (r *RepoClient) GetRelease(ctx context.Context, name string) (*api.Release, error) {
+	suffix := "/releases/" + url.PathEscape(name)
+	var out api.Release
+	if err := r.client.doJSON(ctx, "GET", repoPath(r.repo, suffix), nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// DeleteRelease removes a named release. Admin-only.
+func (r *RepoClient) DeleteRelease(ctx context.Context, name string) error {
+	suffix := "/releases/" + url.PathEscape(name)
+	return r.client.doJSON(ctx, "DELETE", repoPath(r.repo, suffix), nil, nil, nil)
+}
+
+// ---------------------------------------------------------------------------
+// Chain verification and admin
+// ---------------------------------------------------------------------------
+
+// ChainSegment returns commits in [from, to] inclusive as ordered chain
+// entries, for clients that want to verify the hash chain locally.
+func (r *RepoClient) ChainSegment(ctx context.Context, from, to int64) ([]api.ChainEntry, error) {
+	q := url.Values{
+		"from": []string{strconv.FormatInt(from, 10)},
+		"to":   []string{strconv.FormatInt(to, 10)},
+	}
+	var out []api.ChainEntry
+	if err := r.client.doJSON(ctx, "GET", repoPath(r.repo, "/chain"), q, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Purge deletes abandoned/merged branches and their commits older than the
+// cutoff. Admin-only.
+func (r *RepoClient) Purge(ctx context.Context, req api.PurgeRequest) (*api.PurgeResponse, error) {
+	var out api.PurgeResponse
+	if err := r.client.doJSON(ctx, "POST", repoPath(r.repo, "/purge"), nil, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/sdk/go/docstore/repos.go
+++ b/sdk/go/docstore/repos.go
@@ -1,0 +1,45 @@
+package docstore
+
+import (
+	"context"
+
+	"github.com/dlorenc/docstore/api"
+)
+
+// ReposService groups repo CRUD endpoints (create/list/get/delete). For
+// operations scoped inside a single repo, use Client.Repo.
+type ReposService struct {
+	client *Client
+}
+
+// Create creates a new repository under an existing org.
+func (s *ReposService) Create(ctx context.Context, req api.CreateRepoRequest) (*api.Repo, error) {
+	var out api.Repo
+	if err := s.client.doJSON(ctx, "POST", "/repos", nil, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// List returns every repo the caller can see.
+func (s *ReposService) List(ctx context.Context) (*api.ReposResponse, error) {
+	var out api.ReposResponse
+	if err := s.client.doJSON(ctx, "GET", "/repos", nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Get fetches a repo by full path ("owner/name").
+func (s *ReposService) Get(ctx context.Context, name string) (*api.Repo, error) {
+	var out api.Repo
+	if err := s.client.doJSON(ctx, "GET", repoBareCRUD(name), nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Delete removes a repo by full path.
+func (s *ReposService) Delete(ctx context.Context, name string) error {
+	return s.client.doJSON(ctx, "DELETE", repoBareCRUD(name), nil, nil, nil)
+}

--- a/sdk/go/docstore/transport.go
+++ b/sdk/go/docstore/transport.go
@@ -1,0 +1,118 @@
+package docstore
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// reqParams accumulates query-string values set by request options.
+type reqParams struct {
+	query url.Values
+}
+
+func (p *reqParams) ensure() {
+	if p.query == nil {
+		p.query = url.Values{}
+	}
+}
+
+func (p *reqParams) set(key, value string) {
+	p.ensure()
+	p.query.Set(key, value)
+}
+
+// doJSON issues method path with optional JSON body and decodes a successful
+// response into out (pass nil for 204-style responses). All requests go
+// through this path so header and query construction live in one place.
+//
+// path may include a leading slash or not; it is joined to the client base
+// URL. query may be nil. method is one of "GET", "POST", "PUT", "PATCH",
+// "DELETE".
+func (c *Client) doJSON(ctx context.Context, method, path string, query url.Values, body, out any) error {
+	u := c.baseURL
+	if !strings.HasPrefix(path, "/") {
+		u += "/"
+	}
+	u += path
+	if len(query) > 0 {
+		u += "?" + query.Encode()
+	}
+
+	var reqBody io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("docstore: marshal request body: %w", err)
+		}
+		reqBody = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, u, reqBody)
+	if err != nil {
+		return fmt.Errorf("docstore: build request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", c.userAgent)
+	if c.bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.bearerToken)
+	}
+	if c.identity != "" {
+		req.Header.Set("X-DocStore-Identity", c.identity)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("docstore: %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if out == nil || resp.StatusCode == http.StatusNoContent {
+			// Drain for connection reuse.
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return nil
+		}
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return fmt.Errorf("docstore: decode response: %w", err)
+		}
+		return nil
+	}
+	return decodeError(resp)
+}
+
+// repoPath builds "/repos/{owner}/{name}/-/<suffix>" for a repo whose full
+// path may itself contain slashes (e.g. "acme/team/subrepo" — owner=acme,
+// name=team/subrepo). Each path segment is escaped individually.
+func repoPath(repo, suffix string) string {
+	parts := strings.Split(strings.Trim(repo, "/"), "/")
+	for i, p := range parts {
+		parts[i] = url.PathEscape(p)
+	}
+	base := "/repos/" + strings.Join(parts, "/") + "/-"
+	if suffix == "" {
+		return base
+	}
+	if !strings.HasPrefix(suffix, "/") {
+		suffix = "/" + suffix
+	}
+	return base + suffix
+}
+
+// repoBareCRUD builds "/repos/{owner}/{name}" (no "/-/" separator) for the
+// handful of endpoints that address the repo itself: GET/DELETE.
+func repoBareCRUD(repo string) string {
+	parts := strings.Split(strings.Trim(repo, "/"), "/")
+	for i, p := range parts {
+		parts[i] = url.PathEscape(p)
+	}
+	return "/repos/" + strings.Join(parts, "/")
+}


### PR DESCRIPTION
First cut of the Go client library requested in #109. Ships the SDK as its own module at `sdk/go/docstore/` and introduces a public `api/` package that the server, CLI, and SDK all share.

This implements only the Go-SDK portion of #109 (the issue also asks for a Python SDK and publishing to pkg.go.dev). Leaving the issue open to track the remaining work.

## Why a new `api/` package

The SDK needs to type its requests and responses against the same structs the server marshals. `internal/model/` can't serve that role — anything under `internal/` is unimportable from a separate module, and even if we dropped the SDK into the same module, `internal/` still wouldn't be importable from a downstream consumer once the SDK is tagged and depended on externally.

Three options were considered:

1. **Duplicate the types in the SDK.** Clean module boundary, zero server churn. Rejected: drift between server and client is a category of bug we shouldn't invite on day one.
2. **Keep types in `internal/model/` and use a `replace` directive.** Works in-tree; breaks as soon as the SDK is tagged and consumed from outside this repo. Rejected.
3. **Move wire types into a public `api/` package, both server and SDK import it.** Single source of truth; no drift possible; SDK can consume the package over the normal module graph once things are tagged. Chosen.

To minimise churn, `internal/model/` still exports the same identifiers — it just re-exports `api` types via type aliases (`type CommitRequest = api.CommitRequest`). Every existing server/CLI call site (`model.CommitRequest`, `model.RoleAdmin`, etc.) keeps compiling unchanged; the 1000+ `model.*` references in the tree didn't need touching. Follow-up PRs can migrate individual packages to import `api` directly if desired, at their own pace. Same approach for `store.ChainEntry` — aliased to `api.ChainEntry` so `GET /chain` stays round-trippable through the exact same Go type on both sides.

Internal-only types (`model.Document`, `model.FileCommit`) stayed in `internal/model/` because they never cross the wire — no need to expose DB-row shapes.

## Why `sdk/go/docstore` has its own `go.mod`

Issue #109 explicitly says \"SDKs should be versioned separately from the server.\" A sub-module with its own `go.mod` is the canonical Go answer — the SDK can be tagged `sdk/go/docstore/v0.1.0` independently of server releases, consumers can pin a minor SDK without dragging in the server's dependency closure (buildkit, OPA, testcontainers, etc.), and its public surface can evolve on a different cadence.

During development the SDK's `go.mod` has a `replace github.com/dlorenc/docstore => ../../..` directive so it picks up in-tree changes to the shared `api` package. That line comes out on the first real tag.

## Why the client is shaped this way

The surface follows the shape sketched in the issue:

```go
client, _ := docstore.NewClient(url, docstore.WithBearerToken(token))
client.Repo(\"acme/platform\").Commit(ctx, api.CommitRequest{...})
client.Repo(\"acme/platform\").File(ctx, \"config.yaml\", docstore.AtHead(\"main\"))
```

A few specific choices worth noting:

**Functional options for requests (`AtHead`, `AtSequence`, `TreeLimit`, `BranchIncludeDraft`, …).** Most read endpoints take 2–4 optional query params. Named option functions keep call sites readable (`c.Repo(r).File(ctx, path, AtRelease(\"v2\"))`), let us add new params without breaking existing callers, and let each endpoint family carry its own option type so IDE completion stays scoped to what the endpoint actually accepts. One option type per endpoint-family (`FileOption`, `TreeOption`, `BranchListOption`, etc.) rather than a single global grab-bag.

**Auth is two orthogonal options, not a single \"credentials\" object.** `WithBearerToken` sets `Authorization: Bearer <token>` — this is a no-op against today's server but is forward-compatible with the API-token work in #101. `WithIdentity` sets `X-DocStore-Identity` for dev-mode deployments. Both can be set at once without a precedence rule in the SDK; the server decides what it trusts. `WithHTTPClient` is available for anything the SDK can't abstract (IAP-authenticated transport, retries, proxies).

**Errors are a mix of sentinels and rich wrappers.** `*Error` is the base type carrying status code, server message, and raw body. Four sentinels (`ErrUnauthorized`, `ErrForbidden`, `ErrNotFound`, `ErrConflict`) match via `errors.Is` against status code, which covers the common branches. Merge/rebase get richer wrappers: `*ConflictError` carries `[]api.ConflictEntry`, `*PolicyError` carries `[]api.PolicyResult`. These are the two error shapes where the caller genuinely needs the structured payload to do anything useful (show conflicts, report blocking policies). Everything else gets the message string.

**One transport path, not a per-endpoint HTTP layer.** `doJSON(ctx, method, path, query, body, out)` in `transport.go` owns request construction, header application, URL escaping (repo paths can contain slashes like `acme/team/subrepo`), and error decoding. Each endpoint method is a thin wrapper — no duplicated header/URL logic.

**Services vs. repo-scoped handle.** Org and repo CRUD (`/orgs`, `/repos`) are grouped on `OrgsService` and `ReposService` because they don't share a repo scope. Everything that targets `/repos/{owner}/{name}/-/*` is a method on `RepoClient`, which you get from `client.Repo(\"owner/name\")`. The split keeps the surface browsable and matches the server's URL layout.

## Testing

**Unit tests (`client_test.go`) over `httptest.Server`.** A recording handler captures the exact `method`, `path`, `rawQuery`, headers, and request body for every request, so tests assert on both directions of the wire — the SDK sends what the server expects, and the SDK decodes what the server sends. All typed errors (`ErrNotFound`, `ErrConflict`, `ErrUnauthorized`, `ConflictError`, `PolicyError`) have dedicated tests; context cancellation has a test.

**No real-server integration test in this PR.** The plan called for one, but standing the server up inside the SDK module requires importing `internal/testutil` + testcontainers, which would drag all of that into the SDK's `go.mod` and bloat the consumer dependency graph. Better to put a cross-module integration test in a future `tests/sdk/` package inside the server module, which already has testcontainers. The httptest suite covers the HTTP contract completely; the missing piece is \"server actually validates these payloads,\" and the server's own test suite already does that against the shared `api` types.

**godoc examples (`examples_test.go`).** Two runnable `Example*` functions using stub `httptest.Server` so `go test` verifies them and `go doc` renders them.

## What's intentionally not in this PR

- **Python SDK** — issue #109's second priority, deliberately separate.
- **Streaming file downloads** — the server doesn't stream today. When it does (e.g. archive tarballs via `internal/cli/app.go`'s newer archive path), we can add an `io.Reader`-returning variant on `RepoClient`.
- **Retry / backoff** — callers inject a retrying `*http.Client` via `WithHTTPClient`. Keeps the SDK dependency-free.
- **IAP token minting** — documented in `doc.go` as a recipe using `idtoken.NewClient` + `WithHTTPClient`, not built in. No reason to ship a google-cloud dependency inside the SDK when the standard pattern is to inject the transport.
- **Auto-pagination iterators** — easy to add on top of `after`/`limit`, not blocking day-one usage.
- **Tagging / publishing to pkg.go.dev** — done after this lands and after the shape gets some real use.

## Test plan

- [x] `go build ./...` clean in both the server module and `sdk/go/docstore/`
- [x] `go vet ./...` clean in both modules
- [x] `go test -count=1 -short ./...` passes in the server module (all existing server/CLI/store tests, unchanged)
- [x] `go test -count=1 ./...` passes in `sdk/go/docstore/` (unit tests + examples)
- [x] Merged `upstream/main` after the Milestone-1 eventing work landed; `EventSubscription` / `CreateSubscriptionRequest` / `ListSubscriptionsResponse` moved into `api/` alongside the other wire types

Refs #109 (Go SDK portion only — Python SDK and pkg.go.dev publishing remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)