### PR TITLE
test: fill coverage gaps in db, server, and store packages

### DIFF
--- a/internal/db/store_gap_test.go
+++ b/internal/db/store_gap_test.go
@@ -1,0 +1,365 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/testutil"
+)
+
+// ---------------------------------------------------------------------------
+// GetOrg / ListOrgs tests
+// ---------------------------------------------------------------------------
+
+func TestGetOrg_Found(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	if _, err := s.CreateOrg(ctx, "myorg", "alice@example.com"); err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+
+	org, err := s.GetOrg(ctx, "myorg")
+	if err != nil {
+		t.Fatalf("get org: %v", err)
+	}
+	if org.Name != "myorg" {
+		t.Errorf("expected name myorg, got %q", org.Name)
+	}
+	if org.CreatedBy != "alice@example.com" {
+		t.Errorf("expected created_by alice@example.com, got %q", org.CreatedBy)
+	}
+}
+
+func TestGetOrg_NotFound(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.GetOrg(ctx, "nonexistent-org")
+	if !errors.Is(err, ErrOrgNotFound) {
+		t.Errorf("expected ErrOrgNotFound, got %v", err)
+	}
+}
+
+func TestListOrgs_Empty(t *testing.T) {
+	t.Parallel()
+	// Fresh DB has only the 'default' org from migrations.
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	orgs, err := s.ListOrgs(ctx)
+	if err != nil {
+		t.Fatalf("list orgs: %v", err)
+	}
+	// The 'default' org is always inserted by migrations.
+	for _, o := range orgs {
+		if o.Name != "default" {
+			t.Errorf("unexpected org: %q", o.Name)
+		}
+	}
+}
+
+func TestListOrgs_Multiple(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		if _, err := s.CreateOrg(ctx, name, "admin@example.com"); err != nil {
+			t.Fatalf("create org %q: %v", name, err)
+		}
+	}
+
+	orgs, err := s.ListOrgs(ctx)
+	if err != nil {
+		t.Fatalf("list orgs: %v", err)
+	}
+
+	names := make(map[string]bool)
+	for _, o := range orgs {
+		names[o.Name] = true
+	}
+	for _, want := range []string{"alpha", "beta", "gamma"} {
+		if !names[want] {
+			t.Errorf("expected org %q in list", want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UpdateBranchDraft tests
+// ---------------------------------------------------------------------------
+
+func TestUpdateBranchDraft_SetAndUnset(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Create a repo and branch.
+	if _, err := s.CreateRepo(ctx, model.CreateRepoRequest{Owner: "default", Name: "draftrepo"}); err != nil {
+		t.Fatalf("create repo: %v", err)
+	}
+	if _, err := s.CreateBranch(ctx, model.CreateBranchRequest{
+		Repo: "default/draftrepo",
+		Name: "feature/draft-test",
+	}); err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+
+	// Set draft=true.
+	if err := s.UpdateBranchDraft(ctx, "default/draftrepo", "feature/draft-test", true); err != nil {
+		t.Fatalf("set draft=true: %v", err)
+	}
+
+	// Verify via a raw query.
+	var draft bool
+	if err := d.QueryRow(`SELECT draft FROM branches WHERE repo = $1 AND name = $2`,
+		"default/draftrepo", "feature/draft-test").Scan(&draft); err != nil {
+		t.Fatalf("query draft: %v", err)
+	}
+	if !draft {
+		t.Error("expected draft=true after update")
+	}
+
+	// Unset draft.
+	if err := s.UpdateBranchDraft(ctx, "default/draftrepo", "feature/draft-test", false); err != nil {
+		t.Fatalf("set draft=false: %v", err)
+	}
+	if err := d.QueryRow(`SELECT draft FROM branches WHERE repo = $1 AND name = $2`,
+		"default/draftrepo", "feature/draft-test").Scan(&draft); err != nil {
+		t.Fatalf("query draft: %v", err)
+	}
+	if draft {
+		t.Error("expected draft=false after unsetting")
+	}
+}
+
+func TestUpdateBranchDraft_BranchNotFound(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	err := s.UpdateBranchDraft(ctx, "default/default", "no-such-branch", true)
+	if !errors.Is(err, ErrBranchNotFound) {
+		t.Errorf("expected ErrBranchNotFound, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CommitSequenceExists tests
+// ---------------------------------------------------------------------------
+
+func TestCommitSequenceExists_Exists(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Create a commit to get a real sequence number.
+	resp, err := s.Commit(ctx, model.CommitRequest{
+		Repo:    "default/default",
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "seq-check.txt", Content: []byte("hello")}},
+		Message: "seq check commit",
+		Author:  "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	exists, err := s.CommitSequenceExists(ctx, "default/default", resp.Sequence)
+	if err != nil {
+		t.Fatalf("CommitSequenceExists: %v", err)
+	}
+	if !exists {
+		t.Errorf("expected sequence %d to exist", resp.Sequence)
+	}
+}
+
+func TestCommitSequenceExists_NotExists(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	exists, err := s.CommitSequenceExists(ctx, "default/default", 999999)
+	if err != nil {
+		t.Fatalf("CommitSequenceExists: %v", err)
+	}
+	if exists {
+		t.Error("expected sequence 999999 to not exist")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Event subscription store tests
+// ---------------------------------------------------------------------------
+
+func TestCreateSubscription_Success(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	config, _ := json.Marshal(map[string]string{"url": "https://example.com/hook"})
+	req := model.CreateSubscriptionRequest{
+		Backend:   "webhook",
+		Config:    config,
+		CreatedBy: "admin@example.com",
+	}
+
+	sub, err := s.CreateSubscription(ctx, req)
+	if err != nil {
+		t.Fatalf("create subscription: %v", err)
+	}
+	if sub.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if sub.Backend != "webhook" {
+		t.Errorf("expected backend webhook, got %q", sub.Backend)
+	}
+	if sub.CreatedBy != "admin@example.com" {
+		t.Errorf("expected created_by admin@example.com, got %q", sub.CreatedBy)
+	}
+}
+
+func TestListSubscriptions_EmptyAndPopulated(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	// Initially empty (no subscriptions in this test's DB).
+	subs, err := s.ListSubscriptions(ctx)
+	if err != nil {
+		t.Fatalf("list subscriptions (empty): %v", err)
+	}
+	initial := len(subs)
+
+	// Create one.
+	config, _ := json.Marshal(map[string]string{"url": "https://example.com/hook"})
+	if _, err := s.CreateSubscription(ctx, model.CreateSubscriptionRequest{
+		Backend:   "webhook",
+		Config:    config,
+		CreatedBy: "admin@example.com",
+	}); err != nil {
+		t.Fatalf("create subscription: %v", err)
+	}
+
+	subs, err = s.ListSubscriptions(ctx)
+	if err != nil {
+		t.Fatalf("list subscriptions: %v", err)
+	}
+	if len(subs) != initial+1 {
+		t.Errorf("expected %d subscriptions, got %d", initial+1, len(subs))
+	}
+}
+
+func TestDeleteSubscription_Success(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	config, _ := json.Marshal(map[string]string{"url": "https://example.com/hook"})
+	sub, err := s.CreateSubscription(ctx, model.CreateSubscriptionRequest{
+		Backend:   "webhook",
+		Config:    config,
+		CreatedBy: "admin@example.com",
+	})
+	if err != nil {
+		t.Fatalf("create subscription: %v", err)
+	}
+
+	if err := s.DeleteSubscription(ctx, sub.ID); err != nil {
+		t.Fatalf("delete subscription: %v", err)
+	}
+
+	// Verify it's gone.
+	subs, err := s.ListSubscriptions(ctx)
+	if err != nil {
+		t.Fatalf("list after delete: %v", err)
+	}
+	for _, existing := range subs {
+		if existing.ID == sub.ID {
+			t.Errorf("subscription %q still present after delete", sub.ID)
+		}
+	}
+}
+
+func TestDeleteSubscription_NotFound(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	err := s.DeleteSubscription(ctx, "00000000-0000-0000-0000-000000000000")
+	if !errors.Is(err, ErrSubscriptionNotFound) {
+		t.Errorf("expected ErrSubscriptionNotFound, got %v", err)
+	}
+}
+
+func TestResumeSubscription_Success(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	config, _ := json.Marshal(map[string]string{"url": "https://example.com/hook"})
+	sub, err := s.CreateSubscription(ctx, model.CreateSubscriptionRequest{
+		Backend:   "webhook",
+		Config:    config,
+		CreatedBy: "admin@example.com",
+	})
+	if err != nil {
+		t.Fatalf("create subscription: %v", err)
+	}
+
+	// Manually suspend it.
+	if _, err := d.ExecContext(ctx,
+		`UPDATE event_subscriptions SET suspended_at = NOW(), failure_count = 5 WHERE id = $1`, sub.ID); err != nil {
+		t.Fatalf("suspend: %v", err)
+	}
+
+	// Resume it.
+	if err := s.ResumeSubscription(ctx, sub.ID); err != nil {
+		t.Fatalf("resume subscription: %v", err)
+	}
+
+	// Verify suspended_at cleared.
+	var failureCount int
+	var suspendedAtNull bool
+	if err := d.QueryRow(`SELECT failure_count, suspended_at IS NULL FROM event_subscriptions WHERE id = $1`, sub.ID).
+		Scan(&failureCount, &suspendedAtNull); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if !suspendedAtNull {
+		t.Error("expected suspended_at to be NULL after resume")
+	}
+	if failureCount != 0 {
+		t.Errorf("expected failure_count 0 after resume, got %d", failureCount)
+	}
+}
+
+func TestResumeSubscription_NotFound(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	err := s.ResumeSubscription(ctx, "00000000-0000-0000-0000-000000000000")
+	if !errors.Is(err, ErrSubscriptionNotFound) {
+		t.Errorf("expected ErrSubscriptionNotFound, got %v", err)
+	}
+}

--- a/internal/server/handlers_gap_test.go
+++ b/internal/server/handlers_gap_test.go
@@ -1,0 +1,538 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// ---------------------------------------------------------------------------
+// handleListOrgs tests
+// ---------------------------------------------------------------------------
+
+func TestHandleListOrgs_Success(t *testing.T) {
+	ms := &mockStore{
+		listOrgsFn: func(_ context.Context) ([]model.Org, error) {
+			return []model.Org{{Name: "acme"}, {Name: "beta"}}, nil
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/orgs", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp model.ListOrgsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Orgs) != 2 {
+		t.Errorf("expected 2 orgs, got %d", len(resp.Orgs))
+	}
+	if resp.Orgs[0].Name != "acme" {
+		t.Errorf("expected acme, got %q", resp.Orgs[0].Name)
+	}
+}
+
+func TestHandleListOrgs_Empty(t *testing.T) {
+	// Default mockStore.listOrgsFn returns empty slice.
+	srv := New(&mockStore{}, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/orgs", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp model.ListOrgsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Orgs) != 0 {
+		t.Errorf("expected empty orgs, got %d", len(resp.Orgs))
+	}
+}
+
+func TestHandleListOrgs_NilSliceIsEmpty(t *testing.T) {
+	// nil returned from store must be coerced to empty JSON array.
+	ms := &mockStore{
+		listOrgsFn: func(_ context.Context) ([]model.Org, error) {
+			return nil, nil
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/orgs", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp model.ListOrgsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Orgs == nil {
+		t.Error("expected non-nil orgs slice in response")
+	}
+}
+
+func TestHandleListOrgs_StoreError(t *testing.T) {
+	ms := &mockStore{
+		listOrgsFn: func(_ context.Context) ([]model.Org, error) {
+			return nil, errors.New("database gone")
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/orgs", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleGetOrg tests
+// ---------------------------------------------------------------------------
+
+func TestHandleGetOrg_Found(t *testing.T) {
+	ms := &mockStore{
+		getOrgFn: func(_ context.Context, name string) (*model.Org, error) {
+			return &model.Org{Name: name}, nil
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/orgs/acme", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var org model.Org
+	if err := json.NewDecoder(rec.Body).Decode(&org); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if org.Name != "acme" {
+		t.Errorf("expected name acme, got %q", org.Name)
+	}
+}
+
+func TestHandleGetOrg_NotFound(t *testing.T) {
+	ms := &mockStore{
+		getOrgFn: func(_ context.Context, name string) (*model.Org, error) {
+			return nil, db.ErrOrgNotFound
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/orgs/nonexistent", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleGetOrg_StoreError(t *testing.T) {
+	ms := &mockStore{
+		getOrgFn: func(_ context.Context, name string) (*model.Org, error) {
+			return nil, errors.New("query error")
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/orgs/acme", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// requireGlobalAdmin tests
+// ---------------------------------------------------------------------------
+
+func TestRequireGlobalAdmin_NotConfigured(t *testing.T) {
+	// globalAdmin empty → 403.
+	srv := New(&mockStore{}, nil, devID, "") // no global admin
+	req := httptest.NewRequest(http.MethodGet, "/subscriptions", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+}
+
+func TestRequireGlobalAdmin_WrongIdentity(t *testing.T) {
+	// identity (devID = "test@example.com") != globalAdmin → 403.
+	srv := New(&mockStore{}, nil, devID, "admin@other.com")
+	req := httptest.NewRequest(http.MethodGet, "/subscriptions", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleCreateSubscription tests
+// ---------------------------------------------------------------------------
+
+func TestHandleCreateSubscription_MissingBackend(t *testing.T) {
+	srv := New(&mockStore{}, nil, devID, devID)
+	body, _ := json.Marshal(map[string]interface{}{
+		"config": map[string]string{"url": "https://example.com/hook"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing backend, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCreateSubscription_UnsupportedBackend(t *testing.T) {
+	srv := New(&mockStore{}, nil, devID, devID)
+	body, _ := json.Marshal(map[string]interface{}{
+		"backend": "pubsub",
+		"config":  map[string]string{"url": "https://example.com/hook"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unsupported backend, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCreateSubscription_MissingConfig(t *testing.T) {
+	srv := New(&mockStore{}, nil, devID, devID)
+	body, _ := json.Marshal(map[string]interface{}{
+		"backend": "webhook",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing config, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCreateSubscription_MissingURL(t *testing.T) {
+	srv := New(&mockStore{}, nil, devID, devID)
+	body, _ := json.Marshal(map[string]interface{}{
+		"backend": "webhook",
+		"config":  map[string]string{"secret": "s3cr3t"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing config.url, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCreateSubscription_InvalidURL(t *testing.T) {
+	srv := New(&mockStore{}, nil, devID, devID)
+	body, _ := json.Marshal(map[string]interface{}{
+		"backend": "webhook",
+		"config":  map[string]string{"url": "ftp://not-http.example.com"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid URL scheme, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCreateSubscription_Success(t *testing.T) {
+	srv := New(&mockStore{}, nil, devID, devID)
+	body, _ := json.Marshal(map[string]interface{}{
+		"backend": "webhook",
+		"config":  map[string]string{"url": "https://example.com/hook", "secret": "s3cr3t"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var sub model.EventSubscription
+	if err := json.NewDecoder(rec.Body).Decode(&sub); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if sub.Backend != "webhook" {
+		t.Errorf("expected backend webhook, got %q", sub.Backend)
+	}
+}
+
+func TestHandleCreateSubscription_NonAdmin_Forbidden(t *testing.T) {
+	// devID != global admin → 403.
+	srv := New(&mockStore{}, nil, devID, "admin@other.com")
+	body, _ := json.Marshal(map[string]interface{}{
+		"backend": "webhook",
+		"config":  map[string]string{"url": "https://example.com/hook"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+}
+
+func TestHandleCreateSubscription_InvalidBody(t *testing.T) {
+	srv := New(&mockStore{}, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions", bytes.NewReader([]byte("not-json")))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleCreateSubscription_StoreError(t *testing.T) {
+	ms := &mockStore{
+		createSubscriptionFn: func(_ context.Context, req model.CreateSubscriptionRequest) (*model.EventSubscription, error) {
+			return nil, errors.New("db error")
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	body, _ := json.Marshal(map[string]interface{}{
+		"backend": "webhook",
+		"config":  map[string]string{"url": "https://example.com/hook"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleListSubscriptions tests
+// ---------------------------------------------------------------------------
+
+func TestHandleListSubscriptions_Success(t *testing.T) {
+	ms := &mockStore{
+		listSubscriptionsFn: func(_ context.Context) ([]model.EventSubscription, error) {
+			return []model.EventSubscription{{ID: "sub-1", Backend: "webhook"}}, nil
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/subscriptions", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp model.ListSubscriptionsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Subscriptions) != 1 {
+		t.Errorf("expected 1 subscription, got %d", len(resp.Subscriptions))
+	}
+}
+
+func TestHandleListSubscriptions_Empty(t *testing.T) {
+	// Default mockStore returns empty slice.
+	srv := New(&mockStore{}, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/subscriptions", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp model.ListSubscriptionsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Subscriptions) != 0 {
+		t.Errorf("expected 0 subscriptions, got %d", len(resp.Subscriptions))
+	}
+}
+
+func TestHandleListSubscriptions_NonAdmin_Forbidden(t *testing.T) {
+	srv := New(&mockStore{}, nil, devID, "admin@other.com")
+	req := httptest.NewRequest(http.MethodGet, "/subscriptions", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+}
+
+func TestHandleListSubscriptions_StoreError(t *testing.T) {
+	ms := &mockStore{
+		listSubscriptionsFn: func(_ context.Context) ([]model.EventSubscription, error) {
+			return nil, errors.New("db down")
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodGet, "/subscriptions", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleDeleteSubscription tests
+// ---------------------------------------------------------------------------
+
+func TestHandleDeleteSubscription_Success(t *testing.T) {
+	// Default mockStore.deleteSubscriptionFn returns nil.
+	srv := New(&mockStore{}, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodDelete, "/subscriptions/sub-1", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleDeleteSubscription_NotFound(t *testing.T) {
+	ms := &mockStore{
+		deleteSubscriptionFn: func(_ context.Context, id string) error {
+			return db.ErrSubscriptionNotFound
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodDelete, "/subscriptions/no-such-sub", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleDeleteSubscription_NonAdmin_Forbidden(t *testing.T) {
+	srv := New(&mockStore{}, nil, devID, "admin@other.com")
+	req := httptest.NewRequest(http.MethodDelete, "/subscriptions/sub-1", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+}
+
+func TestHandleDeleteSubscription_StoreError(t *testing.T) {
+	ms := &mockStore{
+		deleteSubscriptionFn: func(_ context.Context, id string) error {
+			return errors.New("unexpected error")
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodDelete, "/subscriptions/sub-1", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleResumeSubscription tests
+// ---------------------------------------------------------------------------
+
+func TestHandleResumeSubscription_Success(t *testing.T) {
+	// Default mockStore.resumeSubscriptionFn returns nil.
+	srv := New(&mockStore{}, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions/sub-1/resume", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleResumeSubscription_NotFound(t *testing.T) {
+	ms := &mockStore{
+		resumeSubscriptionFn: func(_ context.Context, id string) error {
+			return db.ErrSubscriptionNotFound
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions/no-such-sub/resume", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleResumeSubscription_NonAdmin_Forbidden(t *testing.T) {
+	srv := New(&mockStore{}, nil, devID, "admin@other.com")
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions/sub-1/resume", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+}
+
+func TestHandleResumeSubscription_StoreError(t *testing.T) {
+	ms := &mockStore{
+		resumeSubscriptionFn: func(_ context.Context, id string) error {
+			return errors.New("unexpected error")
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions/sub-1/resume", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleSSEGlobalEvents tests
+// ---------------------------------------------------------------------------
+
+func TestHandleSSEGlobalEvents_NonAdmin_Forbidden(t *testing.T) {
+	srv := New(&mockStore{}, nil, devID, "admin@other.com")
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-admin, got %d", rec.Code)
+	}
+}
+
+func TestHandleSSEGlobalEvents_NoBroker_ServiceUnavailable(t *testing.T) {
+	// When global admin is configured and identity matches, but no broker → 503.
+	srv := New(&mockStore{}, nil, devID, devID) // no broker
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 (no broker), got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/store/store_gap_test.go
+++ b/internal/store/store_gap_test.go
@@ -1,0 +1,235 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	dbpkg "github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/store"
+	"github.com/dlorenc/docstore/internal/testutil"
+)
+
+// ---------------------------------------------------------------------------
+// GetBranch tests
+// ---------------------------------------------------------------------------
+
+func TestGetBranch_Found(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seed(t, db)
+	s := store.New(db)
+	ctx := context.Background()
+
+	// "main" is always seeded by migrations.
+	b, err := s.GetBranch(ctx, "default/default", "main")
+	if err != nil {
+		t.Fatalf("GetBranch: %v", err)
+	}
+	if b == nil {
+		t.Fatal("expected non-nil branch info")
+	}
+	if b.Name != "main" {
+		t.Errorf("expected name main, got %q", b.Name)
+	}
+}
+
+func TestGetBranch_NotFound(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	s := store.New(db)
+	ctx := context.Background()
+
+	b, err := s.GetBranch(ctx, "default/default", "nonexistent-branch")
+	if err != nil {
+		t.Fatalf("GetBranch: unexpected error %v", err)
+	}
+	if b != nil {
+		t.Errorf("expected nil for non-existent branch, got %+v", b)
+	}
+}
+
+func TestGetBranch_AfterCommit(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	s := store.New(db)
+	ctx := context.Background()
+	ds := dbpkg.NewStore(db)
+
+	// Commit something to main to advance head_sequence.
+	resp, err := ds.Commit(ctx, model.CommitRequest{
+		Repo:    "default/default",
+		Branch:  "main",
+		Files:   []model.FileChange{{Path: "getbranch-test.txt", Content: []byte("hello")}},
+		Message: "getbranch test commit",
+		Author:  "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	b, err := s.GetBranch(ctx, "default/default", "main")
+	if err != nil {
+		t.Fatalf("GetBranch: %v", err)
+	}
+	if b == nil {
+		t.Fatal("expected non-nil branch")
+	}
+	if b.HeadSequence != resp.Sequence {
+		t.Errorf("expected head_sequence %d, got %d", resp.Sequence, b.HeadSequence)
+	}
+}
+
+func TestGetBranch_FeatureBranch(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	s := store.New(db)
+	ctx := context.Background()
+	ds := dbpkg.NewStore(db)
+
+	// Create a feature branch.
+	if _, err := ds.CreateBranch(ctx, model.CreateBranchRequest{
+		Repo: "default/default",
+		Name: "feature/getbranch-test",
+	}); err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+
+	b, err := s.GetBranch(ctx, "default/default", "feature/getbranch-test")
+	if err != nil {
+		t.Fatalf("GetBranch: %v", err)
+	}
+	if b == nil {
+		t.Fatal("expected non-nil branch info for feature branch")
+	}
+	if b.Name != "feature/getbranch-test" {
+		t.Errorf("expected name feature/getbranch-test, got %q", b.Name)
+	}
+	if b.Status != "active" {
+		t.Errorf("expected status active, got %q", b.Status)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetChain tests
+// ---------------------------------------------------------------------------
+
+func TestGetChain_BasicRange(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seed(t, db)
+	s := store.New(db)
+	ctx := context.Background()
+
+	// Seed inserts sequences 1-4 on main.
+	entries, err := s.GetChain(ctx, "default/default", 1, 4)
+	if err != nil {
+		t.Fatalf("GetChain: %v", err)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 chain entries, got %d", len(entries))
+	}
+
+	// Sequences should be in ascending order.
+	for i, e := range entries {
+		want := int64(i + 1)
+		if e.Sequence != want {
+			t.Errorf("entry[%d]: expected sequence %d, got %d", i, want, e.Sequence)
+		}
+	}
+}
+
+func TestGetChain_SingleEntry(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seed(t, db)
+	s := store.New(db)
+	ctx := context.Background()
+
+	entries, err := s.GetChain(ctx, "default/default", 2, 2)
+	if err != nil {
+		t.Fatalf("GetChain: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Sequence != 2 {
+		t.Errorf("expected sequence 2, got %d", entries[0].Sequence)
+	}
+}
+
+func TestGetChain_NoResults(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seed(t, db)
+	s := store.New(db)
+	ctx := context.Background()
+
+	// Range that doesn't exist.
+	entries, err := s.GetChain(ctx, "default/default", 100, 200)
+	if err != nil {
+		t.Fatalf("GetChain: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries for out-of-range, got %d", len(entries))
+	}
+}
+
+func TestGetChain_FileListInEntry(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seed(t, db)
+	s := store.New(db)
+	ctx := context.Background()
+
+	// Sequence 1 has hello.txt and world.txt.
+	entries, err := s.GetChain(ctx, "default/default", 1, 1)
+	if err != nil {
+		t.Fatalf("GetChain: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if len(e.Files) != 2 {
+		t.Errorf("expected 2 files in sequence 1, got %d: %+v", len(e.Files), e.Files)
+	}
+
+	fileNames := make(map[string]bool)
+	for _, f := range e.Files {
+		fileNames[f.Path] = true
+	}
+	for _, want := range []string{"hello.txt", "world.txt"} {
+		if !fileNames[want] {
+			t.Errorf("expected file %q in chain entry", want)
+		}
+	}
+}
+
+func TestGetChain_DeleteEntryHasEmptyHash(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seed(t, db)
+	s := store.New(db)
+	ctx := context.Background()
+
+	// Sequence 4 is the delete of deleted.txt (version_id = NULL).
+	entries, err := s.GetChain(ctx, "default/default", 4, 4)
+	if err != nil {
+		t.Fatalf("GetChain: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if len(e.Files) != 1 {
+		t.Fatalf("expected 1 file in delete commit, got %d", len(e.Files))
+	}
+	if e.Files[0].Path != "deleted.txt" {
+		t.Errorf("expected deleted.txt, got %q", e.Files[0].Path)
+	}
+	// Deletes have empty content hash.
+	if e.Files[0].ContentHash != "" {
+		t.Errorf("expected empty ContentHash for delete, got %q", e.Files[0].ContentHash)
+	}
+}


### PR DESCRIPTION
## Summary

- **`internal/server`** (`handlers_gap_test.go`): 68.6% → 74.8% — covers `handleListOrgs`, `handleGetOrg`, `requireGlobalAdmin`, and all four subscription handlers (`handleCreateSubscription`, `handleListSubscriptions`, `handleDeleteSubscription`, `handleResumeSubscription`) plus `handleSSEGlobalEvents`; tests include success paths, validation errors, store errors, 403/404/503 edge cases
- **`internal/db`** (`store_gap_test.go`): 70.3% → 77.5% — covers `GetOrg`, `ListOrgs`, `UpdateBranchDraft`, `CommitSequenceExists`, `CreateSubscription`, `ListSubscriptions`, `DeleteSubscription`, `ResumeSubscription`
- **`internal/store`** (`store_gap_test.go`): 68.4% → 84.5% — covers `GetBranch` (found, not-found, after commit, feature branch) and `GetChain` (range, single, empty, file list, delete entries)

## Test plan

- [x] `go vet ./internal/server/ ./internal/db/ ./internal/store/` — clean
- [x] New tests pass: `go test ./internal/server/ ./internal/db/ ./internal/store/ -count=1`
- [x] Full suite passes: `go test ./... -count=1` — all packages green

## Notes / opportunities not implemented

- GCS blob/logstore backends remain at 0% — these require a real GCS client and are integration-only; skip unless a fake/emulator is added
- `internal/tui` remains at ~2% — UI testing requires a terminal emulator; not in scope
- `handleListOrgRepos`, `handleCheck`, `handleReview` have partial coverage; additional table-driven cases could raise them further in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)