### PR TITLE
feat(executor): pass source via llb.HTTP instead of local directory

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"archive/tar"
 	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -137,52 +135,6 @@ func fetchConfig(ctx context.Context, client *http.Client, docstoreURL, repo, br
 	return &cfg, nil
 }
 
-func pullBranchSource(ctx context.Context, client *http.Client, docstoreURL, repo, branch string, headSeq int64) (string, error) {
-	tempDir, err := os.MkdirTemp("", "ci-worker-src-*")
-	if err != nil {
-		return "", fmt.Errorf("create temp dir: %w", err)
-	}
-
-	archiveURL := fmt.Sprintf("%s/repos/%s/-/archive?branch=%s&at=%d",
-		docstoreURL, repo, url.QueryEscape(branch), headSeq)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
-	if err != nil {
-		return tempDir, fmt.Errorf("create archive request: %w", err)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return tempDir, fmt.Errorf("fetch archive: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return tempDir, fmt.Errorf("fetch archive: unexpected status %d", resp.StatusCode)
-	}
-
-	tr := tar.NewReader(resp.Body)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return tempDir, fmt.Errorf("read archive: %w", err)
-		}
-		destPath := filepath.Join(tempDir, filepath.FromSlash(hdr.Name))
-		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
-			return tempDir, fmt.Errorf("create dir for %s: %w", hdr.Name, err)
-		}
-		content, err := io.ReadAll(tr)
-		if err != nil {
-			return tempDir, fmt.Errorf("read archive entry %s: %w", hdr.Name, err)
-		}
-		if err := os.WriteFile(destPath, content, 0o644); err != nil {
-			return tempDir, fmt.Errorf("write file %s: %w", hdr.Name, err)
-		}
-	}
-
-	return tempDir, nil
-}
 
 func postCheckRun(ctx context.Context, client *http.Client, docstoreURL, repo string, req model.CreateCheckRunRequest) error {
 	body, err := json.Marshal(req)
@@ -288,14 +240,11 @@ func runJob(
 		return "passed", nil, nil
 	}
 
-	// 2. Pull branch source into temp dir.
-	srcDir, err := pullBranchSource(ctx, httpClient, docstoreURL, job.Repo, job.Branch, job.Sequence)
-	if srcDir != "" {
-		defer os.RemoveAll(srcDir)
-	}
-	if err != nil {
-		return fail(fmt.Sprintf("pull source: %v", err))
-	}
+	// 2. Construct the archive URL; BuildKit fetches it directly via llb.HTTP.
+	// The sequence parameter makes the URL content-addressed, so BuildKit's
+	// HTTP cache deduplicates fetches across parallel checks at the same commit.
+	archiveURL := fmt.Sprintf("%s/repos/%s/-/archive?branch=%s&at=%d",
+		docstoreURL, job.Repo, url.QueryEscape(job.Branch), job.Sequence)
 
 	// 3. Mark each check as pending.
 	for _, check := range cfg.Checks {
@@ -310,7 +259,7 @@ func runJob(
 	}
 
 	// 4. Execute all checks.
-	results, err := exec.Run(ctx, srcDir, *cfg, triggerCtx)
+	results, err := exec.Run(ctx, archiveURL, *cfg, triggerCtx)
 	if err != nil {
 		return fail(fmt.Sprintf("executor: %v", err))
 	}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -62,10 +62,13 @@ func New(buildkitAddr, cacheBucket string) (*Executor, error) {
 	return &Executor{client: c, cacheBucket: cacheBucket}, nil
 }
 
-// Run executes all checks in cfg in parallel against sourceDir.
+// Run executes all checks in cfg in parallel, fetching source from archiveURL.
+// archiveURL must be a tar archive served over HTTP(S); BuildKit fetches it
+// directly so the worker is not in the data path.  Pass "" to use an empty
+// source directory (useful in tests where checks do not read source files).
 // Checks whose if: condition evaluates to false are skipped (omitted from results).
 // It returns once all checks have resolved.
-func (e *Executor) Run(ctx context.Context, sourceDir string, cfg Config, triggerCtx ciconfig.TriggerContext) ([]CheckResult, error) {
+func (e *Executor) Run(ctx context.Context, archiveURL string, cfg Config, triggerCtx ciconfig.TriggerContext) ([]CheckResult, error) {
 	// Pre-filter: evaluate if: conditions before launching goroutines.
 	type indexedCheck struct {
 		idx   int
@@ -106,7 +109,7 @@ func (e *Executor) Run(ctx context.Context, sourceDir string, cfg Config, trigge
 					}
 				}
 			}()
-			results[j] = e.runCheck(ctx, sourceDir, check)
+			results[j] = e.runCheck(ctx, archiveURL, check)
 		}(j, ic.check)
 	}
 	wg.Wait()
@@ -119,7 +122,7 @@ func (e *Executor) Close() error {
 }
 
 // runCheck executes a single check and returns its result.
-func (e *Executor) runCheck(ctx context.Context, sourceDir string, check Check) CheckResult {
+func (e *Executor) runCheck(ctx context.Context, archiveURL string, check Check) CheckResult {
 	var logBuf bytes.Buffer
 	ch := make(chan *client.SolveStatus)
 
@@ -149,10 +152,7 @@ func (e *Executor) runCheck(ctx context.Context, sourceDir string, check Check) 
 		ap.AuthConfigProvider = authprovider.LoadAuthConfig(dockerCfg)
 	}
 
-	localDirs := map[string]string{"src": sourceDir}
-
 	solveOpt := client.SolveOpt{
-		LocalDirs: localDirs,
 		Session: []session.Attachable{
 			authprovider.NewDockerAuthProvider(ap),
 		},
@@ -199,9 +199,24 @@ func (e *Executor) runCheck(ctx context.Context, sourceDir string, check Check) 
 		// share the host network namespace and can reach dockerd via TCP.
 		envOpts = append(envOpts, llb.AddEnv("DOCKER_HOST", "tcp://localhost:2375"))
 
-		source := llb.Local("src")
+		// Build the source mount.  When archiveURL is non-empty BuildKit fetches
+		// the tar directly (no worker intermediary) and a busybox step extracts
+		// it to /src.  The URL includes the commit sequence so BuildKit's HTTP
+		// cache deduplications across parallel checks at the same sequence.
+		// When archiveURL is empty (e.g. tests that do not access source) we use
+		// an empty scratch state.
+		var srcMount llb.State
+		if archiveURL != "" {
+			httpSrc := llb.HTTP(archiveURL, llb.Filename("source.tar"))
+			srcMount = llb.Image("busybox:latest").
+				Run(
+					llb.Args([]string{"sh", "-c", "mkdir -p /src && tar -xf /archive/source.tar -C /src"}),
+					llb.AddMount("/archive", httpSrc),
+				).GetMount("/src")
+		} else {
+			srcMount = llb.Scratch()
+		}
 		state := llb.Image(check.Image).Dir("/src")
-		srcMount := source
 
 		for _, step := range check.Steps {
 			runOpts := []llb.RunOption{

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -41,7 +41,6 @@ func newExecutor(t *testing.T) *executor.Executor {
 // and that output from the steps appears in Logs.
 func TestPass(t *testing.T) {
 	exec := newExecutor(t)
-	dir := t.TempDir()
 
 	cfg := executor.Config{
 		Checks: []executor.Check{
@@ -49,7 +48,7 @@ func TestPass(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{})
+	results, err := exec.Run(context.Background(), "", cfg, ciconfig.TriggerContext{})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -68,7 +67,6 @@ func TestPass(t *testing.T) {
 // TestFail verifies that a check whose step exits non-zero is marked "failed".
 func TestFail(t *testing.T) {
 	exec := newExecutor(t)
-	dir := t.TempDir()
 
 	cfg := executor.Config{
 		Checks: []executor.Check{
@@ -76,7 +74,7 @@ func TestFail(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{})
+	results, err := exec.Run(context.Background(), "", cfg, ciconfig.TriggerContext{})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -92,7 +90,6 @@ func TestFail(t *testing.T) {
 // correct independent result.
 func TestMultiCheck(t *testing.T) {
 	exec := newExecutor(t)
-	dir := t.TempDir()
 
 	cfg := executor.Config{
 		Checks: []executor.Check{
@@ -101,7 +98,7 @@ func TestMultiCheck(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{})
+	results, err := exec.Run(context.Background(), "", cfg, ciconfig.TriggerContext{})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -377,7 +374,6 @@ func TestIfConditionAllSkipped(t *testing.T) {
 // the Logs field.
 func TestLogCapture(t *testing.T) {
 	exec := newExecutor(t)
-	dir := t.TempDir()
 
 	cfg := executor.Config{
 		Checks: []executor.Check{
@@ -392,7 +388,7 @@ func TestLogCapture(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{})
+	results, err := exec.Run(context.Background(), "", cfg, ciconfig.TriggerContext{})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Replaces `llb.Local("src")` with an `llb.HTTP` fetch + busybox extraction step in the LLB DAG, so BuildKit fetches the source archive directly from docstore rather than having the worker download, extract, and re-transfer it over gRPC
- The archive URL includes `at={sequence}` making it content-addressed; BuildKit's HTTP cache deduplicates fetches across parallel checks and re-runs at the same sequence
- Removes `pullBranchSource()` from `cmd/ci-worker/main.go` entirely — no more temp directory creation, buffered extraction, or cleanup
- `executor.Run`/`runCheck` accept `archiveURL string` instead of `sourceDir string`; `localDirs` removed from `SolveOpt`
- Empty `archiveURL` (`""`) falls back to `llb.Scratch()` for tests whose checks don't read source files

Closes #201 (item 2)

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` passes (all packages except `TestDockerSmoke` which is a pre-existing GCP auth failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)