### PR TITLE
feat(tui): fix author column and expand proposal support (#208 items 2&3)

### DIFF
--- a/internal/tui/branchdetail.go
+++ b/internal/tui/branchdetail.go
@@ -18,6 +18,7 @@ const (
 	panelDiff panel = iota
 	panelReviews
 	panelChecks
+	panelProposal
 )
 
 // branchDetailModel shows diff, reviews, and checks for a specific branch.
@@ -223,6 +224,14 @@ func (m branchDetailModel) Update(msg tea.Msg) (branchDetailModel, tea.Cmd) {
 			m.mergeMessage = styleApproved.Render(fmt.Sprintf("Merged into main at sequence %d.", msg.sequence))
 		}
 
+	case proposalClosedMsg:
+		if msg.err != nil {
+			m.mergeMessage = styleError.Render("Close proposal failed: " + msg.err.Error())
+		} else {
+			m.loading = true
+			return m, loadBranchDetail(m.client, m.branchName)
+		}
+
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q":
@@ -233,7 +242,7 @@ func (m branchDetailModel) Update(msg tea.Msg) (branchDetailModel, tea.Cmd) {
 			m.quit = true
 
 		case "tab":
-			m.activePanel = (m.activePanel + 1) % 3
+			m.activePanel = (m.activePanel + 1) % 4
 
 		case "p":
 			// Only open proposal overlay if no open proposal exists.
@@ -241,6 +250,12 @@ func (m branchDetailModel) Update(msg tea.Msg) (branchDetailModel, tea.Cmd) {
 				m.showProposalOverlay = true
 				m.proposalOverlay = newProposalOverlay(m.client, m.branchName)
 				return m, m.proposalOverlay.Init()
+			}
+
+		case "X":
+			// Close an open proposal.
+			if m.proposal != nil && m.proposal.State == model.ProposalOpen {
+				return m, closeProposal(m.client, m.proposal.ID)
 			}
 
 		case "r":
@@ -326,6 +341,8 @@ func (m branchDetailModel) View() string {
 			sb.WriteString(m.renderReviews())
 		case panelChecks:
 			sb.WriteString(m.renderChecks())
+		case panelProposal:
+			sb.WriteString(m.renderProposal())
 		}
 	}
 
@@ -353,6 +370,8 @@ func (m branchDetailModel) View() string {
 		helpText := "  tab panels · enter expand/collapse · r review · m merge · R refresh · q back"
 		if m.proposal == nil && !m.loading {
 			helpText = "  tab panels · enter expand/collapse · p proposal · r review · m merge · R refresh · q back"
+		} else if m.proposal != nil && m.proposal.State == model.ProposalOpen && !m.loading {
+			helpText = "  tab panels · enter expand/collapse · X close proposal · r review · m merge · R refresh · q back"
 		}
 		sb.WriteString(styleHelp.Render(helpText))
 	}
@@ -368,6 +387,7 @@ func (m branchDetailModel) renderTabs() string {
 		{"[Diff]", panelDiff},
 		{"Reviews", panelReviews},
 		{"Checks", panelChecks},
+		{"Proposal", panelProposal},
 	}
 	parts := make([]string, len(tabs))
 	for i, t := range tabs {
@@ -516,6 +536,23 @@ func (m branchDetailModel) renderReviews() string {
 			sb.WriteString(line + "\n")
 		}
 	}
+	return sb.String()
+}
+
+func (m branchDetailModel) renderProposal() string {
+	if m.proposal == nil {
+		return "  No open proposal.\n"
+	}
+	p := m.proposal
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("  Title:       %s\n", p.Title))
+	sb.WriteString(fmt.Sprintf("  Author:      %s\n", p.Author))
+	sb.WriteString(fmt.Sprintf("  Base branch: %s\n", p.BaseBranch))
+	sb.WriteString(fmt.Sprintf("  State:       %s\n", string(p.State)))
+	if p.Description != "" {
+		sb.WriteString(fmt.Sprintf("  Description: %s\n", p.Description))
+	}
+	sb.WriteString(fmt.Sprintf("  Created:     %s\n", p.CreatedAt.Format("2006-01-02 15:04:05")))
 	return sb.String()
 }
 

--- a/internal/tui/branchlist.go
+++ b/internal/tui/branchlist.go
@@ -93,7 +93,7 @@ func (m branchListModel) View() string {
 			ci := formatCISummary(s.passed, s.failed, s.pending)
 
 			line := fmt.Sprintf("%-30s %-5d %-5d %-20s %-5s %-5s",
-				truncate(b.Name, 30), b.HeadSequence, b.BaseSequence, "", rev, ci)
+				truncate(b.Name, 30), b.HeadSequence, b.BaseSequence, truncate(s.author, 20), rev, ci)
 
 			prefix := "  "
 			if i == m.cursor {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -216,9 +216,14 @@ type proposalOpenedMsg struct {
 	err error
 }
 
+type proposalClosedMsg struct {
+	err error
+}
+
 // branchSummary holds a branch plus its review/check summary.
 type branchSummary struct {
 	branch   model.Branch
+	author   string
 	approved int
 	rejected int
 	passed   int
@@ -244,6 +249,19 @@ func loadBranches(c *tuiClient) tea.Cmd {
 		summaries := make([]branchSummary, 0, len(branches))
 		for _, b := range branches {
 			s := branchSummary{branch: b}
+
+			// Fetch head commit to get branch author.
+			if b.HeadSequence > 0 {
+				commitPath := fmt.Sprintf("/commit/%d", b.HeadSequence)
+				cmResp, cmErr := c.get(commitPath)
+				if cmErr == nil {
+					var cm model.GetCommitResponse
+					if jsonErr := c.decodeJSON(cmResp, &cm); jsonErr == nil {
+						s.author = cm.Author
+					}
+					cmResp.Body.Close()
+				}
+			}
 
 			// Fetch reviews (explicit close per iteration; deduplicate per reviewer).
 			rResp, rErr := c.get("/branch/" + url.PathEscape(b.Name) + "/reviews")
@@ -433,11 +451,11 @@ func mergeBranch(c *tuiClient, branchName string) tea.Cmd {
 	}
 }
 
-func openProposal(c *tuiClient, branchName, title, description string) tea.Cmd {
+func openProposal(c *tuiClient, branchName, title, description, baseBranch string) tea.Cmd {
 	return func() tea.Msg {
 		req := model.CreateProposalRequest{
 			Branch:      branchName,
-			BaseBranch:  "main",
+			BaseBranch:  baseBranch,
 			Title:       title,
 			Description: description,
 		}
@@ -456,6 +474,23 @@ func openProposal(c *tuiClient, branchName, title, description string) tea.Cmd {
 		var r model.CreateProposalResponse
 		json.NewDecoder(resp.Body).Decode(&r)
 		return proposalOpenedMsg{id: r.ID}
+	}
+}
+
+func closeProposal(c *tuiClient, proposalID string) tea.Cmd {
+	return func() tea.Msg {
+		resp, err := c.postJSON("/proposals/"+proposalID+"/close", nil)
+		if err != nil {
+			return proposalClosedMsg{err: err}
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+			var errResp model.ErrorResponse
+			json.NewDecoder(resp.Body).Decode(&errResp)
+			return proposalClosedMsg{err: fmt.Errorf("server error: %s", errResp.Error)}
+		}
+		return proposalClosedMsg{}
 	}
 }
 

--- a/internal/tui/proposaloverlay.go
+++ b/internal/tui/proposaloverlay.go
@@ -7,16 +7,26 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+// focus tracks which input field is active in the proposal overlay.
+type proposalFocus int
+
+const (
+	focusTitle proposalFocus = iota
+	focusDesc
+	focusBase
+)
+
 // proposalOverlayModel is the modal for creating a new proposal.
 type proposalOverlayModel struct {
-	client      *tuiClient
-	branch      string
-	titleInput  textinput.Model
-	descInput   textinput.Model
-	focusDesc   bool // true when description input is focused
-	submitting  bool
-	err         error
-	submitted   bool
+	client          *tuiClient
+	branch          string
+	titleInput      textinput.Model
+	descInput       textinput.Model
+	baseBranchInput textinput.Model
+	focus           proposalFocus
+	submitting      bool
+	err             error
+	submitted       bool
 }
 
 func newProposalOverlay(client *tuiClient, branch string) proposalOverlayModel {
@@ -29,11 +39,18 @@ func newProposalOverlay(client *tuiClient, branch string) proposalOverlayModel {
 	di.Placeholder = "Description (optional)"
 	di.Width = 48
 
+	bi := textinput.New()
+	bi.Placeholder = "Base branch"
+	bi.SetValue("main")
+	bi.Width = 48
+
 	return proposalOverlayModel{
-		client:     client,
-		branch:     branch,
-		titleInput: ti,
-		descInput:  di,
+		client:          client,
+		branch:          branch,
+		titleInput:      ti,
+		descInput:       di,
+		baseBranchInput: bi,
+		focus:           focusTitle,
 	}
 }
 
@@ -49,20 +66,28 @@ func (m proposalOverlayModel) Update(msg tea.Msg) (proposalOverlayModel, tea.Cmd
 			return m, nil
 
 		case "tab":
-			m.focusDesc = !m.focusDesc
-			if m.focusDesc {
-				m.titleInput.Blur()
-				m.descInput.Focus()
-			} else {
-				m.descInput.Blur()
+			m.focus = (m.focus + 1) % 3
+			m.titleInput.Blur()
+			m.descInput.Blur()
+			m.baseBranchInput.Blur()
+			switch m.focus {
+			case focusTitle:
 				m.titleInput.Focus()
+			case focusDesc:
+				m.descInput.Focus()
+			case focusBase:
+				m.baseBranchInput.Focus()
 			}
 			return m, textinput.Blink
 
 		case "enter":
 			if !m.submitting && m.titleInput.Value() != "" {
+				baseBranch := m.baseBranchInput.Value()
+				if baseBranch == "" {
+					baseBranch = "main"
+				}
 				m.submitting = true
-				return m, openProposal(m.client, m.branch, m.titleInput.Value(), m.descInput.Value())
+				return m, openProposal(m.client, m.branch, m.titleInput.Value(), m.descInput.Value(), baseBranch)
 			}
 		}
 
@@ -77,10 +102,13 @@ func (m proposalOverlayModel) Update(msg tea.Msg) (proposalOverlayModel, tea.Cmd
 	}
 
 	var cmd tea.Cmd
-	if m.focusDesc {
-		m.descInput, cmd = m.descInput.Update(msg)
-	} else {
+	switch m.focus {
+	case focusTitle:
 		m.titleInput, cmd = m.titleInput.Update(msg)
+	case focusDesc:
+		m.descInput, cmd = m.descInput.Update(msg)
+	case focusBase:
+		m.baseBranchInput, cmd = m.baseBranchInput.Update(msg)
 	}
 	return m, cmd
 }
@@ -91,17 +119,22 @@ func (m proposalOverlayModel) View() string {
 	sb.WriteString(styleTitle.Render("Open Proposal") + "\n\n")
 	sb.WriteString("  Branch: " + m.branch + "\n\n")
 
-	titleLabel := "  Title:       "
-	descLabel := "  Description: "
-	if !m.focusDesc {
+	titleLabel := "  Title:        "
+	descLabel := "  Description:  "
+	baseLabel := "  Base branch:  "
+	if m.focus == focusTitle {
 		titleLabel = styleApproved.Render(titleLabel)
 	}
-	if m.focusDesc {
+	if m.focus == focusDesc {
 		descLabel = styleApproved.Render(descLabel)
+	}
+	if m.focus == focusBase {
+		baseLabel = styleApproved.Render(baseLabel)
 	}
 
 	sb.WriteString(titleLabel + m.titleInput.View() + "\n")
-	sb.WriteString(descLabel + m.descInput.View() + "\n\n")
+	sb.WriteString(descLabel + m.descInput.View() + "\n")
+	sb.WriteString(baseLabel + m.baseBranchInput.View() + "\n\n")
 
 	if m.err != nil {
 		sb.WriteString(styleError.Render("  Error: "+m.err.Error()) + "\n\n")


### PR DESCRIPTION
## Summary

- **Author column** (item 2): `branchlist.go` was hardcoding empty string for author. Now fetches the head commit via `GET /commit/{headSequence}` in `loadBranches` and populates `branchSummary.author`.
- **Proposal detail** (item 3): Added a 4th "Proposal" tab to the branch detail view that shows title, author, base branch, state, description, and created-at timestamp.
- **Close proposal** (item 3): Added `X` key binding in branch detail when an open proposal exists; calls `POST /proposals/{id}/close` and refreshes the view on success.
- **Base branch input** (item 3): Replaced the hardcoded `BaseBranch: "main"` in the proposal creation overlay with a proper text input field (defaulting to "main"); tab now cycles through title → description → base branch.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all pass (only `TestDockerSmoke` fails due to pre-existing gcloud auth issue in this environment, unrelated to these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)