### PR TITLE
feat: add cmd/ci-scheduler binary (issue #157 wave 2)

### DIFF
--- a/cmd/ci-scheduler/main.go
+++ b/cmd/ci-scheduler/main.go
@@ -1,0 +1,418 @@
+// Package main implements the ci-scheduler binary.
+//
+// ci-scheduler is responsible for:
+//   - Receiving webhook deliveries from docstore and inserting ci_jobs rows
+//   - Serving job status and log-proxy endpoints
+//   - Reaping stale (heartbeat-missed) claimed jobs back to 'queued'
+//
+// It does NOT execute builds — that is the ci-worker's job.
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	"github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// ---------------------------------------------------------------------------
+// ciJobStore is the minimal interface the scheduler needs from the DB layer.
+// ---------------------------------------------------------------------------
+
+type ciJobStore interface {
+	InsertCIJob(ctx context.Context, repo, branch string, sequence int64) (*model.CIJob, error)
+	GetCIJob(ctx context.Context, id string) (*model.CIJob, error)
+	ReapStaleCIJobs(ctx context.Context) ([]model.CIJob, error)
+}
+
+// ---------------------------------------------------------------------------
+// HMAC helper
+// ---------------------------------------------------------------------------
+
+// computeHMACHex returns the hex-encoded HMAC-SHA256 of body using secret.
+// Matches the format sent by docstore's outbox dispatcher:
+// "sha256=" + hex(hmac-sha256(body, secret))
+func computeHMACHex(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// ---------------------------------------------------------------------------
+// Webhook subscription registration
+// ---------------------------------------------------------------------------
+
+// registerWebhookSubscription checks whether a subscription for schedulerURL
+// already exists and creates one if not. Errors are logged as warnings.
+func registerWebhookSubscription(ctx context.Context, client *http.Client, docstoreURL, schedulerURL, webhookSecret string) {
+	webhookURL := strings.TrimRight(schedulerURL, "/") + "/webhook"
+	subsURL := strings.TrimRight(docstoreURL, "/") + "/subscriptions"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, subsURL, nil)
+	if err != nil {
+		slog.Warn("webhook registration: build list request failed", "error", err)
+		return
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.Warn("webhook registration: list subscriptions failed", "error", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	type sub struct {
+		ID     string          `json:"id"`
+		Config json.RawMessage `json:"config"`
+	}
+	type listResp struct {
+		Subscriptions []sub `json:"subscriptions"`
+	}
+	if resp.StatusCode == http.StatusOK {
+		var lr listResp
+		if err := json.NewDecoder(resp.Body).Decode(&lr); err == nil {
+			for _, s := range lr.Subscriptions {
+				var cfg map[string]string
+				if err := json.Unmarshal(s.Config, &cfg); err != nil {
+					continue
+				}
+				if cfg["url"] == webhookURL {
+					slog.Info("webhook subscription already registered", "id", s.ID, "url", webhookURL)
+					return
+				}
+			}
+		}
+	}
+
+	cfgJSON, _ := json.Marshal(map[string]string{"url": webhookURL, "secret": webhookSecret})
+	type createReq struct {
+		Backend    string          `json:"backend"`
+		EventTypes []string        `json:"event_types"`
+		Config     json.RawMessage `json:"config"`
+	}
+	createBody, _ := json.Marshal(createReq{
+		Backend:    "webhook",
+		EventTypes: []string{"com.docstore.commit.created"},
+		Config:     cfgJSON,
+	})
+	createReq2, err := http.NewRequestWithContext(ctx, http.MethodPost, subsURL, bytes.NewReader(createBody))
+	if err != nil {
+		slog.Warn("webhook registration: build create request failed", "error", err)
+		return
+	}
+	createReq2.Header.Set("Content-Type", "application/json")
+	createResp, err := client.Do(createReq2)
+	if err != nil {
+		slog.Warn("webhook registration: create subscription failed", "error", err)
+		return
+	}
+	defer createResp.Body.Close()
+
+	if createResp.StatusCode == http.StatusCreated {
+		slog.Info("webhook subscription registered", "url", webhookURL)
+	} else {
+		slog.Warn("webhook registration: unexpected status",
+			"status", createResp.StatusCode, "url", webhookURL)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// scheduler holds handler dependencies
+// ---------------------------------------------------------------------------
+
+type scheduler struct {
+	store         ciJobStore
+	webhookSecret string
+}
+
+// handleWebhook handles POST /webhook — receives CloudEvents from docstore outbox.
+func (s *scheduler) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	// Verify HMAC signature when a secret is configured.
+	if s.webhookSecret != "" {
+		sig := r.Header.Get("X-DocStore-Signature")
+		expected := "sha256=" + computeHMACHex(body, s.webhookSecret)
+		if !hmac.Equal([]byte(sig), []byte(expected)) {
+			http.Error(w, "invalid signature", http.StatusBadRequest)
+			return
+		}
+	}
+
+	// Parse CloudEvents envelope.
+	var env struct {
+		Type string          `json:"type"`
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		http.Error(w, "invalid cloudevent body", http.StatusBadRequest)
+		return
+	}
+
+	// Unknown event types are silently acknowledged (forward-compat).
+	if env.Type != "com.docstore.commit.created" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	var data struct {
+		Repo     string `json:"repo"`
+		Branch   string `json:"branch"`
+		Sequence int64  `json:"sequence"`
+	}
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		http.Error(w, "invalid event data", http.StatusBadRequest)
+		return
+	}
+	if data.Repo == "" || data.Branch == "" {
+		http.Error(w, "missing repo or branch in event data", http.StatusBadRequest)
+		return
+	}
+
+	job, err := s.store.InsertCIJob(r.Context(), data.Repo, data.Branch, data.Sequence)
+	if err != nil {
+		slog.Error("insert ci job failed", "repo", data.Repo, "branch", data.Branch, "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Info("ci job queued", "id", job.ID, "repo", data.Repo, "branch", data.Branch, "sequence", data.Sequence)
+	w.WriteHeader(http.StatusOK)
+}
+
+// runStatusResponse is the JSON shape returned by GET /run/{id}.
+type runStatusResponse struct {
+	RunID  string `json:"run_id"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+// handleGetRun handles GET /run/{id} — returns job status from ci_jobs.
+func (s *scheduler) handleGetRun(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	job, err := s.store.GetCIJob(r.Context(), id)
+	if errors.Is(err, db.ErrCIJobNotFound) {
+		http.Error(w, "run not found", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		slog.Error("get ci job failed", "id", id, "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	resp := runStatusResponse{
+		RunID:  job.ID,
+		Status: job.Status,
+	}
+	if job.ErrorMessage != nil {
+		resp.Error = *job.ErrorMessage
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp) //nolint:errcheck
+}
+
+// handleGetLogs handles GET /run/{id}/logs/{check}.
+// If the job is claimed and has a worker_pod_ip, it reverse-proxies to the
+// worker. Otherwise it redirects to the job's log_url.
+func (s *scheduler) handleGetLogs(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	check := r.PathValue("check")
+
+	job, err := s.store.GetCIJob(r.Context(), id)
+	if errors.Is(err, db.ErrCIJobNotFound) {
+		http.Error(w, "run not found", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		slog.Error("get ci job for logs failed", "id", id, "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Live proxy to worker if job is claimed and worker IP is known.
+	if job.Status == "claimed" && job.WorkerPodIP != nil {
+		workerURL, err := url.Parse(fmt.Sprintf("http://%s:8081", *job.WorkerPodIP))
+		if err != nil {
+			http.Error(w, "invalid worker address", http.StatusInternalServerError)
+			return
+		}
+		proxy := httputil.NewSingleHostReverseProxy(workerURL)
+		r2 := r.Clone(r.Context())
+		r2.URL.Path = "/logs/" + check
+		r2.URL.RawQuery = ""
+		r2.Host = workerURL.Host
+		proxy.ServeHTTP(w, r2)
+		return
+	}
+
+	// Fall back to redirect to stored log URL.
+	if job.LogURL != nil && *job.LogURL != "" {
+		http.Redirect(w, r, *job.LogURL, http.StatusFound)
+		return
+	}
+
+	http.Error(w, "logs not yet available", http.StatusNotFound)
+}
+
+// ---------------------------------------------------------------------------
+// HTTP mux
+// ---------------------------------------------------------------------------
+
+func newMux(sched *scheduler) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /webhook", sched.handleWebhook)
+	mux.HandleFunc("GET /run/{id}", sched.handleGetRun)
+	mux.HandleFunc("GET /run/{id}/logs/{check}", sched.handleGetLogs)
+	return mux
+}
+
+// ---------------------------------------------------------------------------
+// Stale job reaper
+// ---------------------------------------------------------------------------
+
+func startReaper(ctx context.Context, store ciJobStore, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				jobs, err := store.ReapStaleCIJobs(ctx)
+				if err != nil {
+					slog.Error("reap stale ci jobs failed", "error", err)
+					continue
+				}
+				for _, j := range jobs {
+					slog.Info("reclaimed stale ci job", "id", j.ID, "repo", j.Repo, "branch", j.Branch)
+				}
+			}
+		}
+	}()
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+func main() {
+	port := flag.String("port", "8080", "HTTP listen port")
+	docstoreURL := flag.String("docstore-url", "", "Base URL of the docstore server")
+	schedulerURL := flag.String("scheduler-url", "", "Public URL of this ci-scheduler (used to register webhook subscription)")
+	webhookSecret := flag.String("webhook-secret", "", "Shared HMAC secret for webhook signature verification")
+	flag.Parse()
+
+	// Also accept env-var overrides so the binary is container-friendly.
+	if *docstoreURL == "" {
+		*docstoreURL = os.Getenv("DOCSTORE_URL")
+	}
+	if *schedulerURL == "" {
+		*schedulerURL = os.Getenv("RUNNER_URL") // backward-compat name used by ci-runner
+	}
+	if *webhookSecret == "" {
+		*webhookSecret = os.Getenv("WEBHOOK_SECRET")
+	}
+
+	// Set up structured logging.
+	var logLevel slog.LevelVar
+	if lvlStr := os.Getenv("LOG_LEVEL"); lvlStr != "" {
+		if err := logLevel.UnmarshalText([]byte(lvlStr)); err != nil {
+			logLevel.Set(slog.LevelInfo)
+		}
+	}
+	var handler slog.Handler
+	if os.Getenv("LOG_FORMAT") == "text" {
+		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: &logLevel})
+	} else {
+		handler = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: &logLevel})
+	}
+	slog.SetDefault(slog.New(handler))
+
+	// Connect to Postgres.
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		slog.Error("DATABASE_URL environment variable is required")
+		os.Exit(1)
+	}
+	database, err := db.Open(dsn)
+	if err != nil {
+		slog.Error("failed to connect to database", "error", err)
+		os.Exit(1)
+	}
+	defer database.Close()
+
+	store := db.NewStore(database)
+
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
+
+	// Start stale job reaper.
+	startReaper(serverCtx, store, 30*time.Second)
+
+	sched := &scheduler{
+		store:         store,
+		webhookSecret: *webhookSecret,
+	}
+
+	srv := &http.Server{
+		Addr:        ":" + *port,
+		Handler:     newMux(sched),
+		ReadTimeout: 10 * time.Second,
+		IdleTimeout: 60 * time.Second,
+	}
+
+	go func() {
+		slog.Info("starting ci-scheduler", "port", *port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("server error", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	// Register webhook subscription after server is up.
+	if *schedulerURL != "" && *webhookSecret != "" && *docstoreURL != "" {
+		regCtx, regCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer regCancel()
+		registerWebhookSubscription(regCtx, &http.Client{}, *docstoreURL, *schedulerURL, *webhookSecret)
+	}
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+	slog.Info("shutting down")
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		slog.Error("shutdown error", "error", err)
+		os.Exit(1)
+	}
+	serverCancel()
+	slog.Info("stopped")
+}

--- a/cmd/ci-scheduler/main.go
+++ b/cmd/ci-scheduler/main.go
@@ -203,6 +203,37 @@ func (s *scheduler) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// handleRun handles POST /run — manual trigger for a CI job.
+// Accepts JSON body: {"repo": "...", "branch": "...", "head_sequence": 123}
+// No signature verification is required; this is a direct API call.
+func (s *scheduler) handleRun(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Repo         string `json:"repo"`
+		Branch       string `json:"branch"`
+		HeadSequence int64  `json:"head_sequence"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.Repo == "" || req.Branch == "" {
+		http.Error(w, "repo and branch are required", http.StatusBadRequest)
+		return
+	}
+
+	job, err := s.store.InsertCIJob(r.Context(), req.Repo, req.Branch, req.HeadSequence)
+	if err != nil {
+		slog.Error("insert ci job failed", "repo", req.Repo, "branch", req.Branch, "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Info("ci job manually triggered", "id", job.ID, "repo", req.Repo, "branch", req.Branch)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]string{"run_id": job.ID}) //nolint:errcheck
+}
+
 // runStatusResponse is the JSON shape returned by GET /run/{id}.
 type runStatusResponse struct {
 	RunID  string `json:"run_id"`
@@ -286,6 +317,7 @@ func (s *scheduler) handleGetLogs(w http.ResponseWriter, r *http.Request) {
 func newMux(sched *scheduler) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /webhook", sched.handleWebhook)
+	mux.HandleFunc("POST /run", sched.handleRun)
 	mux.HandleFunc("GET /run/{id}", sched.handleGetRun)
 	mux.HandleFunc("GET /run/{id}/logs/{check}", sched.handleGetLogs)
 	return mux
@@ -380,6 +412,9 @@ func main() {
 		webhookSecret: *webhookSecret,
 	}
 
+	// WriteTimeout is intentionally absent: the log proxy endpoint
+	// (GET /run/{id}/logs/{check}) streams responses from the worker and
+	// must not be cut off by a server-wide write deadline.
 	srv := &http.Server{
 		Addr:        ":" + *port,
 		Handler:     newMux(sched),

--- a/cmd/ci-scheduler/main_test.go
+++ b/cmd/ci-scheduler/main_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// ---------------------------------------------------------------------------
+// stubStore is an in-memory ciJobStore for unit tests.
+// ---------------------------------------------------------------------------
+
+type stubStore struct {
+	insertedJobs []*model.CIJob
+	getJob       *model.CIJob
+	getErr       error
+	reapJobs     []model.CIJob
+	reapErr      error
+}
+
+func (s *stubStore) InsertCIJob(_ context.Context, repo, branch string, sequence int64) (*model.CIJob, error) {
+	j := &model.CIJob{
+		ID:       "test-uuid",
+		Repo:     repo,
+		Branch:   branch,
+		Sequence: sequence,
+		Status:   "queued",
+	}
+	s.insertedJobs = append(s.insertedJobs, j)
+	return j, nil
+}
+
+func (s *stubStore) GetCIJob(_ context.Context, id string) (*model.CIJob, error) {
+	return s.getJob, s.getErr
+}
+
+func (s *stubStore) ReapStaleCIJobs(_ context.Context) ([]model.CIJob, error) {
+	return s.reapJobs, s.reapErr
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func signBody(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func commitCreatedEvent(repo, branch string, sequence int64) []byte {
+	type data struct {
+		Repo     string `json:"repo"`
+		Branch   string `json:"branch"`
+		Sequence int64  `json:"sequence"`
+	}
+	type env struct {
+		Type string `json:"type"`
+		Data data   `json:"data"`
+	}
+	b, _ := json.Marshal(env{
+		Type: "com.docstore.commit.created",
+		Data: data{Repo: repo, Branch: branch, Sequence: sequence},
+	})
+	return b
+}
+
+// ---------------------------------------------------------------------------
+// Tests: HMAC signature verification
+// ---------------------------------------------------------------------------
+
+func TestHandleWebhook_InvalidSignature(t *testing.T) {
+	stub := &stubStore{}
+	sched := &scheduler{store: stub, webhookSecret: "secret"}
+
+	body := commitCreatedEvent("myrepo", "main", 1)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("X-DocStore-Signature", "sha256=badhex")
+	w := httptest.NewRecorder()
+
+	sched.handleWebhook(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if len(stub.insertedJobs) != 0 {
+		t.Fatal("expected no jobs inserted on bad signature")
+	}
+}
+
+func TestHandleWebhook_MissingSignature(t *testing.T) {
+	stub := &stubStore{}
+	sched := &scheduler{store: stub, webhookSecret: "secret"}
+
+	body := commitCreatedEvent("myrepo", "feat", 2)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	// No X-DocStore-Signature header.
+	w := httptest.NewRecorder()
+
+	sched.handleWebhook(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleWebhook_NoSecret_AcceptsAll(t *testing.T) {
+	stub := &stubStore{}
+	sched := &scheduler{store: stub, webhookSecret: ""}
+
+	body := commitCreatedEvent("myrepo", "feat", 3)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	// No signature needed when secret is empty.
+	w := httptest.NewRecorder()
+
+	sched.handleWebhook(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if len(stub.insertedJobs) != 1 {
+		t.Fatalf("expected 1 inserted job, got %d", len(stub.insertedJobs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: happy path insert
+// ---------------------------------------------------------------------------
+
+func TestHandleWebhook_HappyPath(t *testing.T) {
+	const secret = "mysecret"
+	stub := &stubStore{}
+	sched := &scheduler{store: stub, webhookSecret: secret}
+
+	body := commitCreatedEvent("org/myrepo", "feat/new-feature", 42)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("X-DocStore-Signature", signBody(body, secret))
+	w := httptest.NewRecorder()
+
+	sched.handleWebhook(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(stub.insertedJobs) != 1 {
+		t.Fatalf("expected 1 inserted job, got %d", len(stub.insertedJobs))
+	}
+	j := stub.insertedJobs[0]
+	if j.Repo != "org/myrepo" {
+		t.Errorf("repo mismatch: %q", j.Repo)
+	}
+	if j.Branch != "feat/new-feature" {
+		t.Errorf("branch mismatch: %q", j.Branch)
+	}
+	if j.Sequence != 42 {
+		t.Errorf("sequence mismatch: %d", j.Sequence)
+	}
+	if j.Status != "queued" {
+		t.Errorf("status mismatch: %q", j.Status)
+	}
+}
+
+func TestHandleWebhook_UnknownEventType(t *testing.T) {
+	stub := &stubStore{}
+	sched := &scheduler{store: stub, webhookSecret: ""}
+
+	body, _ := json.Marshal(map[string]any{
+		"type": "com.docstore.something.else",
+		"data": map[string]any{},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	sched.handleWebhook(w, req)
+
+	// Unknown events are silently acknowledged.
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if len(stub.insertedJobs) != 0 {
+		t.Fatal("unexpected job insert for unknown event type")
+	}
+}
+
+func TestHandleWebhook_MissingRepo(t *testing.T) {
+	stub := &stubStore{}
+	sched := &scheduler{store: stub, webhookSecret: ""}
+
+	body, _ := json.Marshal(map[string]any{
+		"type": "com.docstore.commit.created",
+		"data": map[string]any{"branch": "main", "sequence": 1},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	sched.handleWebhook(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: GET /run/{id}
+// ---------------------------------------------------------------------------
+
+func TestHandleGetRun_Found(t *testing.T) {
+	errMsg := "something went wrong"
+	stub := &stubStore{
+		getJob: &model.CIJob{
+			ID:           "abc-123",
+			Status:       "failed",
+			ErrorMessage: &errMsg,
+		},
+	}
+	sched := &scheduler{store: stub}
+
+	req := httptest.NewRequest(http.MethodGet, "/run/abc-123", nil)
+	req.SetPathValue("id", "abc-123")
+	w := httptest.NewRecorder()
+
+	sched.handleGetRun(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp runStatusResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.RunID != "abc-123" {
+		t.Errorf("run_id mismatch: %q", resp.RunID)
+	}
+	if resp.Status != "failed" {
+		t.Errorf("status mismatch: %q", resp.Status)
+	}
+	if resp.Error != errMsg {
+		t.Errorf("error mismatch: %q", resp.Error)
+	}
+}

--- a/cmd/ci-scheduler/main_test.go
+++ b/cmd/ci-scheduler/main_test.go
@@ -7,8 +7,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/dlorenc/docstore/internal/model"
@@ -244,5 +246,147 @@ func TestHandleGetRun_Found(t *testing.T) {
 	}
 	if resp.Error != errMsg {
 		t.Errorf("error mismatch: %q", resp.Error)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: GET /run/{id}/logs/{check}
+// ---------------------------------------------------------------------------
+
+func TestHandleGetLogs_ClaimedWithWorkerIP_ProxiesToWorker(t *testing.T) {
+	// The production code dials WorkerPodIP:8081 for live log proxying.
+	// Bind the fake worker to port 8081 on loopback so the proxy connects correctly.
+	ln, err := net.Listen("tcp", "127.0.0.1:8081")
+	if err != nil {
+		t.Skipf("port 8081 unavailable (likely already in use): %v", err)
+	}
+
+	fakeWorker := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("log output from worker")) //nolint:errcheck
+	}))
+	fakeWorker.Listener = ln
+	fakeWorker.Start()
+	defer fakeWorker.Close()
+
+	workerIP := "127.0.0.1"
+	stub := &stubStore{
+		getJob: &model.CIJob{
+			ID:          "job-1",
+			Status:      "claimed",
+			WorkerPodIP: &workerIP,
+		},
+	}
+	sched := &scheduler{store: stub}
+
+	req := httptest.NewRequest(http.MethodGet, "/run/job-1/logs/build", nil)
+	req.SetPathValue("id", "job-1")
+	req.SetPathValue("check", "build")
+	w := httptest.NewRecorder()
+
+	sched.handleGetLogs(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "log output from worker") {
+		t.Errorf("expected proxied log body, got: %q", w.Body.String())
+	}
+}
+
+func TestHandleGetLogs_CompletedWithLogURL_Redirects(t *testing.T) {
+	logURL := "https://logs.example.com/job-2"
+	stub := &stubStore{
+		getJob: &model.CIJob{
+			ID:     "job-2",
+			Status: "passed",
+			LogURL: &logURL,
+		},
+	}
+	sched := &scheduler{store: stub}
+
+	req := httptest.NewRequest(http.MethodGet, "/run/job-2/logs/build", nil)
+	req.SetPathValue("id", "job-2")
+	req.SetPathValue("check", "build")
+	w := httptest.NewRecorder()
+
+	sched.handleGetLogs(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d", w.Code)
+	}
+	if got := w.Header().Get("Location"); got != logURL {
+		t.Errorf("redirect location mismatch: %q", got)
+	}
+}
+
+func TestHandleGetLogs_Queued_Returns404(t *testing.T) {
+	stub := &stubStore{
+		getJob: &model.CIJob{
+			ID:     "job-3",
+			Status: "queued",
+		},
+	}
+	sched := &scheduler{store: stub}
+
+	req := httptest.NewRequest(http.MethodGet, "/run/job-3/logs/build", nil)
+	req.SetPathValue("id", "job-3")
+	req.SetPathValue("check", "build")
+	w := httptest.NewRecorder()
+
+	sched.handleGetLogs(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: POST /run (manual trigger)
+// ---------------------------------------------------------------------------
+
+func TestHandleRun_HappyPath(t *testing.T) {
+	stub := &stubStore{}
+	sched := &scheduler{store: stub}
+
+	body, _ := json.Marshal(map[string]any{
+		"repo":          "org/repo",
+		"branch":        "main",
+		"head_sequence": 10,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/run", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	sched.handleRun(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["run_id"] == "" {
+		t.Error("expected non-empty run_id")
+	}
+	if len(stub.insertedJobs) != 1 {
+		t.Fatalf("expected 1 inserted job, got %d", len(stub.insertedJobs))
+	}
+}
+
+func TestHandleRun_MissingRepo_Returns400(t *testing.T) {
+	stub := &stubStore{}
+	sched := &scheduler{store: stub}
+
+	body, _ := json.Marshal(map[string]any{"branch": "main"})
+	req := httptest.NewRequest(http.MethodPost, "/run", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	sched.handleRun(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
 	}
 }

--- a/internal/db/ci_jobs.go
+++ b/internal/db/ci_jobs.go
@@ -1,0 +1,116 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+const ciJobColumns = `id, repo, branch, sequence, status, claimed_at, last_heartbeat_at,
+                      worker_pod, worker_pod_ip, log_url, error_message, created_at`
+
+// scanCIJob scans a single ci_jobs row into a model.CIJob.
+func scanCIJob(row interface {
+	Scan(...any) error
+}) (*model.CIJob, error) {
+	var j model.CIJob
+	var claimedAt sql.NullTime
+	var lastHeartbeatAt sql.NullTime
+	var workerPod sql.NullString
+	var workerPodIP sql.NullString
+	var logURL sql.NullString
+	var errorMessage sql.NullString
+	if err := row.Scan(
+		&j.ID, &j.Repo, &j.Branch, &j.Sequence, &j.Status,
+		&claimedAt, &lastHeartbeatAt, &workerPod, &workerPodIP,
+		&logURL, &errorMessage, &j.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+	if claimedAt.Valid {
+		j.ClaimedAt = &claimedAt.Time
+	}
+	if lastHeartbeatAt.Valid {
+		j.LastHeartbeatAt = &lastHeartbeatAt.Time
+	}
+	if workerPod.Valid {
+		j.WorkerPod = &workerPod.String
+	}
+	if workerPodIP.Valid {
+		j.WorkerPodIP = &workerPodIP.String
+	}
+	if logURL.Valid {
+		j.LogURL = &logURL.String
+	}
+	if errorMessage.Valid {
+		j.ErrorMessage = &errorMessage.String
+	}
+	return &j, nil
+}
+
+// InsertCIJob creates a new ci_jobs row in the 'queued' state.
+func (s *Store) InsertCIJob(ctx context.Context, repo, branch string, sequence int64) (*model.CIJob, error) {
+	row := s.db.QueryRowContext(ctx,
+		`INSERT INTO ci_jobs (repo, branch, sequence)
+		 VALUES ($1, $2, $3)
+		 RETURNING `+ciJobColumns,
+		repo, branch, sequence,
+	)
+	j, err := scanCIJob(row)
+	if err != nil {
+		return nil, fmt.Errorf("insert ci job: %w", err)
+	}
+	return j, nil
+}
+
+// GetCIJob retrieves a ci_jobs row by UUID. Returns ErrCIJobNotFound if not present.
+func (s *Store) GetCIJob(ctx context.Context, id string) (*model.CIJob, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+ciJobColumns+` FROM ci_jobs WHERE id = $1`,
+		id,
+	)
+	j, err := scanCIJob(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrCIJobNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get ci job: %w", err)
+	}
+	return j, nil
+}
+
+// ReapStaleCIJobs resets claimed jobs that missed heartbeats back to 'queued'.
+// Returns the reclaimed jobs.
+func (s *Store) ReapStaleCIJobs(ctx context.Context) ([]model.CIJob, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`UPDATE ci_jobs
+		 SET status            = 'queued',
+		     claimed_at        = NULL,
+		     last_heartbeat_at = NULL,
+		     worker_pod        = NULL,
+		     worker_pod_ip     = NULL
+		 WHERE status = 'claimed'
+		   AND COALESCE(last_heartbeat_at, claimed_at) < now() - interval '2 minutes'
+		 RETURNING `+ciJobColumns,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("reap stale ci jobs: %w", err)
+	}
+	defer rows.Close()
+
+	var jobs []model.CIJob
+	for rows.Next() {
+		j, err := scanCIJob(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan ci job: %w", err)
+		}
+		jobs = append(jobs, *j)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate ci jobs: %w", err)
+	}
+	return jobs, nil
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -127,6 +127,7 @@ var (
 	ErrBranchDraft            = errors.New("branch is in draft state")
 	ErrSubscriptionNotFound   = errors.New("subscription not found")
 	ErrCommentNotFound        = errors.New("comment not found")
+	ErrCIJobNotFound          = errors.New("ci job not found")
 )
 
 // rebaseFile is one file within a replayed commit group.

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -85,6 +85,22 @@ type Document struct {
 	CreatedBy   string    `json:"created_by"`
 }
 
+// CIJob tracks a CI run scheduled via the ci-scheduler webhook.
+type CIJob struct {
+	ID              string     `json:"id"`
+	Repo            string     `json:"repo"`
+	Branch          string     `json:"branch"`
+	Sequence        int64      `json:"sequence"`
+	Status          string     `json:"status"` // queued, claimed, passed, failed
+	ClaimedAt       *time.Time `json:"claimed_at,omitempty"`
+	LastHeartbeatAt *time.Time `json:"last_heartbeat_at,omitempty"`
+	WorkerPod       *string    `json:"worker_pod,omitempty"`
+	WorkerPodIP     *string    `json:"worker_pod_ip,omitempty"`
+	LogURL          *string    `json:"log_url,omitempty"`
+	ErrorMessage    *string    `json:"error_message,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+}
+
 // FileCommit is the core event log. One row per file change.
 // All rows sharing a sequence number form one atomic commit.
 type FileCommit struct {


### PR DESCRIPTION
## Summary

Implements wave 2 of issue #157: a new standalone `cmd/ci-scheduler` binary that decouples webhook handling and job status serving from the executor.

- **`internal/model/model.go`** — adds `CIJob` struct mapping all `ci_jobs` table columns (nullable fields as pointer types)
- **`internal/db/store.go`** — adds `ErrCIJobNotFound` sentinel error
- **`internal/db/ci_jobs.go`** — adds `Store.InsertCIJob`, `Store.GetCIJob`, `Store.ReapStaleCIJobs` backed by direct SQL (same pattern as rest of store.go)
- **`cmd/ci-scheduler/main.go`**:
  - Connects to Postgres via `DATABASE_URL` on startup
  - Auto-registers webhook subscription with docstore when `RUNNER_URL` + `WEBHOOK_SECRET` are set (same logic as ci-runner)
  - `POST /webhook` — verifies HMAC-SHA256 signature, parses CloudEvent, inserts `ci_jobs` row, returns 200 immediately
  - `GET /run/{id}` — returns `{run_id, status, error}` JSON from `ci_jobs`
  - `GET /run/{id}/logs/{check}` — reverse-proxies to `http://{worker_pod_ip}:8081/logs/{check}` when job is claimed with known worker IP, otherwise redirects to stored `log_url`
  - Background reaper goroutine every 30 seconds via `ReapStaleCIJobs`
- **`cmd/ci-scheduler/main_test.go`** — unit tests using a `ciJobStore` interface stub: signature verification (bad sig, missing sig, no secret), happy-path insert, unknown event type, missing fields, status endpoint

## Test plan

- [x] `go build ./cmd/ci-scheduler/...` — compiles cleanly
- [x] `go test ./cmd/ci-scheduler/...` — 7 unit tests pass
- [x] `go test ./...` — full test suite passes (all packages)
- [x] `go vet ./...` — no issues

## Notes for continuation

- The `ciJobStore` interface in main.go enables easy unit testing without a real DB; integration tests could be added using the testcontainers pattern from `internal/db/db_test.go`
- The log proxy currently only handles single-segment check names; if check names can contain slashes, the route pattern would need `{check...}` and the proxy path construction updated
- No authentication middleware on the scheduler endpoints yet — could be added in a follow-up consistent with the server RBAC pattern

Closes #157 (wave 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)