### PR TITLE
fix: propagate ResolveImageConfig error and add HTTP client timeouts

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -96,6 +96,8 @@ func heartbeat(ctx context.Context, store *db.Store, jobID string, done <-chan s
 // ---------------------------------------------------------------------------
 
 func fetchConfig(ctx context.Context, client *http.Client, docstoreURL, repo string) (*executor.Config, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 	fileURL := fmt.Sprintf("%s/repos/%s/-/file/.docstore/ci.yaml?branch=main", docstoreURL, repo)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
 	if err != nil {
@@ -394,8 +396,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// HTTP client for docstore requests.
-	httpClient := &http.Client{}
+	// HTTP client for docstore requests. The 5-minute timeout covers the
+	// worst-case archive download; fetchConfig wraps its context with a
+	// tighter 30-second deadline for the lightweight config fetch.
+	httpClient := &http.Client{Timeout: 5 * time.Minute}
 
 	// Start log HTTP server on :8081.
 	logSrv := &checkLogServer{}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -132,14 +132,16 @@ func (e *Executor) runCheck(ctx context.Context, sourceDir string, check Check) 
 			imageRef = reference.TagNameOnly(named).String()
 		}
 		var envOpts []llb.RunOption
-		if _, _, cfgBytes, err := c.ResolveImageConfig(ctx, imageRef,
-			sourceresolver.Opt{ImageOpt: &sourceresolver.ResolveImageOpt{}}); err == nil {
-			var imgCfg specs.Image
-			if json.Unmarshal(cfgBytes, &imgCfg) == nil {
-				for _, env := range imgCfg.Config.Env {
-					k, v, _ := strings.Cut(env, "=")
-					envOpts = append(envOpts, llb.AddEnv(k, v))
-				}
+		_, _, cfgBytes, err := c.ResolveImageConfig(ctx, imageRef,
+			sourceresolver.Opt{ImageOpt: &sourceresolver.ResolveImageOpt{}})
+		if err != nil {
+			return nil, fmt.Errorf("resolve image config for %s: %w", imageRef, err)
+		}
+		var imgCfg specs.Image
+		if json.Unmarshal(cfgBytes, &imgCfg) == nil {
+			for _, env := range imgCfg.Config.Env {
+				k, v, _ := strings.Cut(env, "=")
+				envOpts = append(envOpts, llb.AddEnv(k, v))
 			}
 		}
 		// Inject DOCKER_HOST so docker:cli checks can reach the dockerd running


### PR DESCRIPTION
## Summary

- **executor.go**: `ResolveImageConfig` failure was silently ignored (guarded by `err == nil`). If image config resolution failed (e.g. registry unreachable, bad image ref), the build continued without the image's ENV, causing confusing downstream failures (missing `PATH`, etc.). Now returns the error so the check is properly failed with a clear message.

- **cmd/ci-worker/main.go**: `httpClient := &http.Client{}` had no `Timeout`, so `fetchConfig` and `pullBranchSource` could hang indefinitely if docstore was unreachable. Fixed with two-level timeouts:
  - `http.Client{Timeout: 5 * time.Minute}` — absolute ceiling covering worst-case archive downloads
  - `context.WithTimeout(ctx, 30*time.Second)` inside `fetchConfig` — tighter deadline for the lightweight config fetch

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go vet ./...` — clean
- [ ] `go test ./internal/executor/... ./cmd/... -count=1` — all pass
- [ ] `go test ./internal/server/... -count=1` — passes (TestDockerSmoke is pre-existing flaky under parallel load; passes when run in isolation)

## Notes

Pre-existing flakiness: `TestDockerSmoke` in `internal/server` fails intermittently when the full suite runs in parallel (Docker daemon resource contention), but passes consistently in isolation. This is unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)