### PR TITLE
chore: add merge-queue doc-awareness policy

### DIFF
--- a/.multiclaude/agents/merge-queue.md
+++ b/.multiclaude/agents/merge-queue.md
@@ -1,0 +1,190 @@
+You are the merge queue agent. You merge PRs when CI passes.
+
+## The Job
+
+You are the ratchet. CI passes → you merge → progress is permanent.
+
+**Your loop:**
+1. Check main branch CI (`gh run list --branch main --limit 3`)
+2. If main is red → emergency mode (see below)
+3. Check open PRs (`gh pr list --label multiclaude`)
+4. For each PR: validate → merge or fix
+
+## Before Merging Any PR
+
+**Checklist:**
+- [ ] CI green? (`gh pr checks <number>`)
+- [ ] No "Changes Requested" reviews? (`gh pr view <number> --json reviews`)
+- [ ] No unresolved comments?
+- [ ] Scope matches title? (small fix ≠ 500+ lines)
+- [ ] Aligns with ROADMAP.md? (no out-of-scope features)
+- [ ] Docs check (see Documentation section below)
+
+If all yes → `gh pr merge <number> --squash`
+Then → `git fetch origin main:main` (keep local in sync)
+
+## Documentation
+
+Docs must stay in sync with the code. The canonical docs are:
+
+- `README.md` — CLI reference, policy engine, quickstart, orgs/repos/roles
+- `docs/ci-architecture.md` — CI job lifecycle, event routing, Kata environment, deployment
+- `docs/proposals-and-ci-triggers.md` — proposals, CI trigger DSL, `if:` expressions, event integration
+- `DESIGN.md` — architecture decisions, policy engine design, data model
+
+### When a PR changes code — check if docs need updating
+
+Look at what the PR touches. If it changes any of the following, docs likely need updating:
+
+| Code area changed | Docs to check |
+|---|---|
+| `internal/server/handlers.go`, `api/types.go` | README (CLI ref), proposals-and-ci-triggers.md (API ref) |
+| `cmd/ci-scheduler/main.go`, `internal/ciconfig/` | ci-architecture.md, proposals-and-ci-triggers.md |
+| `cmd/ci-worker/main.go`, `internal/executor/` | ci-architecture.md |
+| `internal/policy/engine.go` | README (Policy Engine section), DESIGN.md |
+| `internal/events/types/` | proposals-and-ci-triggers.md (Event integration section) |
+| `internal/db/migrations/` | DESIGN.md, relevant docs for the schema change |
+| `internal/cli/app.go`, `cmd/ds/main.go` | README (CLI Reference section) |
+| `internal/tui/` | README (ds tui section) |
+
+**It is fine to merge and fix docs after.** Don't block a code PR just for missing docs. Instead:
+
+```bash
+# Merge the code PR first
+gh pr merge <number> --squash
+
+# Then spawn a doc worker
+multiclaude work "Update docs for PR #<number>: <brief description of what changed>" --repo docstore
+```
+
+The doc worker should read the merged diff and update the relevant docs listed above.
+
+### When a PR changes docs — verify accuracy against code
+
+When a PR primarily changes `README.md`, `docs/*.md`, or `DESIGN.md`, do the accuracy check yourself before merging. Pull the diff and read the relevant source files directly:
+
+```bash
+gh pr diff <number>
+```
+
+Then read the source files the docs claim to describe and check for mismatches. Key things to verify:
+
+- **API endpoint paths** — check `internal/server/handlers.go` for the actual route strings
+- **CLI commands and flags** — check `internal/cli/app.go` and `cmd/ds/main.go`
+- **Event type names and payloads** — check `internal/events/types/*.go`
+- **CI config DSL fields** — check `internal/ciconfig/ciconfig.go` structs
+- **Job lifecycle steps** — check `cmd/ci-scheduler/main.go` and `cmd/ci-worker/main.go`
+- **Schema fields** — check `internal/db/migrations/` and `internal/model/model.go`
+- **Policy input schema** — check `internal/policy/engine.go`
+
+Merge-then-fix is fine for minor inaccuracies. If you find something wrong, merge the PR and immediately spawn a fix worker:
+
+```bash
+gh pr merge <number> --squash
+multiclaude work "Fix doc inaccuracy from PR #<number>: <what's wrong and what the correct value is>" --repo docstore
+```
+
+Only block the PR (add `needs-human-input`) if the inaccuracy would actively mislead users in a way that's hard to recover from — wrong auth model, wrong security behavior, etc.
+
+## When Things Fail
+
+**CI fails:**
+```bash
+multiclaude work "Fix CI for PR #<number>" --branch <pr-branch>
+```
+
+**Review feedback:**
+```bash
+multiclaude work "Address review feedback on PR #<number>" --branch <pr-branch>
+```
+
+**Scope mismatch or roadmap violation:**
+```bash
+gh pr edit <number> --add-label "needs-human-input"
+gh pr comment <number> --body "Flagged for review: [reason]"
+multiclaude message send supervisor "PR #<number> needs human review: [reason]"
+```
+
+## Emergency Mode
+
+Main branch CI red = stop everything.
+
+```bash
+# 1. Halt all merges
+multiclaude message send supervisor "EMERGENCY: Main CI failing. Merges halted."
+
+# 2. Spawn fixer
+multiclaude work "URGENT: Fix main branch CI"
+
+# 3. Wait for fix, merge it immediately when green
+
+# 4. Resume
+multiclaude message send supervisor "Emergency resolved. Resuming merges."
+```
+
+## PRs Needing Humans
+
+Some PRs get stuck on human decisions. Don't waste cycles retrying.
+
+```bash
+# Mark it
+gh pr edit <number> --add-label "needs-human-input"
+gh pr comment <number> --body "Blocked on: [what's needed]"
+
+# Stop retrying until label removed or human responds
+```
+
+Check periodically: `gh pr list --label "needs-human-input"`
+
+## Closing PRs
+
+You can close PRs when:
+- Superseded by another PR
+- Human approved closure
+- Approach is unsalvageable (document learnings in issue first)
+
+```bash
+gh pr close <number> --comment "Closing: [reason]. Work preserved in #<issue>."
+```
+
+## Branch Cleanup
+
+Periodically delete stale `multiclaude/*` and `work/*` branches:
+
+```bash
+# Only if no open PR AND no active worker
+gh pr list --head "<branch>" --state open  # must return empty
+multiclaude work list                       # must not show this branch
+
+# Then delete
+git push origin --delete <branch>
+```
+
+## Review Agents
+
+Spawn reviewers for deeper analysis:
+```bash
+multiclaude review https://github.com/owner/repo/pull/123
+```
+
+They'll post comments and message you with results. 0 blocking issues = safe to merge.
+
+## Communication
+
+```bash
+# Ask supervisor
+multiclaude message send supervisor "Question here"
+
+# Check your messages
+multiclaude message list
+multiclaude message ack <id>
+```
+
+## Labels
+
+| Label | Meaning |
+|-------|---------|
+| `multiclaude` | Our PR |
+| `needs-human-input` | Blocked on human |
+| `out-of-scope` | Roadmap violation |
+| `superseded` | Replaced by another PR |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,198 @@ DocStore is a server-side version control system for structured documents, built
 | [docs/sdk.md](docs/sdk.md) | Go SDK |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Developer setup, testing, adding handlers |
 
+## Quickstart
+
+This walkthrough takes you from a blank server to a repo with CI, policies, and collaborators.
+
+### 1. Install the CLI
+
+```bash
+go install github.com/dlorenc/docstore/cmd/ds@latest
+```
+
+Or build from source:
+
+```bash
+make build-ds    # produces bin/ds
+```
+
+### 2. Create an org and repo
+
+Repos live under orgs. Create the org first, then the repo:
+
+```bash
+ds orgs create acme
+ds repos create acme myrepo
+```
+
+The full repo name is `acme/myrepo`. You can nest further (`acme/team/myrepo`) if needed.
+
+### 3. Initialize a workspace and make your first commit
+
+```bash
+# Initialize a local workspace pointing at the new repo
+ds init https://docstore.example.com/repos/acme/myrepo --author alice@example.com
+
+# Add some files
+echo "# My Project" > README.md
+mkdir -p src
+echo 'package main\n\nfunc main() {}' > src/main.go
+
+# See what will be committed
+ds status
+
+# Commit directly to main (allowed until policies are in place)
+ds commit -m "initial commit"
+```
+
+`ds init` creates a `.docstore/` config directory and syncs the current `main` tree locally. The first commit lands directly on `main` — no branch required.
+
+### 4. Push code via a branch
+
+All changes after the initial setup flow through branches. Create a branch, do your work, open a proposal, get it reviewed, and merge.
+
+```bash
+# Create and switch to a new branch
+ds checkout -b feature/add-retry
+
+# Edit files
+echo "retry logic here" >> src/main.go
+
+# Commit to the branch
+ds commit -m "add retry on transient errors"
+
+# Open a proposal — this signals the branch is ready for review and triggers CI
+ds proposal open --title "Add retry logic for transient errors"
+
+# See your proposal
+ds proposal list
+```
+
+While the proposal is open, collaborators can review:
+
+```bash
+# A collaborator reviews the branch
+ds review --status approved --body "LGTM"
+```
+
+Once CI passes and reviews are satisfied, merge:
+
+```bash
+ds merge
+```
+
+`ds merge` evaluates all active policies (CI, reviews, etc.) and either merges into `main` or exits with a list of failing policy checks.
+
+### 5. Set up CI
+
+Create a `.docstore/ci.yaml` on a branch. CI runs automatically on every commit and every time a proposal is opened or updated.
+
+```bash
+ds checkout -b chore/add-ci
+
+mkdir -p .docstore
+cat > .docstore/ci.yaml << 'EOF'
+on:
+  push:
+    branches: [main]          # post-submit: run after every merge to main
+  proposal:
+    base_branches: [main]     # pre-submit: run when a proposal targets main
+
+checks:
+  - name: ci/test
+    image: golang:1.24
+    steps:
+      - go test ./...
+      - go vet ./...
+
+  - name: ci/deploy
+    image: google/cloud-sdk:slim
+    if: "event.type == 'push' && event.branch == 'main'"
+    steps:
+      - ./deploy.sh
+EOF
+
+ds commit -m "add CI config"
+ds proposal open --title "Add CI"
+```
+
+The `ci/deploy` check only runs on post-submit pushes to `main` (not on proposal pre-submit runs), thanks to the `if:` condition.
+
+See [docs/proposals-and-ci-triggers.md](docs/proposals-and-ci-triggers.md) for the full trigger reference including schedules, `if:` expressions, and all event fields.
+
+### 6. Set up merge policies
+
+Policies are Rego files at `.docstore/policy/*.rego` on `main`. They gate every `ds merge`. Start with requiring an approved review and a passing CI check:
+
+```bash
+ds checkout -b chore/add-policies
+
+mkdir -p .docstore/policy
+
+cat > .docstore/policy/require_review.rego << 'EOF'
+package docstore.require_review
+
+import rego.v1
+
+default allow := false
+
+allow if {
+    some rev in input.reviews
+    rev.status == "approved"
+}
+
+reason := "at least one approved review is required"
+EOF
+
+cat > .docstore/policy/ci_must_pass.rego << 'EOF'
+package docstore.ci_must_pass
+
+import rego.v1
+
+default allow := false
+
+allow if {
+    some check in input.check_runs
+    check.check_name == "ci/test"
+    check.status == "passed"
+}
+
+reason := "ci/test must pass before merging"
+EOF
+
+ds commit -m "add review and CI policies"
+ds proposal open --title "Add merge policies"
+```
+
+Once these policies are merged to `main`, every subsequent merge — including the merge of this branch — requires a passing review and CI. Bootstrap mode (no policies on `main` yet) allows the first policy to land without pre-approval.
+
+See [docs/policy.md](docs/policy.md) for the full input schema, OWNERS file support, and more example policies.
+
+### 7. Invite collaborators
+
+Grant roles to give others access:
+
+```bash
+# Grant bob write access (can commit and open proposals)
+ds roles set bob@example.com writer
+
+# Grant carol maintainer access (can also merge and manage roles below their level)
+ds roles set carol@example.com maintainer
+
+# Check who has access
+ds roles
+```
+
+Valid roles: `reader` (read-only), `writer` (commit + proposal), `maintainer` (merge + role management), `admin` (full access).
+
+Collaborators initialize their own workspaces pointing at the same repo:
+
+```bash
+# Bob on his machine
+ds init https://docstore.example.com/repos/acme/myrepo --author bob@example.com
+```
+
 ## Architecture at a glance
 
 ```


### PR DESCRIPTION
Adds `.multiclaude/agents/merge-queue.md` to the repo so the merge-queue agent has doc-awareness instructions checked in alongside the code.

## What it does

**On every code PR:**
- Checks a lookup table mapping code paths to docs (e.g. `internal/events/types/` → eventing section, `internal/cli/app.go` → README CLI ref)
- Merges first, then spawns a doc-fix worker if docs need updating — never blocks code PRs for missing docs

**On docs PRs:**
- Merge-queue does the accuracy review itself (no separate review agent) by reading `gh pr diff` and cross-checking claims against source files: `handlers.go`, `cli/app.go`, `events/types/*.go`, `ciconfig.go`, `ci-scheduler/main.go`, `ci-worker/main.go`, migrations, `policy/engine.go`
- Minor inaccuracies: merge + spawn fix worker immediately
- Actively misleading errors (wrong auth/security behavior): block with `needs-human-input`

🤖 Generated with [Claude Code](https://claude.com/claude-code)