### PR TITLE
fix(executor): reject local source paths with '..' to prevent path traversal

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -125,6 +126,23 @@ func (e *Executor) Close() error {
 
 // runCheck executes a single check and returns its result.
 func (e *Executor) runCheck(ctx context.Context, source string, check Check) CheckResult {
+	isHTTP := strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://")
+	isLocal := source != "" && !isHTTP
+
+	// Reject local paths containing ".." segments to prevent directory traversal.
+	if isLocal {
+		cleaned := filepath.Clean(source)
+		for _, seg := range strings.Split(cleaned, string(filepath.Separator)) {
+			if seg == ".." {
+				return CheckResult{
+					Name:   check.Name,
+					Status: "failed",
+					Logs:   "invalid source path: '..' path traversal is not allowed",
+				}
+			}
+		}
+	}
+
 	var logBuf bytes.Buffer
 	ch := make(chan *client.SolveStatus)
 
@@ -153,9 +171,6 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check) Che
 	if dockerCfg != nil {
 		ap.AuthConfigProvider = authprovider.LoadAuthConfig(dockerCfg)
 	}
-
-	isHTTP := strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://")
-	isLocal := source != "" && !isHTTP
 
 	solveOpt := client.SolveOpt{
 		Session: []session.Attachable{

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -407,6 +407,39 @@ func TestLocalPathSource(t *testing.T) {
 	}
 }
 
+// TestPathTraversalRejected verifies that a local source path containing ".."
+// segments is rejected before any build is attempted.
+func TestPathTraversalRejected(t *testing.T) {
+	exec := newExecutor(t)
+
+	cfg := executor.Config{
+		Checks: []executor.Check{
+			{Name: "ci/test", Image: "alpine", Steps: []string{"echo hi"}},
+		},
+	}
+
+	badPaths := []string{
+		"../../etc/passwd",
+		"../secret",
+		"foo/../../bar",
+	}
+	for _, path := range badPaths {
+		results, err := exec.Run(context.Background(), path, cfg, ciconfig.TriggerContext{})
+		if err != nil {
+			t.Fatalf("Run(%q): unexpected error: %v", path, err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("Run(%q): expected 1 result, got %d", path, len(results))
+		}
+		if results[0].Status != "failed" {
+			t.Errorf("Run(%q): expected status failed, got %s (logs: %s)", path, results[0].Status, results[0].Logs)
+		}
+		if !strings.Contains(results[0].Logs, "..") {
+			t.Errorf("Run(%q): expected error message mentioning '..', got: %s", path, results[0].Logs)
+		}
+	}
+}
+
 // TestLogCapture verifies that stdout and stderr from steps both appear in
 // the Logs field.
 func TestLogCapture(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `filepath.Clean()` + `..`-segment rejection to `runCheck()` before any build is attempted
- Moves `isHTTP`/`isLocal` computation to the top of `runCheck()` so the early-return path cannot leak the collector goroutine
- Adds `TestPathTraversalRejected` covering `../../etc/passwd`, `../secret`, and `foo/../../bar`

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)