### PR TITLE
fix: add dockerd readiness wait and docker-credential-gcr checksum

### DIFF
--- a/Dockerfile.ci-worker
+++ b/Dockerfile.ci-worker
@@ -15,7 +15,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         runc \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.22/docker-credential-gcr_linux_amd64-2.1.22.tar.gz \
-    | tar xz -C /usr/local/bin docker-credential-gcr
+    -o /tmp/docker-credential-gcr.tar.gz \
+    && echo "443e897dc383d69e55e6dbcb13802f4ec88444848612e83f0381df2ddd721694  /tmp/docker-credential-gcr.tar.gz" | sha256sum -c - \
+    && tar xz -C /usr/local/bin docker-credential-gcr -f /tmp/docker-credential-gcr.tar.gz \
+    && rm /tmp/docker-credential-gcr.tar.gz
 COPY --from=docker-bins /usr/local/bin/docker /usr/local/bin/docker
 COPY --from=docker-bins /usr/local/bin/dockerd /usr/local/bin/dockerd
 COPY --from=docker-bins /usr/local/bin/docker-proxy /usr/local/bin/docker-proxy

--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -44,8 +44,8 @@ func envOrDefault(key, def string) string {
 	return def
 }
 
-// waitBuildkitReady polls the buildkitd address until a TCP/unix connection succeeds.
-func waitBuildkitReady(ctx context.Context, addr string) error {
+// waitServiceReady polls addr (tcp:// or unix://) until a connection succeeds.
+func waitServiceReady(ctx context.Context, name, addr string) error {
 	var network, address string
 	switch {
 	case strings.HasPrefix(addr, "tcp://"):
@@ -55,14 +55,14 @@ func waitBuildkitReady(ctx context.Context, addr string) error {
 		network = "unix"
 		address = strings.TrimPrefix(addr, "unix://")
 	default:
-		return fmt.Errorf("unsupported buildkitd address scheme: %s", addr)
+		return fmt.Errorf("unsupported address scheme for %s: %s", name, addr)
 	}
-	slog.Info("waiting for buildkitd", "addr", addr)
+	slog.Info("waiting for service", "name", name, "addr", addr)
 	for {
 		conn, err := net.DialTimeout(network, address, time.Second)
 		if err == nil {
 			conn.Close()
-			slog.Info("buildkitd ready")
+			slog.Info("service ready", "name", name)
 			return nil
 		}
 		select {
@@ -71,6 +71,16 @@ func waitBuildkitReady(ctx context.Context, addr string) error {
 		case <-time.After(100 * time.Millisecond):
 		}
 	}
+}
+
+// waitBuildkitReady polls the buildkitd address until a TCP/unix connection succeeds.
+func waitBuildkitReady(ctx context.Context, addr string) error {
+	return waitServiceReady(ctx, "buildkitd", addr)
+}
+
+// waitDockerdReady polls dockerd at tcp://localhost:2375 until ready.
+func waitDockerdReady(ctx context.Context) error {
+	return waitServiceReady(ctx, "dockerd", "tcp://localhost:2375")
 }
 
 // heartbeat sends periodic last_heartbeat_at updates until done is closed.
@@ -362,6 +372,14 @@ func main() {
 	waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Minute)
 	if err := waitBuildkitReady(waitCtx, buildkitAddr); err != nil {
 		slog.Error("buildkitd not ready", "error", err)
+		os.Exit(1)
+	}
+	waitCancel()
+
+	// Wait for dockerd to be ready.
+	waitCtx, waitCancel = context.WithTimeout(ctx, 5*time.Minute)
+	if err := waitDockerdReady(waitCtx); err != nil {
+		slog.Error("dockerd not ready", "error", err)
 		os.Exit(1)
 	}
 	waitCancel()


### PR DESCRIPTION
## Summary

- **dockerd readiness wait**: `waitBuildkitReady` in `cmd/ci-worker/main.go` only polled buildkitd. Added `waitDockerdReady` polling `tcp://localhost:2375` so the worker doesn't claim jobs before dockerd is up. Refactored both into a shared `waitServiceReady(ctx, name, addr)` helper to avoid code duplication.

- **Checksum verification**: `Dockerfile.ci-worker` downloaded `docker-credential-gcr_linux_amd64-2.1.22.tar.gz` and piped directly to `tar` without verifying integrity. Now downloads to `/tmp`, verifies sha256 (`443e897dc383d69e55e6dbcb13802f4ec88444848612e83f0381df2ddd721694`), then extracts — the Docker build fails if the digest doesn't match.

## Test plan

- [x] `go build ./...` passes clean
- [x] `go vet ./...` passes clean
- [ ] `go test ./...` — `internal/server` fails with `"sql: database is closed"` from the outbox goroutine; this is a pre-existing race unrelated to these changes (neither file is touched by the failing tests). All other packages pass.

## Notes

- The `internal/server` test failure is pre-existing flakiness (outbox goroutine races with DB teardown). Not caused by this change.
- Opportunity: the dockerd timeout is hardcoded at 5 minutes (matching buildkitd). Could make it configurable via env var in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)