### PR TITLE
test(executor): add integration tests for if: condition check-skipping

### DIFF
--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -123,6 +123,256 @@ func TestMultiCheck(t *testing.T) {
 }
 
 
+// TestIfConditionSkipsCheck verifies that a check whose if: expression evaluates
+// to false against the TriggerContext is omitted from results entirely.
+func TestIfConditionSkipsCheck(t *testing.T) {
+	exec := newExecutor(t)
+	dir := t.TempDir()
+
+	cfg := executor.Config{
+		Checks: []executor.Check{
+			{
+				Name:  "ci/push-only",
+				Image: "alpine",
+				Steps: []string{"echo should-not-run"},
+				If:    `event.type == "push"`,
+			},
+		},
+	}
+
+	// Trigger type is "proposal", so the push-only check must be skipped.
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "proposal"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results (check skipped), got %d: %+v", len(results), results)
+	}
+}
+
+// TestIfConditionRunsCheck verifies that a check whose if: expression evaluates
+// to true against the TriggerContext is included in results.
+func TestIfConditionRunsCheck(t *testing.T) {
+	exec := newExecutor(t)
+	dir := t.TempDir()
+
+	cfg := executor.Config{
+		Checks: []executor.Check{
+			{
+				Name:  "ci/push-only",
+				Image: "alpine",
+				Steps: []string{"echo ran"},
+				If:    `event.type == "push"`,
+			},
+		},
+	}
+
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != "passed" {
+		t.Errorf("expected passed, got %s (logs: %s)", results[0].Status, results[0].Logs)
+	}
+}
+
+// TestIfConditionMixedChecks verifies that when multiple checks have different
+// if: conditions, only the ones matching the TriggerContext run.
+func TestIfConditionMixedChecks(t *testing.T) {
+	exec := newExecutor(t)
+	dir := t.TempDir()
+
+	cfg := executor.Config{
+		Checks: []executor.Check{
+			{
+				Name:  "ci/push-check",
+				Image: "alpine",
+				Steps: []string{"echo push-ran"},
+				If:    `event.type == "push"`,
+			},
+			{
+				Name:  "ci/proposal-check",
+				Image: "alpine",
+				Steps: []string{"echo proposal-ran"},
+				If:    `event.type == "proposal"`,
+			},
+			{
+				Name:  "ci/always",
+				Image: "alpine",
+				Steps: []string{"echo always-ran"},
+				// No if: condition — always runs.
+			},
+		},
+	}
+
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Only ci/push-check and ci/always should run; ci/proposal-check is skipped.
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d: %+v", len(results), results)
+	}
+	byName := make(map[string]executor.CheckResult)
+	for _, r := range results {
+		byName[r.Name] = r
+	}
+	if _, ok := byName["ci/push-check"]; !ok {
+		t.Errorf("ci/push-check should have run but is absent from results")
+	}
+	if _, ok := byName["ci/always"]; !ok {
+		t.Errorf("ci/always should have run but is absent from results")
+	}
+	if _, ok := byName["ci/proposal-check"]; ok {
+		t.Errorf("ci/proposal-check should have been skipped but appears in results")
+	}
+}
+
+// TestIfConditionBranchFilter verifies that event.branch filtering works.
+func TestIfConditionBranchFilter(t *testing.T) {
+	exec := newExecutor(t)
+	dir := t.TempDir()
+
+	cfg := executor.Config{
+		Checks: []executor.Check{
+			{
+				Name:  "ci/main-only",
+				Image: "alpine",
+				Steps: []string{"echo main-ran"},
+				If:    `event.branch == "main"`,
+			},
+		},
+	}
+
+	// feature branch — should be skipped.
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push", Branch: "feature"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for feature branch, got %d", len(results))
+	}
+
+	// main branch — should run.
+	results, err = exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push", Branch: "main"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for main branch, got %d", len(results))
+	}
+	if results[0].Status != "passed" {
+		t.Errorf("expected passed, got %s", results[0].Status)
+	}
+}
+
+// TestIfConditionAndExpression verifies that compound && expressions are
+// evaluated correctly — both sub-conditions must hold for the check to run.
+func TestIfConditionAndExpression(t *testing.T) {
+	exec := newExecutor(t)
+	dir := t.TempDir()
+
+	cfg := executor.Config{
+		Checks: []executor.Check{
+			{
+				Name:  "ci/push-main",
+				Image: "alpine",
+				Steps: []string{"echo push-main-ran"},
+				If:    `event.type == "push" && event.branch == "main"`,
+			},
+		},
+	}
+
+	// push to main — should run.
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push", Branch: "main"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for push+main, got %d", len(results))
+	}
+
+	// push to feature — should be skipped (branch condition false).
+	results, err = exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push", Branch: "feature"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for push+feature, got %d", len(results))
+	}
+
+	// proposal to main — should be skipped (type condition false).
+	results, err = exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "proposal", Branch: "main"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for proposal+main, got %d", len(results))
+	}
+}
+
+// TestIfConditionOrExpression verifies that || expressions run the check when
+// either sub-condition is true.
+func TestIfConditionOrExpression(t *testing.T) {
+	exec := newExecutor(t)
+	dir := t.TempDir()
+
+	cfg := executor.Config{
+		Checks: []executor.Check{
+			{
+				Name:  "ci/push-or-proposal",
+				Image: "alpine",
+				Steps: []string{"echo ran"},
+				If:    `event.type == "push" || event.type == "proposal"`,
+			},
+		},
+	}
+
+	for _, triggerType := range []string{"push", "proposal"} {
+		results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: triggerType})
+		if err != nil {
+			t.Fatalf("Run(%s): %v", triggerType, err)
+		}
+		if len(results) != 1 {
+			t.Errorf("type=%s: expected 1 result, got %d", triggerType, len(results))
+		}
+	}
+
+	// schedule — neither condition matches, should be skipped.
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "schedule"})
+	if err != nil {
+		t.Fatalf("Run(schedule): %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("type=schedule: expected 0 results, got %d", len(results))
+	}
+}
+
+// TestIfConditionAllSkipped verifies that Run returns an empty (non-nil) slice
+// when every check's if: condition is false.
+func TestIfConditionAllSkipped(t *testing.T) {
+	exec := newExecutor(t)
+	dir := t.TempDir()
+
+	cfg := executor.Config{
+		Checks: []executor.Check{
+			{Name: "ci/a", Image: "alpine", Steps: []string{"echo a"}, If: `event.type == "push"`},
+			{Name: "ci/b", Image: "alpine", Steps: []string{"echo b"}, If: `event.type == "proposal"`},
+		},
+	}
+
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "schedule"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results when all checks skipped, got %d: %+v", len(results), results)
+	}
+}
+
 // TestLogCapture verifies that stdout and stderr from steps both appear in
 // the Logs field.
 func TestLogCapture(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds 7 integration tests to `internal/executor/executor_test.go` exercising the check-skipping pre-filter at `executor.go:80-91`
- Previously `expr_test.go` tested `EvalIf()` in isolation but no test verified that the executor actually skipped checks when `if:` evaluated to false
- Covers: single check skipped/run, mixed checks, `event.branch` filtering, `&&` compound, `||` compound, and all-skipped edge case

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all packages pass; `TestDockerSmoke` in `internal/server` fails but is a pre-existing failure unrelated to this change (confirmed by running on main without the change)

> **Note:** `TestDockerSmoke` (`internal/server`) fails on main — pre-existing flaky test, not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)