### PR TITLE
fix: add NET_ADMIN capability to ci-worker for dockerd iptables

### DIFF
--- a/deploy/k8s/ci-worker.yaml
+++ b/deploy/k8s/ci-worker.yaml
@@ -43,6 +43,10 @@ spec:
       containers:
       - name: ci-worker
         image: us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-worker:latest
+        securityContext:
+          capabilities:
+            add:
+              - NET_ADMIN
         env:
         - name: DOCSTORE_URL
           value: https://docstore-efuj4cj54a-uc.a.run.app


### PR DESCRIPTION
dockerd inside the Kata VM failed to initialize networking because `NET_ADMIN` is not in the default k8s capability set:

```
iptables v1.8.10 (nf_tables): Could not fetch rule set generation id: Permission denied
failed to start daemon: Error initializing network controller: failed to register "bridge" driver: failed to create NAT chain DOCKER
```

Adding `NET_ADMIN` to the ci-worker container is safe — the isolation boundary is the Kata CLH microVM, not the container security context.

Part of #157 (wave 4 operational fix)