### PR TITLE
feat: Stage 4 CI proposal trigger (issue #179)

### DIFF
--- a/cmd/ci-scheduler/main.go
+++ b/cmd/ci-scheduler/main.go
@@ -42,7 +42,7 @@ import (
 // ---------------------------------------------------------------------------
 
 type ciJobStore interface {
-	InsertCIJob(ctx context.Context, repo, branch string, sequence int64, triggerType, triggerBranch string) (*model.CIJob, error)
+	InsertCIJob(ctx context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerProposalID string) (*model.CIJob, error)
 	GetCIJob(ctx context.Context, id string) (*model.CIJob, error)
 	ReapStaleCIJobs(ctx context.Context) ([]model.CIJob, error)
 }
@@ -113,7 +113,7 @@ func registerWebhookSubscription(ctx context.Context, client *http.Client, docst
 	}
 	createBody, _ := json.Marshal(createReq{
 		Backend:    "webhook",
-		EventTypes: []string{"com.docstore.commit.created"},
+		EventTypes: []string{"com.docstore.commit.created", "com.docstore.proposal.opened"},
 		Config:     cfgJSON,
 	})
 	createReq2, err := http.NewRequestWithContext(ctx, http.MethodPost, subsURL, bytes.NewReader(createBody))
@@ -183,6 +183,68 @@ func (s *scheduler) fetchCIConfig(ctx context.Context, repo, branch string, sequ
 	return &cfg, nil
 }
 
+// fetchBranchHead fetches the current head sequence for a branch using the branches list API.
+func (s *scheduler) fetchBranchHead(ctx context.Context, repo, branch string) (int64, error) {
+	if s.docstoreURL == "" {
+		return 0, fmt.Errorf("docstore URL not configured")
+	}
+	branchesURL := fmt.Sprintf("%s/repos/%s/-/branches", s.docstoreURL, repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, branchesURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("build branches request: %w", err)
+	}
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("fetch branches: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("fetch branches: unexpected status %d", resp.StatusCode)
+	}
+	var branches []struct {
+		Name         string `json:"name"`
+		HeadSequence int64  `json:"head_sequence"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&branches); err != nil {
+		return 0, fmt.Errorf("decode branches response: %w", err)
+	}
+	for _, b := range branches {
+		if b.Name == branch {
+			return b.HeadSequence, nil
+		}
+	}
+	return 0, fmt.Errorf("branch not found: %s", branch)
+}
+
+// fetchOpenProposalForBranch returns the open proposal for a branch, or nil if none exists.
+func (s *scheduler) fetchOpenProposalForBranch(ctx context.Context, repo, branch string) (*model.Proposal, error) {
+	if s.docstoreURL == "" {
+		return nil, nil
+	}
+	proposalsURL := fmt.Sprintf("%s/repos/%s/-/proposals?state=open&branch=%s",
+		s.docstoreURL, repo, url.QueryEscape(branch))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, proposalsURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build proposals request: %w", err)
+	}
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch proposals: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch proposals: unexpected status %d", resp.StatusCode)
+	}
+	var proposals []*model.Proposal
+	if err := json.NewDecoder(resp.Body).Decode(&proposals); err != nil {
+		return nil, fmt.Errorf("decode proposals response: %w", err)
+	}
+	if len(proposals) == 0 {
+		return nil, nil
+	}
+	return proposals[0], nil
+}
+
 // handleWebhook handles POST /webhook — receives CloudEvents from docstore outbox.
 func (s *scheduler) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
@@ -211,18 +273,25 @@ func (s *scheduler) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Unknown event types are silently acknowledged (forward-compat).
-	if env.Type != "com.docstore.commit.created" {
+	switch env.Type {
+	case "com.docstore.commit.created":
+		s.handleCommitCreated(w, r, env.Data)
+	case "com.docstore.proposal.opened":
+		s.handleProposalOpened(w, r, env.Data)
+	default:
+		// Unknown event types are silently acknowledged (forward-compat).
 		w.WriteHeader(http.StatusOK)
-		return
 	}
+}
 
+// handleCommitCreated processes com.docstore.commit.created events.
+func (s *scheduler) handleCommitCreated(w http.ResponseWriter, r *http.Request, raw json.RawMessage) {
 	var data struct {
 		Repo     string `json:"repo"`
 		Branch   string `json:"branch"`
 		Sequence int64  `json:"sequence"`
 	}
-	if err := json.Unmarshal(env.Data, &data); err != nil {
+	if err := json.Unmarshal(raw, &data); err != nil {
 		http.Error(w, "invalid event data", http.StatusBadRequest)
 		return
 	}
@@ -238,20 +307,90 @@ func (s *scheduler) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		slog.Warn("could not fetch ci config, proceeding with enqueue", "repo", data.Repo, "branch", data.Branch, "error", err)
 		cfg = nil
 	}
-	if cfg != nil && !cfg.MatchesPush(data.Branch) {
+
+	if cfg == nil || cfg.MatchesPush(data.Branch) {
+		job, err := s.store.InsertCIJob(r.Context(), data.Repo, data.Branch, data.Sequence, "push", data.Branch, "")
+		if err != nil {
+			slog.Error("insert ci job failed", "repo", data.Repo, "branch", data.Branch, "error", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		slog.Info("ci job queued (push)", "id", job.ID, "repo", data.Repo, "branch", data.Branch, "sequence", data.Sequence)
+	} else {
 		slog.Info("push trigger filtered by on: block", "repo", data.Repo, "branch", data.Branch)
+	}
+
+	// Also check if the branch has an open proposal and enqueue a proposal_synchronized job.
+	proposal, err := s.fetchOpenProposalForBranch(r.Context(), data.Repo, data.Branch)
+	if err != nil {
+		slog.Warn("could not check open proposals, skipping proposal_synchronized trigger", "repo", data.Repo, "branch", data.Branch, "error", err)
+	} else if proposal != nil {
+		// Evaluate proposal trigger filter.
+		proposalCfgMatch := true
+		if cfg != nil {
+			proposalCfgMatch = cfg.MatchesProposal(proposal.BaseBranch)
+		}
+		if proposalCfgMatch {
+			job, err := s.store.InsertCIJob(r.Context(), data.Repo, data.Branch, data.Sequence, "proposal_synchronized", data.Branch, proposal.ID)
+			if err != nil {
+				slog.Error("insert proposal_synchronized ci job failed", "repo", data.Repo, "branch", data.Branch, "proposal_id", proposal.ID, "error", err)
+				http.Error(w, "internal error", http.StatusInternalServerError)
+				return
+			}
+			slog.Info("ci job queued (proposal_synchronized)", "id", job.ID, "repo", data.Repo, "branch", data.Branch, "proposal_id", proposal.ID)
+		} else {
+			slog.Info("proposal_synchronized trigger filtered by on: block", "repo", data.Repo, "branch", data.Branch)
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleProposalOpened processes com.docstore.proposal.opened events.
+func (s *scheduler) handleProposalOpened(w http.ResponseWriter, r *http.Request, raw json.RawMessage) {
+	var data struct {
+		Repo       string `json:"repo"`
+		Branch     string `json:"branch"`
+		BaseBranch string `json:"base_branch"`
+		ProposalID string `json:"proposal_id"`
+		Author     string `json:"author"`
+	}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		http.Error(w, "invalid event data", http.StatusBadRequest)
+		return
+	}
+	if data.Repo == "" || data.Branch == "" {
+		http.Error(w, "missing repo or branch in event data", http.StatusBadRequest)
+		return
+	}
+
+	// Fetch the current head sequence for the branch.
+	sequence, err := s.fetchBranchHead(r.Context(), data.Repo, data.Branch)
+	if err != nil {
+		slog.Warn("could not fetch branch head, skipping proposal trigger", "repo", data.Repo, "branch", data.Branch, "error", err)
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 
-	job, err := s.store.InsertCIJob(r.Context(), data.Repo, data.Branch, data.Sequence, "push", data.Branch)
+	// Fetch CI config and evaluate proposal trigger filter.
+	cfg, err := s.fetchCIConfig(r.Context(), data.Repo, data.Branch, sequence)
 	if err != nil {
-		slog.Error("insert ci job failed", "repo", data.Repo, "branch", data.Branch, "error", err)
-		http.Error(w, "internal error", http.StatusInternalServerError)
+		slog.Warn("could not fetch ci config, proceeding with enqueue", "repo", data.Repo, "branch", data.Branch, "error", err)
+		cfg = nil
+	}
+	if cfg != nil && !cfg.MatchesProposal(data.BaseBranch) {
+		slog.Info("proposal trigger filtered by on: block", "repo", data.Repo, "branch", data.Branch, "base_branch", data.BaseBranch)
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 
-	slog.Info("ci job queued", "id", job.ID, "repo", data.Repo, "branch", data.Branch, "sequence", data.Sequence)
+	job, err := s.store.InsertCIJob(r.Context(), data.Repo, data.Branch, sequence, "proposal", data.Branch, data.ProposalID)
+	if err != nil {
+		slog.Error("insert proposal ci job failed", "repo", data.Repo, "branch", data.Branch, "proposal_id", data.ProposalID, "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	slog.Info("ci job queued (proposal)", "id", job.ID, "repo", data.Repo, "branch", data.Branch, "proposal_id", data.ProposalID)
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -273,7 +412,7 @@ func (s *scheduler) handleRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	job, err := s.store.InsertCIJob(r.Context(), req.Repo, req.Branch, req.HeadSequence, "manual", req.Branch)
+	job, err := s.store.InsertCIJob(r.Context(), req.Repo, req.Branch, req.HeadSequence, "manual", req.Branch, "")
 	if err != nil {
 		slog.Error("insert ci job failed", "repo", req.Repo, "branch", req.Branch, "error", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)

--- a/cmd/ci-scheduler/main_test.go
+++ b/cmd/ci-scheduler/main_test.go
@@ -28,7 +28,7 @@ type stubStore struct {
 	reapErr      error
 }
 
-func (s *stubStore) InsertCIJob(_ context.Context, repo, branch string, sequence int64, triggerType, triggerBranch string) (*model.CIJob, error) {
+func (s *stubStore) InsertCIJob(_ context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerProposalID string) (*model.CIJob, error) {
 	j := &model.CIJob{
 		ID:            "test-uuid",
 		Repo:          repo,
@@ -37,6 +37,9 @@ func (s *stubStore) InsertCIJob(_ context.Context, repo, branch string, sequence
 		Status:        "queued",
 		TriggerType:   triggerType,
 		TriggerBranch: triggerBranch,
+	}
+	if triggerProposalID != "" {
+		j.TriggerProposalID = &triggerProposalID
 	}
 	s.insertedJobs = append(s.insertedJobs, j)
 	return j, nil
@@ -58,6 +61,24 @@ func signBody(body []byte, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write(body)
 	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func proposalOpenedEvent(repo, branch, baseBranch, proposalID string) []byte {
+	type data struct {
+		Repo       string `json:"repo"`
+		Branch     string `json:"branch"`
+		BaseBranch string `json:"base_branch"`
+		ProposalID string `json:"proposal_id"`
+	}
+	type env struct {
+		Type string `json:"type"`
+		Data data   `json:"data"`
+	}
+	b, _ := json.Marshal(env{
+		Type: "com.docstore.proposal.opened",
+		Data: data{Repo: repo, Branch: branch, BaseBranch: baseBranch, ProposalID: proposalID},
+	})
+	return b
 }
 
 func commitCreatedEvent(repo, branch string, sequence int64) []byte {
@@ -553,5 +574,194 @@ func TestHandleWebhook_NoCIYAML_AlwaysEnqueues(t *testing.T) {
 	}
 	if len(stub.insertedJobs) != 1 {
 		t.Fatalf("expected 1 inserted job (no ci.yaml = always run), got %d", len(stub.insertedJobs))
+	}
+}
+
+// newDocstoreServer builds a test server that handles both the ci.yaml file
+// endpoint and the proposals endpoint. ciYAML may be empty for no config.
+// proposals is a list of JSON-encodable proposal objects returned for ?state=open.
+func newDocstoreServer(t *testing.T, ciYAML string, branches []map[string]any, proposals []map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/-/file/.docstore/ci.yaml"):
+			if ciYAML == "" {
+				http.NotFound(w, r)
+				return
+			}
+			type fileResp struct {
+				Path    string `json:"path"`
+				Content []byte `json:"content"`
+			}
+			json.NewEncoder(w).Encode(fileResp{Path: ".docstore/ci.yaml", Content: []byte(ciYAML)}) //nolint:errcheck
+		case strings.Contains(r.URL.Path, "/-/branches"):
+			json.NewEncoder(w).Encode(branches) //nolint:errcheck
+		case strings.Contains(r.URL.Path, "/-/proposals"):
+			json.NewEncoder(w).Encode(proposals) //nolint:errcheck
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// ---------------------------------------------------------------------------
+// Tests: proposal.opened event handling
+// ---------------------------------------------------------------------------
+
+func TestHandleWebhook_ProposalOpened_EnqueuesJob(t *testing.T) {
+	branches := []map[string]any{
+		{"name": "feature/foo", "head_sequence": int64(10)},
+	}
+	srv := newDocstoreServer(t, "", branches, nil)
+	defer srv.Close()
+
+	stub := &stubStore{}
+	sched := &scheduler{
+		store:       stub,
+		docstoreURL: srv.URL,
+		httpClient:  &http.Client{},
+	}
+
+	body := proposalOpenedEvent("myrepo", "feature/foo", "main", "proposal-uuid-1")
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	sched.handleWebhook(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(stub.insertedJobs) != 1 {
+		t.Fatalf("expected 1 inserted job, got %d", len(stub.insertedJobs))
+	}
+	j := stub.insertedJobs[0]
+	if j.TriggerType != "proposal" {
+		t.Errorf("TriggerType = %q, want %q", j.TriggerType, "proposal")
+	}
+	if j.TriggerProposalID == nil || *j.TriggerProposalID != "proposal-uuid-1" {
+		t.Errorf("TriggerProposalID = %v, want %q", j.TriggerProposalID, "proposal-uuid-1")
+	}
+}
+
+func TestHandleWebhook_ProposalOpened_FilteredByOnBlock(t *testing.T) {
+	ciYAML := "on:\n  proposal:\n    base_branches:\n      - release/*\n"
+	branches := []map[string]any{
+		{"name": "feature/foo", "head_sequence": int64(10)},
+	}
+	srv := newDocstoreServer(t, ciYAML, branches, nil)
+	defer srv.Close()
+
+	stub := &stubStore{}
+	sched := &scheduler{
+		store:       stub,
+		docstoreURL: srv.URL,
+		httpClient:  &http.Client{},
+	}
+
+	// base_branch is "main" — does not match "release/*", so should be filtered.
+	body := proposalOpenedEvent("myrepo", "feature/foo", "main", "proposal-uuid-2")
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	sched.handleWebhook(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if len(stub.insertedJobs) != 0 {
+		t.Fatalf("expected 0 jobs (filtered), got %d", len(stub.insertedJobs))
+	}
+}
+
+func TestHandleWebhook_ProposalOpened_MissingRepo_Returns400(t *testing.T) {
+	stub := &stubStore{}
+	sched := &scheduler{store: stub, webhookSecret: ""}
+
+	body, _ := json.Marshal(map[string]any{
+		"type": "com.docstore.proposal.opened",
+		"data": map[string]any{"branch": "feature/foo", "base_branch": "main"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	sched.handleWebhook(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: commit.created with open proposal enqueues proposal_synchronized job
+// ---------------------------------------------------------------------------
+
+func TestHandleWebhook_CommitCreated_WithOpenProposal_EnqueuesBothJobs(t *testing.T) {
+	proposals := []map[string]any{
+		{"id": "prop-1", "repo": "myrepo", "branch": "feature/foo", "base_branch": "main", "state": "open"},
+	}
+	branches := []map[string]any{
+		{"name": "feature/foo", "head_sequence": int64(5)},
+	}
+	srv := newDocstoreServer(t, "", branches, proposals)
+	defer srv.Close()
+
+	stub := &stubStore{}
+	sched := &scheduler{
+		store:       stub,
+		docstoreURL: srv.URL,
+		httpClient:  &http.Client{},
+	}
+
+	body := commitCreatedEvent("myrepo", "feature/foo", 5)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	sched.handleWebhook(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(stub.insertedJobs) != 2 {
+		t.Fatalf("expected 2 inserted jobs (push + proposal_synchronized), got %d", len(stub.insertedJobs))
+	}
+	types := map[string]bool{}
+	for _, j := range stub.insertedJobs {
+		types[j.TriggerType] = true
+	}
+	if !types["push"] {
+		t.Error("expected push job")
+	}
+	if !types["proposal_synchronized"] {
+		t.Error("expected proposal_synchronized job")
+	}
+}
+
+func TestHandleWebhook_CommitCreated_NoOpenProposal_EnqueuesOnlyPush(t *testing.T) {
+	// Proposals endpoint returns empty array.
+	srv := newDocstoreServer(t, "", nil, []map[string]any{})
+	defer srv.Close()
+
+	stub := &stubStore{}
+	sched := &scheduler{
+		store:       stub,
+		docstoreURL: srv.URL,
+		httpClient:  &http.Client{},
+	}
+
+	body := commitCreatedEvent("myrepo", "feature/foo", 5)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	sched.handleWebhook(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if len(stub.insertedJobs) != 1 {
+		t.Fatalf("expected 1 inserted job (push only), got %d", len(stub.insertedJobs))
+	}
+	if stub.insertedJobs[0].TriggerType != "push" {
+		t.Errorf("TriggerType = %q, want push", stub.insertedJobs[0].TriggerType)
 	}
 }

--- a/internal/ciconfig/ciconfig.go
+++ b/internal/ciconfig/ciconfig.go
@@ -14,13 +14,21 @@ type CIConfig struct {
 
 // TriggerConfig holds the trigger definitions for a CI config.
 type TriggerConfig struct {
-	Push *PushTrigger `yaml:"push"`
+	Push     *PushTrigger     `yaml:"push"`
+	Proposal *ProposalTrigger `yaml:"proposal"`
 }
 
 // PushTrigger configures which branches a push event triggers CI for.
 type PushTrigger struct {
 	// Branches is a list of glob patterns. A nil or empty list means all branches.
 	Branches []string `yaml:"branches"`
+}
+
+// ProposalTrigger configures which proposals trigger CI runs.
+type ProposalTrigger struct {
+	// BaseBranches is a list of glob patterns for target base branches.
+	// A nil or empty list means all base branches.
+	BaseBranches []string `yaml:"base_branches"`
 }
 
 // MatchesPush reports whether a commit to branch should trigger a push-based CI run.
@@ -50,6 +58,39 @@ func (cfg *CIConfig) MatchesPush(branch string) bool {
 			continue
 		}
 		if g.Match(branch) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchesProposal reports whether a proposal targeting baseBranch should trigger a CI run.
+//
+// Rules:
+//   - No on: block (cfg.On == nil)             → always match (backward compat)
+//   - on: exists, no proposal: key             → never match
+//   - on: proposal: with no base_branches list → always match (all base branches)
+//   - on: proposal: base_branches: [pat, ...]  → match if baseBranch matches any pattern
+//
+// Patterns are evaluated using gobwas/glob which supports **, *, ? and
+// character classes.
+func (cfg *CIConfig) MatchesProposal(baseBranch string) bool {
+	if cfg.On == nil {
+		return true
+	}
+	if cfg.On.Proposal == nil {
+		return false
+	}
+	if len(cfg.On.Proposal.BaseBranches) == 0 {
+		return true
+	}
+	for _, pattern := range cfg.On.Proposal.BaseBranches {
+		g, err := glob.Compile(pattern)
+		if err != nil {
+			// Skip invalid patterns rather than treating them as a match.
+			continue
+		}
+		if g.Match(baseBranch) {
 			return true
 		}
 	}

--- a/internal/ciconfig/ciconfig_test.go
+++ b/internal/ciconfig/ciconfig_test.go
@@ -110,3 +110,96 @@ func TestMatchesPush(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchesProposal(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        CIConfig
+		baseBranch string
+		want       bool
+	}{
+		{
+			name:       "no on block always matches",
+			cfg:        CIConfig{On: nil},
+			baseBranch: "main",
+			want:       true,
+		},
+		{
+			name: "on with no proposal never matches",
+			cfg: CIConfig{
+				On: &TriggerConfig{Push: &PushTrigger{}},
+			},
+			baseBranch: "main",
+			want:       false,
+		},
+		{
+			name: "on proposal no base_branches matches all",
+			cfg: CIConfig{
+				On: &TriggerConfig{
+					Proposal: &ProposalTrigger{BaseBranches: nil},
+				},
+			},
+			baseBranch: "main",
+			want:       true,
+		},
+		{
+			name: "on proposal empty base_branches matches all",
+			cfg: CIConfig{
+				On: &TriggerConfig{
+					Proposal: &ProposalTrigger{BaseBranches: []string{}},
+				},
+			},
+			baseBranch: "develop",
+			want:       true,
+		},
+		{
+			name: "on proposal base_branches main matches main",
+			cfg: CIConfig{
+				On: &TriggerConfig{
+					Proposal: &ProposalTrigger{BaseBranches: []string{"main"}},
+				},
+			},
+			baseBranch: "main",
+			want:       true,
+		},
+		{
+			name: "on proposal base_branches main does not match develop",
+			cfg: CIConfig{
+				On: &TriggerConfig{
+					Proposal: &ProposalTrigger{BaseBranches: []string{"main"}},
+				},
+			},
+			baseBranch: "develop",
+			want:       false,
+		},
+		{
+			name: "wildcard release/* matches release/1.0",
+			cfg: CIConfig{
+				On: &TriggerConfig{
+					Proposal: &ProposalTrigger{BaseBranches: []string{"main", "release/*"}},
+				},
+			},
+			baseBranch: "release/1.0",
+			want:       true,
+		},
+		{
+			name: "wildcard release/* does not match feature/foo",
+			cfg: CIConfig{
+				On: &TriggerConfig{
+					Proposal: &ProposalTrigger{BaseBranches: []string{"main", "release/*"}},
+				},
+			},
+			baseBranch: "feature/foo",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.MatchesProposal(tt.baseBranch)
+			if got != tt.want {
+				t.Errorf("MatchesProposal(%q) = %v, want %v", tt.baseBranch, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/db/ci_jobs.go
+++ b/internal/db/ci_jobs.go
@@ -10,7 +10,7 @@ import (
 
 // ciJobColumns is the ordered list of columns returned by SELECT * on ci_jobs.
 const ciJobColumns = `id, repo, branch, sequence, status, claimed_at, last_heartbeat_at,
-	worker_pod, worker_pod_ip, log_url, error_message, created_at, trigger_type, trigger_branch`
+	worker_pod, worker_pod_ip, log_url, error_message, created_at, trigger_type, trigger_branch, trigger_proposal_id`
 
 // scanCIJob scans a single ci_jobs row into a model.CIJob.
 func scanCIJob(row interface {
@@ -25,11 +25,12 @@ func scanCIJob(row interface {
 	var errorMessage sql.NullString
 	var triggerType sql.NullString
 	var triggerBranch sql.NullString
+	var triggerProposalID sql.NullString
 	if err := row.Scan(
 		&j.ID, &j.Repo, &j.Branch, &j.Sequence, &j.Status,
 		&claimedAt, &lastHeartbeatAt, &workerPod, &workerPodIP,
 		&logURL, &errorMessage, &j.CreatedAt,
-		&triggerType, &triggerBranch,
+		&triggerType, &triggerBranch, &triggerProposalID,
 	); err != nil {
 		return nil, err
 	}
@@ -57,17 +58,25 @@ func scanCIJob(row interface {
 	if triggerBranch.Valid {
 		j.TriggerBranch = triggerBranch.String
 	}
+	if triggerProposalID.Valid {
+		j.TriggerProposalID = &triggerProposalID.String
+	}
 	return &j, nil
 }
 
 // InsertCIJob inserts a new ci_job row with status 'queued' and returns it.
-// triggerType identifies how the job was triggered (e.g. "push", "manual").
+// triggerType identifies how the job was triggered (e.g. "push", "manual", "proposal").
 // triggerBranch is the branch that caused the trigger (may be empty for some trigger types).
-func (s *Store) InsertCIJob(ctx context.Context, repo, branch string, sequence int64, triggerType, triggerBranch string) (*model.CIJob, error) {
+// triggerProposalID is the proposal ID for proposal-triggered jobs (empty string for others).
+func (s *Store) InsertCIJob(ctx context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerProposalID string) (*model.CIJob, error) {
+	var proposalID interface{}
+	if triggerProposalID != "" {
+		proposalID = triggerProposalID
+	}
 	row := s.db.QueryRowContext(ctx,
-		`INSERT INTO ci_jobs (repo, branch, sequence, trigger_type, trigger_branch)
-		 VALUES ($1, $2, $3, $4, $5) RETURNING `+ciJobColumns,
-		repo, branch, sequence, triggerType, triggerBranch,
+		`INSERT INTO ci_jobs (repo, branch, sequence, trigger_type, trigger_branch, trigger_proposal_id)
+		 VALUES ($1, $2, $3, $4, $5, $6) RETURNING `+ciJobColumns,
+		repo, branch, sequence, triggerType, triggerBranch, proposalID,
 	)
 	j, err := scanCIJob(row)
 	if err != nil {

--- a/internal/db/migrations/000011_ci_jobs_proposal.down.sql
+++ b/internal/db/migrations/000011_ci_jobs_proposal.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ci_jobs DROP COLUMN IF EXISTS trigger_proposal_id;

--- a/internal/db/migrations/000011_ci_jobs_proposal.up.sql
+++ b/internal/db/migrations/000011_ci_jobs_proposal.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ci_jobs ADD COLUMN IF NOT EXISTS trigger_proposal_id TEXT;

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2315,13 +2315,18 @@ func (s *Store) GetProposal(ctx context.Context, repo, proposalID string) (*mode
 
 // ListProposals returns proposals for a repo ordered by created_at DESC.
 // If state is non-nil, only proposals with that state are returned.
-func (s *Store) ListProposals(ctx context.Context, repo string, state *model.ProposalState) ([]*model.Proposal, error) {
+// If branch is non-nil, only proposals for that branch are returned.
+func (s *Store) ListProposals(ctx context.Context, repo string, state *model.ProposalState, branch *string) ([]*model.Proposal, error) {
 	q := `SELECT id::text, repo, branch, base_branch, title, description, author, state, created_at, updated_at
 	      FROM proposals WHERE repo = $1`
 	args := []interface{}{repo}
 	if state != nil {
-		q += " AND state = $2"
 		args = append(args, string(*state))
+		q += fmt.Sprintf(" AND state = $%d", len(args))
+	}
+	if branch != nil {
+		args = append(args, *branch)
+		q += fmt.Sprintf(" AND branch = $%d", len(args))
 	}
 	q += " ORDER BY created_at DESC"
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -108,8 +108,9 @@ type CIJob struct {
 	LogURL          *string    `json:"log_url,omitempty"`
 	ErrorMessage    *string    `json:"error_message,omitempty"`
 	CreatedAt       time.Time  `json:"created_at"`
-	TriggerType     string     `json:"trigger_type,omitempty"`
-	TriggerBranch   string     `json:"trigger_branch,omitempty"`
+	TriggerType       string  `json:"trigger_type,omitempty"`
+	TriggerBranch     string  `json:"trigger_branch,omitempty"`
+	TriggerProposalID *string `json:"trigger_proposal_id,omitempty"`
 }
 
 // FileCommit is the core event log. One row per file change.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1714,7 +1714,12 @@ func (s *server) handleListProposals(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	proposals, err := s.commitStore.ListProposals(r.Context(), repo, state)
+	var branch *string
+	if bv := r.URL.Query().Get("branch"); bv != "" {
+		branch = &bv
+	}
+
+	proposals, err := s.commitStore.ListProposals(r.Context(), repo, state, branch)
 	if err != nil {
 		slog.Error("internal error", "op", "list_proposals", "repo", repo, "error", err)
 		writeError(w, http.StatusInternalServerError, "internal server error")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -114,7 +114,7 @@ type WriteStore interface {
 	// Proposal management
 	CreateProposal(ctx context.Context, repo, branch, baseBranch, title, description, author string) (*model.Proposal, error)
 	GetProposal(ctx context.Context, repo, proposalID string) (*model.Proposal, error)
-	ListProposals(ctx context.Context, repo string, state *model.ProposalState) ([]*model.Proposal, error)
+	ListProposals(ctx context.Context, repo string, state *model.ProposalState, branch *string) ([]*model.Proposal, error)
 	UpdateProposal(ctx context.Context, repo, proposalID string, title, description *string) (*model.Proposal, error)
 	CloseProposal(ctx context.Context, repo, proposalID string) error
 	MergeProposal(ctx context.Context, repo, branch string) (*model.Proposal, error)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -374,7 +374,7 @@ func (m *mockStore) GetProposal(_ context.Context, _, _ string) (*model.Proposal
 	return nil, db.ErrProposalNotFound
 }
 
-func (m *mockStore) ListProposals(_ context.Context, _ string, _ *model.ProposalState) ([]*model.Proposal, error) {
+func (m *mockStore) ListProposals(_ context.Context, _ string, _ *model.ProposalState, _ *string) ([]*model.Proposal, error) {
 	return []*model.Proposal{}, nil
 }
 


### PR DESCRIPTION
## Summary

Implements Stage 4 CI proposal trigger per issue #179. Stages 1 (proposals DB + API + events) and 2 (CI DSL `on:` block with push trigger) are already merged.

- **Migration 000011**: adds `trigger_proposal_id TEXT` column to `ci_jobs`
- **`model.CIJob`**: adds `TriggerProposalID *string` field
- **`db/ci_jobs`**: `InsertCIJob` accepts new `triggerProposalID string` param; `scanCIJob` reads the new column
- **`ciconfig`**: adds `ProposalTrigger` type and `CIConfig.MatchesProposal(baseBranch)` method mirroring `MatchesPush`
- **`ciconfig_test`**: adds `TestMatchesProposal` covering all rule cases (no `on:`, no `proposal:`, empty `base_branches`, exact match, glob, glob no-match)
- **`db/store.ListProposals`**: accepts optional `branch *string` filter (adds `AND branch = $N` when set)
- **`server.WriteStore` interface + `handleListProposals`**: exposes `?branch=` query param, passes filter through to DB
- **`server_test` mock**: updated signature
- **`ci-scheduler/main.go`**:
  - `ciJobStore.InsertCIJob` interface updated with `triggerProposalID`
  - `registerWebhookSubscription` now subscribes to both `com.docstore.commit.created` and `com.docstore.proposal.opened`
  - New `handleProposalOpened`: fetches branch head sequence via `GET /-/branches`, evaluates `MatchesProposal`, enqueues `trigger_type='proposal'` job
  - Extended `handleCommitCreated`: after push check, calls `fetchOpenProposalForBranch` (`GET /-/proposals?state=open&branch=…`); if open proposal found and `MatchesProposal` passes, enqueues second `trigger_type='proposal_synchronized'` job
- **`ci-scheduler/main_test.go`**: updated stub, added `proposalOpenedEvent` helper and 5 new tests covering proposal.opened happy path, on-block filtering, missing repo validation, commit+proposal dual-enqueue, and commit with no open proposal

All tests pass (`go test ./... -skip TestDockerSmoke`). `TestDockerSmoke` is a pre-existing failure due to missing gcloud auth in this environment — not caused by this change.

## Notable opportunities (not implemented)

- The `fetchBranchHead` fetches all branches and filters client-side. A dedicated single-branch endpoint would be more efficient.
- The webhook subscription registration creates a single subscription for both event types; if the subscription already exists for only `commit.created`, it will not be updated. Future work could check and update existing subscriptions.

Closes #179