### PR TITLE
perf(ci-worker): post pending check runs in parallel

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -297,17 +297,23 @@ func runJob(
 		return fail(fmt.Sprintf("pull source: %v", err))
 	}
 
-	// 3. Mark each check as pending.
+	// 3. Mark each check as pending (in parallel).
+	var pendingWg sync.WaitGroup
 	for _, check := range cfg.Checks {
-		if err := postCheckRun(ctx, httpClient, docstoreURL, job.Repo, model.CreateCheckRunRequest{
-			Branch:    job.Branch,
-			CheckName: check.Name,
-			Status:    model.CheckRunPending,
-			Sequence:  &job.Sequence,
-		}); err != nil {
-			slog.Warn("mark pending failed", "check", check.Name, "error", err)
-		}
+		pendingWg.Add(1)
+		go func(checkName string) {
+			defer pendingWg.Done()
+			if err := postCheckRun(ctx, httpClient, docstoreURL, job.Repo, model.CreateCheckRunRequest{
+				Branch:    job.Branch,
+				CheckName: checkName,
+				Status:    model.CheckRunPending,
+				Sequence:  &job.Sequence,
+			}); err != nil {
+				slog.Warn("mark pending failed", "check", checkName, "error", err)
+			}
+		}(check.Name)
 	}
+	pendingWg.Wait()
 
 	// 4. Execute all checks.
 	results, err := exec.Run(ctx, srcDir, *cfg, triggerCtx)


### PR DESCRIPTION
## Summary

- Replaces the sequential `for` loop that posts pending check runs (issue #201 item 3) with concurrent goroutines coordinated by `sync.WaitGroup`
- All pending-state POSTs now fire simultaneously; execution proceeds only after all complete (or warn on error)
- `sync` was already imported; no new dependencies added

## Test plan

- [ ] `go build ./...` — passes
- [ ] `go vet ./...` — passes
- [ ] `go test ./... -count=1` — all packages pass; `TestDockerSmoke` fails due to missing GCP credentials (pre-existing environment issue, unrelated to this change)

Closes #201 (item 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)