### PR TITLE
feat: add BuildKit GCS cache to CI executor

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -400,7 +400,8 @@ func main() {
 	store := db.NewStore(sqlDB)
 
 	// Build executor.
-	exec, err := executor.New(buildkitAddr)
+	cacheBucket := os.Getenv("CACHE_BUCKET")
+	exec, err := executor.New(buildkitAddr, cacheBucket)
 	if err != nil {
 		slog.Error("connect to buildkitd", "error", err)
 		os.Exit(1)

--- a/deploy/k8s/ci-worker.yaml
+++ b/deploy/k8s/ci-worker.yaml
@@ -74,6 +74,8 @@ spec:
           value: gcs
         - name: LOG_BUCKET
           value: docstore-ci-logs
+        - name: CACHE_BUCKET
+          value: docstore-ci-cache
         ports:
         - containerPort: 8081
         resources:

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -43,16 +43,18 @@ type CheckResult struct {
 
 // Executor translates a Config into an LLB DAG and dispatches it to buildkitd.
 type Executor struct {
-	client *client.Client
+	client      *client.Client
+	cacheBucket string // empty = no cache
 }
 
 // New creates an Executor connected to the buildkitd at buildkitAddr.
-func New(buildkitAddr string) (*Executor, error) {
+// cacheBucket is an optional GCS bucket name for BuildKit cache; pass "" to disable.
+func New(buildkitAddr, cacheBucket string) (*Executor, error) {
 	c, err := client.New(context.Background(), buildkitAddr)
 	if err != nil {
 		return nil, fmt.Errorf("connect to buildkitd at %s: %w", buildkitAddr, err)
 	}
-	return &Executor{client: c}, nil
+	return &Executor{client: c, cacheBucket: cacheBucket}, nil
 }
 
 // Run executes all checks in cfg in parallel against sourceDir.
@@ -118,12 +120,29 @@ func (e *Executor) runCheck(ctx context.Context, sourceDir string, check Check) 
 
 	localDirs := map[string]string{"src": sourceDir}
 
-	_, solveErr := e.client.Build(ctx, client.SolveOpt{
+	solveOpt := client.SolveOpt{
 		LocalDirs: localDirs,
 		Session: []session.Attachable{
 			authprovider.NewDockerAuthProvider(ap),
 		},
-	}, "", func(ctx context.Context, c gwclient.Client) (*gwclient.Result, error) {
+	}
+	if e.cacheBucket != "" {
+		solveOpt.CacheImports = []client.CacheOptionsEntry{
+			{Type: "gcs", Attrs: map[string]string{
+				"bucket": e.cacheBucket,
+				"prefix": "buildkit-cache/",
+			}},
+		}
+		solveOpt.CacheExports = []client.CacheOptionsEntry{
+			{Type: "gcs", Attrs: map[string]string{
+				"bucket": e.cacheBucket,
+				"prefix": "buildkit-cache/",
+				"mode":   "max",
+			}},
+		}
+	}
+
+	_, solveErr := e.client.Build(ctx, solveOpt, "", func(ctx context.Context, c gwclient.Client) (*gwclient.Result, error) {
 		// Resolve image config to get ENV (e.g. PATH in golang:1.25).
 		// --oci-worker-no-process-sandbox skips applying image ENV automatically,
 		// and empirically the standard OCI worker also requires explicit injection.

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 // newExecutor creates an Executor for tests using the package-level buildkitd address.
 func newExecutor(t *testing.T) *executor.Executor {
 	t.Helper()
-	exec, err := executor.New(pkgBuildkitAddr)
+	exec, err := executor.New(pkgBuildkitAddr, "")
 	if err != nil {
 		t.Fatalf("cannot connect to buildkitd at %s: %v", pkgBuildkitAddr, err)
 	}

--- a/scripts/setup-gke.sh
+++ b/scripts/setup-gke.sh
@@ -78,6 +78,21 @@ kubectl create secret generic "${KSA}" \
   --dry-run=client -o yaml | kubectl apply -f -
 echo "    Done."
 
+echo "==> Creating GCS cache bucket docstore-ci-cache (no-op if it already exists)..."
+gcloud storage buckets create "gs://docstore-ci-cache" \
+  --project="${PROJECT}" \
+  --location="${REGION}" \
+  --uniform-bucket-level-access \
+  --quiet || true
+echo "    Done."
+
+echo "==> Granting ci-runner SA storage.objectAdmin on docstore-ci-cache..."
+gcloud storage buckets add-iam-policy-binding "gs://docstore-ci-cache" \
+  --member="serviceAccount:${GSA}" \
+  --role=roles/storage.objectAdmin \
+  --quiet
+echo "    Done."
+
 echo ""
 echo "GKE setup complete."
 echo ""


### PR DESCRIPTION
## Summary

- Add optional `cacheBucket` field to `Executor` struct; `New()` now takes `buildkitAddr, cacheBucket string`
- Wire `CacheImports` and `CacheExports` (mode=max) into `SolveOpt` in `runCheck` when `cacheBucket` is non-empty — mode=max exports all intermediate layers for maximum cache hit rate on steps like `go mod download`
- Read `CACHE_BUCKET` env var in `cmd/ci-worker/main.go` and pass to `executor.New()`
- Add `CACHE_BUCKET=docstore-ci-cache` env var to `deploy/k8s/ci-worker.yaml`
- Add GCS bucket creation (`docstore-ci-cache`) and `storage.objectAdmin` IAM grant for the ci-runner SA to `scripts/setup-gke.sh`

## Behaviour

- When `CACHE_BUCKET` is unset (local dev), cache options are omitted entirely — no GCS dependency
- A single shared prefix `buildkit-cache/` is used; BuildKit's content-addressed keys mean no collision risk across repos/branches
- The GCS cache backend is built into buildkitd; no extra binaries needed

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` passes (all packages including `internal/executor`)
- [ ] On GKE: verify `buildkitd` writes cache entries to `gs://docstore-ci-cache/buildkit-cache/` after first run and subsequent runs are faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)