### PR TITLE
feat: inline review comments on files (issue #93)

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -432,6 +432,40 @@ type CreateReviewResponse struct {
 }
 
 // ---------------------------------------------------------------------------
+// POST /comment, GET /branch/:branch/comments, DELETE /comment/:id
+// ---------------------------------------------------------------------------
+
+// ReviewComment is an inline file annotation on a branch.
+// version_id is required; comments on deleted files are not supported.
+// review_id is optional; comments may exist independently of a formal review.
+type ReviewComment struct {
+	ID        string    `json:"id"`
+	ReviewID  *string   `json:"review_id,omitempty"`
+	Branch    string    `json:"branch"`
+	Path      string    `json:"path"`
+	VersionID string    `json:"version_id"`
+	Body      string    `json:"body"`
+	Author    string    `json:"author"`
+	Sequence  int64     `json:"sequence"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// CreateReviewCommentRequest is the body for POST /comment.
+type CreateReviewCommentRequest struct {
+	Branch    string  `json:"branch"`
+	Path      string  `json:"path"`
+	VersionID string  `json:"version_id"`
+	Body      string  `json:"body"`
+	ReviewID  *string `json:"review_id,omitempty"`
+}
+
+// CreateReviewCommentResponse is the response for POST /comment.
+type CreateReviewCommentResponse struct {
+	ID       string `json:"id"`
+	Sequence int64  `json:"sequence"`
+}
+
+// ---------------------------------------------------------------------------
 // POST /check
 // ---------------------------------------------------------------------------
 

--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -37,6 +37,8 @@ commands:
   review --status approved|rejected [--body "…"] [--branch <name>]  Submit a review
   checks [--branch <name>] [--all]                List check runs for a branch
   check --name <n> --status passed|failed [--branch <name>] [--log-url <url>] [--sequence <n>]  Report a CI check
+  comment --path <path> --body <body> [--branch <name>]  Add an inline file comment
+  comments [--path <path>] [--branch <name>]      List inline file comments
   import-git <path> [--mode squash|replay]        Import a git repo into docstore main
   tui                                             Launch the terminal UI
   purge --older-than <Nd> [--dry-run]             Purge old merged/abandoned branches
@@ -638,6 +640,54 @@ func main() {
 			fmt.Fprintln(os.Stderr, usage)
 			os.Exit(1)
 		}
+
+	case "comment":
+		path := ""
+		body := ""
+		branch := ""
+		for i := 1; i < len(args); i++ {
+			switch args[i] {
+			case "--path":
+				if i+1 < len(args) {
+					path = args[i+1]
+					i++
+				}
+			case "--body":
+				if i+1 < len(args) {
+					body = args[i+1]
+					i++
+				}
+			case "--branch":
+				if i+1 < len(args) {
+					branch = args[i+1]
+					i++
+				}
+			}
+		}
+		if path == "" || body == "" {
+			fmt.Fprintln(os.Stderr, "usage: ds comment --path <path> --body <body> [--branch <name>]")
+			os.Exit(1)
+		}
+		err = app.Comment(branch, path, body)
+
+	case "comments":
+		path := ""
+		branch := ""
+		for i := 1; i < len(args); i++ {
+			switch args[i] {
+			case "--path":
+				if i+1 < len(args) {
+					path = args[i+1]
+					i++
+				}
+			case "--branch":
+				if i+1 < len(args) {
+					branch = args[i+1]
+					i++
+				}
+			}
+		}
+		err = app.Comments(branch, path)
 
 	case "ready":
 		err = app.Ready()

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1697,6 +1697,113 @@ func (a *App) Review(branch, status, body string) error {
 	return nil
 }
 
+// Comment creates an inline file annotation on a branch.
+// The version_id is resolved automatically by fetching the file metadata from the server.
+func (a *App) Comment(branch, path, body string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	if branch == "" {
+		branch = cfg.Branch
+	}
+
+	// Resolve version_id for the file on this branch.
+	q := url.Values{}
+	q.Set("branch", branch)
+	fileResp, err := a.httpGet(cfg, repoBase(cfg)+"/file/"+url.PathEscape(path)+"?"+q.Encode())
+	if err != nil {
+		return fmt.Errorf("fetching file info: %w", err)
+	}
+	defer fileResp.Body.Close()
+	if fileResp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("file %q not found on branch %q", path, branch)
+	}
+	if fileResp.StatusCode != http.StatusOK {
+		return a.readError(fileResp)
+	}
+	var fileMeta struct {
+		VersionID string `json:"version_id"`
+	}
+	if err := json.NewDecoder(fileResp.Body).Decode(&fileMeta); err != nil {
+		return fmt.Errorf("decoding file info: %w", err)
+	}
+	if fileMeta.VersionID == "" {
+		return fmt.Errorf("file %q was deleted on branch %q", path, branch)
+	}
+
+	req := model.CreateReviewCommentRequest{
+		Branch:    branch,
+		Path:      path,
+		VersionID: fileMeta.VersionID,
+		Body:      body,
+	}
+	resp, err := a.postJSON(cfg, repoBase(cfg)+"/comment", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return a.readError(resp)
+	}
+
+	var createResp model.CreateReviewCommentResponse
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	fmt.Fprintf(a.Out, "Comment created: id=%s, sequence=%d\n", createResp.ID, createResp.Sequence)
+	return nil
+}
+
+// Comments lists inline file comments for a branch. If path is non-empty, only
+// comments on that path are shown.
+func (a *App) Comments(branch, path string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	if branch == "" {
+		branch = cfg.Branch
+	}
+
+	q := url.Values{}
+	if path != "" {
+		q.Set("path", path)
+	}
+	urlStr := repoBase(cfg) + "/branch/" + url.PathEscape(branch) + "/comments"
+	if len(q) > 0 {
+		urlStr += "?" + q.Encode()
+	}
+
+	resp, err := a.httpGet(cfg, urlStr)
+	if err != nil {
+		return fmt.Errorf("fetching comments: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+
+	var comments []model.ReviewComment
+	if err := json.NewDecoder(resp.Body).Decode(&comments); err != nil {
+		return fmt.Errorf("decoding comments: %w", err)
+	}
+
+	if len(comments) == 0 {
+		fmt.Fprintf(a.Out, "No comments for branch '%s'\n", branch)
+		return nil
+	}
+
+	fmt.Fprintf(a.Out, "%-36s  %-40s  %-4s  %s\n", "ID", "PATH", "SEQ", "BODY")
+	for _, c := range comments {
+		fmt.Fprintf(a.Out, "%-36s  %-40s  %-4d  %s\n", c.ID, c.Path, c.Sequence, c.Body)
+	}
+	return nil
+}
+
 // Checks lists check runs for a branch (defaults to current branch if empty).
 // If showAll is false, only the latest result per check_name is shown.
 func (a *App) Checks(branch string, showAll bool) error {

--- a/internal/db/migrations/000007_review_comments.down.sql
+++ b/internal/db/migrations/000007_review_comments.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS review_comments;

--- a/internal/db/migrations/000007_review_comments.up.sql
+++ b/internal/db/migrations/000007_review_comments.up.sql
@@ -1,0 +1,21 @@
+-- review_comments: inline file annotations on a branch.
+-- version_id is NOT NULL because comments on deleted files are not supported.
+-- review_id is nullable — comments may exist independently of a formal review.
+-- sequence records the branch head_sequence at the time the comment was created.
+
+CREATE TABLE review_comments (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    review_id  UUID REFERENCES reviews(id),
+    repo       TEXT NOT NULL REFERENCES repos(name),
+    branch     TEXT NOT NULL,
+    path       TEXT NOT NULL,
+    version_id UUID NOT NULL REFERENCES documents(version_id),
+    body       TEXT NOT NULL,
+    author     TEXT NOT NULL,
+    sequence   BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT review_comments_repo_branch_fk FOREIGN KEY (repo, branch) REFERENCES branches(repo, name)
+);
+
+CREATE INDEX idx_review_comments_repo_branch ON review_comments (repo, branch);
+CREATE INDEX idx_review_comments_repo_branch_path ON review_comments (repo, branch, path);

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -126,6 +126,7 @@ var (
 	ErrInvalidCursor          = errors.New("invalid pagination cursor")
 	ErrBranchDraft            = errors.New("branch is in draft state")
 	ErrSubscriptionNotFound   = errors.New("subscription not found")
+	ErrCommentNotFound        = errors.New("comment not found")
 )
 
 // rebaseFile is one file within a replayed commit group.
@@ -1194,6 +1195,150 @@ func (s *Store) ListReviews(ctx context.Context, repo, branch string, atSeq *int
 		reviews = append(reviews, rev)
 	}
 	return reviews, rows.Err()
+}
+
+// CreateReviewComment records an inline file comment on a branch at its current
+// head_sequence. Returns ErrBranchNotFound if the branch doesn't exist.
+// reviewID is optional and may associate the comment with a formal review.
+func (s *Store) CreateReviewComment(ctx context.Context, repo, branch, path, versionID, body, author string, reviewID *string) (*model.ReviewComment, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		slog.Error("tx begin failed", "op", "create_review_comment", "error", err)
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			slog.Error("tx rollback failed", "op", "create_review_comment", "error", rollbackErr)
+		}
+	}()
+
+	var headSeq int64
+	err = tx.QueryRowContext(ctx,
+		"SELECT head_sequence FROM branches WHERE repo = $1 AND name = $2 FOR UPDATE",
+		repo, branch,
+	).Scan(&headSeq)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrBranchNotFound
+		}
+		return nil, fmt.Errorf("lock branch: %w", err)
+	}
+
+	var nullReviewID sql.NullString
+	if reviewID != nil && *reviewID != "" {
+		nullReviewID = sql.NullString{String: *reviewID, Valid: true}
+	}
+
+	var id string
+	var createdAt time.Time
+	err = tx.QueryRowContext(ctx,
+		`INSERT INTO review_comments (review_id, repo, branch, path, version_id, body, author, sequence)
+		 VALUES ($1, $2, $3, $4, $5::uuid, $6, $7, $8)
+		 RETURNING id::text, created_at`,
+		nullReviewID, repo, branch, path, versionID, body, author, headSeq,
+	).Scan(&id, &createdAt)
+	if err != nil {
+		return nil, fmt.Errorf("insert review_comment: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit tx: %w", err)
+	}
+
+	rc := &model.ReviewComment{
+		ID:        id,
+		Branch:    branch,
+		Path:      path,
+		VersionID: versionID,
+		Body:      body,
+		Author:    author,
+		Sequence:  headSeq,
+		CreatedAt: createdAt,
+	}
+	if reviewID != nil {
+		rc.ReviewID = reviewID
+	}
+	return rc, nil
+}
+
+// ListReviewComments returns inline file comments for a branch, ordered by
+// created_at ASC. If path is non-nil, only comments on that path are returned.
+func (s *Store) ListReviewComments(ctx context.Context, repo, branch string, path *string) ([]model.ReviewComment, error) {
+	q := `SELECT id::text, review_id::text, path, version_id::text, body, author, sequence, created_at
+	      FROM review_comments
+	      WHERE repo = $1 AND branch = $2`
+	args := []interface{}{repo, branch}
+	if path != nil {
+		q += " AND path = $3"
+		args = append(args, *path)
+	}
+	q += " ORDER BY created_at ASC"
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var comments []model.ReviewComment
+	for rows.Next() {
+		var c model.ReviewComment
+		c.Branch = branch
+		var reviewID sql.NullString
+		if err := rows.Scan(&c.ID, &reviewID, &c.Path, &c.VersionID, &c.Body, &c.Author, &c.Sequence, &c.CreatedAt); err != nil {
+			return nil, err
+		}
+		if reviewID.Valid {
+			s := reviewID.String
+			c.ReviewID = &s
+		}
+		comments = append(comments, c)
+	}
+	return comments, rows.Err()
+}
+
+// GetReviewComment returns a single review comment by ID and repo.
+// Returns ErrCommentNotFound if no matching comment exists.
+func (s *Store) GetReviewComment(ctx context.Context, repo, id string) (*model.ReviewComment, error) {
+	var c model.ReviewComment
+	var reviewID sql.NullString
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id::text, review_id::text, branch, path, version_id::text, body, author, sequence, created_at
+		 FROM review_comments
+		 WHERE repo = $1 AND id = $2::uuid`,
+		repo, id,
+	).Scan(&c.ID, &reviewID, &c.Branch, &c.Path, &c.VersionID, &c.Body, &c.Author, &c.Sequence, &c.CreatedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrCommentNotFound
+		}
+		return nil, fmt.Errorf("get review_comment: %w", err)
+	}
+	if reviewID.Valid {
+		s := reviewID.String
+		c.ReviewID = &s
+	}
+	return &c, nil
+}
+
+// DeleteReviewComment removes a review comment by ID and repo.
+// Returns ErrCommentNotFound if no matching comment exists.
+func (s *Store) DeleteReviewComment(ctx context.Context, repo, id string) error {
+	res, err := s.db.ExecContext(ctx,
+		"DELETE FROM review_comments WHERE repo = $1 AND id = $2::uuid",
+		repo, id,
+	)
+	if err != nil {
+		return fmt.Errorf("delete review_comment: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrCommentNotFound
+	}
+	return nil
 }
 
 // CreateCheckRun records a CI check run for a branch. If atSequence is

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -51,6 +51,9 @@ type RebaseConflictError = api.RebaseConflictError
 type CreateReviewRequest = api.CreateReviewRequest
 type CreateReviewResponse = api.CreateReviewResponse
 
+type CreateReviewCommentRequest = api.CreateReviewCommentRequest
+type CreateReviewCommentResponse = api.CreateReviewCommentResponse
+
 type CreateCheckRunRequest = api.CreateCheckRunRequest
 type CreateCheckRunResponse = api.CreateCheckRunResponse
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -66,6 +66,7 @@ type Branch = api.Branch
 type Role = api.Role
 type Review = api.Review
 type CheckRun = api.CheckRun
+type ReviewComment = api.ReviewComment
 type Release = api.Release
 type EventSubscription = api.EventSubscription
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -148,6 +148,22 @@ func (s *server) handleReposPrefix(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		}
 
+	case endpoint == "comment":
+		if r.Method == http.MethodPost {
+			s.handleCreateReviewComment(w, r)
+		} else {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+
+	case strings.HasPrefix(endpoint, "comment/"):
+		commentID := strings.TrimPrefix(endpoint, "comment/")
+		r.SetPathValue("commentID", commentID)
+		if r.Method == http.MethodDelete {
+			s.handleDeleteReviewComment(w, r)
+		} else {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+
 	case endpoint == "purge":
 		if r.Method == http.MethodPost {
 			s.handlePurge(w, r)
@@ -765,6 +781,9 @@ func (s *server) handleBranchGet(w http.ResponseWriter, r *http.Request) {
 	case strings.HasSuffix(branchPath, "/checks"):
 		branch := strings.TrimSuffix(branchPath, "/checks")
 		s.handleGetChecks(w, r, repo, branch)
+	case strings.HasSuffix(branchPath, "/comments"):
+		branch := strings.TrimSuffix(branchPath, "/comments")
+		s.handleListReviewComments(w, r, repo, branch)
 	default:
 		writeError(w, http.StatusNotFound, "not found")
 	}
@@ -814,6 +833,111 @@ func (s *server) handleGetChecks(w http.ResponseWriter, r *http.Request, repo, b
 		checkRuns = []model.CheckRun{}
 	}
 	writeJSON(w, http.StatusOK, checkRuns)
+}
+
+// handleCreateReviewComment implements POST /repos/:name/comment
+func (s *server) handleCreateReviewComment(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+	author := IdentityFromContext(r.Context())
+
+	var req model.CreateReviewCommentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Branch == "" {
+		writeError(w, http.StatusBadRequest, "branch is required")
+		return
+	}
+	if req.Path == "" {
+		writeError(w, http.StatusBadRequest, "path is required")
+		return
+	}
+	if req.VersionID == "" {
+		writeError(w, http.StatusBadRequest, "version_id is required")
+		return
+	}
+	if req.Body == "" {
+		writeError(w, http.StatusBadRequest, "body is required")
+		return
+	}
+
+	comment, err := s.commitStore.CreateReviewComment(r.Context(), repo, req.Branch, req.Path, req.VersionID, req.Body, author, req.ReviewID)
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrBranchNotFound):
+			writeError(w, http.StatusNotFound, "branch not found")
+		default:
+			slog.Error("internal error", "op", "create_review_comment", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	slog.Info("review comment created", "repo", repo, "branch", req.Branch, "path", req.Path, "author", author)
+	writeJSON(w, http.StatusCreated, model.CreateReviewCommentResponse{
+		ID:       comment.ID,
+		Sequence: comment.Sequence,
+	})
+}
+
+// handleListReviewComments serves GET /repos/:name/branch/:branch/comments
+func (s *server) handleListReviewComments(w http.ResponseWriter, r *http.Request, repo, branch string) {
+	var path *string
+	if v := r.URL.Query().Get("path"); v != "" {
+		path = &v
+	}
+
+	comments, err := s.commitStore.ListReviewComments(r.Context(), repo, branch, path)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if comments == nil {
+		comments = []model.ReviewComment{}
+	}
+	writeJSON(w, http.StatusOK, comments)
+}
+
+// handleDeleteReviewComment implements DELETE /repos/:name/comment/:commentID
+func (s *server) handleDeleteReviewComment(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+	commentID := r.PathValue("commentID")
+	identity := IdentityFromContext(r.Context())
+	role := RoleFromContext(r.Context())
+
+	comment, err := s.commitStore.GetReviewComment(r.Context(), repo, commentID)
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrCommentNotFound):
+			writeError(w, http.StatusNotFound, "comment not found")
+		default:
+			slog.Error("internal error", "op", "get_review_comment", "repo", repo, "comment", commentID, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	// Only the comment author or a maintainer+ may delete a comment.
+	if comment.Author != identity && role != model.RoleMaintainer && role != model.RoleAdmin {
+		writeError(w, http.StatusForbidden, "forbidden: must be comment author or maintainer")
+		return
+	}
+
+	if err := s.commitStore.DeleteReviewComment(r.Context(), repo, commentID); err != nil {
+		slog.Error("internal error", "op", "delete_review_comment", "repo", repo, "comment", commentID, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	slog.Info("review comment deleted", "repo", repo, "comment", commentID, "by", identity)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // parseDayDuration parses a duration string of the form "Nd" (e.g. "7d", "30d").

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -252,6 +252,16 @@ func roleAllows(role model.RoleType, method, subPath string, r *http.Request) bo
 		return true
 	}
 
+	// POST /comment — writer+.
+	if method == http.MethodPost && subPath == "comment" {
+		return role == model.RoleWriter || role == model.RoleMaintainer || role == model.RoleAdmin
+	}
+
+	// DELETE /comment/* — writer+ minimum; handler additionally checks author identity or maintainer role.
+	if method == http.MethodDelete && strings.HasPrefix(subPath, "comment/") {
+		return role == model.RoleWriter || role == model.RoleMaintainer || role == model.RoleAdmin
+	}
+
 	// POST /branch, /merge, /rebase — maintainer+.
 	if method == http.MethodPost && (subPath == "branch" || subPath == "merge" || subPath == "rebase") {
 		return role == model.RoleMaintainer || role == model.RoleAdmin

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -79,6 +79,12 @@ type WriteStore interface {
 	CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64) (*model.CheckRun, error)
 	ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error)
 
+	// Review comment operations
+	CreateReviewComment(ctx context.Context, repo, branch, path, versionID, body, author string, reviewID *string) (*model.ReviewComment, error)
+	ListReviewComments(ctx context.Context, repo, branch string, path *string) ([]model.ReviewComment, error)
+	GetReviewComment(ctx context.Context, repo, id string) (*model.ReviewComment, error)
+	DeleteReviewComment(ctx context.Context, repo, id string) error
+
 	// Role management
 	GetRole(ctx context.Context, repo, identity string) (*model.Role, error)
 	SetRole(ctx context.Context, repo, identity string, role model.RoleType) error

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -61,6 +61,11 @@ type mockStore struct {
 	deleteReleaseFn        func(ctx context.Context, repo, name string) error
 	commitSequenceExistsFn func(ctx context.Context, repo string, sequence int64) (bool, error)
 
+	createReviewCommentFn func(ctx context.Context, repo, branch, path, versionID, body, author string, reviewID *string) (*model.ReviewComment, error)
+	listReviewCommentsFn  func(ctx context.Context, repo, branch string, path *string) ([]model.ReviewComment, error)
+	getReviewCommentFn    func(ctx context.Context, repo, id string) (*model.ReviewComment, error)
+	deleteReviewCommentFn func(ctx context.Context, repo, id string) error
+
 	createSubscriptionFn func(ctx context.Context, req model.CreateSubscriptionRequest) (*model.EventSubscription, error)
 	listSubscriptionsFn  func(ctx context.Context) ([]model.EventSubscription, error)
 	deleteSubscriptionFn func(ctx context.Context, id string) error
@@ -359,6 +364,34 @@ func (m *mockStore) ResumeSubscription(ctx context.Context, id string) error {
 		return m.resumeSubscriptionFn(ctx, id)
 	}
 	return nil
+}
+
+func (m *mockStore) CreateReviewComment(ctx context.Context, repo, branch, path, versionID, body, author string, reviewID *string) (*model.ReviewComment, error) {
+	if m.createReviewCommentFn != nil {
+		return m.createReviewCommentFn(ctx, repo, branch, path, versionID, body, author, reviewID)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockStore) ListReviewComments(ctx context.Context, repo, branch string, path *string) ([]model.ReviewComment, error) {
+	if m.listReviewCommentsFn != nil {
+		return m.listReviewCommentsFn(ctx, repo, branch, path)
+	}
+	return []model.ReviewComment{}, nil
+}
+
+func (m *mockStore) GetReviewComment(ctx context.Context, repo, id string) (*model.ReviewComment, error) {
+	if m.getReviewCommentFn != nil {
+		return m.getReviewCommentFn(ctx, repo, id)
+	}
+	return nil, db.ErrCommentNotFound
+}
+
+func (m *mockStore) DeleteReviewComment(ctx context.Context, repo, id string) error {
+	if m.deleteReviewCommentFn != nil {
+		return m.deleteReviewCommentFn(ctx, repo, id)
+	}
+	return db.ErrCommentNotFound
 }
 
 func TestHealthEndpoint(t *testing.T) {


### PR DESCRIPTION
## Summary

- New `review_comments` table (migration 000007) with `version_id NOT NULL`, nullable `review_id`, `sequence` recording head_sequence at comment time
- `POST /repos/{repo}/-/comment` — create comment (writer+); resolves version_id via branch head
- `GET /repos/{repo}/-/branch/{branch}/comments` — list comments with optional `?path=` server-side filter (reader+)
- `DELETE /repos/{repo}/-/comment/{id}` — delete; requires author identity or maintainer+ role (checked in handler)
- `ds comment --path <path> --body <body> [--branch <name>]` — CLI create (auto-resolves version_id from file endpoint)
- `ds comments [--path <path>] [--branch <name>]` — CLI list

## Design notes

- Comments are independent of formal reviews (review_id nullable); intended as a lightweight annotation tool
- RBAC: POST/DELETE gated at writer+ in middleware; DELETE handler additionally checks `comment.Author == identity OR role >= maintainer`
- CLI resolves version_id automatically via `GET /file/{path}?branch={branch}` before posting — no `--version-id` CLI flag per spec
- No `--review-id` CLI flag per spec (available at API level for tooling)
- Policy integration deferred to issue #149

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` all pass (including db integration, server unit, cli integration tests)
- Mock store updated with all four new WriteStore methods

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)