### PR TITLE
ci: pin archive source to triggering sequence; attribute check runs to specific commit

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -441,6 +441,7 @@ type CreateCheckRunRequest struct {
 	CheckName string         `json:"check_name"`
 	Status    CheckRunStatus `json:"status"`
 	LogURL    *string        `json:"log_url,omitempty"`
+	Sequence  *int64         `json:"sequence,omitempty"`
 }
 
 // CreateCheckRunResponse is the response for POST /check.

--- a/cmd/ci-runner/cirunner_test.go
+++ b/cmd/ci-runner/cirunner_test.go
@@ -236,6 +236,9 @@ func TestPullBranchSource_DownloadsFiles(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/repos/default/myrepo/-/archive" {
+			if at := r.URL.Query().Get("at"); at != "42" {
+				t.Errorf("expected at=42, got %q", at)
+			}
 			w.Header().Set("Content-Type", "application/x-tar")
 			w.Write(tarData) //nolint:errcheck
 			return
@@ -244,7 +247,7 @@ func TestPullBranchSource_DownloadsFiles(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	tempDir, err := pullBranchSource(context.Background(), srv.Client(), srv.URL, "default/myrepo", "feature/x")
+	tempDir, err := pullBranchSource(context.Background(), srv.Client(), srv.URL, "default/myrepo", "feature/x", 42)
 	if tempDir != "" {
 		defer os.RemoveAll(tempDir)
 	}

--- a/cmd/ci-runner/main.go
+++ b/cmd/ci-runner/main.go
@@ -175,17 +175,17 @@ func fetchConfig(ctx context.Context, client *http.Client, docstoreURL, repo str
 	return &cfg, nil
 }
 
-// pullBranchSource materialises the given branch into a new temp directory
-// and returns its path. The caller is responsible for os.RemoveAll.
+// pullBranchSource materialises the given branch at headSeq into a new temp
+// directory and returns its path. The caller is responsible for os.RemoveAll.
 // It uses the /-/archive endpoint to fetch all files in a single request.
-func pullBranchSource(ctx context.Context, client *http.Client, docstoreURL, repo, branch string) (string, error) {
+func pullBranchSource(ctx context.Context, client *http.Client, docstoreURL, repo, branch string, headSeq int64) (string, error) {
 	tempDir, err := os.MkdirTemp("", "ci-runner-src-*")
 	if err != nil {
 		return "", fmt.Errorf("create temp dir: %w", err)
 	}
 
-	archiveURL := fmt.Sprintf("%s/repos/%s/-/archive?branch=%s",
-		docstoreURL, repo, url.QueryEscape(branch))
+	archiveURL := fmt.Sprintf("%s/repos/%s/-/archive?branch=%s&at=%d",
+		docstoreURL, repo, url.QueryEscape(branch), headSeq)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
 	if err != nil {
 		return tempDir, fmt.Errorf("create archive request: %w", err)
@@ -275,6 +275,7 @@ func runAsync(ctx context.Context, client *http.Client, exec *executor.Executor,
 			CheckName: "ci/config",
 			Status:    model.CheckRunFailed,
 			LogURL:    &msg,
+			Sequence:  &headSeq,
 		})
 		if reg != nil {
 			reg.fail(runID, "config fetch failed: "+err.Error())
@@ -283,7 +284,7 @@ func runAsync(ctx context.Context, client *http.Client, exec *executor.Executor,
 	}
 
 	// 2. Pull branch source into temp dir.
-	tempDir, err := pullBranchSource(ctx, client, docstoreURL, repo, branch)
+	tempDir, err := pullBranchSource(ctx, client, docstoreURL, repo, branch, headSeq)
 	if tempDir != "" {
 		defer os.RemoveAll(tempDir)
 	}
@@ -301,6 +302,7 @@ func runAsync(ctx context.Context, client *http.Client, exec *executor.Executor,
 			Branch:    branch,
 			CheckName: check.Name,
 			Status:    model.CheckRunPending,
+			Sequence:  &headSeq,
 		}); err != nil {
 			slog.Warn("mark pending failed", "check", check.Name, "error", err)
 		}
@@ -333,6 +335,7 @@ func runAsync(ctx context.Context, client *http.Client, exec *executor.Executor,
 			CheckName: result.Name,
 			Status:    model.CheckRunStatus(result.Status),
 			LogURL:    logURL,
+			Sequence:  &headSeq,
 		}); err != nil {
 			slog.Warn("post result failed", "check", result.Name, "error", err)
 		}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1196,10 +1196,12 @@ func (s *Store) ListReviews(ctx context.Context, repo, branch string, atSeq *int
 	return reviews, rows.Err()
 }
 
-// CreateCheckRun records a CI check run for a branch at its current
-// head_sequence. Returns ErrBranchNotFound if the branch doesn't exist.
+// CreateCheckRun records a CI check run for a branch. If atSequence is
+// non-nil it is used as the recorded sequence; otherwise the branch's
+// current head_sequence is used. Returns ErrBranchNotFound if the branch
+// doesn't exist.
 // logURL is optional (may be nil) and stores a GCS URI or local file path.
-func (s *Store) CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string) (*model.CheckRun, error) {
+func (s *Store) CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64) (*model.CheckRun, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		slog.Error("tx begin failed", "op", "create_check_run", "error", err)
@@ -1221,6 +1223,9 @@ func (s *Store) CreateCheckRun(ctx context.Context, repo, branch, checkName stri
 			return nil, ErrBranchNotFound
 		}
 		return nil, fmt.Errorf("lock branch: %w", err)
+	}
+	if atSequence != nil {
+		headSeq = *atSequence
 	}
 
 	id := uuid.New().String()

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -1848,7 +1848,7 @@ func TestCreateCheckRun_Success(t *testing.T) {
 	s := NewStore(d)
 	ctx := context.Background()
 
-	cr, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil)
+	cr, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil)
 	if err != nil {
 		t.Fatalf("CreateCheckRun: %v", err)
 	}
@@ -1881,7 +1881,7 @@ func TestCreateCheckRun_RecordedAtHeadSequence(t *testing.T) {
 		t.Fatalf("commit: %v", err)
 	}
 
-	cr, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil)
+	cr, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil)
 	if err != nil {
 		t.Fatalf("CreateCheckRun: %v", err)
 	}
@@ -1896,11 +1896,11 @@ func TestListCheckRuns_ByBranch(t *testing.T) {
 	s := NewStore(d)
 	ctx := context.Background()
 
-	_, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil)
+	_, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil)
 	if err != nil {
 		t.Fatalf("check 1: %v", err)
 	}
-	_, err = s.CreateCheckRun(ctx, "default/default", "main", "ci/lint", model.CheckRunFailed, "ci-bot", nil)
+	_, err = s.CreateCheckRun(ctx, "default/default", "main", "ci/lint", model.CheckRunFailed, "ci-bot", nil, nil)
 	if err != nil {
 		t.Fatalf("check 2: %v", err)
 	}
@@ -1921,12 +1921,12 @@ func TestListCheckRuns_LatestPerName(t *testing.T) {
 	ctx := context.Background()
 
 	// First run: pending
-	_, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPending, "ci-bot", nil)
+	_, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPending, "ci-bot", nil, nil)
 	if err != nil {
 		t.Fatalf("check 1: %v", err)
 	}
 	// Second run: passed (same check_name, more recent)
-	_, err = s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil)
+	_, err = s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil)
 	if err != nil {
 		t.Fatalf("check 2: %v", err)
 	}
@@ -2421,7 +2421,7 @@ func TestPurge_DeletesReviewsAndChecks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create review: %v", err)
 	}
-	_, err = s.CreateCheckRun(ctx, "default/default", "feature/rev", "ci/build", model.CheckRunPassed, "ci-bot", nil)
+	_, err = s.CreateCheckRun(ctx, "default/default", "feature/rev", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil)
 	if err != nil {
 		t.Fatalf("create check_run: %v", err)
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -722,7 +722,7 @@ func (s *server) handleCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cr, err := s.commitStore.CreateCheckRun(r.Context(), repo, req.Branch, req.CheckName, req.Status, reporter, req.LogURL)
+	cr, err := s.commitStore.CreateCheckRun(r.Context(), repo, req.Branch, req.CheckName, req.Status, reporter, req.LogURL, req.Sequence)
 	if err != nil {
 		switch {
 		case errors.Is(err, db.ErrBranchNotFound):
@@ -1941,6 +1941,16 @@ func (s *server) handleArchive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var atSequence *int64
+	if v := r.URL.Query().Get("at"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid 'at' parameter")
+			return
+		}
+		atSequence = &n
+	}
+
 	// Verify the branch exists before we start streaming.
 	bi, err := s.readStore.GetBranch(r.Context(), repo, branch)
 	if err != nil {
@@ -1958,13 +1968,13 @@ func (s *server) handleArchive(w http.ResponseWriter, r *http.Request) {
 
 	afterPath := ""
 	for {
-		entries, err := s.readStore.MaterializeTree(r.Context(), repo, branch, nil, 100, afterPath)
+		entries, err := s.readStore.MaterializeTree(r.Context(), repo, branch, atSequence, 100, afterPath)
 		if err != nil {
 			slog.Error("archive: materialize tree error", "repo", repo, "branch", branch, "error", err)
 			return
 		}
 		for _, entry := range entries {
-			fc, err := s.readStore.GetFile(r.Context(), repo, branch, entry.Path, nil)
+			fc, err := s.readStore.GetFile(r.Context(), repo, branch, entry.Path, atSequence)
 			if err != nil || fc == nil {
 				slog.Error("archive: get file error", "repo", repo, "branch", branch, "path", entry.Path, "error", err)
 				continue

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -76,7 +76,7 @@ type WriteStore interface {
 	// Review and check-run operations
 	CreateReview(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error)
 	ListReviews(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error)
-	CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string) (*model.CheckRun, error)
+	CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64) (*model.CheckRun, error)
 	ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error)
 
 	// Role management

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -31,7 +31,7 @@ type mockStore struct {
 	getRepoFn       func(ctx context.Context, name string) (*model.Repo, error)
 	createReviewFn  func(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error)
 	listReviewsFn   func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error)
-	createCheckRunFn func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string) (*model.CheckRun, error)
+	createCheckRunFn func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64) (*model.CheckRun, error)
 	listCheckRunsFn  func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error)
 	getRoleFn      func(ctx context.Context, repo, identity string) (*model.Role, error)
 	setRoleFn      func(ctx context.Context, repo, identity string, role model.RoleType) error
@@ -151,9 +151,9 @@ func (m *mockStore) ListReviews(ctx context.Context, repo, branch string, atSeq 
 	return nil, errors.New("not implemented")
 }
 
-func (m *mockStore) CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string) (*model.CheckRun, error) {
+func (m *mockStore) CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64) (*model.CheckRun, error) {
 	if m.createCheckRunFn != nil {
-		return m.createCheckRunFn(ctx, repo, branch, checkName, status, reporter, logURL)
+		return m.createCheckRunFn(ctx, repo, branch, checkName, status, reporter, logURL, atSequence)
 	}
 	return nil, errors.New("not implemented")
 }
@@ -1439,7 +1439,7 @@ func TestHandleReview_BranchNotFound(t *testing.T) {
 func TestHandleCheck_Success(t *testing.T) {
 	const identity = "ci-bot@example.com"
 	store := &mockStore{
-		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string) (*model.CheckRun, error) {
+		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64) (*model.CheckRun, error) {
 			if repo != "default/default" {
 				t.Errorf("expected repo default, got %q", repo)
 			}
@@ -1480,9 +1480,42 @@ func TestHandleCheck_Success(t *testing.T) {
 	}
 }
 
+func TestHandleCheck_ExplicitSequence(t *testing.T) {
+	const identity = "ci-bot@example.com"
+	const wantSeq int64 = 15
+	var gotSeq *int64
+	store := &mockStore{
+		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64) (*model.CheckRun, error) {
+			gotSeq = atSequence
+			seq := int64(0)
+			if atSequence != nil {
+				seq = *atSequence
+			}
+			return &model.CheckRun{ID: "chk", Sequence: seq}, nil
+		},
+	}
+	srv := New(store, nil, identity, identity)
+
+	seq := wantSeq
+	b, _ := json.Marshal(model.CreateCheckRunRequest{Branch: "main", CheckName: "ci/build", Status: model.CheckRunPassed, Sequence: &seq})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/check", bytes.NewReader(b))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	if gotSeq == nil {
+		t.Fatal("expected atSequence to be forwarded, got nil")
+	}
+	if *gotSeq != wantSeq {
+		t.Errorf("expected atSequence=%d, got %d", wantSeq, *gotSeq)
+	}
+}
+
 func TestHandleCheck_BranchNotFound(t *testing.T) {
 	store := &mockStore{
-		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string) (*model.CheckRun, error) {
+		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64) (*model.CheckRun, error) {
 			return nil, db.ErrBranchNotFound
 		},
 	}
@@ -2554,7 +2587,7 @@ default allow = true
 			writeDetector()
 			return nil, nil
 		},
-		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string) (*model.CheckRun, error) {
+		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64) (*model.CheckRun, error) {
 			writeDetector()
 			return nil, nil
 		},
@@ -3323,6 +3356,50 @@ func TestHandleArchive_Success(t *testing.T) {
 	}
 	if files["sub/util.go"] != "package sub" {
 		t.Errorf("sub/util.go = %q, want \"package sub\"", files["sub/util.go"])
+	}
+}
+
+func TestHandleArchive_AtSequence(t *testing.T) {
+	const wantSeq int64 = 7
+	var gotSeq *int64
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, repo, branch string) (*store.BranchInfo, error) {
+			return &store.BranchInfo{Name: branch, HeadSequence: 99, BaseSequence: 0, Status: "active"}, nil
+		},
+		materializeTreeFn: func(_ context.Context, repo, branch string, atSeq *int64, limit int, afterPath string) ([]store.TreeEntry, error) {
+			gotSeq = atSeq
+			return nil, nil // empty archive is fine
+		},
+		getFileFn: func(_ context.Context, repo, branch, path string, atSeq *int64) (*store.FileContent, error) {
+			return nil, nil
+		},
+	}
+	h := newTestHandler(&mockStore{}, rs, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/archive?branch=main&at=7", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if gotSeq == nil {
+		t.Fatal("expected atSequence to be passed to MaterializeTree, got nil")
+	}
+	if *gotSeq != wantSeq {
+		t.Errorf("expected atSequence=%d, got %d", wantSeq, *gotSeq)
+	}
+}
+
+func TestHandleArchive_AtInvalid(t *testing.T) {
+	rs := &mockReadStore{}
+	h := newTestHandler(&mockStore{}, rs, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/archive?branch=main&at=notanumber", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes two gaps that caused all CI check results to land at the current branch HEAD rather than the specific commit that triggered the run.

**Gap 1 — archive endpoint ignores `?at=N`**
- `handleArchive` called `MaterializeTree` and `GetFile` with `atSequence=nil`, always serving HEAD content regardless of what triggered the run.
- Fixed by parsing `?at=N` from the query string (same pattern as `handleTree`/`handleFile`) and forwarding it to both calls.

**Gap 2 — `CreateCheckRunRequest` had no `Sequence` field**
- The server inferred sequence from branch HEAD at POST time, so a result from a seq-15 run would land at seq-19 if main moved on.
- Fixed by adding `Sequence *int64` to `CreateCheckRunRequest`; the DB layer uses it when non-nil instead of the current head.

**ci-runner wiring**
- `pullBranchSource` now takes `headSeq int64` and appends `&at=<headSeq>` to the archive URL so tests run against the exact commit that triggered them.
- All `postCheckRun` calls pass `Sequence: &headSeq`; `runAsync` already received `headSeq` so no new threading was needed.

## Changes

| File | Change |
|---|---|
| `api/types.go` | Add `Sequence *int64 \`json:"sequence,omitempty"\`` to `CreateCheckRunRequest` |
| `internal/db/store.go` | `CreateCheckRun` accepts `atSequence *int64`; uses it if non-nil |
| `internal/server/server.go` | Update `CommitStore` interface |
| `internal/server/handlers.go` | `handleArchive`: parse `?at=N`; `handleCheck`: forward `req.Sequence` |
| `cmd/ci-runner/main.go` | `pullBranchSource` + all `postCheckRun` calls pass `headSeq` |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all packages pass
- [x] New `TestHandleArchive_AtSequence` — verifies `atSequence` forwarded to `MaterializeTree`
- [x] New `TestHandleArchive_AtInvalid` — verifies 400 on bad `?at=` value
- [x] New `TestHandleCheck_ExplicitSequence` — verifies `Sequence` field forwarded to `CreateCheckRun`
- [x] Extended `TestPullBranchSource_DownloadsFiles` — asserts `?at=42` present in archive request

## Opportunities noted (not implemented)

- The `?at=` param on archive could also accept release names (like `handleTree` does) — left as a follow-up since the CI runner only needs numeric sequences.
- `fetchConfig` fetches from main branch with no pinning; could similarly pin to a sequence if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)