### PR TITLE
fix(ci-scheduler): restore fetchBranchHead for schedule cron runner

### DIFF
--- a/cmd/ci-scheduler/main.go
+++ b/cmd/ci-scheduler/main.go
@@ -510,6 +510,37 @@ func (s *scheduler) fetchAllRepos(ctx context.Context) ([]string, error) {
 	return names, nil
 }
 
+// fetchBranchHead returns the current head sequence for the named branch in
+// repo by calling GET /repos/{repo}/-/branches and finding the matching entry.
+func (s *scheduler) fetchBranchHead(ctx context.Context, repo, bname string) (int64, error) {
+	if s.docstoreURL == "" {
+		return 0, nil
+	}
+	branchesURL := fmt.Sprintf("%s/repos/%s/-/branches", s.docstoreURL, repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, branchesURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("build branches request: %w", err)
+	}
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("fetch branches: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("fetch branches: unexpected status %d", resp.StatusCode)
+	}
+	var result model.BranchesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("decode branches response: %w", err)
+	}
+	for _, b := range result.Branches {
+		if b.Name == bname {
+			return b.HeadSequence, nil
+		}
+	}
+	return 0, fmt.Errorf("branch %q not found in repo %q", bname, repo)
+}
+
 // runScheduledJobs checks all repos for schedule-triggered CI jobs that should
 // fire at time t (truncated to the minute).
 func (s *scheduler) runScheduledJobs(ctx context.Context, t time.Time) {


### PR DESCRIPTION
## Summary

- PR #187 removed `fetchBranchHead` after adding a `Sequence` field to the `ProposalOpened` event so `handleProposalOpened` could use `event.Sequence` directly
- However `runScheduledJobs` (the cron-based schedule trigger) still called `fetchBranchHead` to get the current head sequence of `main` before fetching the CI config and enqueueing schedule-triggered jobs — causing a build failure on main after #189 merged
- Re-adds `fetchBranchHead` as a method on `scheduler` that calls `GET /repos/{repo}/-/branches`, decodes `model.BranchesResponse`, and returns the `HeadSequence` for the named branch

## Root Cause

`handleProposalOpened` correctly uses `data.Sequence` from the webhook event (no HTTP round-trip needed). But `runScheduledJobs` is a polling loop over all repos — there is no event to get `Sequence` from, so it must fetch the branch head from the docstore API.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` — all packages pass; `TestDockerSmoke` in `internal/server` fails due to missing gcloud credentials (pre-existing infrastructure issue unrelated to this change)

## Notes

The `handleProposalOpened` path is unchanged — it continues to use `event.Sequence` directly as intended by PR #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)