### PR TITLE
feat: Stage 6 — schedule trigger + OPA proposal integration

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -196,6 +196,20 @@ reason := "at least one approval required"
 
 OPA v1 syntax is required (use `if` in rule bodies, `import rego.v1`).
 
+Policies also receive `input.proposal` (nil if no open proposal exists for the branch) with fields `id`, `base_branch`, `title`, and `state`. This allows policies to require an open proposal before merging:
+
+```rego
+package docstore.require_proposal
+
+import rego.v1
+
+default allow := false
+
+allow if { input.proposal != null }
+
+reason := "an open proposal is required before merging"
+```
+
 ### Policy Storage
 
 Policies live in `.docstore/policy/*.rego` files in the repo on `main`. They are versioned documents like any other file and go through the same branch/review/merge workflow. This means policy changes require review and approval just like code changes.

--- a/cmd/ci-scheduler/main.go
+++ b/cmd/ci-scheduler/main.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	_ "github.com/lib/pq"
+	"github.com/robfig/cron/v3"
 	"gopkg.in/yaml.v3"
 
 	"github.com/dlorenc/docstore/internal/ciconfig"
@@ -515,6 +516,99 @@ func newMux(sched *scheduler) *http.ServeMux {
 }
 
 // ---------------------------------------------------------------------------
+// Schedule-based cron runner
+// ---------------------------------------------------------------------------
+
+// fetchAllRepos fetches all repo names from docstore (GET /repos).
+func (s *scheduler) fetchAllRepos(ctx context.Context) ([]string, error) {
+	if s.docstoreURL == "" {
+		return nil, nil
+	}
+	reposURL := s.docstoreURL + "/repos"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reposURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build repos request: %w", err)
+	}
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch repos: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch repos: unexpected status %d", resp.StatusCode)
+	}
+	var result model.ReposResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode repos response: %w", err)
+	}
+	names := make([]string, 0, len(result.Repos))
+	for _, r := range result.Repos {
+		names = append(names, r.Name)
+	}
+	return names, nil
+}
+
+// runScheduledJobs checks all repos for schedule-triggered CI jobs that should
+// fire at time t (truncated to the minute).
+func (s *scheduler) runScheduledJobs(ctx context.Context, t time.Time) {
+	repos, err := s.fetchAllRepos(ctx)
+	if err != nil {
+		slog.Error("schedule runner: fetch repos failed", "error", err)
+		return
+	}
+	now := t.Truncate(time.Minute)
+	for _, repo := range repos {
+		headSeq, err := s.fetchBranchHead(ctx, repo, "main")
+		if err != nil {
+			slog.Warn("schedule runner: fetch branch head failed", "repo", repo, "error", err)
+			continue
+		}
+		cfg, err := s.fetchCIConfig(ctx, repo, "main", headSeq)
+		if err != nil {
+			slog.Warn("schedule runner: fetch ci config failed", "repo", repo, "error", err)
+			continue
+		}
+		if cfg == nil || cfg.On == nil || len(cfg.On.Schedule) == 0 {
+			continue
+		}
+		for _, entry := range cfg.On.Schedule {
+			sched, err := cron.ParseStandard(entry.Cron)
+			if err != nil {
+				slog.Warn("schedule runner: invalid cron expression", "repo", repo, "cron", entry.Cron, "error", err)
+				continue
+			}
+			// Check if the cron fires at this minute: the next fire time after
+			// (now - 1 minute) must equal now.
+			if sched.Next(now.Add(-time.Minute)).Equal(now) {
+				job, err := s.store.InsertCIJob(ctx, repo, "main", headSeq, "schedule", "main", "")
+				if err != nil {
+					slog.Error("schedule runner: insert ci job failed", "repo", repo, "cron", entry.Cron, "error", err)
+					continue
+				}
+				slog.Info("ci job queued (schedule)", "id", job.ID, "repo", repo, "cron", entry.Cron)
+			}
+		}
+	}
+}
+
+// startCronRunner starts a goroutine that fires every minute and enqueues
+// schedule-triggered CI jobs for all repos whose ci.yaml schedules match.
+func startCronRunner(ctx context.Context, sched *scheduler) {
+	go func() {
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case t := <-ticker.C:
+				sched.runScheduledJobs(ctx, t)
+			}
+		}
+	}()
+}
+
+// ---------------------------------------------------------------------------
 // Stale job reaper
 // ---------------------------------------------------------------------------
 
@@ -606,6 +700,9 @@ func main() {
 		docstoreURL:   strings.TrimRight(*docstoreURL, "/"),
 		httpClient:    httpClient,
 	}
+
+	// Start schedule-based cron runner.
+	startCronRunner(serverCtx, sched)
 
 	// WriteTimeout is intentionally absent: the log proxy endpoint
 	// (GET /run/{id}/logs/{check}) streams responses from the worker and

--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.10.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -343,6 +343,8 @@ github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 h1:bsUq1dX0N8A
 github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/secure-systems-lab/go-securesystemslib v0.10.0 h1:l+H5ErcW0PAehBNrBxoGv1jjNpGYdZ9RcheFkB2WI14=

--- a/internal/ciconfig/ciconfig.go
+++ b/internal/ciconfig/ciconfig.go
@@ -12,10 +12,16 @@ type CIConfig struct {
 	On *TriggerConfig `yaml:"on"`
 }
 
+// ScheduleEntry holds a single cron-based schedule trigger.
+type ScheduleEntry struct {
+	Cron string `yaml:"cron"`
+}
+
 // TriggerConfig holds the trigger definitions for a CI config.
 type TriggerConfig struct {
 	Push     *PushTrigger     `yaml:"push"`
 	Proposal *ProposalTrigger `yaml:"proposal"`
+	Schedule []ScheduleEntry  `yaml:"schedule"`
 }
 
 // PushTrigger configures which branches a push event triggers CI for.

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -37,6 +37,14 @@ type CheckRunInput struct {
 	Sequence  int64  `json:"sequence"`
 }
 
+// ProposalInput is the proposal data exposed to OPA policies.
+type ProposalInput struct {
+	ID         string `json:"id"`
+	BaseBranch string `json:"base_branch"`
+	Title      string `json:"title"`
+	State      string `json:"state"`
+}
+
 // Input is the structured context passed to every policy evaluation.
 type Input struct {
 	Actor        string              `json:"actor"`
@@ -51,6 +59,7 @@ type Input struct {
 	Owners       map[string][]string `json:"owners"`
 	HeadSeq      int64               `json:"head_sequence"`
 	BaseSeq      int64               `json:"base_sequence"`
+	Proposal     *ProposalInput      `json:"proposal"`
 }
 
 // preparedPolicy holds compiled OPA queries for a single .rego file.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1990,6 +1990,23 @@ func (s *server) assembleMergeInput(ctx context.Context, repo, branch, actor str
 		return nil, fmt.Errorf("list check runs: %w", err)
 	}
 
+	// Fetch the open proposal for this branch (nil if none exists).
+	openState := model.ProposalOpen
+	proposals, err := s.commitStore.ListProposals(ctx, repo, &openState, &branch)
+	if err != nil {
+		return nil, fmt.Errorf("list proposals: %w", err)
+	}
+	var proposalInput *policy.ProposalInput
+	if len(proposals) > 0 {
+		p := proposals[0]
+		proposalInput = &policy.ProposalInput{
+			ID:         p.ID,
+			BaseBranch: p.BaseBranch,
+			Title:      p.Title,
+			State:      string(p.State),
+		}
+	}
+
 	// Look up actor roles (empty slice if not assigned).
 	actorRoles := []string{}
 	if r, err := s.commitStore.GetRole(ctx, repo, actor); err == nil && r != nil {
@@ -2033,6 +2050,7 @@ func (s *server) assembleMergeInput(ctx context.Context, repo, branch, actor str
 		Owners:       resolvedOwners,
 		HeadSeq:      branchInfo.HeadSequence,
 		BaseSeq:      branchInfo.BaseSequence,
+		Proposal:     proposalInput,
 	}, nil
 }
 


### PR DESCRIPTION
Closes #179 (Stage 6)

## Summary

- **Part A: Schedule trigger** — adds cron-based CI scheduling to ci-scheduler
- **Part B: OPA proposal integration** — exposes open proposal data to merge policies

## Part A: Schedule trigger

### `internal/ciconfig/ciconfig.go`
Added `ScheduleEntry` struct and `Schedule []ScheduleEntry` to `TriggerConfig`:
```yaml
on:
  schedule:
    - cron: "0 * * * *"   # hourly
```

### `cmd/ci-scheduler/main.go`
- Added `github.com/robfig/cron/v3` for cron expression parsing/matching
- `startCronRunner` — goroutine with 1-minute ticker (mirrors `startReaper` pattern)
- `runScheduledJobs(ctx, t)` — for each repo: fetches main branch head, fetches CI config, evaluates each `schedule[].cron` entry; if `Next(now-1min) == now` enqueues with `trigger_type="schedule"`, `trigger_branch="main"`
- `fetchAllRepos` — calls `GET /repos` to enumerate repos
- Wired into `main()` after `startReaper`

No DB migration needed — `trigger_type="schedule"` uses the existing column.

## Part B: OPA proposal integration

### `internal/policy/engine.go`
- Added `ProposalInput` struct (`id`, `base_branch`, `title`, `state`)
- Added `Proposal *ProposalInput` to `Input` (`nil` if no open proposal)

### `internal/server/handlers.go`
- `assembleMergeInput` now calls `ListProposals(state=open, branch=branch)` and populates `input.proposal` before evaluating OPA

### `DESIGN.md`
Documents the new `input.proposal` field and includes an example policy:
```rego
package docstore.require_proposal
import rego.v1
default allow := false
allow if { input.proposal != null }
reason := "an open proposal is required before merging"
```

## Test plan
- [ ] `go build ./...` — passes
- [ ] `go vet ./...` — passes
- [ ] `go test ./... -count=1 -short` — all packages pass

## Notes / future opportunities
- The cron runner fires every wall-clock minute; it does not catch up on missed ticks (e.g. after a scheduler restart). This matches the typical "best-effort" semantics of cron triggers.
- `fetchAllRepos` requires the docstore `/repos` endpoint to be accessible from the scheduler; if `docstoreURL` is empty the runner is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)