### PR TITLE
fix: add docker-proxy to ci-worker image and disable userland-proxy

### DIFF
--- a/Dockerfile.ci-worker
+++ b/Dockerfile.ci-worker
@@ -17,6 +17,7 @@ RUN curl -fsSL https://github.com/GoogleCloudPlatform/docker-credential-gcr/rele
     | tar xz -C /usr/local/bin docker-credential-gcr
 COPY --from=docker-bins /usr/local/bin/docker /usr/local/bin/docker
 COPY --from=docker-bins /usr/local/bin/dockerd /usr/local/bin/dockerd
+COPY --from=docker-bins /usr/local/bin/docker-proxy /usr/local/bin/docker-proxy
 COPY --from=docker-bins /usr/local/bin/containerd /usr/local/bin/containerd
 COPY --from=buildkit /usr/bin/buildkitd /usr/bin/buildkitd
 COPY --from=build /ci-worker /usr/bin/ci-worker

--- a/entrypoint-worker.sh
+++ b/entrypoint-worker.sh
@@ -19,7 +19,7 @@ export DOCKER_CONFIG="$HOME/.docker"
 # Start buildkitd in background (standard, non-rootless — runs natively inside Kata VM).
 buildkitd --addr tcp://localhost:1234 &
 
-# Start dockerd in background.
-dockerd &
+# Start dockerd in background (--userland-proxy=false avoids needing docker-proxy for port forwarding).
+dockerd --userland-proxy=false &
 
 exec ci-worker


### PR DESCRIPTION
## Problem

dockerd inside the Kata VM crashed on startup:
```
invalid userland-proxy-path: userland-proxy is enabled, but userland-proxy-path is not set
```

`docker-proxy` was not copied from `docker:27-dind` in `Dockerfile.ci-worker`. This caused dockerd to fail, which prevented buildkitd from starting cleanly, which blocked `waitBuildkitReady` in ci-worker, which kept port 8081 (readiness probe target) from coming up — leaving pods stuck at `1/2`.

## Fix

- Copy `docker-proxy` from `docker:27-dind` in `Dockerfile.ci-worker`
- Add `--userland-proxy=false` to dockerd in `entrypoint-worker.sh` (belt-and-suspenders)

Closes part of #157 (wave 4 operational fix)