### PR TITLE
feat: DB migration and SQL queries for ci_jobs table (issue #157 wave 1)

### DIFF
--- a/internal/db/migrations/000008_ci_jobs.down.sql
+++ b/internal/db/migrations/000008_ci_jobs.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS ci_jobs;
+DROP TYPE IF EXISTS ci_job_status;

--- a/internal/db/migrations/000008_ci_jobs.up.sql
+++ b/internal/db/migrations/000008_ci_jobs.up.sql
@@ -1,0 +1,19 @@
+CREATE TYPE ci_job_status AS ENUM ('queued', 'claimed', 'passed', 'failed');
+
+CREATE TABLE ci_jobs (
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    repo               TEXT NOT NULL,
+    branch             TEXT NOT NULL,
+    sequence           BIGINT NOT NULL,
+    status             ci_job_status NOT NULL DEFAULT 'queued',
+    claimed_at         TIMESTAMPTZ,
+    last_heartbeat_at  TIMESTAMPTZ,
+    worker_pod         TEXT,
+    worker_pod_ip      TEXT,
+    log_url            TEXT,
+    error_message      TEXT,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_ci_jobs_queued ON ci_jobs (created_at)
+    WHERE status = 'queued';

--- a/internal/db/queries/ci_jobs.sql
+++ b/internal/db/queries/ci_jobs.sql
@@ -1,0 +1,48 @@
+-- name: InsertCIJob :one
+INSERT INTO ci_jobs (repo, branch, sequence)
+VALUES ($1, $2, $3)
+RETURNING *;
+
+-- name: ClaimCIJob :one
+-- Atomically claims the oldest queued job. SKIP LOCKED avoids contention between workers.
+UPDATE ci_jobs
+SET status     = 'claimed',
+    claimed_at = now(),
+    worker_pod    = $1,
+    worker_pod_ip = $2
+WHERE id = (
+    SELECT id FROM ci_jobs
+    WHERE status = 'queued'
+    ORDER BY created_at
+    FOR UPDATE SKIP LOCKED
+    LIMIT 1
+)
+RETURNING *;
+
+-- name: HeartbeatCIJob :exec
+UPDATE ci_jobs
+SET last_heartbeat_at = now()
+WHERE id = $1;
+
+-- name: CompleteCIJob :exec
+UPDATE ci_jobs
+SET status        = $2,
+    log_url       = $3,
+    error_message = $4
+WHERE id = $1;
+
+-- name: GetCIJob :one
+SELECT * FROM ci_jobs
+WHERE id = $1;
+
+-- name: ReapStaleCIJobs :many
+-- Reset claimed jobs that have not sent a heartbeat within the last 2 minutes back to queued.
+UPDATE ci_jobs
+SET status            = 'queued',
+    claimed_at        = NULL,
+    last_heartbeat_at = NULL,
+    worker_pod        = NULL,
+    worker_pod_ip     = NULL
+WHERE status = 'claimed'
+  AND COALESCE(last_heartbeat_at, claimed_at) < now() - interval '2 minutes'
+RETURNING *;


### PR DESCRIPTION
## Summary

- Adds migration `000008_ci_jobs` introducing the `ci_job_status` enum and `ci_jobs` table
- Partial index `idx_ci_jobs_queued` on `created_at WHERE status = 'queued'` for efficient job claiming
- Adds `internal/db/queries/ci_jobs.sql` with sqlc-annotated queries for all CI job lifecycle operations

## Queries

| Query | Purpose |
|---|---|
| `InsertCIJob` | Insert a new job in `queued` state |
| `ClaimCIJob` | Atomic claim via `SELECT FOR UPDATE SKIP LOCKED` — safe for concurrent workers |
| `HeartbeatCIJob` | Touch `last_heartbeat_at` to keep lease alive |
| `CompleteCIJob` | Set final status, log_url, error_message |
| `GetCIJob` | Fetch job by id |
| `ReapStaleCIJobs` | Reset stale `claimed` jobs (no heartbeat in 2 min) back to `queued` |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Migration applies cleanly against a live Postgres instance (deferred to integration test wave)

## Notes for follow-up waves

- Wave 2 will add the Go handler wiring and RBAC checks
- The `ci_jobs` table intentionally has no FK to `branches` to allow job records to outlive branch deletion

Closes #157 (wave 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)