### PR TITLE
Add ci-runner deploy job and one-time setup script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,3 +52,61 @@ jobs:
             --min-instances=0 \
             --max-instances=1 \
             --port=8080
+
+  # One-time setup: run scripts/setup.sh before the first push to main.
+  # See OPERATIONS.md "Initial Setup" for details.
+  build-and-deploy-ci-runner:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/320310132788/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: docstore-deployer@dlorenc-chainguard.iam.gserviceaccount.com
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - name: Build and push ci-runner image
+        id: build
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          docker build -f Dockerfile.ci-runner \
+            -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner:latest \
+            -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner:${SHA} \
+            .
+          docker push us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner:latest
+          docker push us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner:${SHA}
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+
+      - name: Ensure GCS log bucket exists
+        run: |
+          gcloud storage buckets create gs://docstore-ci-logs \
+            --project=dlorenc-chainguard \
+            --location=us-central1 \
+            --uniform-bucket-level-access \
+            2>/dev/null || true
+
+      - name: Deploy ci-runner to Cloud Run
+        run: |
+          gcloud run deploy ci-runner \
+            --image=us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner:${{ steps.build.outputs.sha }} \
+            --project=dlorenc-chainguard \
+            --region=us-central1 \
+            --execution-environment=gen2 \
+            --service-account=ci-runner@dlorenc-chainguard.iam.gserviceaccount.com \
+            --set-env-vars=DOCSTORE_URL=https://docstore-efuj4cj54a-uc.a.run.app \
+            --set-env-vars=LOG_STORE=gcs \
+            --set-env-vars=LOG_BUCKET=docstore-ci-logs \
+            --update-secrets=WEBHOOK_SECRET=ci-runner-webhook-secret:latest \
+            --update-secrets=RUNNER_URL=ci-runner-url:latest \
+            --allow-unauthenticated \
+            --concurrency=1 \
+            --min-instances=0 \
+            --max-instances=10 \
+            --memory=4Gi \
+            --cpu=4 \
+            --port=8080

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1223,6 +1223,87 @@ The server uses the standard `log/slog` package for structured JSON logging. All
 
 ---
 
+## Initial Setup: CI Runner
+
+The CI runner is a separate Cloud Run service (`ci-runner`) that executes checks triggered by docstore events. Before the first push to `main` will succeed, run the one-time setup script to provision the required infrastructure.
+
+### When to run
+
+Run `scripts/setup.sh` once per project, before pushing to `main` for the first time. It is safe to re-run (all steps are idempotent).
+
+### What it creates
+
+| Resource | Description |
+|---------|-------------|
+| `ci-runner` service account | Runs the Cloud Run service |
+| `gs://docstore-ci-logs` GCS bucket | Stores CI check run logs |
+| `ci-runner-webhook-secret` Secret Manager secret | HMAC secret for webhook payload verification |
+| `ci-runner-url` Secret Manager secret | Public URL of the deployed ci-runner service |
+| IAM bindings | See below |
+
+**IAM bindings created:**
+- `ci-runner` SA → `roles/storage.objectCreator` on `gs://docstore-ci-logs`
+- `ci-runner` SA → `roles/secretmanager.secretAccessor` on both secrets (runtime access)
+- `docstore-deployer` SA → `roles/run.admin` on the project (to deploy the service)
+- `docstore-deployer` SA → `roles/iam.serviceAccountUser` on `ci-runner` SA (to assign it to the Cloud Run service)
+- `docstore-deployer` SA → `roles/secretmanager.viewer` on both secrets (to validate `--update-secrets` references at deploy time)
+
+**Required APIs enabled:** `run.googleapis.com`, `secretmanager.googleapis.com`, `storage.googleapis.com`, `artifactregistry.googleapis.com`
+
+### How to run
+
+```bash
+bash scripts/setup.sh
+```
+
+Override project or region if needed:
+
+```bash
+PROJECT=my-project REGION=us-east1 bash scripts/setup.sh
+```
+
+### Updating placeholder secrets
+
+The script creates both secrets with a `PLACEHOLDER` value. Before the first deploy you must update them:
+
+**1. Set the real HMAC webhook secret** (choose any random string; must match what the docstore outbox dispatcher sends):
+
+```bash
+echo -n 'your-hmac-secret' | gcloud secrets versions add ci-runner-webhook-secret \
+  --data-file=- --project=dlorenc-chainguard
+```
+
+**2. Push to `main`** — `deploy.yml` builds and deploys the ci-runner image.
+
+**3. After the first deploy, get the service URL and update `ci-runner-url`:**
+
+```bash
+URL=$(gcloud run services describe ci-runner \
+  --region=us-central1 --project=dlorenc-chainguard --format='value(status.url)')
+echo -n "${URL}" | gcloud secrets versions add ci-runner-url \
+  --data-file=- --project=dlorenc-chainguard
+```
+
+The `ci-runner-url` secret is read at runtime by the ci-runner service and used by the docstore event outbox dispatcher to know where to send webhook events.
+
+### Full E2E flow after setup
+
+1. Run `scripts/setup.sh` (once)
+2. Update `ci-runner-webhook-secret` with the real HMAC secret
+3. Push to `main` → `deploy.yml` runs two parallel jobs:
+   - `deploy` — builds and deploys the docstore server via ko
+   - `build-and-deploy-ci-runner` — builds the ci-runner Docker image and deploys it to Cloud Run gen2
+4. Retrieve the ci-runner URL and update `ci-runner-url` (step 3 above)
+5. Commits to any branch in docstore trigger the outbox dispatcher, which POSTs to `ci-runner/webhook` (future endpoint), which runs `.docstore/ci.yaml` checks and posts results back via `POST /repos/{name}/-/check`
+
+### Notes
+
+- `--allow-unauthenticated` is intentional on the ci-runner service. It receives webhook POSTs from the docstore outbox dispatcher; request authenticity is verified via HMAC signature (WEBHOOK_SECRET), not IAP.
+- The docstore service is also `--allow-unauthenticated` in this project, so the ci-runner SA does not need `roles/run.invoker` on the docstore service.
+- The ci-runner uses `--execution-environment=gen2` (required for running buildkitd inside the container) with `--concurrency=1` to avoid concurrent buildkitd access per instance.
+
+---
+
 ## CLI Reference
 
 The `ds` CLI wraps the DocStore API. All workspace commands require a `.docstore/` directory (created by `ds init`). Org, repo, and role management commands work without a workspace when a default remote URL is compiled in.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# scripts/setup.sh — One-time infrastructure setup for the ci-runner service.
+# Safe to re-run (idempotent).
+#
+# Usage:
+#   bash scripts/setup.sh
+#   PROJECT=my-project REGION=us-east1 bash scripts/setup.sh
+
+set -euo pipefail
+
+PROJECT="${PROJECT:-dlorenc-chainguard}"
+REGION="${REGION:-us-central1}"
+
+DEPLOYER_SA="docstore-deployer@${PROJECT}.iam.gserviceaccount.com"
+CI_RUNNER_SA="ci-runner@${PROJECT}.iam.gserviceaccount.com"
+LOG_BUCKET="docstore-ci-logs"
+CI_RUNNER_SERVICE="ci-runner"
+
+echo "==> Enabling required APIs..."
+gcloud services enable \
+  run.googleapis.com \
+  secretmanager.googleapis.com \
+  storage.googleapis.com \
+  artifactregistry.googleapis.com \
+  --project="${PROJECT}" --quiet
+echo "    Done."
+
+echo "==> Creating ci-runner service account (if not exists)..."
+if ! gcloud iam service-accounts describe "${CI_RUNNER_SA}" \
+     --project="${PROJECT}" --quiet 2>/dev/null; then
+  gcloud iam service-accounts create ci-runner \
+    --project="${PROJECT}" \
+    --display-name="CI Runner" \
+    --quiet
+  echo "    Created ${CI_RUNNER_SA}"
+else
+  echo "    Already exists: ${CI_RUNNER_SA}"
+fi
+
+echo "==> Creating GCS log bucket (if not exists)..."
+if ! gcloud storage buckets describe "gs://${LOG_BUCKET}" \
+     --project="${PROJECT}" 2>/dev/null; then
+  gcloud storage buckets create "gs://${LOG_BUCKET}" \
+    --project="${PROJECT}" \
+    --location="${REGION}" \
+    --uniform-bucket-level-access \
+    --quiet
+  echo "    Created gs://${LOG_BUCKET}"
+else
+  echo "    Already exists: gs://${LOG_BUCKET}"
+fi
+
+echo "==> Granting ci-runner SA storage.objectCreator on log bucket..."
+gcloud storage buckets add-iam-policy-binding "gs://${LOG_BUCKET}" \
+  --member="serviceAccount:${CI_RUNNER_SA}" \
+  --role=roles/storage.objectCreator \
+  --project="${PROJECT}" \
+  --quiet
+echo "    Done."
+
+echo "==> Granting deployer SA run.admin on project (needed to deploy ci-runner)..."
+gcloud projects add-iam-policy-binding "${PROJECT}" \
+  --member="serviceAccount:${DEPLOYER_SA}" \
+  --role=roles/run.admin \
+  --condition=None \
+  --quiet
+echo "    Done."
+
+echo "==> Granting deployer SA iam.serviceAccountUser on ci-runner SA..."
+gcloud iam service-accounts add-iam-policy-binding "${CI_RUNNER_SA}" \
+  --project="${PROJECT}" \
+  --member="serviceAccount:${DEPLOYER_SA}" \
+  --role=roles/iam.serviceAccountUser \
+  --quiet
+echo "    Done."
+
+echo "==> Creating Secret Manager secrets (if not exists)..."
+for SECRET_NAME in ci-runner-webhook-secret ci-runner-url; do
+  if ! gcloud secrets describe "${SECRET_NAME}" \
+       --project="${PROJECT}" 2>/dev/null; then
+    gcloud secrets create "${SECRET_NAME}" \
+      --project="${PROJECT}" \
+      --replication-policy=automatic \
+      --quiet
+    # Add a placeholder version so the secret is non-empty.
+    echo -n "PLACEHOLDER" | gcloud secrets versions add "${SECRET_NAME}" \
+      --project="${PROJECT}" \
+      --data-file=- \
+      --quiet
+    echo "    Created ${SECRET_NAME} with placeholder value — update before deploying!"
+  else
+    echo "    Already exists: ${SECRET_NAME}"
+  fi
+done
+
+echo "==> Granting ci-runner SA secretmanager.secretAccessor on ci-runner secrets..."
+for SECRET_NAME in ci-runner-webhook-secret ci-runner-url; do
+  gcloud secrets add-iam-policy-binding "${SECRET_NAME}" \
+    --project="${PROJECT}" \
+    --member="serviceAccount:${CI_RUNNER_SA}" \
+    --role=roles/secretmanager.secretAccessor \
+    --quiet
+done
+echo "    Done."
+
+echo "==> Granting deployer SA secretmanager.viewer on ci-runner secrets..."
+# Required so gcloud run deploy can validate the --update-secrets references.
+for SECRET_NAME in ci-runner-webhook-secret ci-runner-url; do
+  gcloud secrets add-iam-policy-binding "${SECRET_NAME}" \
+    --project="${PROJECT}" \
+    --member="serviceAccount:${DEPLOYER_SA}" \
+    --role=roles/secretmanager.viewer \
+    --quiet
+done
+echo "    Done."
+
+echo ""
+echo "Setup complete."
+echo ""
+echo "NEXT STEPS:"
+echo ""
+echo "  1. Set the real HMAC webhook secret (replace PLACEHOLDER):"
+echo "     echo -n '<your-hmac-secret>' | gcloud secrets versions add ci-runner-webhook-secret \\"
+echo "       --data-file=- --project=${PROJECT}"
+echo ""
+echo "  2. Push to main to trigger the first ci-runner deploy."
+echo ""
+echo "  3. After the first deploy, get the ci-runner URL and update the secret:"
+echo "     URL=\$(gcloud run services describe ${CI_RUNNER_SERVICE} \\"
+echo "       --region=${REGION} --project=${PROJECT} --format='value(status.url)')"
+echo "     echo -n \"\${URL}\" | gcloud secrets versions add ci-runner-url \\"
+echo "       --data-file=- --project=${PROJECT}"


### PR DESCRIPTION
## Summary

- **`.github/workflows/deploy.yml`**: adds a new `build-and-deploy-ci-runner` job that runs in parallel with the existing `deploy` job on every push to `main`. It builds the ci-runner image with `docker build -f Dockerfile.ci-runner` (not ko — buildkitd must be bundled in), pushes both `latest` and `<sha>` tags to Artifact Registry, ensures the `gs://docstore-ci-logs` GCS bucket exists, and deploys to Cloud Run gen2 with appropriate env vars and Secret Manager-backed secrets.

- **`scripts/setup.sh`**: new idempotent one-time setup script. Creates the `ci-runner` service account, GCS log bucket, `ci-runner-webhook-secret` and `ci-runner-url` secrets (with placeholder values), all required IAM bindings, and enables required APIs. Safe to re-run.

- **`OPERATIONS.md`**: adds "Initial Setup: CI Runner" section documenting when to run `setup.sh`, what it provisions, how to update placeholder secrets after first deploy, and the full E2E flow.

## Notes

**`entrypoint.sh` not changed**: `cmd/ci-runner/main.go` has no `--runner-url` or `--webhook-secret` flags. `WEBHOOK_SECRET` and `RUNNER_URL` are injected as env vars via `--update-secrets` for future use when the webhook endpoint is implemented.

**Bootstrap order for the `ci-runner-url` secret**: The script creates it with a placeholder. After the first successful deploy, the operator retrieves the Cloud Run service URL and updates the secret (instructions in OPERATIONS.md and printed by `setup.sh`).

## Opportunities (not implemented)

- The `ci-runner` binary has no `/webhook` endpoint yet — `WEBHOOK_SECRET` and `RUNNER_URL` are wired up in the infrastructure but unused by the current binary.
- The `--allow-unauthenticated` flag on ci-runner is appropriate for now (HMAC auth on the webhook endpoint), but the `ci-runner-webhook-secret` will need to be wired into the binary when that endpoint is added.

## Test plan

- [x] `go test ./... -count=1` — all tests pass
- [x] `go build ./...` and `go vet ./...` — clean
- [ ] After merging: verify `build-and-deploy-ci-runner` job succeeds in GitHub Actions (requires `scripts/setup.sh` to have been run first and placeholder secrets updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)