### PR TITLE
ci-runner: switch DinD to TCP so docker works in build steps

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1230,7 +1230,7 @@ All log entries go to stdout.
 
 ## Initial Setup: CI Runner
 
-The CI runner (`ci-runner`) executes `.docstore/ci.yaml` checks triggered by docstore commit events. It runs on GKE Autopilot using rootless buildkitd. See [docs/ci-runner.md](docs/ci-runner.md) for full architecture details.
+The CI runner (`ci-runner`) executes `.docstore/ci.yaml` checks triggered by docstore commit events. It runs on standard GKE using rootless buildkitd alongside a privileged `docker:27-dind` sidecar (TCP port 2375) for Docker access in build steps. See [docs/ci-runner.md](docs/ci-runner.md) for full architecture details.
 
 Before the first deploy, run the one-time setup scripts to provision GCP and GKE infrastructure.
 

--- a/cmd/ci-runner/main.go
+++ b/cmd/ci-runner/main.go
@@ -572,6 +572,7 @@ func newMux(serverCtx context.Context, exec *executor.Executor, ls logstore.LogS
 func main() {
 	buildkitAddr := flag.String("buildkit-addr", "unix:///run/buildkit/buildkitd.sock", "buildkitd socket address")
 	dockerSocket := flag.String("docker-socket", "", "path to Docker socket; sets DOCKER_HOST=unix://<path> in build steps (optional)")
+	dockerHost := flag.String("docker-host", "", "Docker host URL for build steps via DOCKER_HOST (e.g. tcp://localhost:2375); overrides --docker-socket")
 	port := flag.String("port", "8080", "HTTP listen port")
 	docstoreURL := flag.String("docstore-url", "", "Base URL of the docstore server (required)")
 	devIdentity := flag.String("dev-identity", "", "Identity header to send to docstore (local dev only)")
@@ -617,7 +618,14 @@ func main() {
 	}
 
 	// Build executor.
-	exec, err := executor.New(*buildkitAddr, executor.WithDockerSocket(*dockerSocket))
+	var dockerOpt executor.Option
+	switch {
+	case *dockerHost != "":
+		dockerOpt = executor.WithDockerHost(*dockerHost)
+	case *dockerSocket != "":
+		dockerOpt = executor.WithDockerSocket(*dockerSocket)
+	}
+	exec, err := executor.New(*buildkitAddr, dockerOpt)
 	if err != nil {
 		slog.Error("failed to connect to buildkitd", "addr", *buildkitAddr, "error", err)
 		os.Exit(1)

--- a/deploy/k8s/ci-runner.yaml
+++ b/deploy/k8s/ci-runner.yaml
@@ -2,7 +2,9 @@
 #
 # Uses rootless buildkitd (moby/buildkit-rootless) so no SYS_ADMIN is needed.
 # DinD sidecar uses docker:27-dind (privileged) — standard GKE allows privileged
-# pods unlike Autopilot. The docker socket emptyDir is mounted at /var/shared.
+# pods unlike Autopilot. DinD listens on TCP 2375; build steps reach it via
+# DOCKER_HOST=tcp://localhost:2375. Socket files are not accessible from BuildKit
+# OCI worker containers even with --oci-worker-no-process-sandbox.
 #
 # Pre-requisites (run scripts/setup-gke.sh first):
 #   - GKE cluster with Workload Identity enabled
@@ -38,9 +40,6 @@ spec:
       securityContext:
         appArmorProfile:
           type: Unconfined
-      volumes:
-      - name: docker-socket
-        emptyDir: {}
       containers:
       - name: ci-runner
         image: us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-runner-gke:latest
@@ -80,27 +79,21 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 10
           failureThreshold: 3
-        volumeMounts:
-        - name: docker-socket
-          mountPath: /var/shared
       - name: docker-dind
         image: docker:27-dind
-        args: ["--host=unix:///var/shared/docker.sock", "--tls=false"]
+        args: ["--host=tcp://0.0.0.0:2375", "--tls=false"]
         env:
         - name: DOCKER_TLS_CERTDIR
           value: ""
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: docker-socket
-          mountPath: /var/shared
         resources:
           requests:
             cpu: "500m"
             memory: "512Mi"
         readinessProbe:
-          exec:
-            command: ["sh", "-c", "test -S /var/shared/docker.sock"]
+          tcpSocket:
+            port: 2375
           initialDelaySeconds: 5
           periodSeconds: 3
 ---

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -13,7 +13,7 @@ In the full production flow:
 4. BuildKit executes the checks; logs are written to GCS
 5. Results are written back to docstore as check runs via `POST /-/check`
 
-**Production deployment:** ci-runner runs on GKE Autopilot (cluster `chainguardener`, namespace `docstore-ci`) using rootless buildkitd (`moby/buildkit-rootless`). The docstore Cloud Run service delivers webhook events to ci-runner's internal GKE LoadBalancer (IP `10.128.0.40`) via VPC Direct Egress. Logs are stored at `gs://docstore-ci-logs`. See [GKE Deployment](#gke-deployment) for details.
+**Production deployment:** ci-runner runs on standard GKE (cluster `chainguardener`, namespace `docstore-ci`) using rootless buildkitd (`moby/buildkit-rootless`) alongside a privileged `docker:27-dind` sidecar. The docstore Cloud Run service delivers webhook events to ci-runner's internal GKE LoadBalancer via VPC Direct Egress. Logs are stored at `gs://docstore-ci-logs`. See [GKE Deployment](#gke-deployment) for details.
 
 ## How It Works
 
@@ -51,7 +51,9 @@ No matrix, conditionals, or artifact config in v1.
 
 `internal/executor` (`executor.go`) translates each check into an independent LLB chain using the BuildKit gateway API (`client.Build`). The source directory is mounted as a local input named `"src"`.
 
-**Image ENV injection (gateway API):** The executor uses `client.Build` rather than `client.Solve` so it can call `ResolveImageConfig` to fetch the image's OCI config and extract its `Env` array. These ENV variables are then injected as `llb.AddEnv` `RunOption`s on every exec. This is required because `--oci-worker-no-process-sandbox` (needed for rootless buildkitd on GKE Autopilot, where `SYS_ADMIN` is blocked) does not apply the image's ENV automatically. Without this fix, tools like `go` are not found at runtime because the image's `PATH` is never set.
+**Image ENV injection (gateway API):** The executor uses `client.Build` rather than `client.Solve` so it can call `ResolveImageConfig` to fetch the image's OCI config and extract its `Env` array. These ENV variables are then injected as `llb.AddEnv` `RunOption`s on every exec. This is required because `--oci-worker-no-process-sandbox` does not apply the image's ENV automatically. Without this fix, tools like `go` are not found at runtime because the image's `PATH` is never set.
+
+**Docker-in-Docker access:** When a `--docker-host` URL is configured, `DOCKER_HOST` is injected as an env var into every build step. This allows CI steps to run `docker build`, `docker info`, testcontainers, etc. The value must be a TCP URL (e.g. `tcp://localhost:2375`) rather than a Unix socket path. BuildKit OCI worker containers do not inherit pod volume mounts even with `--oci-worker-no-process-sandbox`, so a socket file mounted via an emptyDir volume is not accessible from inside a build step. TCP works because `--oci-worker-no-process-sandbox` shares the host network namespace.
 
 For each check, the executor:
 1. Resolves the image config via `ResolveImageConfig` to extract ENV variables
@@ -243,6 +245,8 @@ Flags:
 | Flag | Default | Description |
 |---|---|---|
 | `--buildkit-addr` | `unix:///run/buildkit/buildkitd.sock` | buildkitd socket address |
+| `--docker-host` | `""` | Docker host URL injected as `DOCKER_HOST` in every build step (e.g. `tcp://localhost:2375`); use this for DinD access. Takes precedence over `--docker-socket`. |
+| `--docker-socket` | `""` | Path to a Docker socket; sets `DOCKER_HOST=unix://<path>` in build steps. Only reachable if buildkitd runs with `--oci-worker-no-process-sandbox` and the socket is on the host. Prefer `--docker-host` with a TCP URL. |
 | `--port` | `8080` | HTTP listen port |
 | `--docstore-url` | (required) | Base URL of the docstore server |
 | `--dev-identity` | `""` | Identity header for local dev (sets X-Goog-IAP-JWT-Assertion) |
@@ -362,32 +366,40 @@ The test (`TestE2EGoPipeline`):
 
 ## GKE Deployment
 
-The production ci-runner runs on GKE Autopilot rather than Cloud Run because buildkitd requires Linux user namespaces (`SYS_ADMIN`) that Autopilot blocks. The rootless buildkitd image (`moby/buildkit:v0.29.0-rootless`) works around this using `rootlesskit`, which sets up mount namespaces inside a user namespace.
+The production ci-runner runs on standard GKE (not Autopilot). Standard GKE allows privileged pods, which is required for the `docker:27-dind` sidecar. Autopilot blocks privileged pods and also blocks `ip tuntap` operations needed by rootless DinD networking modes, so it is not suitable.
 
 ### Components
 
 | File | Purpose |
 |---|---|
 | `Dockerfile.ci-runner-gke` | Two-stage build: Go binary + rootless buildkitd image |
-| `entrypoint-gke.sh` | Configures GCR auth, starts rootlesskit buildkitd, then starts ci-runner |
-| `deploy/k8s/ci-runner.yaml` | GKE Deployment + internal LoadBalancer + Workload Identity SA |
+| `entrypoint-gke.sh` | Configures GCR auth, starts rootlesskit buildkitd, waits for DinD TCP, then starts ci-runner |
+| `deploy/k8s/ci-runner.yaml` | GKE Deployment (ci-runner + docker-dind sidecar) + internal LoadBalancer + Workload Identity SA |
 | `scripts/setup-gke.sh` | One-time GKE setup (Workload Identity, secrets, IAM) |
 
 ### Network topology
 
 ```
 Cloud Run (docstore)
-  └─[VPC Direct Egress]─► internal LB 10.128.0.40:8080
+  └─[VPC Direct Egress]─► internal LB :8080
                                  └─► ci-runner pod (docstore-ci namespace)
-                                           └─► rootlesskit buildkitd (tcp://localhost:1234)
+                                           ├─► rootlesskit buildkitd (tcp://localhost:1234)
+                                           └─► docker:27-dind sidecar  (tcp://localhost:2375)
 ```
 
 Docstore uses VPC Direct Egress to reach the GKE internal LoadBalancer IP. The ci-runner is not exposed to the public internet.
 
+### DinD sidecar
+
+The `docker:27-dind` container runs as a privileged sidecar. It listens on TCP port 2375 (not a Unix socket). The `entrypoint-gke.sh` waits for port 2375 before starting ci-runner, and passes `--docker-host tcp://localhost:2375` to make `DOCKER_HOST` available to all build steps.
+
+**Why TCP and not a socket file?** BuildKit OCI worker containers don't inherit pod volume mounts even with `--oci-worker-no-process-sandbox`. A socket file on an emptyDir volume is only visible to the pod's named containers (`ci-runner`, `docker-dind`), not to the isolated container rootfs BuildKit creates for each build step. TCP works because `--oci-worker-no-process-sandbox` shares the host network namespace, making `localhost:2375` reachable from inside any build step.
+
 ### Security
 
 - **Workload Identity:** The `ci-runner` k8s ServiceAccount is bound to the `ci-runner@dlorenc-chainguard.iam.gserviceaccount.com` GCP SA via `iam.workloadIdentityUser`. This grants access to GCS log storage without static credentials.
-- **seccompProfile / AppArmor:** Both must be `Unconfined` for rootlesskit to set up mount namespaces. This is configured in `deploy/k8s/ci-runner.yaml`.
+- **seccompProfile / AppArmor:** Both must be `Unconfined` on the ci-runner container for rootlesskit to set up mount namespaces. This is configured in `deploy/k8s/ci-runner.yaml`.
+- **Privileged DinD:** The `docker-dind` sidecar runs with `privileged: true`. This is required for Docker-in-Docker and is only available on standard GKE nodes (not Autopilot).
 - **Webhook HMAC:** The ci-runner verifies the `X-DocStore-Signature` header on all incoming webhooks using the `WEBHOOK_SECRET` env var (sourced from a k8s Secret backed by Secret Manager).
 
 ### First-time setup
@@ -412,8 +424,8 @@ After deploy, the `build-and-deploy-ci-runner` CI job in `deploy.yml` handles su
 ### rootlesskit flags
 
 `entrypoint-gke.sh` starts buildkitd with:
-- `--oci-worker-snapshotter=native` — uses overlay-less snapshotter compatible with Autopilot
-- `--oci-worker-no-process-sandbox` — disables the per-process sandbox (required because there is no seccomp/apparmor inside the user namespace); the image ENV fix in `executor.go` compensates for the side effect of this flag not applying image ENV
+- `--oci-worker-snapshotter=native` — uses overlay-less snapshotter; avoids overlay-on-overlay issues inside user namespaces
+- `--oci-worker-no-process-sandbox` — disables the per-process sandbox (required because there is no seccomp/apparmor inside the user namespace). Side effects: (1) image ENV is not applied automatically — compensated by the `ResolveImageConfig` ENV injection in `executor.go`; (2) build steps share the host network namespace — this is what makes `DOCKER_HOST=tcp://localhost:2375` work
 
 ## Architecture Notes
 

--- a/entrypoint-gke.sh
+++ b/entrypoint-gke.sh
@@ -26,9 +26,11 @@ rootlesskit buildkitd \
 until nc -z localhost 1234 2>/dev/null; do sleep 0.1; done
 echo "buildkitd ready" >&2
 
-# Wait for docker socket from DinD sidecar
-until [ -S /var/shared/docker.sock ] 2>/dev/null; do sleep 0.2; done
-echo "docker socket ready" >&2
+# Wait for DinD TCP port — socket files are not accessible from BuildKit OCI
+# worker containers even with --oci-worker-no-process-sandbox; TCP works because
+# host networking is shared.
+until nc -z localhost 2375 2>/dev/null; do sleep 0.2; done
+echo "docker daemon ready" >&2
 
 if [ -n "${DEV_IDENTITY}" ]; then
   set -- "$@" --dev-identity "${DEV_IDENTITY}"
@@ -42,7 +44,7 @@ fi
 
 exec ci-runner \
   --buildkit-addr tcp://localhost:1234 \
-  --docker-socket /var/shared/docker.sock \
+  --docker-host tcp://localhost:2375 \
   --docstore-url "${DOCSTORE_URL}" \
   --port "${PORT:-8080}" \
   "$@"


### PR DESCRIPTION
## Problem

`docker info` was failing in CI build steps with:
```
dial unix /var/shared/docker.sock: connect: no such file or directory
```

BuildKit OCI worker containers don't inherit pod volume mounts even with `--oci-worker-no-process-sandbox`. The socket at `/var/shared/docker.sock` is mounted into the pod's `ci-runner` and `docker-dind` containers via an emptyDir volume, but BuildKit creates its own isolated container rootfs for each build step — that volume is not present there.

TCP works because `--oci-worker-no-process-sandbox` shares the **host network namespace**, making `localhost:2375` reachable from inside any build step.

## Changes

- DinD args: `--host=tcp://0.0.0.0:2375` (was `unix:///var/shared/docker.sock`)
- DinD readiness probe: `tcpSocket: port: 2375` (was `test -S /var/shared/docker.sock`)
- Remove `docker-socket` emptyDir volume and mounts (no longer needed)
- `entrypoint-gke.sh`: wait on `nc -z localhost 2375`, pass `--docker-host tcp://localhost:2375`
- `cmd/ci-runner/main.go`: add `--docker-host` flag calling `executor.WithDockerHost` directly

## Verified

```json
{"name": "ci/docker", "status": "passed", "logs": "Server Version: 27.5.1 ... Architecture: x86_64 ..."}
```

Live smoke test on GKE cluster confirms `docker info` passes end-to-end inside a BuildKit build step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)