### PR TITLE
feat: fetch CI config from branch under test, not main

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -105,10 +105,10 @@ func heartbeat(ctx context.Context, store *db.Store, jobID string, done <-chan s
 // Docstore API helpers (same as ci-runner)
 // ---------------------------------------------------------------------------
 
-func fetchConfig(ctx context.Context, client *http.Client, docstoreURL, repo string) (*executor.Config, error) {
+func fetchConfig(ctx context.Context, client *http.Client, docstoreURL, repo, branch string, headSeq int64) (*executor.Config, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	fileURL := fmt.Sprintf("%s/repos/%s/-/file/.docstore/ci.yaml?branch=main", docstoreURL, repo)
+	fileURL := fmt.Sprintf("%s/repos/%s/-/file/.docstore/ci.yaml?branch=%s&at=%d", docstoreURL, repo, url.QueryEscape(branch), headSeq)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create config request: %w", err)
@@ -119,7 +119,8 @@ func fetchConfig(ctx context.Context, client *http.Client, docstoreURL, repo str
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("ci config not found at %s", fileURL)
+		// No ci.yaml on this branch — CI is not configured; skip silently.
+		return nil, nil
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("fetch config: unexpected status %d", resp.StatusCode)
@@ -268,8 +269,8 @@ func runJob(
 		return "failed", nil, &msg
 	}
 
-	// 1. Fetch CI config.
-	cfg, err := fetchConfig(ctx, httpClient, docstoreURL, job.Repo)
+	// 1. Fetch CI config from the branch under test at its head sequence.
+	cfg, err := fetchConfig(ctx, httpClient, docstoreURL, job.Repo, job.Branch, job.Sequence)
 	if err != nil {
 		_ = postCheckRun(ctx, httpClient, docstoreURL, job.Repo, model.CreateCheckRunRequest{
 			Branch:    job.Branch,
@@ -278,6 +279,11 @@ func runJob(
 			Sequence:  &job.Sequence,
 		})
 		return fail(err.Error())
+	}
+	if cfg == nil {
+		// No .docstore/ci.yaml on this branch — CI not configured; skip.
+		slog.Info("no ci.yaml on branch, skipping CI", "job_id", job.ID, "branch", job.Branch)
+		return "passed", nil, nil
 	}
 
 	// 2. Pull branch source into temp dir.

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -9,7 +9,7 @@ The runner sits between docstore and a co-located `buildkitd` instance. It accep
 In the full production flow:
 1. A commit lands on a branch
 2. Docstore's outbox dispatcher sends a `commit.created` CloudEvent to the ci-runner webhook
-3. The ci-runner fetches `.docstore/ci.yaml` from `main` and downloads the branch tree to disk
+3. The ci-runner fetches `.docstore/ci.yaml` from the branch under test (pinned to its head sequence) and downloads the branch tree to disk
 4. BuildKit executes the checks; logs are written to GCS
 5. Results are written back to docstore as check runs via `POST /-/check`
 
@@ -19,7 +19,13 @@ In the full production flow:
 
 ### `.docstore/ci.yaml` DSL
 
-Committed to `main` (always read from `main`, never from the branch under test):
+Read from the **branch under test**, pinned to its head sequence at the time the CI job was queued. This means changes to `ci.yaml` on a branch take effect immediately for that branch's CI runs without requiring a merge to `main` first.
+
+If `.docstore/ci.yaml` does not exist on the branch, CI is skipped entirely — no check runs are posted. The merge policy independently enforces required check names, so removing `ci.yaml` from a branch does not bypass the merge gate; it just means CI produces no results (which may cause required checks to be absent and block merging, depending on policy).
+
+**Security note:** Policy files (`.docstore/policy/*.rego`) are always loaded from `main`, not from the branch. This means the merge gate cannot be weakened by changes on a branch — a branch cannot modify the policies that govern whether it is allowed to merge.
+
+Example `ci.yaml`:
 
 ```yaml
 checks:


### PR DESCRIPTION
## Summary

- `fetchConfig` now accepts `branch` and `headSeq` parameters and fetches `.docstore/ci.yaml` from the branch under test pinned to its head sequence (was hardcoded to `branch=main`)
- A 404 on `.docstore/ci.yaml` is now treated as "no CI configured" — returns `nil` config, job returns `passed` silently. Previously it posted a `ci/config` failure check run and failed the job.
- `runJob` passes `job.Branch` and `job.Sequence` into `fetchConfig` and handles the `nil` config by returning immediately with `passed`
- `docs/ci-runner.md` updated: production flow step, DSL section rewritten to document branch-relative fetch, nil-config skip semantics, and security note that `.docstore/policy/*.rego` is always loaded from `main`

## Security note

Policy files are always loaded from `main` (unchanged). Branches cannot weaken the merge gate by modifying policies.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all pass

## Opportunities noted (not implemented)

- The `ci-runner` (non-worker) also fetches ci.yaml from main (`cmd/ci-runner/main.go`); it may warrant the same treatment in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)