### PR TITLE
feat: TUI/CLI CI check improvements (issue #131)

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -35,8 +35,8 @@ commands:
   branches [--status active|merged|abandoned] [--draft] [--include-draft]  List branches
   reviews [--branch <name>]                       List reviews for a branch
   review --status approved|rejected [--body "…"] [--branch <name>]  Submit a review
-  checks [--branch <name>]                        List check runs for a branch
-  check --name <n> --status passed|failed [--branch <name>]  Report a CI check
+  checks [--branch <name>] [--all]                List check runs for a branch
+  check --name <n> --status passed|failed [--branch <name>] [--log-url <url>] [--sequence <n>]  Report a CI check
   import-git <path> [--mode squash|replay]        Import a git repo into docstore main
   tui                                             Launch the terminal UI
   purge --older-than <Nd> [--dry-run]             Purge old merged/abandoned branches
@@ -284,18 +284,26 @@ func main() {
 
 	case "checks":
 		branch := ""
+		showAll := false
 		for i := 1; i < len(args); i++ {
-			if args[i] == "--branch" && i+1 < len(args) {
-				branch = args[i+1]
-				i++
+			switch args[i] {
+			case "--branch":
+				if i+1 < len(args) {
+					branch = args[i+1]
+					i++
+				}
+			case "--all":
+				showAll = true
 			}
 		}
-		err = app.Checks(branch)
+		err = app.Checks(branch, showAll)
 
 	case "check":
 		name := ""
 		status := ""
 		branch := ""
+		var logURL *string
+		var sequence *int64
 		for i := 1; i < len(args); i++ {
 			switch args[i] {
 			case "--name":
@@ -313,13 +321,29 @@ func main() {
 					branch = args[i+1]
 					i++
 				}
+			case "--log-url":
+				if i+1 < len(args) {
+					u := args[i+1]
+					logURL = &u
+					i++
+				}
+			case "--sequence":
+				if i+1 < len(args) {
+					n, parseErr := strconv.ParseInt(args[i+1], 10, 64)
+					if parseErr != nil {
+						fmt.Fprintln(os.Stderr, "ds check: --sequence must be an integer")
+						os.Exit(1)
+					}
+					sequence = &n
+					i++
+				}
 			}
 		}
 		if name == "" || status == "" {
-			fmt.Fprintln(os.Stderr, "usage: ds check --name <check_name> --status passed|failed [--branch <name>]")
+			fmt.Fprintln(os.Stderr, "usage: ds check --name <check_name> --status passed|failed [--branch <name>] [--log-url <url>] [--sequence <n>]")
 			os.Exit(1)
 		}
-		err = app.Check(branch, name, status)
+		err = app.Check(branch, name, status, logURL, sequence)
 
 	case "import-git":
 		if len(args) < 2 {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1698,7 +1698,8 @@ func (a *App) Review(branch, status, body string) error {
 }
 
 // Checks lists check runs for a branch (defaults to current branch if empty).
-func (a *App) Checks(branch string) error {
+// If showAll is false, only the latest result per check_name is shown.
+func (a *App) Checks(branch string, showAll bool) error {
 	cfg, err := a.loadConfig()
 	if err != nil {
 		return err
@@ -1732,6 +1733,24 @@ func (a *App) Checks(branch string) error {
 		return err
 	}
 
+	// Deduplicate by check_name keeping highest sequence unless --all is set.
+	if !showAll {
+		latest := make(map[string]model.CheckRun)
+		for _, c := range checkRuns {
+			prev, ok := latest[c.CheckName]
+			if !ok || c.Sequence > prev.Sequence {
+				latest[c.CheckName] = c
+			}
+		}
+		checkRuns = make([]model.CheckRun, 0, len(latest))
+		for _, c := range latest {
+			checkRuns = append(checkRuns, c)
+		}
+		sort.Slice(checkRuns, func(i, j int) bool {
+			return checkRuns[i].CheckName < checkRuns[j].CheckName
+		})
+	}
+
 	fmt.Fprintf(a.Out, "%-8s  %-20s  %-4s  %-10s  %s\n", "ID", "CHECK NAME", "SEQ", "STATUS", "REPORTER")
 	for _, c := range checkRuns {
 		stale := ""
@@ -1744,12 +1763,16 @@ func (a *App) Checks(branch string) error {
 		}
 		fmt.Fprintf(a.Out, "%-8s  %-20s  %-4d  %-10s  %s%s\n",
 			id, c.CheckName, c.Sequence, string(c.Status), c.Reporter, stale)
+		if c.LogURL != nil {
+			fmt.Fprintf(a.Out, "         log: %s\n", *c.LogURL)
+		}
 	}
 	return nil
 }
 
 // Check reports a CI check result for a branch.
-func (a *App) Check(branch, name, status string) error {
+// logURL and sequence are optional; pass nil to omit them from the request.
+func (a *App) Check(branch, name, status string, logURL *string, sequence *int64) error {
 	cfg, err := a.loadConfig()
 	if err != nil {
 		return err
@@ -1767,6 +1790,8 @@ func (a *App) Check(branch, name, status string) error {
 		Branch:    branch,
 		CheckName: name,
 		Status:    checkStatus,
+		LogURL:    logURL,
+		Sequence:  sequence,
 	}
 	resp, err := a.postJSON(cfg, repoBase(cfg)+"/check", req)
 	if err != nil {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -2018,7 +2018,7 @@ func TestChecks_ListsWithStale(t *testing.T) {
 	app, out := newTestApp(t, srv)
 	initWorkspace(t, app, srv.URL, "feature/x", "alice")
 
-	if err := app.Checks("feature/x"); err != nil {
+	if err := app.Checks("feature/x", false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2049,7 +2049,7 @@ func TestChecks_Empty(t *testing.T) {
 	app, out := newTestApp(t, srv)
 	initWorkspace(t, app, srv.URL, "main", "alice")
 
-	if err := app.Checks("main"); err != nil {
+	if err := app.Checks("main", false); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(out.String(), "No check runs") {
@@ -2078,7 +2078,7 @@ func TestCheckSubmit_Passed(t *testing.T) {
 	app, out := newTestApp(t, srv)
 	initWorkspace(t, app, srv.URL, "feature/x", "alice")
 
-	if err := app.Check("feature/x", "ci/build", "passed"); err != nil {
+	if err := app.Check("feature/x", "ci/build", "passed", nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2116,7 +2116,7 @@ func TestCheckSubmit_DefaultBranch(t *testing.T) {
 	app, _ := newTestApp(t, srv)
 	initWorkspace(t, app, srv.URL, "feature/current", "alice")
 
-	if err := app.Check("", "ci/test", "failed"); err != nil {
+	if err := app.Check("", "ci/test", "failed", nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2129,7 +2129,7 @@ func TestCheckSubmit_InvalidStatus(t *testing.T) {
 	app, _ := newTestApp(t, nil)
 	initWorkspace(t, app, "http://test", "main", "alice")
 
-	err := app.Check("main", "ci/build", "unknown")
+	err := app.Check("main", "ci/build", "unknown", nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "status must be") {
 		t.Errorf("expected status validation error, got: %v", err)
 	}
@@ -2192,7 +2192,7 @@ func TestChecks_ExplicitBranchOverride(t *testing.T) {
 	app, _ := newTestApp(t, srv)
 	initWorkspace(t, app, srv.URL, "main", "alice")
 
-	app.Checks("feature/other")
+	app.Checks("feature/other", false)
 
 	wantChecksPath := "/repos/default/default/-/branch/feature%2Fother/checks"
 	if gotChecksPath != wantChecksPath {
@@ -2242,7 +2242,7 @@ func TestCheckSubmit_ExplicitBranchOverride(t *testing.T) {
 	app, _ := newTestApp(t, srv)
 	initWorkspace(t, app, srv.URL, "main", "alice") // workspace is on "main"
 
-	if err := app.Check("feature/other", "ci/build", "passed"); err != nil {
+	if err := app.Check("feature/other", "ci/build", "passed", nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	if gotReq.Branch != "feature/other" {

--- a/internal/tui/branchdetail.go
+++ b/internal/tui/branchdetail.go
@@ -2,7 +2,9 @@ package tui
 
 import (
 	"fmt"
+	"sort"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -47,8 +49,20 @@ type branchDetailModel struct {
 	showReviewOverlay bool
 	reviewOverlay     reviewOverlayModel
 
+	// Auto-refresh: true when any HEAD check is pending.
+	autoRefreshPending bool
+
 	goBack bool
 	quit   bool
+}
+
+// checkRefreshTick is sent by the auto-refresh ticker.
+type checkRefreshTick struct{}
+
+func scheduleCheckRefresh() tea.Cmd {
+	return tea.Tick(5*time.Second, func(time.Time) tea.Msg {
+		return checkRefreshTick{}
+	})
 }
 
 func newBranchDetailModel(client *tuiClient, branchName string) branchDetailModel {
@@ -129,6 +143,12 @@ func (m branchDetailModel) Update(msg tea.Msg) (branchDetailModel, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
+	case checkRefreshTick:
+		if m.autoRefreshPending {
+			m.loading = true
+			return m, loadBranchDetail(m.client, m.branchName)
+		}
+
 	case branchDetailLoadedMsg:
 		m.loading = false
 		m.err = msg.err
@@ -139,6 +159,17 @@ func (m branchDetailModel) Update(msg tea.Msg) (branchDetailModel, tea.Cmd) {
 			m.headSeq = msg.headSeq
 			m.baseSeq = msg.baseSeq
 			m.baseTreePaths = msg.baseTreePaths
+		}
+		// Auto-refresh: schedule a tick if any HEAD check is pending.
+		m.autoRefreshPending = false
+		for _, c := range m.checks {
+			if c.Sequence == m.headSeq && c.Status == model.CheckRunPending {
+				m.autoRefreshPending = true
+				break
+			}
+		}
+		if m.autoRefreshPending {
+			return m, scheduleCheckRefresh()
 		}
 
 	case mergeResultMsg:
@@ -158,6 +189,7 @@ func (m branchDetailModel) Update(msg tea.Msg) (branchDetailModel, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q":
+			m.autoRefreshPending = false
 			m.goBack = true
 
 		case "Q", "ctrl+c":
@@ -423,8 +455,24 @@ func (m branchDetailModel) renderChecks() string {
 		return "  No check runs.\n"
 	}
 
-	var sb strings.Builder
+	// Deduplicate by CheckName, keeping the entry with the highest Sequence.
+	latest := make(map[string]model.CheckRun)
 	for _, c := range m.checks {
+		prev, ok := latest[c.CheckName]
+		if !ok || c.Sequence > prev.Sequence {
+			latest[c.CheckName] = c
+		}
+	}
+	deduped := make([]model.CheckRun, 0, len(latest))
+	for _, c := range latest {
+		deduped = append(deduped, c)
+	}
+	sort.Slice(deduped, func(i, j int) bool {
+		return deduped[i].CheckName < deduped[j].CheckName
+	})
+
+	var sb strings.Builder
+	for _, c := range deduped {
 		isStale := c.Sequence < m.headSeq
 		icon := "?"
 		var iconStyled string
@@ -450,6 +498,9 @@ func (m branchDetailModel) renderChecks() string {
 			sb.WriteString(styleStale.Render(line) + "\n")
 		} else {
 			sb.WriteString(line + "\n")
+		}
+		if c.LogURL != nil {
+			sb.WriteString("       log: " + *c.LogURL + "\n")
 		}
 	}
 	return sb.String()


### PR DESCRIPTION
## Summary

- **Show log_url**: `renderChecks()` (TUI) and `App.Checks()` (CLI) now display `log_url` when non-nil, as an indented line after each check
- **New `ds check` flags**: `--log-url <url>` and `--sequence <n>` flags added; both are forwarded to `CreateCheckRunRequest`
- **Deduplication**: Both TUI and CLI show only the latest result per `check_name` (highest sequence). CLI adds `--all` flag to opt out of deduplication and see full history
- **TUI auto-refresh**: When `branchDetailLoadedMsg` arrives and any check at `headSeq` has `status == pending`, a 5-second ticker is started. On each tick, `loadBranchDetail` is re-run. Once all HEAD checks resolve, the ticker stops. Navigating back (`q`) also clears the flag

## Test plan

- [x] `go test ./... -count=1` passes (all packages)
- [x] `go build ./...` and `go vet ./...` clean
- Existing `TestChecks_*` and `TestCheckSubmit_*` tests updated to match new signatures and pass

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)