### PR TITLE
fix: dockerd readiness wait and docker-credential-gcr checksum verification

### DIFF
--- a/Dockerfile.ci-worker
+++ b/Dockerfile.ci-worker
@@ -15,7 +15,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         runc \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.22/docker-credential-gcr_linux_amd64-2.1.22.tar.gz \
-    | tar xz -C /usr/local/bin docker-credential-gcr
+      -o /tmp/docker-credential-gcr.tar.gz \
+    && echo "443e897dc383d69e55e6dbcb13802f4ec88444848612e83f0381df2ddd721694  /tmp/docker-credential-gcr.tar.gz" | sha256sum -c - \
+    && tar xz -C /usr/local/bin -f /tmp/docker-credential-gcr.tar.gz docker-credential-gcr \
+    && rm /tmp/docker-credential-gcr.tar.gz
 COPY --from=docker-bins /usr/local/bin/docker /usr/local/bin/docker
 COPY --from=docker-bins /usr/local/bin/dockerd /usr/local/bin/dockerd
 COPY --from=docker-bins /usr/local/bin/docker-proxy /usr/local/bin/docker-proxy

--- a/entrypoint-worker.sh
+++ b/entrypoint-worker.sh
@@ -47,4 +47,17 @@ buildkitd --addr tcp://localhost:1234 --oci-worker-net=host --oci-worker-snapsho
 # host network can use DOCKER_HOST=tcp://localhost:2375.
 dockerd --userland-proxy=false -H unix:///var/run/docker.sock -H tcp://127.0.0.1:2375 &
 
+# Wait for dockerd to be ready on TCP port 2375.
+echo "waiting for dockerd..." >&2
+i=0
+while ! curl -sf --max-time 1 http://127.0.0.1:2375/_ping >/dev/null 2>&1; do
+  i=$((i+1))
+  if [ "$i" -ge 60 ]; then
+    echo "ERROR: dockerd not ready after 60s" >&2
+    exit 1
+  fi
+  sleep 1
+done
+echo "dockerd ready" >&2
+
 exec ci-worker


### PR DESCRIPTION
## Summary

- **dockerd readiness wait** (`entrypoint-worker.sh`): Added a `curl`-based TCP poll on `http://127.0.0.1:2375/_ping` (up to 60 s, 1 s sleep per retry) before `exec ci-worker`. Previously, `ci-worker` could start before `dockerd` finished initializing, causing build failures if any check step tried to contact Docker before it was ready.

- **Checksum verification** (`Dockerfile.ci-worker`): Changed the `docker-credential-gcr` download to save to a temp file and verify the sha256 checksum (`443e897dc383d69e55e6dbcb13802f4ec88444848612e83f0381df2ddd721694`) before extracting. The old one-liner piped directly to `tar` with no integrity check, so a corrupted or tampered tarball would have been silently installed.

## Test plan
- [ ] All existing tests pass (`go test ./... -count=1` — verified locally)
- [ ] Build is clean (`go build ./... && go vet ./...` — verified locally)
- [ ] No Go code changed; only shell script and Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)