### PR TITLE
fix: replace Docker socket file transfer with DOCKER_HOST env injection

### DIFF
--- a/cmd/ci-runner/cirunner_test.go
+++ b/cmd/ci-runner/cirunner_test.go
@@ -148,6 +148,20 @@ func TestPostCheckRun_ServerError(t *testing.T) {
 	}
 }
 
+// newErrDocstore starts a minimal httptest.Server that returns HTTP 404 for
+// every request and registers it for cleanup via t.Cleanup. It is used by
+// unit tests that need a reachable docstore URL so that runAsync can fail fast
+// rather than getting a connection-refused error that might coincidentally
+// collide with a real server (e.g. an integration test's mock on the same port).
+func newErrDocstore(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
 // ---------------------------------------------------------------------------
 // POST /run handler tests
 // ---------------------------------------------------------------------------
@@ -155,7 +169,7 @@ func TestPostCheckRun_ServerError(t *testing.T) {
 func TestPostRunHandler_ReturnsRunID(t *testing.T) {
 	// Use a nil executor and logstore (the goroutine won't do anything useful
 	// but the handler itself should return 200 with a run_id immediately).
-	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, "")
+	mux := newMux(context.Background(), nil, nil, newErrDocstore(t), &http.Client{}, 30*time.Minute, "")
 
 	body := `{"repo":"default/myrepo","branch":"feature/x","head_sequence":42}`
 	req := httptest.NewRequest(http.MethodPost, "/run", strings.NewReader(body))
@@ -176,7 +190,7 @@ func TestPostRunHandler_ReturnsRunID(t *testing.T) {
 }
 
 func TestPostRunHandler_MissingRepo(t *testing.T) {
-	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, "")
+	mux := newMux(context.Background(), nil, nil, newErrDocstore(t), &http.Client{}, 30*time.Minute, "")
 
 	req := httptest.NewRequest(http.MethodPost, "/run", strings.NewReader(`{"branch":"feature/x"}`))
 	rec := httptest.NewRecorder()
@@ -188,7 +202,7 @@ func TestPostRunHandler_MissingRepo(t *testing.T) {
 }
 
 func TestPostRunHandler_MissingBranch(t *testing.T) {
-	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, "")
+	mux := newMux(context.Background(), nil, nil, newErrDocstore(t), &http.Client{}, 30*time.Minute, "")
 
 	req := httptest.NewRequest(http.MethodPost, "/run", strings.NewReader(`{"repo":"default/myrepo"}`))
 	rec := httptest.NewRecorder()
@@ -307,7 +321,9 @@ func signBody(body []byte, secret string) string {
 
 func TestWebhookHandler_ValidSignature(t *testing.T) {
 	const secret = "test-secret"
-	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, secret)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	mux := newMux(ctx, nil, nil, newErrDocstore(t), &http.Client{}, 30*time.Minute, secret)
 
 	body := buildWebhookBody(t, "com.docstore.commit.created", map[string]any{
 		"repo":       "default/myrepo",
@@ -331,7 +347,7 @@ func TestWebhookHandler_ValidSignature(t *testing.T) {
 
 func TestWebhookHandler_InvalidSignature(t *testing.T) {
 	const secret = "test-secret"
-	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, secret)
+	mux := newMux(context.Background(), nil, nil, newErrDocstore(t), &http.Client{}, 30*time.Minute, secret)
 
 	body := buildWebhookBody(t, "com.docstore.commit.created", map[string]any{
 		"repo":   "default/myrepo",
@@ -351,7 +367,7 @@ func TestWebhookHandler_InvalidSignature(t *testing.T) {
 
 func TestWebhookHandler_MissingSignature(t *testing.T) {
 	const secret = "test-secret"
-	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, secret)
+	mux := newMux(context.Background(), nil, nil, newErrDocstore(t), &http.Client{}, 30*time.Minute, secret)
 
 	body := buildWebhookBody(t, "com.docstore.commit.created", map[string]any{
 		"repo":   "default/myrepo",
@@ -370,7 +386,7 @@ func TestWebhookHandler_MissingSignature(t *testing.T) {
 }
 
 func TestWebhookHandler_UnknownEventType(t *testing.T) {
-	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, "")
+	mux := newMux(context.Background(), nil, nil, newErrDocstore(t), &http.Client{}, 30*time.Minute, "")
 
 	body := buildWebhookBody(t, "com.docstore.branch.created", map[string]any{
 		"repo":   "default/myrepo",
@@ -392,7 +408,7 @@ func TestWebhookHandler_UnknownEventType(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestGetRunStatus_NotFound(t *testing.T) {
-	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, "")
+	mux := newMux(context.Background(), nil, nil, newErrDocstore(t), &http.Client{}, 30*time.Minute, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/run/nonexistent-id", nil)
 	rec := httptest.NewRecorder()
@@ -444,7 +460,7 @@ func TestRunStatus_TracksInFlight(t *testing.T) {
 }
 
 func TestRunStatus_ViaHTTP(t *testing.T) {
-	mux := newMux(context.Background(), nil, nil, "http://localhost:9999", &http.Client{}, 30*time.Minute, "")
+	mux := newMux(context.Background(), nil, nil, newErrDocstore(t), &http.Client{}, 30*time.Minute, "")
 
 	// Trigger a run via POST /run to register it in the registry.
 	runBody := `{"repo":"default/myrepo","branch":"feature/x","head_sequence":1}`

--- a/cmd/ci-runner/main.go
+++ b/cmd/ci-runner/main.go
@@ -571,7 +571,7 @@ func newMux(serverCtx context.Context, exec *executor.Executor, ls logstore.LogS
 
 func main() {
 	buildkitAddr := flag.String("buildkit-addr", "unix:///run/buildkit/buildkitd.sock", "buildkitd socket address")
-	dockerSocket := flag.String("docker-socket", "", "path to Docker socket to mount into build steps (optional)")
+	dockerSocket := flag.String("docker-socket", "", "path to Docker socket; sets DOCKER_HOST=unix://<path> in build steps (optional)")
 	port := flag.String("port", "8080", "HTTP listen port")
 	docstoreURL := flag.String("docstore-url", "", "Base URL of the docstore server (required)")
 	devIdentity := flag.String("dev-identity", "", "Identity header to send to docstore (local dev only)")

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -44,17 +43,26 @@ type CheckResult struct {
 
 // options holds optional configuration for an Executor.
 type options struct {
-	dockerSocket string
+	dockerHost string
 }
 
 // Option is a functional option for configuring an Executor.
 type Option func(*options)
 
-// WithDockerSocket configures the executor to mount the Docker socket at the
-// standard location (/var/run/docker.sock) inside every build step, and sets
-// DOCKER_HOST accordingly. An empty path disables the feature.
+// WithDockerHost configures the executor to set DOCKER_HOST to the given URL
+// (e.g. "tcp://localhost:2375" or "unix:///var/shared/docker.sock") in every
+// build step. An empty URL disables the feature.
+// This works because --oci-worker-no-process-sandbox shares the host mount
+// namespace, so unix sockets on the host are accessible at their host path
+// inside build steps without any file transfer.
+func WithDockerHost(url string) Option {
+	return func(o *options) { o.dockerHost = url }
+}
+
+// WithDockerSocket is a convenience wrapper around WithDockerHost that accepts
+// a filesystem path and converts it to a unix:// URL.
 func WithDockerSocket(path string) Option {
-	return func(o *options) { o.dockerSocket = path }
+	return WithDockerHost("unix://" + path)
 }
 
 // Executor translates a Config into an LLB DAG and dispatches it to buildkitd.
@@ -138,9 +146,6 @@ func (e *Executor) runCheck(ctx context.Context, sourceDir string, check Check) 
 	}
 
 	localDirs := map[string]string{"src": sourceDir}
-	if e.opts.dockerSocket != "" {
-		localDirs["docker-socket"] = filepath.Dir(e.opts.dockerSocket)
-	}
 
 	_, solveErr := e.client.Build(ctx, client.SolveOpt{
 		LocalDirs: localDirs,
@@ -183,14 +188,8 @@ func (e *Executor) runCheck(ctx context.Context, sourceDir string, check Check) 
 			k, v, _ := strings.Cut(env, "=")
 			envOpts = append(envOpts, llb.AddEnv(k, v))
 		}
-		if e.opts.dockerSocket != "" {
-			envOpts = append(envOpts,
-				llb.AddEnv("DOCKER_HOST", "unix:///var/run/docker.sock"),
-				llb.AddMount("/var/run/docker.sock",
-					llb.Local("docker-socket"),
-					llb.SourcePath(filepath.Base(e.opts.dockerSocket)),
-				),
-			)
+		if e.opts.dockerHost != "" {
+			envOpts = append(envOpts, llb.AddEnv("DOCKER_HOST", e.opts.dockerHost))
 		}
 
 		for _, step := range check.Steps {


### PR DESCRIPTION
## Problem

`WithDockerSocket` in `internal/executor/executor.go` used `llb.Local('docker-socket')` + `llb.AddMount` to transfer the socket file into build steps. Socket files cannot go through BuildKit's local-dir transport, so `DOCKER_HOST` was set but the socket was never actually accessible — `docker info` in build steps fails.

## Fix

**`internal/executor/executor.go`:**
- Remove `llb.Local('docker-socket')` source and `llb.AddMount` for the socket entirely
- Remove the `'docker-socket'` entry from `localDirs`
- Add `WithDockerHost(url string) Option` as the general form, accepting any URL (`tcp://` or `unix://`)
- `WithDockerSocket(path string)` becomes a convenience wrapper calling `WithDockerHost("unix://"+path)`
- Drop unused `path/filepath` import

This works because buildkitd runs with `--oci-worker-no-process-sandbox` which shares the host mount namespace, making `/var/shared/docker.sock` accessible at its host path inside build steps without any file transfer.

**`cmd/ci-runner/main.go`:**
- Updated `--docker-socket` flag description to accurately describe the new behaviour (sets `DOCKER_HOST`, no longer mounts anything)

**`cmd/ci-runner/cirunner_test.go`:**
- Fixed flaky `TestIntegration_FullFlow` by replacing hardcoded `http://localhost:9999` with per-test `httptest.Server` instances

## Test flakiness fix (added in follow-up commit)

Unit tests used `http://localhost:9999` as a placeholder docstore URL. `TestWebhookHandler_ValidSignature` spawns a background goroutine (via the webhook handler) that calls `runAsync` against this URL. Since `httptest.NewServer` allocates a random available port, there was a small probability that `TestIntegration_FullFlow`'s mock docstore gets port 9999. When that happened, the leaked goroutine connected to the integration test's mock, posted unexpected `ci/hello` check runs as "failed", and `waitForCheckName` returned the wrong result — a flaky failure.

Fix: replaced all `http://localhost:9999` uses with `newErrDocstore(t)`, a helper starting a real `httptest.Server` that returns 404 for all requests (registered with `t.Cleanup`). Also added a cancellable context for `TestWebhookHandler_ValidSignature` so its goroutine is cancelled at test teardown.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1 -short` — all packages pass

## Opportunities noted (not implemented)

- Could add a `--docker-host` flag to `ci-runner` to expose `WithDockerHost` directly for TCP socket use cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)