### PR TITLE
feat: Stage 5 — job-level if: conditions for CI checks

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/lib/pq"
 	"gopkg.in/yaml.v3"
 
+	"github.com/dlorenc/docstore/internal/ciconfig"
 	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/executor"
 	"github.com/dlorenc/docstore/internal/logstore"
@@ -263,6 +264,7 @@ func runJob(
 	docstoreURL string,
 	job *model.CIJob,
 	logDir string,
+	triggerCtx ciconfig.TriggerContext,
 ) (status string, logURL *string, errMsg *string) {
 	fail := func(msg string) (string, *string, *string) {
 		slog.Error("job failed", "job_id", job.ID, "reason", msg)
@@ -308,7 +310,7 @@ func runJob(
 	}
 
 	// 4. Execute all checks.
-	results, err := exec.Run(ctx, srcDir, *cfg)
+	results, err := exec.Run(ctx, srcDir, *cfg, triggerCtx)
 	if err != nil {
 		return fail(fmt.Sprintf("executor: %v", err))
 	}
@@ -471,8 +473,17 @@ func main() {
 		defer os.RemoveAll(logDir)
 		logSrv.setDir(logDir)
 
+		// Build trigger context from claimed job.
+		triggerCtx := ciconfig.TriggerContext{
+			Type:   job.TriggerType,
+			Branch: job.TriggerBranch,
+		}
+		if job.TriggerProposalID != nil {
+			triggerCtx.ProposalID = *job.TriggerProposalID
+		}
+
 		// Execute the job.
-		jobStatus, jobLogURL, jobErrMsg := runJob(ctx, httpClient, exec, ls, docstoreURL, job, logDir)
+		jobStatus, jobLogURL, jobErrMsg := runJob(ctx, httpClient, exec, ls, docstoreURL, job, logDir, triggerCtx)
 
 		// Stop heartbeat and clear log dir.
 		close(hbDone)

--- a/internal/ciconfig/context.go
+++ b/internal/ciconfig/context.go
@@ -1,0 +1,10 @@
+package ciconfig
+
+// TriggerContext holds runtime information about what triggered a CI run.
+// It is used to evaluate job-level if: expressions.
+type TriggerContext struct {
+	Type       string // "push", "proposal", "proposal_synchronized", "manual", "schedule"
+	Branch     string // branch being tested
+	BaseBranch string // base branch (proposals only; empty for push/manual)
+	ProposalID string // proposal ID (proposals only; empty otherwise)
+}

--- a/internal/ciconfig/expr.go
+++ b/internal/ciconfig/expr.go
@@ -1,0 +1,237 @@
+package ciconfig
+
+import (
+	"fmt"
+	"strings"
+)
+
+// EvalIf evaluates an if: expression string against the given TriggerContext.
+//
+// Supported syntax:
+//   - String literals: "value" or 'value'
+//   - Context field access: event.type, event.branch, event.base_branch, event.proposal_id
+//   - Equality:   event.type == "push"
+//   - Inequality: event.type != "push"
+//   - Logical AND: expr && expr
+//   - Logical OR:  expr || expr
+//   - Parentheses for grouping
+//
+// Empty expr returns true (no condition = always run).
+// Unknown field references return an error (treated as false with a warning by the caller).
+// Malformed expressions return an error.
+func EvalIf(expr string, ctx TriggerContext) (bool, error) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return true, nil
+	}
+	p := &parser{input: expr, pos: 0, ctx: ctx}
+	result, err := p.parseOr()
+	if err != nil {
+		return false, err
+	}
+	p.skipWS()
+	if p.pos != len(p.input) {
+		return false, fmt.Errorf("unexpected trailing input at position %d: %q", p.pos, p.input[p.pos:])
+	}
+	return result, nil
+}
+
+// parser holds the parsing state.
+type parser struct {
+	input string
+	pos   int
+	ctx   TriggerContext
+}
+
+func (p *parser) skipWS() {
+	for p.pos < len(p.input) && (p.input[p.pos] == ' ' || p.input[p.pos] == '\t') {
+		p.pos++
+	}
+}
+
+func (p *parser) peek(s string) bool {
+	return strings.HasPrefix(p.input[p.pos:], s)
+}
+
+// consume advances past s if it is next in input. Returns true if consumed.
+func (p *parser) consume(s string) bool {
+	if strings.HasPrefix(p.input[p.pos:], s) {
+		p.pos += len(s)
+		return true
+	}
+	return false
+}
+
+// parseOr handles expr || expr (lowest precedence).
+func (p *parser) parseOr() (bool, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return false, err
+	}
+	for {
+		p.skipWS()
+		if !p.consume("||") {
+			break
+		}
+		right, err := p.parseAnd()
+		if err != nil {
+			return false, err
+		}
+		left = left || right
+	}
+	return left, nil
+}
+
+// parseAnd handles expr && expr.
+func (p *parser) parseAnd() (bool, error) {
+	left, err := p.parseComparison()
+	if err != nil {
+		return false, err
+	}
+	for {
+		p.skipWS()
+		if !p.consume("&&") {
+			break
+		}
+		right, err := p.parseComparison()
+		if err != nil {
+			return false, err
+		}
+		left = left && right
+	}
+	return left, nil
+}
+
+// parseComparison handles value == value, value != value, or parenthesized expr.
+func (p *parser) parseComparison() (bool, error) {
+	p.skipWS()
+
+	// Parenthesized sub-expression.
+	if p.pos < len(p.input) && p.input[p.pos] == '(' {
+		p.pos++
+		result, err := p.parseOr()
+		if err != nil {
+			return false, err
+		}
+		p.skipWS()
+		if p.pos >= len(p.input) || p.input[p.pos] != ')' {
+			return false, fmt.Errorf("expected ')' at position %d", p.pos)
+		}
+		p.pos++
+		return result, nil
+	}
+
+	left, err := p.parseValue()
+	if err != nil {
+		return false, err
+	}
+
+	p.skipWS()
+
+	var op string
+	switch {
+	case p.consume("=="):
+		op = "=="
+	case p.consume("!="):
+		op = "!="
+	default:
+		// No operator — treat a bare boolean field as truthy if non-empty.
+		return left != "", nil
+	}
+
+	right, err := p.parseValue()
+	if err != nil {
+		return false, err
+	}
+
+	switch op {
+	case "==":
+		return left == right, nil
+	case "!=":
+		return left != right, nil
+	default:
+		return false, fmt.Errorf("unknown operator %q", op)
+	}
+}
+
+// parseValue parses a string literal (single or double quoted) or a field reference.
+// Returns the string value of the token.
+func (p *parser) parseValue() (string, error) {
+	p.skipWS()
+	if p.pos >= len(p.input) {
+		return "", fmt.Errorf("unexpected end of expression at position %d", p.pos)
+	}
+
+	ch := p.input[p.pos]
+
+	// Double-quoted string literal.
+	if ch == '"' {
+		return p.parseStringLiteral('"')
+	}
+
+	// Single-quoted string literal.
+	if ch == '\'' {
+		return p.parseStringLiteral('\'')
+	}
+
+	// Field reference: must start with a letter or underscore.
+	if isIdentStart(ch) {
+		return p.parseFieldRef()
+	}
+
+	return "", fmt.Errorf("unexpected character %q at position %d", ch, p.pos)
+}
+
+func (p *parser) parseStringLiteral(quote byte) (string, error) {
+	p.pos++ // skip opening quote
+	start := p.pos
+	for p.pos < len(p.input) && p.input[p.pos] != quote {
+		p.pos++
+	}
+	if p.pos >= len(p.input) {
+		return "", fmt.Errorf("unterminated string literal starting at position %d", start-1)
+	}
+	val := p.input[start:p.pos]
+	p.pos++ // skip closing quote
+	return val, nil
+}
+
+// parseFieldRef parses a dotted identifier like event.type and resolves it
+// against the TriggerContext.
+func (p *parser) parseFieldRef() (string, error) {
+	start := p.pos
+	for p.pos < len(p.input) && isIdentChar(p.input[p.pos]) {
+		p.pos++
+	}
+	field := p.input[start:p.pos]
+
+	val, err := p.resolveField(field)
+	if err != nil {
+		return "", err
+	}
+	return val, nil
+}
+
+// resolveField maps a dotted field name to a value from TriggerContext.
+func (p *parser) resolveField(field string) (string, error) {
+	switch field {
+	case "event.type":
+		return p.ctx.Type, nil
+	case "event.branch":
+		return p.ctx.Branch, nil
+	case "event.base_branch":
+		return p.ctx.BaseBranch, nil
+	case "event.proposal_id":
+		return p.ctx.ProposalID, nil
+	default:
+		return "", fmt.Errorf("unknown field reference %q", field)
+	}
+}
+
+func isIdentStart(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
+}
+
+func isIdentChar(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9') || c == '.'
+}

--- a/internal/ciconfig/expr_test.go
+++ b/internal/ciconfig/expr_test.go
@@ -1,0 +1,241 @@
+package ciconfig
+
+import "testing"
+
+func TestEvalIf(t *testing.T) {
+	pushCtx := TriggerContext{
+		Type:   "push",
+		Branch: "main",
+	}
+	proposalCtx := TriggerContext{
+		Type:       "proposal",
+		Branch:     "feature/foo",
+		BaseBranch: "main",
+		ProposalID: "42",
+	}
+
+	tests := []struct {
+		name    string
+		expr    string
+		ctx     TriggerContext
+		want    bool
+		wantErr bool
+	}{
+		// Empty expression — always true.
+		{
+			name: "empty expr always true",
+			expr: "",
+			ctx:  pushCtx,
+			want: true,
+		},
+		{
+			name: "whitespace only always true",
+			expr: "   ",
+			ctx:  pushCtx,
+			want: true,
+		},
+
+		// Equality on event.type.
+		{
+			name: "event.type == push with push context",
+			expr: `event.type == "push"`,
+			ctx:  pushCtx,
+			want: true,
+		},
+		{
+			name: "event.type == push with proposal context",
+			expr: `event.type == "push"`,
+			ctx:  proposalCtx,
+			want: false,
+		},
+		{
+			name: "event.type == proposal with proposal context",
+			expr: `event.type == "proposal"`,
+			ctx:  proposalCtx,
+			want: true,
+		},
+
+		// Single-quoted string literals.
+		{
+			name: "single-quoted literal push",
+			expr: "event.type == 'push'",
+			ctx:  pushCtx,
+			want: true,
+		},
+		{
+			name: "single-quoted literal mismatch",
+			expr: "event.type == 'proposal'",
+			ctx:  pushCtx,
+			want: false,
+		},
+
+		// Inequality.
+		{
+			name: "event.type != push with push context",
+			expr: `event.type != "push"`,
+			ctx:  pushCtx,
+			want: false,
+		},
+		{
+			name: "event.type != push with proposal context",
+			expr: `event.type != "push"`,
+			ctx:  proposalCtx,
+			want: true,
+		},
+
+		// event.branch matching.
+		{
+			name: "event.branch == main matches main",
+			expr: `event.branch == "main"`,
+			ctx:  pushCtx,
+			want: true,
+		},
+		{
+			name: "event.branch == main does not match feature branch",
+			expr: `event.branch == "main"`,
+			ctx:  proposalCtx,
+			want: false,
+		},
+
+		// event.base_branch.
+		{
+			name: "event.base_branch == main with proposal context",
+			expr: `event.base_branch == "main"`,
+			ctx:  proposalCtx,
+			want: true,
+		},
+		{
+			name: "event.base_branch == main with push context (empty)",
+			expr: `event.base_branch == "main"`,
+			ctx:  pushCtx,
+			want: false,
+		},
+
+		// event.proposal_id.
+		{
+			name: "event.proposal_id == 42 with proposal context",
+			expr: `event.proposal_id == "42"`,
+			ctx:  proposalCtx,
+			want: true,
+		},
+
+		// Logical AND.
+		{
+			name: "push AND main branch true",
+			expr: `event.type == "push" && event.branch == "main"`,
+			ctx:  pushCtx,
+			want: true,
+		},
+		{
+			name: "push AND feature branch false",
+			expr: `event.type == "push" && event.branch == "feature/foo"`,
+			ctx:  pushCtx,
+			want: false,
+		},
+		{
+			name: "proposal type AND main base AND proposal context",
+			expr: `event.type == "proposal" && event.base_branch == "main"`,
+			ctx:  proposalCtx,
+			want: true,
+		},
+
+		// Logical OR.
+		{
+			name: "proposal OR proposal_synchronized with proposal ctx",
+			expr: `event.type == "proposal" || event.type == "proposal_synchronized"`,
+			ctx:  proposalCtx,
+			want: true,
+		},
+		{
+			name: "proposal OR proposal_synchronized with push ctx",
+			expr: `event.type == "proposal" || event.type == "proposal_synchronized"`,
+			ctx:  pushCtx,
+			want: false,
+		},
+		{
+			name: "push OR proposal with push ctx",
+			expr: `event.type == "push" || event.type == "proposal"`,
+			ctx:  pushCtx,
+			want: true,
+		},
+
+		// Parenthesized expressions.
+		{
+			name: "parenthesized OR then AND",
+			expr: `(event.type == "proposal" || event.type == "push") && event.branch == "main"`,
+			ctx:  pushCtx,
+			want: true,
+		},
+		{
+			name: "parenthesized OR then AND false branch",
+			expr: `(event.type == "proposal" || event.type == "push") && event.branch == "main"`,
+			ctx:  proposalCtx,
+			want: false,
+		},
+		{
+			name: "nested parens",
+			expr: `(event.type == "push")`,
+			ctx:  pushCtx,
+			want: true,
+		},
+
+		// Real-world examples from the task description.
+		{
+			name: "task example push and main",
+			expr: "event.type == 'push' && event.branch == 'main'",
+			ctx:  pushCtx,
+			want: true,
+		},
+		{
+			name: "task example proposal types",
+			expr: "event.type == 'proposal' || event.type == 'proposal_synchronized'",
+			ctx:  proposalCtx,
+			want: true,
+		},
+
+		// Error cases.
+		{
+			name:    "unknown field",
+			expr:    `event.unknown == "x"`,
+			ctx:     pushCtx,
+			wantErr: true,
+		},
+		{
+			name:    "unterminated string",
+			expr:    `event.type == "push`,
+			ctx:     pushCtx,
+			wantErr: true,
+		},
+		{
+			name:    "trailing garbage",
+			expr:    `event.type == "push" extra`,
+			ctx:     pushCtx,
+			wantErr: true,
+		},
+		{
+			name:    "unmatched paren",
+			expr:    `(event.type == "push"`,
+			ctx:     pushCtx,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := EvalIf(tt.expr, tt.ctx)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("EvalIf(%q) = %v, nil error; want error", tt.expr, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("EvalIf(%q) unexpected error: %v", tt.expr, err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("EvalIf(%q) = %v, want %v", tt.expr, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"runtime"
 	"strings"
@@ -19,6 +20,8 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth/authprovider"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/dlorenc/docstore/internal/ciconfig"
 )
 
 // Config mirrors the .docstore/ci.yaml DSL and is used for both JSON decode
@@ -32,6 +35,8 @@ type Check struct {
 	Name  string   `json:"name"  yaml:"name"`
 	Image string   `json:"image" yaml:"image"`
 	Steps []string `json:"steps" yaml:"steps"`
+	If    string   `json:"if,omitempty"    yaml:"if,omitempty"`    // expression; empty = always run
+	Needs []string `json:"needs,omitempty" yaml:"needs,omitempty"` // parsed but not yet implemented
 }
 
 // CheckResult is the result of executing a single check.
@@ -58,25 +63,51 @@ func New(buildkitAddr, cacheBucket string) (*Executor, error) {
 }
 
 // Run executes all checks in cfg in parallel against sourceDir.
+// Checks whose if: condition evaluates to false are skipped (omitted from results).
 // It returns once all checks have resolved.
-func (e *Executor) Run(ctx context.Context, sourceDir string, cfg Config) ([]CheckResult, error) {
-	results := make([]CheckResult, len(cfg.Checks))
-	var wg sync.WaitGroup
+func (e *Executor) Run(ctx context.Context, sourceDir string, cfg Config, triggerCtx ciconfig.TriggerContext) ([]CheckResult, error) {
+	// Pre-filter: evaluate if: conditions before launching goroutines.
+	type indexedCheck struct {
+		idx   int
+		check Check
+	}
+	var toRun []indexedCheck
 	for i, check := range cfg.Checks {
+		if check.If == "" {
+			toRun = append(toRun, indexedCheck{i, check})
+			continue
+		}
+		run, err := ciconfig.EvalIf(check.If, triggerCtx)
+		if err != nil {
+			slog.Warn("if: condition evaluation error, running job anyway",
+				"check", check.Name, "if", check.If, "error", err)
+			toRun = append(toRun, indexedCheck{i, check})
+			continue
+		}
+		if !run {
+			slog.Info("skipping job: if condition false", "check", check.Name, "if", check.If)
+			continue
+		}
+		toRun = append(toRun, indexedCheck{i, check})
+	}
+
+	results := make([]CheckResult, len(toRun))
+	var wg sync.WaitGroup
+	for j, ic := range toRun {
 		wg.Add(1)
-		go func(i int, check Check) {
+		go func(j int, check Check) {
 			defer wg.Done()
 			defer func() {
 				if r := recover(); r != nil {
-					results[i] = CheckResult{
+					results[j] = CheckResult{
 						Name:   check.Name,
 						Status: "failed",
 						Logs:   fmt.Sprintf("panic: %v", r),
 					}
 				}
 			}()
-			results[i] = e.runCheck(ctx, sourceDir, check)
-		}(i, check)
+			results[j] = e.runCheck(ctx, sourceDir, check)
+		}(j, ic.check)
 	}
 	wg.Wait()
 	return results, nil

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dlorenc/docstore/internal/ciconfig"
 	"github.com/dlorenc/docstore/internal/executor"
 	"github.com/dlorenc/docstore/internal/testutil"
 )
@@ -48,7 +49,7 @@ func TestPass(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), dir, cfg)
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -75,7 +76,7 @@ func TestFail(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), dir, cfg)
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -100,7 +101,7 @@ func TestMultiCheck(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), dir, cfg)
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -141,7 +142,7 @@ func TestLogCapture(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), dir, cfg)
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}


### PR DESCRIPTION
## Summary

Closes #179 (Stage 5)

Adds expression-based conditional job execution to the ci-worker. Jobs with a false `if:` condition are skipped rather than run.

### Changes

- **`internal/ciconfig/context.go`** — New `TriggerContext` struct holding runtime trigger info (type, branch, base_branch, proposal_id)
- **`internal/ciconfig/expr.go`** — New `EvalIf(expr string, ctx TriggerContext) (bool, error)` with a recursive descent parser supporting: string literals (single/double quoted), `event.*` field references, `==`/`!=`, `&&`, `||`, parentheses
- **`internal/ciconfig/expr_test.go`** — 29 test cases covering all syntax forms, edge cases, and error paths
- **`internal/executor/executor.go`** — Added `If` and `Needs` fields to `Check` struct; `Run` now accepts `ciconfig.TriggerContext` and skips checks whose `if:` condition evaluates to false (fail-open on eval errors)
- **`cmd/ci-worker/main.go`** — Builds `TriggerContext` from claimed job's `TriggerType`/`TriggerBranch`/`TriggerProposalID` fields and passes it to executor

### Behavior

- Empty `if:` → always run (backward compatible)
- `if:` evaluates false → job skipped, logged, omitted from check run reporting (not a failure)
- `if:` evaluation error → warning logged, job runs anyway (fail-open)

### Supported expressions

```yaml
# push to main only
if: "event.type == 'push' && event.branch == 'main'"

# proposals and synchronized proposals
if: "event.type == 'proposal' || event.type == 'proposal_synchronized'"
```

### Notes

- `Needs []string` field is parsed from YAML but DAG execution is not implemented (left for a future stage per the issue)
- `BaseBranch` in `TriggerContext` is populated from the struct but no DB column exists yet for it; it will be empty for all current trigger types
- `TestDockerSmoke` in `internal/server` fails due to missing gcloud credentials — pre-existing environment issue, not caused by this change

## Test plan

- [x] `go test ./internal/ciconfig/... -count=1` — all 29 new expr tests pass
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all tests pass except pre-existing `TestDockerSmoke` (gcloud auth env issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)