### PR TITLE
docs: user guide for proposals and CI triggers (issue #179)

### DIFF
--- a/cmd/ci-scheduler/main.go
+++ b/cmd/ci-scheduler/main.go
@@ -481,6 +481,36 @@ func newMux(sched *scheduler) *http.ServeMux {
 // Schedule-based cron runner
 // ---------------------------------------------------------------------------
 
+// fetchBranchHead fetches the head sequence for a named branch from docstore.
+func (s *scheduler) fetchBranchHead(ctx context.Context, repo, branch string) (int64, error) {
+	if s.docstoreURL == "" {
+		return 0, fmt.Errorf("docstore URL not configured")
+	}
+	branchesURL := fmt.Sprintf("%s/repos/%s/-/branches", s.docstoreURL, repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, branchesURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("build branches request: %w", err)
+	}
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("fetch branches: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("fetch branches: unexpected status %d", resp.StatusCode)
+	}
+	var result model.BranchesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("decode branches response: %w", err)
+	}
+	for _, b := range result.Branches {
+		if b.Name == branch {
+			return b.HeadSequence, nil
+		}
+	}
+	return 0, fmt.Errorf("branch %q not found in repo %q", branch, repo)
+}
+
 // fetchAllRepos fetches all repo names from docstore (GET /repos).
 func (s *scheduler) fetchAllRepos(ctx context.Context) ([]string, error) {
 	if s.docstoreURL == "" {

--- a/docs/proposals-and-ci-triggers.md
+++ b/docs/proposals-and-ci-triggers.md
@@ -1,0 +1,346 @@
+# Proposals and CI Triggers
+
+This document covers the proposals feature and the CI trigger model introduced in issue #179.
+
+---
+
+## Proposals
+
+A **proposal** is a named intent to merge a branch into a base branch. Proposals are lightweight
+pre-merge records — they carry a title, an optional description, and track the lifecycle of the
+branch from creation through merge or close.
+
+### Why proposals?
+
+Branches already hold the diff, reviews, and check runs. A proposal adds:
+
+- A human-readable title and description surfaced to reviewers
+- A stable identity that OPA policies can gate on (require an open proposal before merging)
+- Lifecycle events that trigger CI runs on proposal open and commit push
+
+### Data model
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | UUID | Unique proposal identifier |
+| `repo` | string | Full repo name (e.g. `acme/myrepo`) |
+| `branch` | string | Source branch being proposed |
+| `base_branch` | string | Target branch (usually `main`) |
+| `title` | string | Human-readable title |
+| `description` | string | Optional extended description |
+| `author` | string | Identity that opened the proposal |
+| `state` | enum | `open`, `closed`, or `merged` |
+| `created_at` | timestamp | |
+| `updated_at` | timestamp | |
+
+### Lifecycle
+
+```
+                   ds proposal open
+                         │
+                         ▼
+                       open
+                     /       \
+     ds merge        │         │  ds proposal close
+  (branch merges)    ▼         ▼
+                  merged     closed
+```
+
+- **open → merged**: automatically when `POST /merge` succeeds for the proposal's branch
+- **open → closed**: manually via `ds proposal close <id>` or `POST /proposals/:id/close`
+
+A branch can have at most one open proposal at a time. Attempting to open a second proposal while
+one is already open returns `409 Conflict`.
+
+### CLI usage
+
+#### Open a proposal
+
+```
+ds proposal open --title "Add retry logic" [--branch <name>] [--base main] [--description "..."]
+```
+
+- `--title` (required): short title displayed in reviews and CI
+- `--branch`: branch to propose; defaults to the current workspace branch
+- `--base`: target base branch; defaults to `main`
+- `--description`: optional extended description
+
+Example:
+
+```bash
+ds proposal open --title "Fix login timeout" --branch feature/login-fix --base main
+# Proposal opened: a3f7c2d8-1234-...
+```
+
+#### List proposals
+
+```
+ds proposal list [--state open|closed|merged]
+```
+
+Default shows all proposals. Filter by state with `--state`.
+
+```bash
+ds proposal list --state open
+```
+
+Output example:
+
+```
+ID                                    BRANCH              STATE   TITLE
+a3f7c2d8-1234-5678-abcd-000000000001  feature/login-fix   open    Fix login timeout
+```
+
+#### Close a proposal
+
+```
+ds proposal close <proposal-id>
+```
+
+Closes an open proposal without merging the branch. Only the proposal author or a maintainer may
+close a proposal.
+
+```bash
+ds proposal close a3f7c2d8-1234-5678-abcd-000000000001
+# Proposal a3f7c2d8-... closed
+```
+
+### How proposals relate to reviews
+
+Reviews (`ds review`) are attached to a branch at a specific head sequence, not to a proposal.
+When a proposal exists, the TUI and `GET /-/branch/:name/status` surface the proposal metadata
+alongside the branch's reviews and check runs. The proposal provides a stable title for the review
+thread; the reviews themselves are stored and queried against the branch.
+
+### Requiring an open proposal via OPA policy
+
+Policies receive an `input.proposal` object (or `null` if no open proposal exists for the branch).
+Fields: `id`, `branch`, `base_branch`, `title`, `state`.
+
+To block merges unless an open proposal exists:
+
+```rego
+package docstore.require_proposal
+
+import rego.v1
+
+default allow := false
+
+allow if { input.proposal != null }
+
+reason := "an open proposal is required before merging"
+```
+
+Store this file at `.docstore/policy/require_proposal.rego` on `main` (via the normal
+branch → review → merge workflow) to enforce it.
+
+---
+
+## CI Trigger Model (`.docstore/ci.yaml`)
+
+The CI configuration file lives at `.docstore/ci.yaml` in the repository. It is read from the
+branch under test (pinned to the head sequence at the time the job was queued), so changes to
+`ci.yaml` on a branch take effect for that branch's CI runs without requiring a merge first.
+
+### Complete annotated example
+
+```yaml
+on:
+  push:
+    branches: [main]            # trigger on pushes to main (deploy-style)
+  proposal:
+    base_branches: [main]       # trigger when a proposal targeting main is opened
+  schedule:
+    - cron: '0 2 * * *'         # nightly at 2 AM UTC
+  # manual: trigger via API POST /run — no config needed, always enabled
+
+checks:
+  - name: ci/test
+    image: golang:1.24
+    steps:
+      - go test ./...
+      - go vet ./...
+
+  - name: ci/deploy
+    image: google/cloud-sdk:slim
+    needs: [ci/test]
+    if: "event.type == 'push' && event.branch == 'main'"
+    steps:
+      - ./deploy.sh
+```
+
+### `on:` — trigger types
+
+All four trigger types can coexist in a single `on:` block. Triggers are independent — a single
+commit can fire both a `push` job (if the branch matches `branches`) and a
+`proposal_synchronized` job (if the branch has an open proposal and `proposal:` is configured).
+
+#### `push`
+
+Fires on every commit pushed to a matching branch.
+
+```yaml
+on:
+  push:
+    branches: [main]        # only main
+    # branches: [main, release/**]  # glob patterns supported
+    # (omit branches: to match all branches)
+```
+
+- `branches`: list of glob patterns (uses `**`, `*`, `?`, character classes). Omitting `branches`
+  or leaving it empty matches all branches.
+
+#### `proposal`
+
+Fires when a proposal is **opened** (`ds proposal open`) targeting a matching base branch.
+
+```yaml
+on:
+  proposal:
+    base_branches: [main]   # only proposals targeting main
+```
+
+- `base_branches`: list of glob patterns for the proposal's target (base) branch. Omit to match
+  all base branches.
+
+When a branch with an open proposal receives a new commit, a separate `proposal_synchronized`
+event is also fired (see event types below).
+
+#### `schedule`
+
+Fires at a cron schedule. Runs are triggered against `main` at its current head sequence.
+
+```yaml
+on:
+  schedule:
+    - cron: '0 2 * * *'     # nightly at 2 AM UTC (standard 5-field cron)
+    - cron: '0 12 * * 1'    # every Monday at noon UTC
+```
+
+#### `manual`
+
+Always enabled. Trigger a run via the scheduler API:
+
+```bash
+curl -X POST http://<ci-scheduler>:8080/run \
+  -H "Content-Type: application/json" \
+  -d '{"repo": "acme/myrepo", "branch": "feature/x", "head_sequence": 42}'
+# Returns: {"run_id": "..."}
+```
+
+No configuration needed in `ci.yaml`.
+
+### `checks:` — job definitions
+
+Each entry in `checks` is an independent job that runs inside a container image. All checks in a
+config run concurrently unless limited by `needs` dependencies.
+
+| Field | Required | Notes |
+|---|---|---|
+| `name` | yes | Check run name posted to docstore (e.g. `ci/build`); conventionally namespaced with `/` |
+| `image` | yes | Any pullable Docker image |
+| `steps` | yes | Ordered shell commands run sequentially inside the image with source mounted at `/src` |
+| `if` | no | Conditional expression; check is skipped (not failed) when false. Empty = always run. |
+| `needs` | no | List of check names that must complete before this one starts (parsed; see below) |
+
+Steps within a single check share the `/src` filesystem — files written by an earlier step are
+visible to later steps.
+
+### `if:` expressions
+
+Per-check `if:` expressions filter which checks run for a given trigger event. A check with no
+`if:` key always runs.
+
+#### Supported fields
+
+| Field | Description | Example value |
+|---|---|---|
+| `event.type` | What triggered the run | `push`, `proposal`, `proposal_synchronized`, `manual`, `schedule` |
+| `event.branch` | Branch being tested | `main`, `feature/login-fix` |
+| `event.base_branch` | Proposal target branch (proposals only; empty otherwise) | `main` |
+| `event.proposal_id` | Proposal UUID (proposals only; empty otherwise) | `a3f7c2d8-...` |
+
+#### Supported operators
+
+| Operator | Description |
+|---|---|
+| `==` | Equality |
+| `!=` | Inequality |
+| `&&` | Logical AND |
+| `\|\|` | Logical OR |
+| `(...)` | Grouping |
+
+String literals use single or double quotes: `"main"` or `'main'`.
+
+#### Examples
+
+```yaml
+# Only run on direct pushes to main
+if: "event.type == 'push' && event.branch == 'main'"
+
+# Only run on proposal events (opened or synchronized)
+if: "event.type == 'proposal' || event.type == 'proposal_synchronized'"
+
+# Only run on proposals targeting main
+if: "event.type == 'proposal' && event.base_branch == 'main'"
+
+# Scheduled or manual only
+if: "event.type == 'schedule' || event.type == 'manual'"
+```
+
+A check whose `if:` expression is false is **skipped** (not posted to docstore as a check run).
+This means a skipped check does not satisfy a merge policy that requires it — design your `if:`
+conditions so required checks always run for the events that trigger merges.
+
+#### `needs:` (parsed, not yet enforced)
+
+The `needs:` field is parsed and stored but dependency ordering is not yet enforced — all checks
+run concurrently regardless of `needs`. This field is reserved for a future release.
+
+---
+
+## Backward compatibility
+
+Repos whose `.docstore/ci.yaml` has **no `on:` block** get the previous behavior: CI runs on every
+commit to every branch (equivalent to `push:` with no `branches:` filter, matching all branches).
+
+If `.docstore/ci.yaml` does not exist on the branch under test, CI is skipped entirely and no
+check runs are posted.
+
+---
+
+## API reference
+
+### Proposal endpoints
+
+All proposal endpoints are repo-scoped under `/repos/{name}/-/`.
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/proposals` | Open a proposal. Body: `{branch, base_branch, title, description?}`. Returns `{id}`. |
+| `GET` | `/proposals` | List proposals. Query: `?state=open\|closed\|merged&branch=<name>`. |
+| `GET` | `/proposals/:id` | Get a single proposal by ID. |
+| `PATCH` | `/proposals/:id` | Update title or description. Body: `{title?, description?}`. Author or maintainer only. |
+| `POST` | `/proposals/:id/close` | Close an open proposal. Author or maintainer only. |
+
+The merge endpoint (`POST /merge`) automatically transitions the proposal to `merged` state when
+the branch merge succeeds.
+
+### OPA policy input
+
+The `input.proposal` field is populated when evaluating merge policies for a branch that has an
+open proposal:
+
+```json
+{
+  "proposal": {
+    "id": "a3f7c2d8-1234-5678-abcd-000000000001",
+    "branch": "feature/login-fix",
+    "base_branch": "main",
+    "title": "Fix login timeout",
+    "state": "open"
+  }
+}
+```
+
+`input.proposal` is `null` when no open proposal exists for the branch being merged.


### PR DESCRIPTION
## Summary

- Adds `docs/proposals-and-ci-triggers.md`, a complete user-facing reference for the proposals and CI trigger model features implemented across Stages 1–6 of issue #179
- Fixes a pre-existing build error in `cmd/ci-scheduler/main.go`: commit `ad4ad0b` removed `fetchBranchHead` but left its call site in `runScheduledJobs`; this PR restores the method using the existing `/branches` API pattern

## Documentation covers

**Proposals**
- What a proposal is and why it exists
- Full data model table
- Lifecycle diagram: open → merged (auto) or closed (manual)
- CLI: `ds proposal open`, `ds proposal list`, `ds proposal close`
- How proposals relate to reviews (reviews are on branches; proposals surface them)
- OPA `input.proposal` field and `require_proposal` policy example

**CI trigger model (`.docstore/ci.yaml`)**
- Complete annotated example with all four trigger types
- `on.push` — branch glob patterns
- `on.proposal` — base_branch glob patterns; distinction between `proposal` and `proposal_synchronized` events
- `on.schedule` — standard 5-field cron
- `manual` — always enabled via `POST /run`
- `checks:` fields: `name`, `image`, `steps`, `if`, `needs`
- `if:` expression reference: all `event.*` fields, operators (`==`, `!=`, `&&`, `||`, `(...)`)
- Backward compatibility: repos without `on:` get previous behavior (CI on every commit)

**API reference**
- Proposal endpoint table
- OPA `input.proposal` schema

## Test plan
- [ ] `go build ./...` passes (verified locally — fixes the pre-existing `fetchBranchHead` build error)
- [ ] All tests pass with `go test ./... -count=1 -skip TestDockerSmoke` (TestDockerSmoke requires GCR auth, pre-existing infra issue)
- [ ] Documentation is prose-only; no behavior changes

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)