### PR TITLE
test(ci-scheduler): validate request URL in fetchCIConfig test server

### DIFF
--- a/cmd/ci-scheduler/main_test.go
+++ b/cmd/ci-scheduler/main_test.go
@@ -454,9 +454,17 @@ func TestHandleRun_SetsTrigerTypeManual(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // newCIConfigServer returns a test HTTP server that serves the given ci.yaml content.
+// It validates that the request path ends with /-/file/.docstore/ci.yaml and that
+// the branch and at query params are present and non-empty; returns 404 otherwise.
 func newCIConfigServer(t *testing.T, ciYAML string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/-/file/.docstore/ci.yaml") ||
+			r.URL.Query().Get("branch") == "" ||
+			r.URL.Query().Get("at") == "" {
+			http.NotFound(w, r)
+			return
+		}
 		type fileResp struct {
 			Path    string `json:"path"`
 			Content []byte `json:"content"`


### PR DESCRIPTION
## Summary

- Updates `newCIConfigServer` to assert the incoming request path contains `/-/file/.docstore/ci.yaml` and that `branch` and `at` query params are present and non-empty
- Returns 404 for requests that don't match, so a URL regression in `fetchCIConfig` will cause tests to fail rather than silently pass
- All existing tests continue to pass — the URL constructed by `fetchCIConfig` already matches the expected format

Closes #179

## Test plan

- [ ] `go test ./cmd/ci-scheduler/... -count=1` passes
- [ ] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)