### PR TITLE
feat: add rootless Docker-in-Docker sidecar to ci-runner pod

### DIFF
--- a/cmd/ci-runner/main.go
+++ b/cmd/ci-runner/main.go
@@ -571,6 +571,7 @@ func newMux(serverCtx context.Context, exec *executor.Executor, ls logstore.LogS
 
 func main() {
 	buildkitAddr := flag.String("buildkit-addr", "unix:///run/buildkit/buildkitd.sock", "buildkitd socket address")
+	dockerSocket := flag.String("docker-socket", "", "path to Docker socket to mount into build steps (optional)")
 	port := flag.String("port", "8080", "HTTP listen port")
 	docstoreURL := flag.String("docstore-url", "", "Base URL of the docstore server (required)")
 	devIdentity := flag.String("dev-identity", "", "Identity header to send to docstore (local dev only)")
@@ -609,7 +610,7 @@ func main() {
 	}
 
 	// Build executor.
-	exec, err := executor.New(*buildkitAddr)
+	exec, err := executor.New(*buildkitAddr, executor.WithDockerSocket(*dockerSocket))
 	if err != nil {
 		slog.Error("failed to connect to buildkitd", "addr", *buildkitAddr, "error", err)
 		os.Exit(1)

--- a/deploy/k8s/ci-runner.yaml
+++ b/deploy/k8s/ci-runner.yaml
@@ -37,6 +37,9 @@ spec:
       securityContext:
         appArmorProfile:
           type: Unconfined
+      volumes:
+      - name: docker-socket
+        emptyDir: {}
       containers:
       - name: ci-runner
         image: us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner-gke:latest
@@ -76,6 +79,32 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 10
           failureThreshold: 3
+        volumeMounts:
+        - name: docker-socket
+          mountPath: /run/shared
+      - name: docker-dind
+        image: docker:27-dind-rootless
+        args: ["--host=unix:///run/shared/docker.sock", "--tls=false"]
+        env:
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
+        securityContext:
+          seccompProfile:
+            type: Unconfined
+          runAsUser: 1000
+          runAsNonRoot: true
+        volumeMounts:
+        - name: docker-socket
+          mountPath: /run/shared
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "512Mi"
+        readinessProbe:
+          exec:
+            command: ["sh", "-c", "test -S /run/shared/docker.sock"]
+          initialDelaySeconds: 5
+          periodSeconds: 3
 ---
 apiVersion: v1
 kind: Service

--- a/entrypoint-gke.sh
+++ b/entrypoint-gke.sh
@@ -26,6 +26,10 @@ rootlesskit buildkitd \
 until nc -z localhost 1234 2>/dev/null; do sleep 0.1; done
 echo "buildkitd ready" >&2
 
+# Wait for docker socket from DinD sidecar
+until [ -S /run/shared/docker.sock ] 2>/dev/null; do sleep 0.2; done
+echo "docker socket ready" >&2
+
 if [ -n "${DEV_IDENTITY}" ]; then
   set -- "$@" --dev-identity "${DEV_IDENTITY}"
 fi
@@ -38,6 +42,7 @@ fi
 
 exec ci-runner \
   --buildkit-addr tcp://localhost:1234 \
+  --docker-socket /run/shared/docker.sock \
   --docstore-url "${DOCSTORE_URL}" \
   --port "${PORT:-8080}" \
   "$@"

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -41,18 +42,38 @@ type CheckResult struct {
 	Logs   string `json:"logs"`
 }
 
+// options holds optional configuration for an Executor.
+type options struct {
+	dockerSocket string
+}
+
+// Option is a functional option for configuring an Executor.
+type Option func(*options)
+
+// WithDockerSocket configures the executor to mount the Docker socket at the
+// standard location (/var/run/docker.sock) inside every build step, and sets
+// DOCKER_HOST accordingly. An empty path disables the feature.
+func WithDockerSocket(path string) Option {
+	return func(o *options) { o.dockerSocket = path }
+}
+
 // Executor translates a Config into an LLB DAG and dispatches it to buildkitd.
 type Executor struct {
 	client *client.Client
+	opts   options
 }
 
 // New creates an Executor connected to the buildkitd at buildkitAddr.
-func New(buildkitAddr string) (*Executor, error) {
+func New(buildkitAddr string, opts ...Option) (*Executor, error) {
 	c, err := client.New(context.Background(), buildkitAddr)
 	if err != nil {
 		return nil, fmt.Errorf("connect to buildkitd at %s: %w", buildkitAddr, err)
 	}
-	return &Executor{client: c}, nil
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &Executor{client: c, opts: o}, nil
 }
 
 // Run executes all checks in cfg in parallel against sourceDir.
@@ -116,8 +137,13 @@ func (e *Executor) runCheck(ctx context.Context, sourceDir string, check Check) 
 		ap.AuthConfigProvider = authprovider.LoadAuthConfig(dockerCfg)
 	}
 
+	localDirs := map[string]string{"src": sourceDir}
+	if e.opts.dockerSocket != "" {
+		localDirs["docker-socket"] = filepath.Dir(e.opts.dockerSocket)
+	}
+
 	_, solveErr := e.client.Build(ctx, client.SolveOpt{
-		LocalDirs: map[string]string{"src": sourceDir},
+		LocalDirs: localDirs,
 		Session: []session.Attachable{
 			authprovider.NewDockerAuthProvider(ap),
 		},
@@ -156,6 +182,15 @@ func (e *Executor) runCheck(ctx context.Context, sourceDir string, check Check) 
 		for _, env := range imageEnv {
 			k, v, _ := strings.Cut(env, "=")
 			envOpts = append(envOpts, llb.AddEnv(k, v))
+		}
+		if e.opts.dockerSocket != "" {
+			envOpts = append(envOpts,
+				llb.AddEnv("DOCKER_HOST", "unix:///var/run/docker.sock"),
+				llb.AddMount("/var/run/docker.sock",
+					llb.Local("docker-socket"),
+					llb.SourcePath(filepath.Base(e.opts.dockerSocket)),
+				),
+			)
 		}
 
 		for _, step := range check.Steps {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -121,6 +121,44 @@ func TestMultiCheck(t *testing.T) {
 	}
 }
 
+// TestDockerSocket verifies that when WithDockerSocket is configured the socket
+// is mounted at /var/run/docker.sock inside the build step. Only runs when the
+// DOCKER_SOCKET environment variable points at a real Docker socket.
+func TestDockerSocket(t *testing.T) {
+	socketPath := os.Getenv("DOCKER_SOCKET")
+	if socketPath == "" {
+		t.Skip("DOCKER_SOCKET not set; skipping docker socket test")
+	}
+
+	exec, err := executor.New(pkgBuildkitAddr, executor.WithDockerSocket(socketPath))
+	if err != nil {
+		t.Fatalf("cannot connect to buildkitd at %s: %v", pkgBuildkitAddr, err)
+	}
+	dir := t.TempDir()
+
+	cfg := executor.Config{
+		Checks: []executor.Check{
+			{
+				Name:  "ci/docker-socket",
+				Image: "alpine",
+				Steps: []string{"test -S /var/run/docker.sock"},
+			},
+		},
+	}
+
+	results, err := exec.Run(context.Background(), dir, cfg)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.Status != "passed" {
+		t.Errorf("expected status passed, got %s (logs: %s)", r.Status, r.Logs)
+	}
+}
+
 // TestLogCapture verifies that stdout and stderr from steps both appear in
 // the Logs field.
 func TestLogCapture(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `docker:27-dind-rootless` sidecar to `deploy/k8s/ci-runner.yaml` with a shared `docker-socket` emptyDir volume (mounted at `/run/shared` in both containers)
- Add readiness probe on DinD sidecar (`test -S /run/shared/docker.sock`)
- `entrypoint-gke.sh`: wait for socket before starting ci-runner; pass `--docker-socket /run/shared/docker.sock`
- `cmd/ci-runner/main.go`: new `--docker-socket` flag, forwarded to executor via `WithDockerSocket` option
- `internal/executor/executor.go`: functional-option pattern (`options`/`Option`/`WithDockerSocket`); when set, adds `docker-socket` local dir to `SolveOpt.LocalDirs` and mounts the socket at `/var/run/docker.sock` inside every build step via `llb.AddMount(…, llb.Local("docker-socket"), llb.SourcePath("docker.sock"))` + `DOCKER_HOST` env var
- `internal/executor/executor_test.go`: `TestDockerSocket` verifies the socket mount; skips gracefully when `DOCKER_SOCKET` env is not set

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all 17 packages pass; existing 4 executor tests unaffected
- [ ] Integration: deploy to GKE and verify `docker info` works from a build step (requires DinD sidecar to be running)

## Notes / opportunities

- The `llb.Local` approach syncs the socket-containing directory from the client to buildkitd. If fsutil doesn't transport socket files faithfully, an alternative is to use the BuildKit SSH-forwarding mechanism or expose DinD on TCP (`--host=tcp://0.0.0.0:2375`) and just set `DOCKER_HOST=tcp://localhost:2375` without any mount. The TCP approach is simpler but requires the build step to share the pod network namespace.
- DinD resource requests (`500m` CPU, `512Mi` memory) are conservative; tune based on observed usage.
- The `entrypoint.sh` (Cloud Run, legacy) was intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)