### PR TITLE
fix(ci-scheduler): add Sequence to ProposalOpened, remove fetchBranchHead

### DIFF
--- a/cmd/ci-scheduler/main.go
+++ b/cmd/ci-scheduler/main.go
@@ -183,39 +183,6 @@ func (s *scheduler) fetchCIConfig(ctx context.Context, repo, branch string, sequ
 	return &cfg, nil
 }
 
-// fetchBranchHead fetches the current head sequence for a branch using the branches list API.
-func (s *scheduler) fetchBranchHead(ctx context.Context, repo, branch string) (int64, error) {
-	if s.docstoreURL == "" {
-		return 0, fmt.Errorf("docstore URL not configured")
-	}
-	branchesURL := fmt.Sprintf("%s/repos/%s/-/branches", s.docstoreURL, repo)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, branchesURL, nil)
-	if err != nil {
-		return 0, fmt.Errorf("build branches request: %w", err)
-	}
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		return 0, fmt.Errorf("fetch branches: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("fetch branches: unexpected status %d", resp.StatusCode)
-	}
-	var branches []struct {
-		Name         string `json:"name"`
-		HeadSequence int64  `json:"head_sequence"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&branches); err != nil {
-		return 0, fmt.Errorf("decode branches response: %w", err)
-	}
-	for _, b := range branches {
-		if b.Name == branch {
-			return b.HeadSequence, nil
-		}
-	}
-	return 0, fmt.Errorf("branch not found: %s", branch)
-}
-
 // fetchOpenProposalForBranch returns the open proposal for a branch, or nil if none exists.
 func (s *scheduler) fetchOpenProposalForBranch(ctx context.Context, repo, branch string) (*model.Proposal, error) {
 	if s.docstoreURL == "" {
@@ -354,6 +321,7 @@ func (s *scheduler) handleProposalOpened(w http.ResponseWriter, r *http.Request,
 		BaseBranch string `json:"base_branch"`
 		ProposalID string `json:"proposal_id"`
 		Author     string `json:"author"`
+		Sequence   int64  `json:"sequence"`
 	}
 	if err := json.Unmarshal(raw, &data); err != nil {
 		http.Error(w, "invalid event data", http.StatusBadRequest)
@@ -364,13 +332,7 @@ func (s *scheduler) handleProposalOpened(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	// Fetch the current head sequence for the branch.
-	sequence, err := s.fetchBranchHead(r.Context(), data.Repo, data.Branch)
-	if err != nil {
-		slog.Warn("could not fetch branch head, skipping proposal trigger", "repo", data.Repo, "branch", data.Branch, "error", err)
-		w.WriteHeader(http.StatusOK)
-		return
-	}
+	sequence := data.Sequence
 
 	// Fetch CI config and evaluate proposal trigger filter.
 	cfg, err := s.fetchCIConfig(r.Context(), data.Repo, data.Branch, sequence)

--- a/internal/events/types/proposal.go
+++ b/internal/events/types/proposal.go
@@ -7,6 +7,7 @@ type ProposalOpened struct {
 	BaseBranch string `json:"base_branch"`
 	ProposalID string `json:"proposal_id"`
 	Author     string `json:"author"`
+	Sequence   int64  `json:"sequence"`
 }
 
 func (e ProposalOpened) Type() string   { return "com.docstore.proposal.opened" }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1684,12 +1684,19 @@ func (s *server) handleCreateProposal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var headSeq int64
+	if bi, err := s.readStore.GetBranch(r.Context(), repo, req.Branch); err == nil {
+		headSeq = bi.HeadSequence
+	} else {
+		slog.Warn("could not fetch branch head for proposal event", "repo", repo, "branch", req.Branch, "error", err)
+	}
 	s.emit(r.Context(), evtypes.ProposalOpened{
 		Repo:       repo,
 		Branch:     req.Branch,
 		BaseBranch: baseBranch,
 		ProposalID: p.ID,
 		Author:     author,
+		Sequence:   headSeq,
 	})
 	slog.Info("proposal opened", "repo", repo, "branch", req.Branch, "proposal_id", p.ID, "author", author)
 	writeJSON(w, http.StatusCreated, model.CreateProposalResponse{ID: p.ID})


### PR DESCRIPTION
## Summary

- Add `Sequence int64` to `ProposalOpened` event type so ci-scheduler gets the branch head sequence directly from the event payload
- Populate `Sequence` in `handleCreateProposal` by calling `readStore.GetBranch` after successful proposal creation
- In `handleProposalOpened` (ci-scheduler): read `sequence` from `data.Sequence` instead of calling `fetchBranchHead`; remove `fetchBranchHead` entirely

## Fix 2 (/-/ consistency)

After investigation, the scheduler's `/-/proposals` URL is **already correct**:
- `handleReposPrefix` routes all sub-endpoints (including `proposals`) using the `/-/` separator
- The CLI's `repoBase()` returns `.../-` making its proposals URL `.../-/proposals`
- No change needed; added a comment in the commit message documenting this

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./cmd/ci-scheduler/... -count=1` passes
- [x] `go test ./internal/events/... -count=1` passes

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)