### PR TITLE
fix: add resource limits to ci-worker pods and use image digest in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,14 +88,16 @@ jobs:
             -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-scheduler:latest \
             -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-scheduler:${SHA} \
             --push \
+            --metadata-file /tmp/ci-scheduler-metadata.json \
             .
-          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+          DIGEST=$(jq -r '."containerimage.digest"' /tmp/ci-scheduler-metadata.json)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
       - name: Deploy ci-scheduler to GKE
         run: |
           kubectl apply -f deploy/k8s/ci-scheduler.yaml
           kubectl set image deployment/ci-scheduler \
-            ci-scheduler=us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-scheduler:${{ steps.build.outputs.sha }} \
+            ci-scheduler=us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-scheduler@${{ steps.build.outputs.digest }} \
             -n docstore-ci
           kubectl rollout status deployment/ci-scheduler -n docstore-ci --timeout=300s
 
@@ -153,13 +155,15 @@ jobs:
             -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-worker:latest \
             -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-worker:${SHA} \
             --push \
+            --metadata-file /tmp/ci-worker-metadata.json \
             .
-          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+          DIGEST=$(jq -r '."containerimage.digest"' /tmp/ci-worker-metadata.json)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
       - name: Deploy ci-worker to GKE
         run: |
           kubectl apply -f deploy/k8s/ci-worker.yaml
           kubectl set image deployment/ci-worker \
-            ci-worker=us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-worker:${{ steps.build.outputs.sha }} \
+            ci-worker=us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-worker@${{ steps.build.outputs.digest }} \
             -n docstore-ci
           kubectl rollout status deployment/ci-worker -n docstore-ci --timeout=600s

--- a/deploy/k8s/ci-worker.yaml
+++ b/deploy/k8s/ci-worker.yaml
@@ -80,6 +80,9 @@ spec:
           requests:
             cpu: "2000m"
             memory: "8Gi"
+          limits:
+            cpu: "2000m"
+            memory: "8Gi"
         readinessProbe:
           tcpSocket:
             port: 8081
@@ -95,5 +98,8 @@ spec:
           runAsNonRoot: true
         resources:
           requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
             cpu: 100m
             memory: 128Mi


### PR DESCRIPTION
## Summary

- **Issue 9**: Added `limits` matching `requests` to both the `ci-worker` container (cpu: 2000m, memory: 8Gi) and the `cloud-sql-proxy` sidecar (cpu: 100m, memory: 128Mi) in `deploy/k8s/ci-worker.yaml`. This gives both pods Kubernetes **Guaranteed QoS class**, preventing the kubelet from evicting them when memory pressure occurs on the node.

- **Issue 10**: Changed both `build-and-deploy-ci-scheduler` and `build-and-deploy-ci-worker` jobs in `.github/workflows/deploy.yml` to capture the image digest after `docker buildx build --push` via `--metadata-file`, then parse the digest with `jq` and pass `image@sha256:...` to `kubectl set image` instead of the mutable SHA tag. This ensures the exact built image is deployed even if a pod is evicted mid-rollout and a new one starts after a tag could theoretically point elsewhere.

## Test plan

- [ ] Verify `ci-worker.yaml` shows `requests == limits` for both containers (Guaranteed QoS confirmed via `kubectl describe pod`)
- [ ] Trigger a deploy to main; confirm `kubectl set image` uses `@sha256:` reference in workflow logs
- [ ] Confirm rollout succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)