### PR TITLE
feat: add K8s manifests for ci-scheduler and ci-worker (issue #157 wave 3)

### DIFF
--- a/deploy/k8s/ci-scheduler.yaml
+++ b/deploy/k8s/ci-scheduler.yaml
@@ -1,0 +1,88 @@
+# GKE standard node deployment for ci-scheduler.
+#
+# ci-scheduler receives webhook deliveries from docstore, queues jobs in
+# PostgreSQL, reaps stale claimed jobs, and serves job-status / log-proxy
+# endpoints.  It does NOT execute builds.
+#
+# Pre-requisites (run scripts/setup-gke.sh first):
+#   - GKE cluster with Workload Identity enabled
+#   - ci-scheduler GCP SA bound to the k8s SA below
+#   - docstore-ci/ci-scheduler k8s Secret with database-url
+#   - docstore-ci/ci-runner k8s Secret with webhook-secret and runner-url
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ci-scheduler
+  namespace: docstore-ci
+  annotations:
+    iam.gke.io/gcp-service-account: ci-scheduler@dlorenc-chainguard.iam.gserviceaccount.com
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ci-scheduler
+  namespace: docstore-ci
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ci-scheduler
+  template:
+    metadata:
+      labels:
+        app: ci-scheduler
+    spec:
+      serviceAccountName: ci-scheduler
+      containers:
+      - name: ci-scheduler
+        image: us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-scheduler-gke:latest
+        env:
+        - name: DOCSTORE_URL
+          value: https://docstore-efuj4cj54a-uc.a.run.app
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: ci-scheduler
+              key: database-url
+        - name: WEBHOOK_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: ci-runner
+              key: webhook-secret
+              optional: true
+        - name: RUNNER_URL
+          valueFrom:
+            secretKeyRef:
+              name: ci-runner
+              key: runner-url
+              optional: true
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "512Mi"
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ci-scheduler
+  namespace: docstore-ci
+  annotations:
+    # Internal load balancer: reachable from Cloud Run via VPC Direct Egress,
+    # not exposed to the public internet.
+    networking.gke.io/load-balancer-type: "Internal"
+spec:
+  selector:
+    app: ci-scheduler
+  ports:
+  - port: 8080
+    targetPort: 8080
+  type: LoadBalancer

--- a/deploy/k8s/ci-scheduler.yaml
+++ b/deploy/k8s/ci-scheduler.yaml
@@ -16,7 +16,7 @@ metadata:
   name: ci-scheduler
   namespace: docstore-ci
   annotations:
-    iam.gke.io/gcp-service-account: ci-scheduler@dlorenc-chainguard.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: ci-runner@dlorenc-chainguard.iam.gserviceaccount.com
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: ci-scheduler
       containers:
       - name: ci-scheduler
-        image: us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-scheduler-gke:latest
+        image: us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-scheduler:latest
         env:
         - name: DOCSTORE_URL
           value: https://docstore-efuj4cj54a-uc.a.run.app

--- a/deploy/k8s/ci-worker.yaml
+++ b/deploy/k8s/ci-worker.yaml
@@ -1,0 +1,67 @@
+# GKE Kata Containers deployment for ci-worker.
+#
+# ci-worker pods each claim exactly one job from the ci_jobs queue, execute
+# it inside a Kata Cloud-Hypervisor microVM, upload logs, and then exit.
+# The Deployment controller replaces exited pods to maintain the pool size.
+#
+# Kata CLH provides a real kernel per pod so Docker/buildkitd run natively
+# inside the VM — no DinD nesting, no privileged containers required.
+#
+# Pre-requisites (run scripts/setup-gke.sh first):
+#   - GKE node pool with Kata 3.28.0, RuntimeClass kata-clh registered
+#   - Nodes labelled runtime=kata
+#   - ci-worker GCP SA bound to the k8s SA below
+#   - docstore-ci/ci-scheduler k8s Secret with database-url
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ci-worker
+  namespace: docstore-ci
+  annotations:
+    iam.gke.io/gcp-service-account: ci-worker@dlorenc-chainguard.iam.gserviceaccount.com
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ci-worker
+  namespace: docstore-ci
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: ci-worker
+  template:
+    metadata:
+      labels:
+        app: ci-worker
+    spec:
+      serviceAccountName: ci-worker
+      runtimeClassName: kata-clh
+      nodeSelector:
+        runtime: kata
+      containers:
+      - name: ci-worker
+        image: us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-worker-gke:latest
+        env:
+        - name: DOCSTORE_URL
+          value: https://docstore-efuj4cj54a-uc.a.run.app
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: ci-scheduler
+              key: database-url
+        ports:
+        - containerPort: 8081
+        resources:
+          requests:
+            cpu: "2000m"
+            memory: "4Gi"

--- a/deploy/k8s/ci-worker.yaml
+++ b/deploy/k8s/ci-worker.yaml
@@ -19,7 +19,7 @@ metadata:
   name: ci-worker
   namespace: docstore-ci
   annotations:
-    iam.gke.io/gcp-service-account: ci-worker@dlorenc-chainguard.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: ci-runner@dlorenc-chainguard.iam.gserviceaccount.com
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -42,7 +42,7 @@ spec:
         runtime: kata
       containers:
       - name: ci-worker
-        image: us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-worker-gke:latest
+        image: us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-worker:latest
         env:
         - name: DOCSTORE_URL
           value: https://docstore-efuj4cj54a-uc.a.run.app
@@ -59,9 +59,19 @@ spec:
             secretKeyRef:
               name: ci-scheduler
               key: database-url
+        - name: LOG_STORE
+          value: gcs
+        - name: LOG_BUCKET
+          value: docstore-ci-logs
         ports:
         - containerPort: 8081
         resources:
           requests:
             cpu: "2000m"
             memory: "4Gi"
+        readinessProbe:
+          tcpSocket:
+            port: 8081
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 6


### PR DESCRIPTION
## Summary

- Adds `deploy/k8s/ci-scheduler.yaml`: ServiceAccount + Deployment (replicas:1) + Internal LB Service. Single container, no buildkitd/DinD. Pulls `DATABASE_URL` from the `ci-scheduler` Secret and `WEBHOOK_SECRET`/`RUNNER_URL` from the `ci-runner` Secret (both optional). Standard security context (no AppArmor/seccomp overrides).
- Adds `deploy/k8s/ci-worker.yaml`: ServiceAccount + Deployment (replicas:3, `runtimeClassName: kata-clh`, `nodeSelector: runtime=kata`). Single container. Injects `POD_NAME` and `POD_IP` via downward API. Pulls `DATABASE_URL` from the `ci-scheduler` Secret. No privileged security context, no AppArmor/seccomp overrides.
- Both manifests follow the patterns established in `deploy/k8s/ci-runner.yaml` (namespace `docstore-ci`, Workload Identity annotations, GCP service account naming convention, static `DOCSTORE_URL`).

Closes #157 (wave 3).

## Test plan

- [x] `go test ./... -count=1` — all packages pass
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [ ] Deploy to GKE cluster and verify pods start, scheduler registers webhook, workers claim jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)