### PR TITLE
feat(tui): tab bar polish, merge conflict warning, refresh feedback (#208 items 4/5/7)

### DIFF
--- a/internal/tui/branchdetail.go
+++ b/internal/tui/branchdetail.go
@@ -43,10 +43,16 @@ type branchDetailModel struct {
 	expandedFiles  map[int]bool
 	diffFileHunks  []string // raw diff content per file (simplified)
 
+	mainHeadSeq int64 // current head sequence of main branch
+
 	// Merge confirmation state.
-	merging        bool
-	mergeConfirm   bool // waiting for y/N
-	mergeMessage   string
+	merging      bool
+	mergeConfirm bool // waiting for y/N
+	mergeMessage string
+
+	// Refresh feedback state.
+	refreshing    bool
+	lastRefreshed time.Time
 
 	// Review overlay.
 	showReviewOverlay bool
@@ -187,6 +193,8 @@ func (m branchDetailModel) Update(msg tea.Msg) (branchDetailModel, tea.Cmd) {
 
 	case branchDetailLoadedMsg:
 		m.loading = false
+		m.refreshing = false
+		m.lastRefreshed = time.Now()
 		m.err = msg.err
 		if msg.err == nil {
 			m.diff = msg.diff
@@ -194,6 +202,7 @@ func (m branchDetailModel) Update(msg tea.Msg) (branchDetailModel, tea.Cmd) {
 			m.checks = msg.checks
 			m.headSeq = msg.headSeq
 			m.baseSeq = msg.baseSeq
+			m.mainHeadSeq = msg.mainHeadSeq
 			m.baseTreePaths = msg.baseTreePaths
 			m.proposal = msg.proposal
 		}
@@ -256,6 +265,7 @@ func (m branchDetailModel) Update(msg tea.Msg) (branchDetailModel, tea.Cmd) {
 
 		case "R":
 			m.loading = true
+			m.refreshing = true
 			m.err = nil
 			m.mergeMessage = ""
 			return m, loadBranchDetail(m.client, m.branchName)
@@ -332,6 +342,11 @@ func (m branchDetailModel) View() string {
 	// Merge confirmation or message.
 	if m.mergeConfirm {
 		sb.WriteString("\n")
+		if m.mainHeadSeq > 0 && m.baseSeq < m.mainHeadSeq {
+			sb.WriteString(styleError.Render(fmt.Sprintf(
+				"  ⚠ base seq %d is behind main head seq %d — conflicts possible",
+				m.baseSeq, m.mainHeadSeq)) + "\n")
+		}
 		sb.WriteString(styleConfirm.Render(fmt.Sprintf("  Merge %s into main? [y/N] ", m.branchName)))
 	} else if m.merging {
 		sb.WriteString("\n  Merging...\n")
@@ -355,6 +370,11 @@ func (m branchDetailModel) View() string {
 			helpText = "  tab panels · enter expand/collapse · p proposal · r review · m merge · R refresh · q back"
 		}
 		sb.WriteString(styleHelp.Render(helpText))
+		if m.refreshing {
+			sb.WriteString("\n" + styleHelp.Render("  ↻ refreshing…"))
+		} else if !m.lastRefreshed.IsZero() {
+			sb.WriteString("\n" + styleHelp.Render("  last refreshed at "+m.lastRefreshed.Format("15:04:05")))
+		}
 	}
 
 	return sb.String()
@@ -365,7 +385,7 @@ func (m branchDetailModel) renderTabs() string {
 		label string
 		p     panel
 	}{
-		{"[Diff]", panelDiff},
+		{"Diff", panelDiff},
 		{"Reviews", panelReviews},
 		{"Checks", panelChecks},
 	}

--- a/internal/tui/branchlist.go
+++ b/internal/tui/branchlist.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -16,6 +17,9 @@ type branchListModel struct {
 	err        error
 	openBranch string
 	quit       bool
+
+	refreshing    bool
+	lastRefreshed time.Time
 }
 
 func newBranchListModel(client *tuiClient) branchListModel {
@@ -34,6 +38,8 @@ func (m branchListModel) Update(msg tea.Msg) (branchListModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case branchesLoadedMsg:
 		m.loading = false
+		m.refreshing = false
+		m.lastRefreshed = time.Now()
 		m.err = msg.err
 		m.branches = msg.branches
 		if m.cursor >= len(m.branches) {
@@ -62,6 +68,7 @@ func (m branchListModel) Update(msg tea.Msg) (branchListModel, tea.Cmd) {
 
 		case "R":
 			m.loading = true
+			m.refreshing = true
 			m.err = nil
 			return m, loadBranches(m.client)
 		}
@@ -105,7 +112,13 @@ func (m branchListModel) View() string {
 	}
 
 	sb.WriteString("\n")
-	sb.WriteString(styleHelp.Render("  j/k navigate · enter open · R refresh · q quit"))
+	if m.refreshing {
+		sb.WriteString(styleHelp.Render("  j/k navigate · enter open · R refresh · q quit  ↻ refreshing…"))
+	} else if !m.lastRefreshed.IsZero() {
+		sb.WriteString(styleHelp.Render("  j/k navigate · enter open · R refresh · q quit  · last refreshed at " + m.lastRefreshed.Format("15:04:05")))
+	} else {
+		sb.WriteString(styleHelp.Render("  j/k navigate · enter open · R refresh · q quit"))
+	}
 
 	return sb.String()
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -195,6 +195,7 @@ type branchDetailLoadedMsg struct {
 	checks        []model.CheckRun
 	headSeq       int64
 	baseSeq       int64
+	mainHeadSeq   int64 // current head sequence of main branch
 	baseTreePaths map[string]bool
 	proposal      *model.Proposal // nil if no open proposal
 	err           error
@@ -312,12 +313,14 @@ func loadBranchDetail(c *tuiClient, branchName string) tea.Cmd {
 		if err := c.decodeJSON(bResp, &allBranches); err != nil {
 			return branchDetailLoadedMsg{err: err}
 		}
-		var headSeq, baseSeq int64
+		var headSeq, baseSeq, mainHeadSeq int64
 		for _, b := range allBranches {
 			if b.Name == branchName {
 				headSeq = b.HeadSequence
 				baseSeq = b.BaseSequence
-				break
+			}
+			if b.Name == "main" {
+				mainHeadSeq = b.HeadSequence
 			}
 		}
 
@@ -400,6 +403,7 @@ func loadBranchDetail(c *tuiClient, branchName string) tea.Cmd {
 			checks:        checks,
 			headSeq:       headSeq,
 			baseSeq:       baseSeq,
+			mainHeadSeq:   mainHeadSeq,
 			baseTreePaths: baseTreePaths,
 			proposal:      openProposal,
 		}


### PR DESCRIPTION
## Summary

- **Item 4 — Tab bar label fix**: The `renderTabs()` function already rendered a styled tab bar; the first tab label had a stale `[Diff]` bracket that was inconsistent with `Reviews` and `Checks`. Cleaned up to just `Diff`; active/inactive distinction is handled entirely by `styleTabActive`/`styleTabInactive`.

- **Item 5 — Merge conflict warning**: `loadBranchDetail` now captures `mainHeadSeq` from the `/branches` list alongside the branch's own `headSeq`/`baseSeq`. This flows through `branchDetailLoadedMsg` into `branchDetailModel`. Before showing the `[y/N]` merge prompt, the view now renders a red warning line if `baseSeq < mainHeadSeq` (branch is behind main head — conflicts possible).

- **Item 7 — Refresh feedback**: Both `branchListModel` and `branchDetailModel` gain `refreshing bool` and `lastRefreshed time.Time` fields. Manual `R`-press sets `refreshing = true`; the `*LoadedMsg` handler clears it and stamps `lastRefreshed = time.Now()`. The help footer now shows `↻ refreshing…` while in-flight and `last refreshed at HH:MM:SS` once complete.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/tui/...` — passes
- [x] `go test ./... -count=1` — all pass except `TestDockerSmoke` (pre-existing Docker infra failure, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)