### PR TITLE
fix: add runc to ci-worker image for buildkitd OCI worker

### DIFF
--- a/Dockerfile.ci-worker
+++ b/Dockerfile.ci-worker
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         iptables \
+        runc \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.22/docker-credential-gcr_linux_amd64-2.1.22.tar.gz \
     | tar xz -C /usr/local/bin docker-credential-gcr


### PR DESCRIPTION
buildkitd was crashing with 'no worker found' immediately after starting because `runc` was missing — the OCI worker requires it. This caused a race condition where `waitBuildkitReady` connected in the ~100ms window before buildkitd died, so some pods appeared healthy and others stayed at `1/2`. Part of #157.