### PR TITLE
CI Milestone 2: GKE Autopilot executor + webhook triggering

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,12 +49,16 @@ jobs:
             --add-cloudsql-instances=dlorenc-chainguard:us-central1:docstore-mvp \
             --update-secrets=DATABASE_URL=docstore-db-url:latest \
             --allow-unauthenticated \
-            --min-instances=0 \
+            --min-instances=1 \
             --max-instances=1 \
-            --port=8080
+            --no-cpu-throttling \
+            --port=8080 \
+            --network=default \
+            --subnet=default \
+            --vpc-egress=private-ranges-only
 
-  # One-time setup: run scripts/setup.sh before the first push to main.
-  # See OPERATIONS.md "Initial Setup" for details.
+  # One-time setup: run scripts/setup.sh and scripts/setup-gke.sh before the
+  # first push to main. See OPERATIONS.md "Initial Setup" for details.
   build-and-deploy-ci-runner:
     runs-on: ubuntu-latest
     steps:
@@ -67,6 +71,12 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v2
 
+      - uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: chainguardener
+          location: us-central1
+          project_id: dlorenc-chainguard
+
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
@@ -74,41 +84,34 @@ jobs:
         id: build
         run: |
           SHA=$(git rev-parse --short HEAD)
-          docker build -f Dockerfile.ci-runner \
-            -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner:latest \
-            -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner:${SHA} \
+          docker buildx build --platform linux/amd64 \
+            -f Dockerfile.ci-runner-gke \
+            -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner-gke:latest \
+            -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner-gke:${SHA} \
+            --push \
             .
-          docker push us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner:latest
-          docker push us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner:${SHA}
           echo "sha=${SHA}" >> $GITHUB_OUTPUT
 
-      - name: Ensure GCS log bucket exists
+      - name: Deploy ci-runner to GKE
         run: |
-          gcloud storage buckets create gs://docstore-ci-logs \
-            --project=dlorenc-chainguard \
-            --location=us-central1 \
-            --uniform-bucket-level-access \
-            2>/dev/null || true
+          kubectl apply -f deploy/k8s/ci-runner.yaml
+          kubectl set image deployment/ci-runner \
+            ci-runner=us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner-gke:${{ steps.build.outputs.sha }} \
+            -n docstore-ci
+          kubectl rollout status deployment/ci-runner -n docstore-ci --timeout=300s
 
-      - name: Deploy ci-runner to Cloud Run
+      - name: Update ci-runner-url secret
         run: |
-          gcloud run deploy ci-runner \
-            --image=us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner:${{ steps.build.outputs.sha }} \
-            --project=dlorenc-chainguard \
-            --region=us-central1 \
-            --execution-environment=gen2 \
-            --service-account=ci-runner@dlorenc-chainguard.iam.gserviceaccount.com \
-            --set-env-vars=DOCSTORE_URL=https://docstore-efuj4cj54a-uc.a.run.app \
-            --set-env-vars=LOG_STORE=gcs \
-            --set-env-vars=LOG_BUCKET=docstore-ci-logs \
-            --update-secrets=WEBHOOK_SECRET=ci-runner-webhook-secret:latest \
-            --update-secrets=RUNNER_URL=ci-runner-url:latest \
-            --allow-unauthenticated \
-            --concurrency=1 \
-            --min-instances=0 \
-            --max-instances=10 \
-            --memory=4Gi \
-            --cpu=4 \
-            --no-cpu-throttling \
-            --timeout=3600 \
-            --port=8080
+          # Wait for the internal load balancer IP to be assigned, then update
+          # the Secret Manager secret so ci-runner can register its webhook URL.
+          IP=$(kubectl get svc ci-runner -n docstore-ci \
+            -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null)
+          if [ -n "$IP" ]; then
+            printf "http://%s:8080" "$IP" | \
+              gcloud secrets versions add ci-runner-url \
+                --data-file=- \
+                --project=dlorenc-chainguard
+            echo "ci-runner-url updated to http://${IP}:8080"
+          else
+            echo "WARNING: internal LB IP not yet assigned; ci-runner-url not updated"
+          fi

--- a/Dockerfile.ci-runner-gke
+++ b/Dockerfile.ci-runner-gke
@@ -1,0 +1,15 @@
+FROM golang:1.25 AS runner-build
+COPY . /src
+WORKDIR /src
+RUN CGO_ENABLED=0 go build -o /ci-runner ./cmd/ci-runner
+
+# rootless image: buildkitd runs in a user namespace, no SYS_ADMIN required.
+# Works on GKE Autopilot which blocks SYS_ADMIN.
+FROM moby/buildkit:v0.29.0-rootless
+USER root
+RUN apk add --no-cache ca-certificates curl
+COPY --from=runner-build /ci-runner /usr/bin/ci-runner
+COPY entrypoint-gke.sh /entrypoint-gke.sh
+RUN chmod +x /entrypoint-gke.sh
+USER 1000
+ENTRYPOINT ["/entrypoint-gke.sh"]

--- a/cmd/ci-runner/e2e_test.go
+++ b/cmd/ci-runner/e2e_test.go
@@ -5,10 +5,13 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,18 +24,19 @@ import (
 	"github.com/dlorenc/docstore/internal/testutil"
 )
 
-// TestE2E_WebhookTriggersRun is a full end-to-end test that:
+// TestE2EGoPipeline is a full end-to-end test that:
 //  1. Starts a real docstore server backed by a testcontainers postgres
-//  2. Starts a real ci-runner backed by a testcontainers buildkitd
-//  3. Creates a repo and commits a .docstore/ci.yaml to main
-//  4. Creates a branch and commits a source file to it
-//  5. Registers a webhook subscription pointing at the ci-runner
-//  6. Posts a commit to trigger a commit.created event via the outbox dispatcher
-//  7. Polls GET /run/{run_id} until the run is done or failed
-//  8. Asserts at least one check run was posted back to docstore
+//  2. Starts a real buildkitd (with --oci-worker-no-process-sandbox, matching
+//     the GKE Autopilot production config) via testcontainers
+//  3. Seeds a repo with a Go module, source, and .docstore/ci.yaml using
+//     golang:1.25 for build/test/vet
+//  4. Registers a webhook subscription on the ci-runner
+//  5. Commits a source change to trigger a commit.created event
+//  6. Polls until all three checks (ci/build, ci/test, ci/vet) resolve
+//  7. Asserts all three checks passed
 //
 // Run with: go test ./cmd/ci-runner/ -tags=e2e -v -timeout=5m
-func TestE2E_WebhookTriggersRun(t *testing.T) {
+func TestE2EGoPipeline(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test in short mode")
 	}
@@ -56,12 +60,10 @@ func TestE2E_WebhookTriggersRun(t *testing.T) {
 	t.Cleanup(docstoreSrv.Close)
 	t.Logf("docstore URL: %s", docstoreSrv.URL)
 
-	// Start the outbox dispatcher so webhook deliveries happen.
 	dispatchCtx, dispatchCancel := context.WithCancel(ctx)
 	t.Cleanup(dispatchCancel)
 	events.StartDispatcher(dispatchCtx, db)
 
-	// Admin HTTP client (sets IAP identity header).
 	adminClient := &http.Client{
 		Transport: &devTransport{base: http.DefaultTransport, identity: adminIdentity},
 	}
@@ -79,47 +81,63 @@ func TestE2E_WebhookTriggersRun(t *testing.T) {
 	}
 	t.Cleanup(func() { exec.Close() }) //nolint:errcheck
 
-	ls, _ := logstore.NewLocalLogStore(t.TempDir())
+	logDir := t.TempDir()
+	ls, _ := logstore.NewLocalLogStore(logDir)
 	const webhookSecret = "e2e-test-secret"
 	runnerMux := newMux(ctx, exec, ls, docstoreSrv.URL, adminClient, 10*time.Minute, webhookSecret)
 	runnerSrv := httptest.NewServer(runnerMux)
 	t.Cleanup(runnerSrv.Close)
 	t.Logf("ci-runner URL: %s", runnerSrv.URL)
 
-	// --- 3. Seed docstore: create org, repo, and commit ci.yaml to main ---
+	// --- 3. Seed docstore: org, repo, Go source + ci.yaml on main ---
 	mustPost(t, adminClient, docstoreSrv.URL+"/orgs",
-		map[string]any{"name": "e2e"})
+		map[string]any{"name": "testci"})
 
+	// Name is just the repo component; owner provides the org prefix.
 	mustPost(t, adminClient, docstoreSrv.URL+"/repos",
-		map[string]any{"name": "e2e/myrepo", "owner": "e2e"})
-
-	// Give admin role to adminIdentity on the repo.
-	mustPost(t, adminClient, docstoreSrv.URL+"/repos/e2e/myrepo/-/roles",
-		map[string]any{"identity": adminIdentity, "role": "admin"})
+		map[string]any{"owner": "testci", "name": "app"})
 
 	ciYAML := `checks:
-  - name: ci/hello
-    image: alpine
+  - name: ci/build
+    image: golang:1.25
     steps:
-      - echo "hello from e2e"
+      - go build ./...
+
+  - name: ci/test
+    image: golang:1.25
+    steps:
+      - go test ./...
+
+  - name: ci/vet
+    image: golang:1.25
+    steps:
+      - go vet ./...
 `
-	mustCommit(t, adminClient, docstoreSrv.URL, "e2e/myrepo", "main",
-		"add ci config", []model.FileChange{
+	goMod := `module testci/app
+
+go 1.22
+`
+	mainGo := `package main
+
+import "fmt"
+
+func main() { fmt.Println("hello") }
+`
+	mainTestGo := `package main
+
+import "testing"
+
+func TestSmoke(t *testing.T) {}
+`
+	mustCommit(t, adminClient, docstoreSrv.URL, "testci/app", "main",
+		"initial: add go source and ci config", []model.FileChange{
 			{Path: ".docstore/ci.yaml", Content: []byte(ciYAML)},
+			{Path: "go.mod", Content: []byte(goMod)},
+			{Path: "main.go", Content: []byte(mainGo)},
+			{Path: "main_test.go", Content: []byte(mainTestGo)},
 		})
 
-	// --- 4. Create branch and commit a source file ---
-	mustPost(t, adminClient, docstoreSrv.URL+"/repos/e2e/myrepo/-/branch",
-		map[string]any{"name": "feature/e2e-test", "base": "main"})
-
-	commitResp := mustCommit(t, adminClient, docstoreSrv.URL, "e2e/myrepo", "feature/e2e-test",
-		"add source file", []model.FileChange{
-			{Path: "hello.txt", Content: []byte("hello world\n")},
-		})
-
-	t.Logf("branch commit sequence: %d", commitResp.Sequence)
-
-	// --- 5. Register webhook subscription pointing at ci-runner ---
+	// --- 4. Register webhook subscription pointing at the ci-runner ---
 	cfgJSON, _ := json.Marshal(map[string]string{
 		"url":    runnerSrv.URL + "/webhook",
 		"secret": webhookSecret,
@@ -129,7 +147,7 @@ func TestE2E_WebhookTriggersRun(t *testing.T) {
 		EventTypes: []string{"com.docstore.commit.created"},
 		Config:     cfgJSON,
 	})
-	resp, err := adminClient.Post(
+	subResp, err := adminClient.Post(
 		docstoreSrv.URL+"/subscriptions",
 		"application/json",
 		bytes.NewReader(subBody),
@@ -137,25 +155,31 @@ func TestE2E_WebhookTriggersRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create subscription: %v", err)
 	}
-	resp.Body.Close()
-	if resp.StatusCode != http.StatusCreated {
-		t.Fatalf("create subscription: expected 201, got %d", resp.StatusCode)
+	subResp.Body.Close()
+	if subResp.StatusCode != http.StatusCreated {
+		t.Fatalf("create subscription: expected 201, got %d", subResp.StatusCode)
 	}
 	t.Log("webhook subscription created")
 
-	// --- 6. Post another commit to trigger commit.created event ---
-	// The outbox dispatcher will deliver the event to the ci-runner webhook.
-	triggerResp := mustCommit(t, adminClient, docstoreSrv.URL, "e2e/myrepo", "feature/e2e-test",
-		"trigger ci run", []model.FileChange{
-			{Path: "trigger.txt", Content: []byte("trigger\n")},
+	// --- 5. Commit a source change to trigger commit.created ---
+	triggerResp := mustCommit(t, adminClient, docstoreSrv.URL, "testci/app", "main",
+		"trigger: update smoke test", []model.FileChange{
+			{Path: "main_test.go", Content: []byte(`package main
+
+import "testing"
+
+func TestSmoke(t *testing.T) { t.Log("smoke ok") }
+`)},
 		})
 	t.Logf("trigger commit sequence: %d", triggerResp.Sequence)
 
-	// --- 7. Poll the docstore checks endpoint until checks appear ---
-	checksURL := fmt.Sprintf("%s/repos/e2e/myrepo/-/branch/feature/e2e-test/checks", docstoreSrv.URL)
-	deadline := time.Now().Add(3 * time.Minute)
+	// --- 6. Poll until all three checks resolve (passed or failed) ---
+	checksURL := fmt.Sprintf("%s/repos/testci/app/-/branch/main/checks", docstoreSrv.URL)
+	deadline := time.Now().Add(4 * time.Minute)
+	wantChecks := map[string]bool{"ci/build": false, "ci/test": false, "ci/vet": false}
+
 	for time.Now().Before(deadline) {
-		time.Sleep(2 * time.Second)
+		time.Sleep(3 * time.Second)
 
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, checksURL, nil)
 		cr, err := adminClient.Do(req)
@@ -163,25 +187,73 @@ func TestE2E_WebhookTriggersRun(t *testing.T) {
 			t.Logf("poll checks: %v", err)
 			continue
 		}
-		var checksResp struct {
-			Checks []struct {
-				CheckName string `json:"check_name"`
-				Status    string `json:"status"`
-			} `json:"checks"`
+		var runs []model.CheckRun
+		if err := json.NewDecoder(cr.Body).Decode(&runs); err != nil {
+			cr.Body.Close()
+			continue
 		}
-		_ = json.NewDecoder(cr.Body).Decode(&checksResp)
 		cr.Body.Close()
 
-		for _, c := range checksResp.Checks {
-			if c.CheckName == "ci/hello" && (c.Status == "passed" || c.Status == "failed") {
-				t.Logf("check ci/hello completed with status: %s", c.Status)
-				return // success
+		for _, run := range runs {
+			if run.Sequence != triggerResp.Sequence {
+				continue
+			}
+			if run.Status == model.CheckRunPassed || run.Status == model.CheckRunFailed {
+				wantChecks[run.CheckName] = true
 			}
 		}
-		t.Logf("waiting for check run... current checks: %+v", checksResp.Checks)
+
+		allDone := true
+		for _, done := range wantChecks {
+			if !done {
+				allDone = false
+				break
+			}
+		}
+		if allDone {
+			break
+		}
+		t.Logf("waiting... resolved: %v", wantChecks)
 	}
 
-	t.Fatal("timed out waiting for check run to appear")
+	// --- 7. Assert all checks resolved and passed ---
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, checksURL, nil)
+	finalResp, err := adminClient.Do(req)
+	if err != nil {
+		t.Fatalf("final check fetch: %v", err)
+	}
+	var finalRuns []model.CheckRun
+	if err := json.NewDecoder(finalResp.Body).Decode(&finalRuns); err != nil {
+		t.Fatalf("decode final checks: %v", err)
+	}
+	finalResp.Body.Close()
+
+	byName := make(map[string]model.CheckRun)
+	for _, run := range finalRuns {
+		if run.Sequence == triggerResp.Sequence &&
+			(run.Status == model.CheckRunPassed || run.Status == model.CheckRunFailed) {
+			byName[run.CheckName] = run
+		}
+	}
+
+	for _, name := range []string{"ci/build", "ci/test", "ci/vet"} {
+		run, ok := byName[name]
+		if !ok {
+			t.Errorf("check %s: no resolved run found", name)
+			continue
+		}
+		if run.Status != model.CheckRunPassed {
+			// Print log content to help debug failures.
+			logContent := ""
+			if run.LogURL != nil {
+				logContent = readLocalLog(t, *run.LogURL)
+			}
+			t.Errorf("check %s: expected passed, got %s\nlogs:\n%s", name, run.Status, logContent)
+		} else {
+			t.Logf("check %s: passed ✓", name)
+		}
+	}
+	_ = logDir // keep temp dir alive until assertions complete
 }
 
 // ---------------------------------------------------------------------------
@@ -197,18 +269,40 @@ func mustPost(t *testing.T, client *http.Client, url string, body any) {
 	}
 	resp.Body.Close()
 	if resp.StatusCode >= 300 {
-		t.Logf("POST %s: status %d (may be OK for idempotent calls)", url, resp.StatusCode)
+		t.Logf("POST %s: status %d", url, resp.StatusCode)
 	}
+}
+
+func readLocalLog(t *testing.T, logURL string) string {
+	t.Helper()
+	// Local log store uses file:// URLs.
+	path := strings.TrimPrefix(logURL, "file://")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Sprintf("(could not read log %s: %v)", path, err)
+	}
+	return string(data)
 }
 
 func mustCommit(t *testing.T, client *http.Client, docstoreURL, repo, branch, message string, files []model.FileChange) model.CommitResponse {
 	t.Helper()
-	commitReq := model.CommitRequest{
-		Branch:  branch,
-		Message: message,
-		Files:   files,
+	type filePayload struct {
+		Path    string `json:"path"`
+		Content string `json:"content"` // base64-encoded
 	}
-	b, _ := json.Marshal(commitReq)
+	type commitPayload struct {
+		Branch  string        `json:"branch"`
+		Message string        `json:"message"`
+		Files   []filePayload `json:"files"`
+	}
+	payload := commitPayload{Branch: branch, Message: message}
+	for _, f := range files {
+		payload.Files = append(payload.Files, filePayload{
+			Path:    f.Path,
+			Content: base64.StdEncoding.EncodeToString(f.Content),
+		})
+	}
+	b, _ := json.Marshal(payload)
 	resp, err := client.Post(
 		fmt.Sprintf("%s/repos/%s/-/commit", docstoreURL, repo),
 		"application/json",

--- a/deploy/k8s/ci-runner.yaml
+++ b/deploy/k8s/ci-runner.yaml
@@ -82,10 +82,14 @@ kind: Service
 metadata:
   name: ci-runner
   namespace: docstore-ci
+  annotations:
+    # Internal load balancer: reachable from Cloud Run via VPC Direct Egress,
+    # not exposed to the public internet.
+    networking.gke.io/load-balancer-type: "Internal"
 spec:
   selector:
     app: ci-runner
   ports:
   - port: 8080
     targetPort: 8080
-  type: ClusterIP
+  type: LoadBalancer

--- a/deploy/k8s/ci-runner.yaml
+++ b/deploy/k8s/ci-runner.yaml
@@ -1,0 +1,91 @@
+# GKE Autopilot deployment for ci-runner.
+#
+# Uses rootless buildkitd (moby/buildkit-rootless) so no SYS_ADMIN is needed,
+# which is required because GKE Autopilot blocks that capability.
+#
+# Pre-requisites (run scripts/setup-gke.sh first):
+#   - GKE cluster with Workload Identity enabled
+#   - ci-runner GCP SA bound to the k8s SA below
+#   - docstore-ci/ci-runner k8s Secret populated
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ci-runner
+  namespace: docstore-ci
+  annotations:
+    iam.gke.io/gcp-service-account: ci-runner@dlorenc-chainguard.iam.gserviceaccount.com
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ci-runner
+  namespace: docstore-ci
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ci-runner
+  template:
+    metadata:
+      labels:
+        app: ci-runner
+    spec:
+      serviceAccountName: ci-runner
+      # rootlesskit needs AppArmor unconfined to set up mount namespaces within
+      # the user namespace. seccompProfile Unconfined is also required.
+      securityContext:
+        appArmorProfile:
+          type: Unconfined
+      containers:
+      - name: ci-runner
+        image: us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner-gke:latest
+        env:
+        - name: DOCSTORE_URL
+          value: https://docstore-efuj4cj54a-uc.a.run.app
+        - name: LOG_STORE
+          value: gcs
+        - name: LOG_BUCKET
+          value: docstore-ci-logs
+        - name: WEBHOOK_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: ci-runner
+              key: webhook-secret
+              optional: true
+        - name: RUNNER_URL
+          valueFrom:
+            secretKeyRef:
+              name: ci-runner
+              key: runner-url
+              optional: true
+        ports:
+        - containerPort: 8080
+        securityContext:
+          seccompProfile:
+            type: Unconfined
+          runAsUser: 1000
+          runAsNonRoot: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ci-runner
+  namespace: docstore-ci
+spec:
+  selector:
+    app: ci-runner
+  ports:
+  - port: 8080
+    targetPort: 8080
+  type: ClusterIP

--- a/entrypoint-gke.sh
+++ b/entrypoint-gke.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -e
+
+# Configure registry auth for buildkitd using GCP workload identity token.
+TOKEN=$(curl -sf -H "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
+  | tr ',' '\n' | grep '"access_token"' | cut -d'"' -f4)
+if [ -n "$TOKEN" ]; then
+  AUTH=$(printf "oauth2accesstoken:%s" "$TOKEN" | base64 | tr -d '\n')
+  mkdir -p "$HOME/.docker"
+  printf '{"auths":{"us-central1-docker.pkg.dev":{"auth":"%s"},"mirror.gcr.io":{"auth":"%s"},"gcr.io":{"auth":"%s"}}}' \
+    "$AUTH" "$AUTH" "$AUTH" > "$HOME/.docker/config.json"
+  echo "registry auth configured" >&2
+else
+  echo "WARNING: could not fetch workload identity token" >&2
+fi
+export DOCKER_CONFIG="$HOME/.docker"
+
+# Start rootless buildkitd in background.
+# rootlesskit wraps buildkitd in a user namespace so SYS_ADMIN is not required.
+rootlesskit buildkitd \
+  --oci-worker-snapshotter=native \
+  --oci-worker-no-process-sandbox \
+  --addr tcp://localhost:1234 &
+
+until nc -z localhost 1234 2>/dev/null; do sleep 0.1; done
+echo "buildkitd ready" >&2
+
+if [ -n "${DEV_IDENTITY}" ]; then
+  set -- "$@" --dev-identity "${DEV_IDENTITY}"
+fi
+
+exec ci-runner \
+  --buildkit-addr tcp://localhost:1234 \
+  --docstore-url "${DOCSTORE_URL}" \
+  --port "${PORT:-8080}" \
+  "$@"

--- a/entrypoint-gke.sh
+++ b/entrypoint-gke.sh
@@ -29,6 +29,12 @@ echo "buildkitd ready" >&2
 if [ -n "${DEV_IDENTITY}" ]; then
   set -- "$@" --dev-identity "${DEV_IDENTITY}"
 fi
+if [ -n "${RUNNER_URL}" ]; then
+  set -- "$@" --runner-url "${RUNNER_URL}"
+fi
+if [ -n "${WEBHOOK_SECRET}" ]; then
+  set -- "$@" --webhook-secret "${WEBHOOK_SECRET}"
+fi
 
 exec ci-runner \
   --buildkit-addr tcp://localhost:1234 \

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3,15 +3,22 @@ package executor
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
+	"strings"
 	"sync"
 
 	dockerconfig "github.com/docker/cli/cli/config"
+	"github.com/distribution/reference"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/client/llb/sourceresolver"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth/authprovider"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Config mirrors the .docstore/ci.yaml DSL and is used for both JSON decode
@@ -80,29 +87,6 @@ func (e *Executor) Close() error {
 
 // runCheck executes a single check and returns its result.
 func (e *Executor) runCheck(ctx context.Context, sourceDir string, check Check) CheckResult {
-	source := llb.Local("src")
-	state := llb.Image(check.Image).Dir("/src")
-	srcMount := source
-
-	for _, step := range check.Steps {
-		exec := state.Run(
-			llb.Args([]string{"sh", "-c", step}),
-			llb.WithCustomName(check.Name+": "+step),
-			llb.AddMount("/src", srcMount),
-		)
-		state = exec.Root()
-		srcMount = exec.GetMount("/src")
-	}
-
-	def, err := state.Marshal(ctx, llb.LinuxAmd64)
-	if err != nil {
-		return CheckResult{
-			Name:   check.Name,
-			Status: "failed",
-			Logs:   fmt.Sprintf("marshal error: %v", err),
-		}
-	}
-
 	var logBuf bytes.Buffer
 	ch := make(chan *client.SolveStatus)
 
@@ -117,8 +101,6 @@ func (e *Executor) runCheck(ctx context.Context, sourceDir string, check Check) 
 		}
 	}()
 
-	// Load Docker credentials from DOCKER_CONFIG or ~/.docker so buildkitd
-	// can pull images from authenticated registries via the session auth provider.
 	dockerConfigDir := os.Getenv("DOCKER_CONFIG")
 	if dockerConfigDir == "" {
 		home := os.Getenv("HOME")
@@ -134,12 +116,78 @@ func (e *Executor) runCheck(ctx context.Context, sourceDir string, check Check) 
 		ap.AuthConfigProvider = authprovider.LoadAuthConfig(dockerCfg)
 	}
 
-	_, solveErr := e.client.Solve(ctx, def, client.SolveOpt{
+	_, solveErr := e.client.Build(ctx, client.SolveOpt{
 		LocalDirs: map[string]string{"src": sourceDir},
 		Session: []session.Attachable{
 			authprovider.NewDockerAuthProvider(ap),
 		},
+	}, "", func(ctx context.Context, c gwclient.Client) (*gwclient.Result, error) {
+		// Resolve the image config to extract its ENV variables.
+		// Required because --oci-worker-no-process-sandbox (needed on GKE
+		// Autopilot where SYS_ADMIN is blocked) does not apply the image's
+		// ENV automatically. We add them to the LLB state explicitly so that
+		// PATH and other variables set by the image (e.g. in golang:1.25) are
+		// available when steps run.
+		// Normalize the image reference (e.g. "golang:1.25" →
+		// "docker.io/library/golang:1.25") so that ResolveImageConfig can parse
+		// it — bare short names without a registry host confuse the URL parser.
+		imageRef := check.Image
+		if named, err := reference.ParseNormalizedNamed(check.Image); err == nil {
+			imageRef = reference.TagNameOnly(named).String()
+		}
+
+		var imageEnv []string
+		if _, _, cfgBytes, err := c.ResolveImageConfig(ctx, imageRef,
+			sourceresolver.Opt{ImageOpt: &sourceresolver.ResolveImageOpt{}}); err == nil {
+			var imgCfg specs.Image
+			if json.Unmarshal(cfgBytes, &imgCfg) == nil {
+				imageEnv = imgCfg.Config.Env
+			}
+		}
+
+		source := llb.Local("src")
+		state := llb.Image(check.Image).Dir("/src")
+		srcMount := source
+
+		// Build RunOptions that apply the image ENV to each exec.
+		// llb.State.AddEnv only sets metadata; llb.AddEnv as a RunOption is
+		// what actually injects variables into the exec environment.
+		envOpts := make([]llb.RunOption, 0, len(imageEnv))
+		for _, env := range imageEnv {
+			k, v, _ := strings.Cut(env, "=")
+			envOpts = append(envOpts, llb.AddEnv(k, v))
+		}
+
+		for _, step := range check.Steps {
+			runOpts := []llb.RunOption{
+				llb.Args([]string{"sh", "-c", step}),
+				llb.WithCustomName(check.Name + ": " + step),
+				llb.AddMount("/src", srcMount),
+			}
+			runOpts = append(runOpts, envOpts...)
+			exec := state.Run(runOpts...)
+			state = exec.Root()
+			srcMount = exec.GetMount("/src")
+		}
+
+		// Use the host architecture so builds work on both amd64 (GKE) and
+		// arm64 (Apple Silicon dev machines).
+		var platformOpt llb.ConstraintsOpt
+		if runtime.GOARCH == "arm64" {
+			platformOpt = llb.LinuxArm64
+		} else {
+			platformOpt = llb.LinuxAmd64
+		}
+		def, err := state.Marshal(ctx, platformOpt)
+		if err != nil {
+			return nil, fmt.Errorf("marshal: %w", err)
+		}
+
+		return c.Solve(ctx, gwclient.SolveRequest{
+			Definition: def.ToPB(),
+		})
 	}, ch)
+
 	collectWg.Wait()
 
 	status := "passed"

--- a/scripts/setup-gke.sh
+++ b/scripts/setup-gke.sh
@@ -15,6 +15,15 @@ CLUSTER="${CLUSTER:-chainguardener}"
 NAMESPACE="docstore-ci"
 KSA="ci-runner"
 GSA="ci-runner@${PROJECT}.iam.gserviceaccount.com"
+DEPLOYER_SA="docstore-deployer@${PROJECT}.iam.gserviceaccount.com"
+
+echo "==> Granting deployer SA container.developer (needed for kubectl in CI)..."
+gcloud projects add-iam-policy-binding "${PROJECT}" \
+  --member="serviceAccount:${DEPLOYER_SA}" \
+  --role=roles/container.developer \
+  --condition=None \
+  --quiet
+echo "    Done."
 
 echo "==> Getting cluster credentials..."
 gcloud container clusters get-credentials "${CLUSTER}" \

--- a/scripts/setup-gke.sh
+++ b/scripts/setup-gke.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# scripts/setup-gke.sh — One-time GKE setup for the ci-runner service.
+# Run this after scripts/setup.sh (which creates the GCP service account and secrets).
+# Safe to re-run (idempotent).
+#
+# Usage:
+#   bash scripts/setup-gke.sh
+#   PROJECT=my-project CLUSTER=my-cluster bash scripts/setup-gke.sh
+
+set -euo pipefail
+
+PROJECT="${PROJECT:-dlorenc-chainguard}"
+REGION="${REGION:-us-central1}"
+CLUSTER="${CLUSTER:-chainguardener}"
+NAMESPACE="docstore-ci"
+KSA="ci-runner"
+GSA="ci-runner@${PROJECT}.iam.gserviceaccount.com"
+
+echo "==> Getting cluster credentials..."
+gcloud container clusters get-credentials "${CLUSTER}" \
+  --region="${REGION}" \
+  --project="${PROJECT}"
+echo "    Done."
+
+echo "==> Creating namespace ${NAMESPACE} (if not exists)..."
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+echo "    Done."
+
+echo "==> Binding GCP SA to k8s SA for Workload Identity..."
+gcloud iam service-accounts add-iam-policy-binding "${GSA}" \
+  --project="${PROJECT}" \
+  --role=roles/iam.workloadIdentityUser \
+  --member="serviceAccount:${PROJECT}.svc.id.goog[${NAMESPACE}/${KSA}]" \
+  --quiet
+echo "    Done."
+
+echo "==> Populating k8s Secret from Secret Manager..."
+WEBHOOK_SECRET=$(gcloud secrets versions access latest \
+  --secret=ci-runner-webhook-secret \
+  --project="${PROJECT}")
+RUNNER_URL=$(gcloud secrets versions access latest \
+  --secret=ci-runner-url \
+  --project="${PROJECT}")
+
+kubectl create secret generic "${KSA}" \
+  --namespace="${NAMESPACE}" \
+  --from-literal=webhook-secret="${WEBHOOK_SECRET}" \
+  --from-literal=runner-url="${RUNNER_URL}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+echo "    Done."
+
+echo ""
+echo "GKE setup complete."
+echo ""
+echo "NEXT STEPS:"
+echo ""
+echo "  1. Build and push the GKE image:"
+echo "     docker build -f Dockerfile.ci-runner-gke \\"
+echo "       -t us-central1-docker.pkg.dev/${PROJECT}/images/ci-runner-gke:latest ."
+echo "     docker push us-central1-docker.pkg.dev/${PROJECT}/images/ci-runner-gke:latest"
+echo ""
+echo "  2. Deploy to GKE:"
+echo "     kubectl apply -f deploy/k8s/ci-runner.yaml"
+echo ""
+echo "  3. Test with port-forward:"
+echo "     kubectl port-forward svc/ci-runner 8080:8080 -n ${NAMESPACE}"
+echo "     curl -s -X POST http://localhost:8080/run \\"
+echo "       -H 'Content-Type: application/json' \\"
+echo "       -d '{\"repo\":\"default/default\",\"branch\":\"main\",\"head_sequence\":1}'"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -50,10 +50,12 @@ else
   echo "    Already exists: gs://${LOG_BUCKET}"
 fi
 
-echo "==> Granting ci-runner SA storage.objectCreator on log bucket..."
+echo "==> Granting ci-runner SA storage.objectUser on log bucket..."
+# objectUser (not objectCreator) is required: the GCS multipart writer needs
+# delete access to compose/clean up intermediate chunk objects.
 gcloud storage buckets add-iam-policy-binding "gs://${LOG_BUCKET}" \
   --member="serviceAccount:${CI_RUNNER_SA}" \
-  --role=roles/storage.objectCreator \
+  --role=roles/storage.objectUser \
   --project="${PROJECT}" \
   --quiet
 echo "    Done."

--- a/test/hello/.docstore/ci.yaml
+++ b/test/hello/.docstore/ci.yaml
@@ -1,15 +1,15 @@
 checks:
   - name: ci/build
-    image: us-central1-docker.pkg.dev/dlorenc-chainguard/images/golang:1.22
+    image: golang:1.25
     steps:
       - go build ./...
 
   - name: ci/test
-    image: us-central1-docker.pkg.dev/dlorenc-chainguard/images/golang:1.22
+    image: golang:1.25
     steps:
       - go test ./...
 
   - name: ci/vet
-    image: us-central1-docker.pkg.dev/dlorenc-chainguard/images/golang:1.22
+    image: golang:1.25
     steps:
       - go vet ./...


### PR DESCRIPTION
## Summary

Closes #135. Completes CI Milestone 2 end-to-end.

### Architecture

```
commit → docstore (Cloud Run, VPC Direct Egress)
           ↓ webhook POST to private RFC 1918 address
         ci-runner (GKE Autopilot, internal LB 10.128.0.40)
           ├─ rootless buildkitd (rootlesskit, no SYS_ADMIN required)
           └─ executor: ResolveImageConfig → inject ENV as RunOptions
         GCS logs + docstore check runs
```

### Root causes fixed

| Problem | Fix |
|---|---|
| SIGBUS on Cloud Run | Rootless buildkitd on GKE Autopilot (`moby/buildkit-rootless`) |
| `SYS_ADMIN` blocked by Autopilot | rootlesskit user namespace; `appArmorProfile: Unconfined` |
| `go: not found` despite golang:1.25 image | `--oci-worker-no-process-sandbox` skips image ENV; fix: gateway `c.ResolveImageConfig` + `llb.AddEnv` RunOption per exec |
| `golang:1.25` reference parse error in gateway | Normalize via `reference.ParseNormalizedNamed` before resolving |
| Cloud Run outbox dispatcher not firing | `--min-instances=1 --no-cpu-throttling` on docstore |
| GCS upload 403 | `objectUser` not `objectCreator` (multipart writer needs delete) |
| Webhook not wired | `RUNNER_URL`/`WEBHOOK_SECRET` env vars not passed as `--flags` in entrypoint |

### Changes

- `internal/executor/executor.go` — gateway-based solve with image ENV injection
- `cmd/ci-runner/e2e_test.go` — `TestE2EGoPipeline`: real Go build/test/vet via webhook trigger, all pass locally
- `Dockerfile.ci-runner-gke`, `entrypoint-gke.sh` — rootless buildkitd image
- `deploy/k8s/ci-runner.yaml` — internal LoadBalancer + Workload Identity
- `deploy.yml` — GKE job (replace Cloud Run), VPC egress on docstore
- `scripts/setup-gke.sh`, `scripts/setup.sh` — GKE WIF + GCS IAM fix

### Verified end-to-end

**Locally** (`go test -tags=e2e ./cmd/ci-runner/`):
```
check ci/build: passed ✓
check ci/test:  passed ✓
check ci/vet:   passed ✓
```

**Production** (GKE Autopilot, seq=13):
```
seq=13 ci/build  passed  gs://docstore-ci-logs/default/default/main/13/ci_build.log
seq=13 ci/test   passed  gs://docstore-ci-logs/default/default/main/13/ci_test.log
seq=13 ci/vet    passed  gs://docstore-ci-logs/default/default/main/13/ci_vet.log
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)