### PR TITLE
fix: switch dind sidecar to privileged docker:27-dind on standard GKE

### DIFF
--- a/deploy/k8s/ci-runner.yaml
+++ b/deploy/k8s/ci-runner.yaml
@@ -1,7 +1,8 @@
-# GKE Autopilot deployment for ci-runner.
+# GKE standard node deployment for ci-runner.
 #
-# Uses rootless buildkitd (moby/buildkit-rootless) so no SYS_ADMIN is needed,
-# which is required because GKE Autopilot blocks that capability.
+# Uses rootless buildkitd (moby/buildkit-rootless) so no SYS_ADMIN is needed.
+# DinD sidecar uses docker:27-dind (privileged) — standard GKE allows privileged
+# pods unlike Autopilot. The docker socket emptyDir is mounted at /var/shared.
 #
 # Pre-requisites (run scripts/setup-gke.sh first):
 #   - GKE cluster with Workload Identity enabled
@@ -71,7 +72,7 @@ spec:
           runAsNonRoot: true
         resources:
           requests:
-            cpu: "4"
+            cpu: "2500m"
             memory: "4Gi"
         readinessProbe:
           tcpSocket:
@@ -81,28 +82,25 @@ spec:
           failureThreshold: 3
         volumeMounts:
         - name: docker-socket
-          mountPath: /run/shared
+          mountPath: /var/shared
       - name: docker-dind
-        image: docker:27-dind-rootless
-        args: ["--host=unix:///run/shared/docker.sock", "--tls=false"]
+        image: docker:27-dind
+        args: ["--host=unix:///var/shared/docker.sock", "--tls=false"]
         env:
         - name: DOCKER_TLS_CERTDIR
           value: ""
         securityContext:
-          seccompProfile:
-            type: Unconfined
-          runAsUser: 1000
-          runAsNonRoot: true
+          privileged: true
         volumeMounts:
         - name: docker-socket
-          mountPath: /run/shared
+          mountPath: /var/shared
         resources:
           requests:
             cpu: "500m"
             memory: "512Mi"
         readinessProbe:
           exec:
-            command: ["sh", "-c", "test -S /run/shared/docker.sock"]
+            command: ["sh", "-c", "test -S /var/shared/docker.sock"]
           initialDelaySeconds: 5
           periodSeconds: 3
 ---

--- a/entrypoint-gke.sh
+++ b/entrypoint-gke.sh
@@ -27,7 +27,7 @@ until nc -z localhost 1234 2>/dev/null; do sleep 0.1; done
 echo "buildkitd ready" >&2
 
 # Wait for docker socket from DinD sidecar
-until [ -S /run/shared/docker.sock ] 2>/dev/null; do sleep 0.2; done
+until [ -S /var/shared/docker.sock ] 2>/dev/null; do sleep 0.2; done
 echo "docker socket ready" >&2
 
 if [ -n "${DEV_IDENTITY}" ]; then
@@ -42,7 +42,7 @@ fi
 
 exec ci-runner \
   --buildkit-addr tcp://localhost:1234 \
-  --docker-socket /run/shared/docker.sock \
+  --docker-socket /var/shared/docker.sock \
   --docstore-url "${DOCSTORE_URL}" \
   --port "${PORT:-8080}" \
   "$@"


### PR DESCRIPTION
## Summary

Follow-up to #146 — the `docker:27-dind-rootless` approach encountered two problems on the standard GKE cluster:

1. **rootlesskit overlay masks the emptyDir volume**: rootlesskit uses `--copy-up=/run`, which creates an overlayfs over `/run` inside the user namespace. The emptyDir volume mounted at `/run/shared` is hidden by this overlay, so the socket created by dockerd was invisible to the ci-runner sidecar. Workaround: mount at `/var/shared` (outside the copy-up scope).

2. **dockerd failed silently inside the user namespace**: Even with vpnkit networking (`DOCKERD_ROOTLESS_ROOTLESSKIT_NET=vpnkit`), dockerd exited immediately inside rootlesskit's user namespace (became a zombie, PID 43 in `ps`). Root cause appears to be a mount namespace capability issue with the GKE containerd runtime — rootless dockerd requires user-namespace capabilities that aren't available in this nested-namespace configuration.

**Fix**: Switch to `docker:27-dind` with `privileged: true`. Standard GKE (unlike Autopilot) allows privileged pods. This is simpler and battle-tested.

Additional fixes in this PR:
- Move socket emptyDir mount from `/run/shared` → `/var/shared` (avoids rootlesskit copy-up scope regardless of rootless/privileged)
- Reduce ci-runner CPU request `4` → `2500m` (n2-standard-4 nodes have 3920m allocatable after system pods; 4000m didn't fit, causing pods to stay Pending)

## Deployment status

- `docstore-ci` standard GKE cluster: **RUNNING** (3 nodes, n2-standard-4, spot)
- ci-runner pod: **2/2 Running, Ready**
- `ci-runner-url` secret: updated to `http://10.128.0.92:8080`
- DinD: `docker info` responds successfully via `/var/shared/docker.sock`

## Test plan

- [x] `kubectl rollout status deployment/ci-runner -n docstore-ci` → success
- [x] Pod 2/2 Ready
- [x] `docker info` via `/var/shared/docker.sock` works in the dind container
- [x] ci-runner port 8080 open, logs show "docker socket ready" and "starting ci-runner"
- [ ] Smoke test: `docker info` build step via ci.yaml (pending)

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)