### PR TITLE
fix(ci-scheduler): restore fetchBranchHead for schedule trigger

### DIFF
--- a/cmd/ci-scheduler/main.go
+++ b/cmd/ci-scheduler/main.go
@@ -510,6 +510,38 @@ func (s *scheduler) fetchAllRepos(ctx context.Context) ([]string, error) {
 	return names, nil
 }
 
+// fetchBranchHead fetches the current head sequence of a named branch in the
+// given repo. It is used by the schedule runner to determine the commit to
+// build against, since schedule events carry no sequence of their own.
+func (s *scheduler) fetchBranchHead(ctx context.Context, repo, branch string) (int64, error) {
+	if s.docstoreURL == "" {
+		return 0, fmt.Errorf("docstore URL not configured")
+	}
+	branchesURL := fmt.Sprintf("%s/repos/%s/-/branches", s.docstoreURL, repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, branchesURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("build branches request: %w", err)
+	}
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("fetch branches: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("fetch branches: unexpected status %d", resp.StatusCode)
+	}
+	var branches []model.Branch
+	if err := json.NewDecoder(resp.Body).Decode(&branches); err != nil {
+		return 0, fmt.Errorf("decode branches response: %w", err)
+	}
+	for _, b := range branches {
+		if b.Name == branch {
+			return b.HeadSequence, nil
+		}
+	}
+	return 0, fmt.Errorf("branch %q not found in repo %q", branch, repo)
+}
+
 // runScheduledJobs checks all repos for schedule-triggered CI jobs that should
 // fire at time t (truncated to the minute).
 func (s *scheduler) runScheduledJobs(ctx context.Context, t time.Time) {


### PR DESCRIPTION
## Summary

- Fixes build break introduced when PR #187 deleted `fetchBranchHead` from `cmd/ci-scheduler/main.go`
- PR #189's schedule runner calls `s.fetchBranchHead(ctx, repo, "main")` in `runScheduledJobs` — that method was still needed
- Re-adds `fetchBranchHead` using `GET /repos/{repo}/-/branches`, decoding the list to find the matching branch and returning its `HeadSequence`
- URL pattern is consistent with other branch-related fetches in the codebase (same pattern as CLI's `branchHeadSequence`)

## Why fetchBranchHead is still needed

Schedule triggers have no event carrying a commit sequence. The runner must fetch the current head of `main` itself before it can look up `ci.yaml` or enqueue a job. Unlike `proposal.opened` (which now includes a `Sequence` field per PR #187's fix), cron-based triggers are fired by a timer, not an event.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` passes (all packages — `TestDockerSmoke` in `internal/server` fails due to pre-existing gcloud credential issue in CI environment, unrelated to this change)

Fixes #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)