### PR TITLE
fix: Cloud SQL proxy sidecar + nodeSelector for GKE deployments (issue #157)

### DIFF
--- a/deploy/k8s/ci-runner.yaml
+++ b/deploy/k8s/ci-runner.yaml
@@ -35,6 +35,8 @@ spec:
         app: ci-runner
     spec:
       serviceAccountName: ci-runner
+      nodeSelector:
+        cloud.google.com/gke-nodepool: default-pool
       # rootlesskit needs AppArmor unconfined to set up mount namespaces within
       # the user namespace. seccompProfile Unconfined is also required.
       securityContext:

--- a/deploy/k8s/ci-scheduler.yaml
+++ b/deploy/k8s/ci-scheduler.yaml
@@ -34,6 +34,8 @@ spec:
         app: ci-scheduler
     spec:
       serviceAccountName: ci-scheduler
+      nodeSelector:
+        cloud.google.com/gke-nodepool: default-pool
       containers:
       - name: ci-scheduler
         image: us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-scheduler:latest
@@ -69,6 +71,17 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 10
           failureThreshold: 3
+      - name: cloud-sql-proxy
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2
+        args:
+          - dlorenc-chainguard:us-central1:docstore-mvp
+          - --port=5432
+        securityContext:
+          runAsNonRoot: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/k8s/ci-worker.yaml
+++ b/deploy/k8s/ci-worker.yaml
@@ -75,3 +75,14 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 10
           failureThreshold: 6
+      - name: cloud-sql-proxy
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2
+        args:
+          - dlorenc-chainguard:us-central1:docstore-mvp
+          - --port=5432
+        securityContext:
+          runAsNonRoot: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi


### PR DESCRIPTION
## Summary

Fixes three deployment issues found after the first deploy attempt for issue #157:

- **Cloud SQL Auth Proxy sidecar** added to `ci-scheduler` and `ci-worker`: GKE pods cannot reach Cloud SQL via Unix socket (Cloud Run only). Added `cloud-sql-proxy:2` sidecar listening on `localhost:5432`. The `DATABASE_URL` secret already uses `127.0.0.1:5432`.
- **nodeSelector on ci-runner**: Pins `ci-runner` to `default-pool` so it doesn't consume kata-pool nodes reserved for `ci-worker`.
- **nodeSelector on ci-scheduler**: Same fix — pins `ci-scheduler` to `default-pool`.

## Files changed

- `deploy/k8s/ci-scheduler.yaml` — proxy sidecar + nodeSelector
- `deploy/k8s/ci-worker.yaml` — proxy sidecar
- `deploy/k8s/ci-runner.yaml` — nodeSelector

Closes #157 (post-deploy follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)