### PR TITLE
docs: update CI system docs for GKE deployment (Milestones 1+2)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1225,32 +1225,13 @@ The server uses the standard `log/slog` package for structured JSON logging. All
 
 ## Initial Setup: CI Runner
 
-The CI runner is a separate Cloud Run service (`ci-runner`) that executes checks triggered by docstore events. Before the first push to `main` will succeed, run the one-time setup script to provision the required infrastructure.
+The CI runner (`ci-runner`) executes `.docstore/ci.yaml` checks triggered by docstore commit events. It runs on GKE Autopilot using rootless buildkitd. See [docs/ci-runner.md](docs/ci-runner.md) for full architecture details.
 
-### When to run
+Before the first deploy, run the one-time setup scripts to provision GCP and GKE infrastructure.
 
-Run `scripts/setup.sh` once per project, before pushing to `main` for the first time. It is safe to re-run (all steps are idempotent).
+### Step 1: GCP setup (`scripts/setup.sh`)
 
-### What it creates
-
-| Resource | Description |
-|---------|-------------|
-| `ci-runner` service account | Runs the Cloud Run service |
-| `gs://docstore-ci-logs` GCS bucket | Stores CI check run logs |
-| `ci-runner-webhook-secret` Secret Manager secret | HMAC secret for webhook payload verification |
-| `ci-runner-url` Secret Manager secret | Public URL of the deployed ci-runner service |
-| IAM bindings | See below |
-
-**IAM bindings created:**
-- `ci-runner` SA → `roles/storage.objectCreator` on `gs://docstore-ci-logs`
-- `ci-runner` SA → `roles/secretmanager.secretAccessor` on both secrets (runtime access)
-- `docstore-deployer` SA → `roles/run.admin` on the project (to deploy the service)
-- `docstore-deployer` SA → `roles/iam.serviceAccountUser` on `ci-runner` SA (to assign it to the Cloud Run service)
-- `docstore-deployer` SA → `roles/secretmanager.viewer` on both secrets (to validate `--update-secrets` references at deploy time)
-
-**Required APIs enabled:** `run.googleapis.com`, `secretmanager.googleapis.com`, `storage.googleapis.com`, `artifactregistry.googleapis.com`
-
-### How to run
+Run once to create the GCP service account, GCS bucket, and Secret Manager secrets.
 
 ```bash
 bash scripts/setup.sh
@@ -1262,45 +1243,88 @@ Override project or region if needed:
 PROJECT=my-project REGION=us-east1 bash scripts/setup.sh
 ```
 
-### Updating placeholder secrets
+**What it creates:**
 
-The script creates both secrets with a `PLACEHOLDER` value. Before the first deploy you must update them:
+| Resource | Description |
+|---------|-------------|
+| `ci-runner` GCP service account | Identity for the GKE pod (via Workload Identity) |
+| `gs://docstore-ci-logs` GCS bucket | Stores CI check run logs |
+| `ci-runner-webhook-secret` Secret Manager secret | HMAC secret for webhook payload verification |
+| `ci-runner-url` Secret Manager secret | Internal LB IP:port of the deployed ci-runner |
+| IAM bindings | See below |
 
-**1. Set the real HMAC webhook secret** (choose any random string; must match what the docstore outbox dispatcher sends):
+**IAM bindings created by `scripts/setup.sh`:**
+- `ci-runner` SA → `roles/storage.objectUser` on `gs://docstore-ci-logs` (read/write logs)
+- `ci-runner` SA → `roles/secretmanager.secretAccessor` on both secrets (runtime access)
+- `docstore-deployer` SA → `roles/secretmanager.secretVersionAdder` on `ci-runner-url` (update LB IP after deploy)
+
+**Required APIs enabled:** `secretmanager.googleapis.com`, `storage.googleapis.com`, `artifactregistry.googleapis.com`, `container.googleapis.com`
+
+### Step 2: GKE setup (`scripts/setup-gke.sh`)
+
+Run once after `scripts/setup.sh` to configure Workload Identity, create the k8s namespace, and populate the k8s Secret from Secret Manager.
+
+```bash
+bash scripts/setup-gke.sh
+```
+
+**What it does:**
+
+- Grants `docstore-deployer` SA `roles/container.developer` (for `kubectl` in CI)
+- Binds the `ci-runner` GCP SA to the `docstore-ci/ci-runner` k8s ServiceAccount via Workload Identity (`roles/iam.workloadIdentityUser`)
+- Creates the `docstore-ci` namespace
+- Populates the `ci-runner` k8s Secret from Secret Manager (`ci-runner-webhook-secret` and `ci-runner-url`)
+
+Override cluster or project if needed:
+
+```bash
+PROJECT=my-project CLUSTER=my-cluster bash scripts/setup-gke.sh
+```
+
+### Step 3: Populate secrets
+
+The setup scripts create secrets with a `PLACEHOLDER` value. Update them before the first deploy:
+
+**Set the HMAC webhook secret:**
 
 ```bash
 echo -n 'your-hmac-secret' | gcloud secrets versions add ci-runner-webhook-secret \
   --data-file=- --project=dlorenc-chainguard
 ```
 
-**2. Push to `main`** — `deploy.yml` builds and deploys the ci-runner image.
+Then re-run `scripts/setup-gke.sh` to propagate the updated value to the k8s Secret.
 
-**3. After the first deploy, get the service URL and update `ci-runner-url`:**
+### Step 4: Deploy
+
+Push to `main` — `deploy.yml` builds the ci-runner image (from `Dockerfile.ci-runner-gke`), deploys to GKE, and updates the `ci-runner-url` secret with the internal LB IP.
+
+To deploy manually:
 
 ```bash
-URL=$(gcloud run services describe ci-runner \
-  --region=us-central1 --project=dlorenc-chainguard --format='value(status.url)')
-echo -n "${URL}" | gcloud secrets versions add ci-runner-url \
-  --data-file=- --project=dlorenc-chainguard
-```
+docker build -f Dockerfile.ci-runner-gke \
+  -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner-gke:latest .
+docker push us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner-gke:latest
 
-The `ci-runner-url` secret is read at runtime by the ci-runner service and used by the docstore event outbox dispatcher to know where to send webhook events.
+kubectl apply -f deploy/k8s/ci-runner.yaml
+kubectl rollout status deployment/ci-runner -n docstore-ci
+```
 
 ### Full E2E flow after setup
 
-1. Run `scripts/setup.sh` (once)
-2. Update `ci-runner-webhook-secret` with the real HMAC secret
+1. Run `scripts/setup.sh` and `scripts/setup-gke.sh` (once each)
+2. Populate `ci-runner-webhook-secret` with the real HMAC secret
 3. Push to `main` → `deploy.yml` runs two parallel jobs:
-   - `deploy` — builds and deploys the docstore server via ko
-   - `build-and-deploy-ci-runner` — builds the ci-runner Docker image and deploys it to Cloud Run gen2
-4. Retrieve the ci-runner URL and update `ci-runner-url` (step 3 above)
-5. Commits to any branch in docstore trigger the outbox dispatcher, which POSTs to `ci-runner/webhook` (future endpoint), which runs `.docstore/ci.yaml` checks and posts results back via `POST /repos/{name}/-/check`
+   - `deploy` — builds and deploys the docstore server via ko to Cloud Run
+   - `build-and-deploy-ci-runner` — builds ci-runner and deploys to GKE; updates `ci-runner-url`
+4. The ci-runner auto-registers a webhook subscription with docstore on startup
+5. Commits to any branch trigger the outbox dispatcher → `POST /webhook` on ci-runner → `.docstore/ci.yaml` checks run → results posted back via `POST /repos/{name}/-/check`
 
 ### Notes
 
-- `--allow-unauthenticated` is intentional on the ci-runner service. It receives webhook POSTs from the docstore outbox dispatcher; request authenticity is verified via HMAC signature (WEBHOOK_SECRET), not IAP.
-- The docstore service is also `--allow-unauthenticated` in this project, so the ci-runner SA does not need `roles/run.invoker` on the docstore service.
-- The ci-runner uses `--execution-environment=gen2` (required for running buildkitd inside the container) with `--concurrency=1` to avoid concurrent buildkitd access per instance.
+- The ci-runner is reachable only via the GKE internal LoadBalancer (not public internet). Docstore reaches it via VPC Direct Egress.
+- Webhook authenticity is verified via HMAC signature (`X-DocStore-Signature` header), not IAP.
+- The `ci-runner-url` secret stores the internal LB `http://IP:8080` address. The deploy job updates it if the IP changes.
+- Logs are stored in GCS at `gs://docstore-ci-logs/{repo}/{branch}/{seq}/{check}.log`.
 
 ---
 

--- a/cmd/ci-runner/main.go
+++ b/cmd/ci-runner/main.go
@@ -449,8 +449,7 @@ func newMux(serverCtx context.Context, exec *executor.Executor, ls logstore.LogS
 	mux := http.NewServeMux()
 
 	// POST /run — manual trigger. Runs synchronously so the HTTP connection
-	// stays open for the duration of the build, preventing Cloud Run from
-	// terminating the instance mid-build. Returns when all checks complete.
+	// stays open for the duration of the build. Returns when all checks complete.
 	mux.HandleFunc("POST /run", func(w http.ResponseWriter, r *http.Request) {
 		var req runRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -469,8 +468,8 @@ func newMux(serverCtx context.Context, exec *executor.Executor, ls logstore.LogS
 		runID := uuid.New().String()
 		reg.start(runID, req.Repo, req.Branch, req.HeadSequence)
 
-		// Flush headers immediately so the Cloud Run load balancer doesn't
-		// timeout waiting for the first byte while the build runs.
+		// Flush headers immediately so the load balancer doesn't timeout
+		// waiting for the first byte while the build runs.
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.WriteHeader(http.StatusOK)

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -6,15 +6,14 @@ The CI runner is a standalone HTTP service (`cmd/ci-runner`) that executes `.doc
 
 The runner sits between docstore and a co-located `buildkitd` instance. It accepts a source directory and a check configuration over HTTP, translates each check into an LLB DAG, dispatches the build to BuildKit, collects logs, and returns pass/fail results synchronously.
 
-In the full production flow (Milestone 1):
+In the full production flow:
 1. A commit lands on a branch
-2. The runner fetches `.docstore/ci.yaml` from `main` and downloads the branch tree to disk
-3. The runner calls itself (`POST /run`) with the local source path
-4. Results are written back to docstore as check runs via `POST /-/check`
+2. Docstore's outbox dispatcher sends a `commit.created` CloudEvent to the ci-runner webhook
+3. The ci-runner fetches `.docstore/ci.yaml` from `main` and downloads the branch tree to disk
+4. BuildKit executes the checks; logs are written to GCS
+5. Results are written back to docstore as check runs via `POST /-/check`
 
-Milestone 1 wires in full docstore integration: fetching `.docstore/ci.yaml` from `main`, pulling branch source, posting check runs back to docstore, and writing logs to a configurable log store.
-
-Milestone 2 (this document) adds webhook-triggered runs, a run status polling endpoint, and auto-registration of the webhook subscription at startup.
+**Production deployment:** ci-runner runs on GKE Autopilot (cluster `chainguardener`, namespace `docstore-ci`) using rootless buildkitd (`moby/buildkit-rootless`). The docstore Cloud Run service delivers webhook events to ci-runner's internal GKE LoadBalancer (IP `10.128.0.40`) via VPC Direct Egress. Logs are stored at `gs://docstore-ci-logs`. See [GKE Deployment](#gke-deployment) for details.
 
 ## How It Works
 
@@ -50,24 +49,47 @@ No matrix, conditionals, or artifact config in v1.
 
 ### LLB Translation
 
-`internal/executor` (`executor.go:78`) translates each check into an independent LLB chain. The source directory is mounted as a local input named `"src"`.
+`internal/executor` (`executor.go`) translates each check into an independent LLB chain using the BuildKit gateway API (`client.Build`). The source directory is mounted as a local input named `"src"`.
+
+**Image ENV injection (gateway API):** The executor uses `client.Build` rather than `client.Solve` so it can call `ResolveImageConfig` to fetch the image's OCI config and extract its `Env` array. These ENV variables are then injected as `llb.AddEnv` `RunOption`s on every exec. This is required because `--oci-worker-no-process-sandbox` (needed for rootless buildkitd on GKE Autopilot, where `SYS_ADMIN` is blocked) does not apply the image's ENV automatically. Without this fix, tools like `go` are not found at runtime because the image's `PATH` is never set.
 
 For each check, the executor:
-1. Starts from the check's container image with working directory `/src`
-2. Chains each step as a `Run` vertex with the source mounted at `/src`
-3. **Threads `srcMount` forward between steps** — each step receives the output `/src` from the previous step as its input mount, so in-source changes (e.g. `go generate` producing files) persist across steps within one check
-4. Marshals the final DAG and dispatches to buildkitd
+1. Resolves the image config via `ResolveImageConfig` to extract ENV variables
+2. Starts from the check's container image with working directory `/src`
+3. Chains each step as a `Run` vertex with the source mounted at `/src` and all image ENV variables applied
+4. **Threads `srcMount` forward between steps** — each step receives the output `/src` from the previous step as its input mount, so in-source changes (e.g. `go generate` producing files) persist across steps within one check
+5. Marshals the final DAG and dispatches via the gateway solve
 
-Key snippet (`executor.go:83-90`):
+Key snippet:
 ```go
+// Resolve image ENV so tools like `go` are on PATH under --oci-worker-no-process-sandbox.
+imageRef := check.Image
+if named, err := reference.ParseNormalizedNamed(check.Image); err == nil {
+    imageRef = reference.TagNameOnly(named).String()
+}
+var imageEnv []string
+if _, _, cfgBytes, err := c.ResolveImageConfig(ctx, imageRef, ...); err == nil {
+    var imgCfg specs.Image
+    if json.Unmarshal(cfgBytes, &imgCfg) == nil {
+        imageEnv = imgCfg.Config.Env
+    }
+}
+envOpts := make([]llb.RunOption, 0, len(imageEnv))
+for _, env := range imageEnv {
+    k, v, _ := strings.Cut(env, "=")
+    envOpts = append(envOpts, llb.AddEnv(k, v))
+}
+
 state := llb.Image(check.Image).Dir("/src")
 srcMount := source  // llb.Local("src")
 
 for _, step := range check.Steps {
-    exec := state.Run(
+    runOpts := []llb.RunOption{
         llb.Args([]string{"sh", "-c", step}),
         llb.AddMount("/src", srcMount),
-    )
+    }
+    runOpts = append(runOpts, envOpts...)
+    exec := state.Run(runOpts...)
     state = exec.Root()
     srcMount = exec.GetMount("/src")  // carry forward for next step
 }
@@ -228,6 +250,14 @@ Flags:
 | `--runner-url` | `""` | Public URL of this runner (enables auto-registration with docstore) |
 | `--webhook-secret` | `""` | HMAC secret for verifying incoming webhook deliveries |
 
+Environment variables (log storage):
+
+| Variable | Default | Description |
+|---|---|---|
+| `LOG_STORE` | `local` | Log store backend: `local` or `gcs` |
+| `LOG_LOCAL_DIR` | `/tmp/ci-logs` | Directory for local log store (when `LOG_STORE=local`) |
+| `LOG_BUCKET` | (required when gcs) | GCS bucket name (when `LOG_STORE=gcs`) |
+
 Log format defaults to JSON. Set `LOG_FORMAT=text` for human-readable output:
 ```bash
 LOG_FORMAT=text go run ./cmd/ci-runner
@@ -305,23 +335,78 @@ go build ./...
 go vet ./...
 ```
 
-### End-to-End Tests (Milestone 2)
+### End-to-End Tests
 
 The e2e test (`cmd/ci-runner/e2e_test.go`) requires Docker to start real postgres, docstore, and buildkitd containers. It is tagged `//go:build e2e` and excluded from the default test run.
 
 ```bash
 # Run the e2e test (requires Docker)
-go test ./cmd/ci-runner/ -tags=e2e -run TestE2E_WebhookTriggersRun -v -timeout=5m
+go test ./cmd/ci-runner/ -tags=e2e -run TestE2EGoPipeline -v -timeout=10m
 ```
 
-The test:
+The test (`TestE2EGoPipeline`):
 1. Starts a Postgres container via testcontainers and runs docstore migrations
 2. Starts a real docstore HTTP server wired to the database
 3. Starts a testcontainers buildkitd instance
-4. Creates an org, repo, commits `.docstore/ci.yaml` to `main`, and creates a feature branch
+4. Creates an org, repo, commits `.docstore/ci.yaml` (using `golang:1.25`) and the `test/hello` source tree to `main`, then creates a feature branch
 5. Registers a webhook subscription pointing at the in-process ci-runner
-6. Posts a commit to trigger the `commit.created` event via the outbox dispatcher
-7. Polls docstore `GET /repos/{repo}/-/branch/{branch}/checks` until `ci/hello` completes
+6. Posts a commit to the feature branch to trigger `commit.created` via the outbox dispatcher
+7. Polls docstore `GET /repos/{repo}/-/branch/{branch}/checks` until all three checks (`ci/build`, `ci/test`, `ci/vet`) complete with `passed`
+
+## GKE Deployment
+
+The production ci-runner runs on GKE Autopilot rather than Cloud Run because buildkitd requires Linux user namespaces (`SYS_ADMIN`) that Autopilot blocks. The rootless buildkitd image (`moby/buildkit:v0.29.0-rootless`) works around this using `rootlesskit`, which sets up mount namespaces inside a user namespace.
+
+### Components
+
+| File | Purpose |
+|---|---|
+| `Dockerfile.ci-runner-gke` | Two-stage build: Go binary + rootless buildkitd image |
+| `entrypoint-gke.sh` | Configures GCR auth, starts rootlesskit buildkitd, then starts ci-runner |
+| `deploy/k8s/ci-runner.yaml` | GKE Deployment + internal LoadBalancer + Workload Identity SA |
+| `scripts/setup-gke.sh` | One-time GKE setup (Workload Identity, secrets, IAM) |
+
+### Network topology
+
+```
+Cloud Run (docstore)
+  └─[VPC Direct Egress]─► internal LB 10.128.0.40:8080
+                                 └─► ci-runner pod (docstore-ci namespace)
+                                           └─► rootlesskit buildkitd (tcp://localhost:1234)
+```
+
+Docstore uses VPC Direct Egress to reach the GKE internal LoadBalancer IP. The ci-runner is not exposed to the public internet.
+
+### Security
+
+- **Workload Identity:** The `ci-runner` k8s ServiceAccount is bound to the `ci-runner@dlorenc-chainguard.iam.gserviceaccount.com` GCP SA via `iam.workloadIdentityUser`. This grants access to GCS log storage without static credentials.
+- **seccompProfile / AppArmor:** Both must be `Unconfined` for rootlesskit to set up mount namespaces. This is configured in `deploy/k8s/ci-runner.yaml`.
+- **Webhook HMAC:** The ci-runner verifies the `X-DocStore-Signature` header on all incoming webhooks using the `WEBHOOK_SECRET` env var (sourced from a k8s Secret backed by Secret Manager).
+
+### First-time setup
+
+```bash
+# One-time setup (idempotent):
+bash scripts/setup.sh          # GCP SA, GCS bucket, Secret Manager secrets, IAM
+bash scripts/setup-gke.sh      # Workload Identity binding, k8s namespace and Secret
+
+# Build and push the image:
+docker build -f Dockerfile.ci-runner-gke \
+  -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner-gke:latest .
+docker push us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner-gke:latest
+
+# Deploy:
+kubectl apply -f deploy/k8s/ci-runner.yaml
+kubectl rollout status deployment/ci-runner -n docstore-ci
+```
+
+After deploy, the `build-and-deploy-ci-runner` CI job in `deploy.yml` handles subsequent deploys automatically on every push to `main`. It also updates the `ci-runner-url` Secret Manager secret with the internal LB IP if it has changed.
+
+### rootlesskit flags
+
+`entrypoint-gke.sh` starts buildkitd with:
+- `--oci-worker-snapshotter=native` — uses overlay-less snapshotter compatible with Autopilot
+- `--oci-worker-no-process-sandbox` — disables the per-process sandbox (required because there is no seccomp/apparmor inside the user namespace); the image ENV fix in `executor.go` compensates for the side effect of this flag not applying image ENV
 
 ## Architecture Notes
 


### PR DESCRIPTION
## Summary

- **Production repo cleanup**: removed `trigger.txt`, `trigger2.txt`, `trigger3.txt` from `default/default` main branch via the docstore API (commit sequence 14). No `e2e.txt` was present.
- **`docs/ci-runner.md`**: major update for GKE/Milestone 2 architecture — new GKE Deployment section, updated LLB translation section explaining the gateway-based solve + image ENV injection, new log store env var table, corrected e2e test name (`TestE2EGoPipeline`), updated overview.
- **`OPERATIONS.md`**: replaced stale Cloud Run CI runner setup section with current two-step GKE setup (`scripts/setup.sh` + `scripts/setup-gke.sh`), updated IAM bindings, documented Workload Identity, internal LB, VPC Direct Egress, and full E2E flow.
- **`cmd/ci-runner/main.go`**: removed two stale "Cloud Run" references from comments in the `POST /run` handler.

## Test plan

- [x] `go test ./... -count=1` passes
- [x] `go build ./... && go vet ./...` clean
- [x] Production `default/default` repo tree verified clean (only `.docstore/ci.yaml`, `go.mod`, `main.go`, `main_test.go`, `README.md`)

## Notes for reviewers

- The `test/hello/README.md` accurately describes the current architecture and needed no changes.
- The `test/hello/.docstore/ci.yaml` already uses `golang:1.25`.
- Opportunities not addressed (out of scope per ROADMAP): self-hosting docstore CI on the docstore source itself; adding the GKE internal LB IP to the architecture diagram in OPERATIONS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)