### PR TITLE
feat(tui): render inline line-level diffs in branch detail diff tab

### DIFF
--- a/internal/tui/branchdetail.go
+++ b/internal/tui/branchdetail.go
@@ -20,6 +20,18 @@ const (
 	panelChecks
 )
 
+// diffHunkLine is a single line in a computed line-level diff.
+type diffHunkLine struct {
+	kind byte   // '+', '-', or ' '
+	text string
+}
+
+// fileDiffData holds pre-computed diff lines for a single changed file.
+type fileDiffData struct {
+	hunks []diffHunkLine
+	err   string // non-empty if fetch or diff computation failed
+}
+
 // branchDetailModel shows diff, reviews, and checks for a specific branch.
 type branchDetailModel struct {
 	client     *tuiClient
@@ -34,14 +46,14 @@ type branchDetailModel struct {
 	headSeq       int64
 	baseSeq       int64
 	baseTreePaths map[string]bool
+	fileContents  map[string]fileDiffData // pre-fetched diffs keyed by path
 
 	// Proposal state for the current branch.
 	proposal *model.Proposal // nil = not yet loaded or no open proposal
 
-	activePanel    panel
-	diffCursor     int
-	expandedFiles  map[int]bool
-	diffFileHunks  []string // raw diff content per file (simplified)
+	activePanel   panel
+	diffCursor    int
+	expandedFiles map[int]bool
 
 	// Merge confirmation state.
 	merging        bool
@@ -195,6 +207,7 @@ func (m branchDetailModel) Update(msg tea.Msg) (branchDetailModel, tea.Cmd) {
 			m.headSeq = msg.headSeq
 			m.baseSeq = msg.baseSeq
 			m.baseTreePaths = msg.baseTreePaths
+			m.fileContents = msg.fileContents
 			m.proposal = msg.proposal
 		}
 		// Auto-refresh: schedule a tick if any HEAD check is pending.
@@ -441,12 +454,14 @@ func (m branchDetailModel) renderDiff() string {
 			sb.WriteString(prefix + iconStyled + " " + pathLabel + "\n")
 		}
 
-		// If expanded, show placeholder or binary notice.
+		// If expanded, show diff content or binary notice.
 		if m.expandedFiles[i] {
 			if f.binary {
 				sb.WriteString(styleModified.Render("    binary file, no preview") + "\n")
+			} else if data, ok := m.fileContents[f.path]; ok {
+				sb.WriteString(renderFileDiff(data))
 			} else {
-				sb.WriteString(styleModified.Render("    (file contents diff not available in current view)") + "\n")
+				sb.WriteString(styleModified.Render("    (diff not available)") + "\n")
 			}
 		}
 	}
@@ -573,4 +588,118 @@ func (m branchDetailModel) renderChecks() string {
 		}
 	}
 	return sb.String()
+}
+
+// renderFileDiff renders pre-computed diff hunks as coloured lines.
+func renderFileDiff(data fileDiffData) string {
+	var sb strings.Builder
+	if data.err != "" {
+		sb.WriteString(styleModified.Render("    "+data.err) + "\n")
+		return sb.String()
+	}
+	const maxLines = 300
+	hunks := data.hunks
+	truncated := false
+	if len(hunks) > maxLines {
+		hunks = hunks[:maxLines]
+		truncated = true
+	}
+	for _, h := range hunks {
+		line := "    " + string([]byte{h.kind}) + " " + h.text
+		switch h.kind {
+		case '+':
+			sb.WriteString(styleAdded.Render(line) + "\n")
+		case '-':
+			sb.WriteString(styleRemoved.Render(line) + "\n")
+		default:
+			sb.WriteString(styleStale.Render(line) + "\n")
+		}
+	}
+	if truncated {
+		sb.WriteString(styleModified.Render("    ... (output truncated)") + "\n")
+	}
+	return sb.String()
+}
+
+// computeFileDiff builds a fileDiffData from raw base and head file content.
+// changeType is "+", "-", or "~".
+func computeFileDiff(baseContent, headContent []byte, changeType string) fileDiffData {
+	splitLines := func(b []byte) []string {
+		lines := strings.Split(string(b), "\n")
+		// Trim trailing empty line produced by a trailing newline.
+		if len(lines) > 0 && lines[len(lines)-1] == "" {
+			lines = lines[:len(lines)-1]
+		}
+		return lines
+	}
+
+	switch changeType {
+	case "+":
+		lines := splitLines(headContent)
+		hunks := make([]diffHunkLine, len(lines))
+		for i, l := range lines {
+			hunks[i] = diffHunkLine{'+', l}
+		}
+		return fileDiffData{hunks: hunks}
+	case "-":
+		lines := splitLines(baseContent)
+		hunks := make([]diffHunkLine, len(lines))
+		for i, l := range lines {
+			hunks[i] = diffHunkLine{'-', l}
+		}
+		return fileDiffData{hunks: hunks}
+	default: // "~"
+		base := splitLines(baseContent)
+		head := splitLines(headContent)
+		if len(base)+len(head) > 4000 {
+			return fileDiffData{err: "(file too large to diff inline)"}
+		}
+		return fileDiffData{hunks: lcsLineDiff(base, head)}
+	}
+}
+
+// lcsLineDiff computes a line-level diff of base → head using LCS.
+func lcsLineDiff(base, head []string) []diffHunkLine {
+	m, n := len(base), len(head)
+
+	// Build DP table.
+	dp := make([][]int, m+1)
+	for i := range dp {
+		dp[i] = make([]int, n+1)
+	}
+	for i := 1; i <= m; i++ {
+		for j := 1; j <= n; j++ {
+			if base[i-1] == head[j-1] {
+				dp[i][j] = dp[i-1][j-1] + 1
+			} else if dp[i-1][j] >= dp[i][j-1] {
+				dp[i][j] = dp[i-1][j]
+			} else {
+				dp[i][j] = dp[i][j-1]
+			}
+		}
+	}
+
+	// Traceback (builds result in reverse).
+	result := make([]diffHunkLine, 0, m+n)
+	i, j := m, n
+	for i > 0 || j > 0 {
+		switch {
+		case i > 0 && j > 0 && base[i-1] == head[j-1]:
+			result = append(result, diffHunkLine{' ', base[i-1]})
+			i--
+			j--
+		case j > 0 && (i == 0 || dp[i][j-1] > dp[i-1][j]):
+			result = append(result, diffHunkLine{'+', head[j-1]})
+			j--
+		default:
+			result = append(result, diffHunkLine{'-', base[i-1]})
+			i--
+		}
+	}
+
+	// Reverse to get forward order.
+	for l, r := 0, len(result)-1; l < r; l, r = l+1, r-1 {
+		result[l], result[r] = result[r], result[l]
+	}
+	return result
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -196,6 +197,7 @@ type branchDetailLoadedMsg struct {
 	headSeq       int64
 	baseSeq       int64
 	baseTreePaths map[string]bool
+	fileContents  map[string]fileDiffData
 	proposal      *model.Proposal // nil if no open proposal
 	err           error
 }
@@ -394,6 +396,51 @@ func loadBranchDetail(c *tuiClient, branchName string) tea.Cmd {
 			pResp.Body.Close()
 		}
 
+		// Fetch file content for each non-binary changed file so the diff tab
+		// can render inline diffs when the user expands a file.
+		fileContents := make(map[string]fileDiffData, len(diff.BranchChanges))
+		for _, entry := range diff.BranchChanges {
+			if entry.Binary {
+				continue
+			}
+			changeType := "~"
+			if entry.VersionID == nil {
+				changeType = "-"
+			} else if !baseTreePaths[entry.Path] {
+				changeType = "+"
+			}
+
+			var baseBytes, headBytes []byte
+
+			// Fetch head content when the file exists at head.
+			if entry.VersionID != nil && headSeq > 0 {
+				path := "/file/" + entry.Path + "?branch=" + url.QueryEscape(branchName) +
+					"&at=" + strconv.FormatInt(headSeq, 10)
+				if fResp, fErr := c.get(path); fErr == nil {
+					var fr model.FileResponse
+					if decErr := c.decodeJSON(fResp, &fr); decErr == nil {
+						headBytes = fr.Content
+					}
+					fResp.Body.Close()
+				}
+			}
+
+			// Fetch base content when the file existed before the branch changes.
+			if baseTreePaths[entry.Path] && baseSeq > 0 {
+				path := "/file/" + entry.Path + "?branch=" + url.QueryEscape(branchName) +
+					"&at=" + strconv.FormatInt(baseSeq, 10)
+				if fResp, fErr := c.get(path); fErr == nil {
+					var fr model.FileResponse
+					if decErr := c.decodeJSON(fResp, &fr); decErr == nil {
+						baseBytes = fr.Content
+					}
+					fResp.Body.Close()
+				}
+			}
+
+			fileContents[entry.Path] = computeFileDiff(baseBytes, headBytes, changeType)
+		}
+
 		return branchDetailLoadedMsg{
 			diff:          &diff,
 			reviews:       reviews,
@@ -401,6 +448,7 @@ func loadBranchDetail(c *tuiClient, branchName string) tea.Cmd {
 			headSeq:       headSeq,
 			baseSeq:       baseSeq,
 			baseTreePaths: baseTreePaths,
+			fileContents:  fileContents,
 			proposal:      openProposal,
 		}
 	}


### PR DESCRIPTION
## Summary

- Fetches file content at both base and head sequences in `loadBranchDetail` for each non-binary changed file
- Computes a line-level LCS diff and stores it in the model as `fileDiffData`
- When a file is expanded in the diff tab, renders added lines in green (`+`), removed lines in red (`-`), and context lines in gray instead of the placeholder message
- Added files show all lines as `+`, deleted files show all lines as `-`, modified files get full LCS diff
- Files >4000 combined lines show `(file too large to diff inline)`, output capped at 300 lines with truncation notice

## Test plan

- [ ] Existing TUI tests pass (`go test ./internal/tui/... -count=1`)
- [ ] `go build ./...` and `go vet ./...` clean
- [ ] Manually verify: open a branch in the TUI diff tab, press Enter on a changed file — should now show actual diff lines instead of the placeholder

Note: `TestDockerSmoke` in `internal/server` fails due to missing `gcloud` credentials in this environment — pre-existing issue unrelated to this change.

Closes #208 item 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)