### PR TITLE
fix(executor): initialize FrontendAttrs to avoid nil map panic with GCS cache

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -158,6 +158,10 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check) Che
 	isLocal := source != "" && !isHTTP
 
 	solveOpt := client.SolveOpt{
+		// FrontendAttrs must be non-nil: BuildKit v0.29 calls maps.Clone(opt.FrontendAttrs)
+		// then maps.Copy(result, cacheOpt.frontendAttrs), which panics when CacheImports/
+		// CacheExports are set and FrontendAttrs is nil.
+		FrontendAttrs: map[string]string{},
 		Session: []session.Attachable{
 			authprovider.NewDockerAuthProvider(ap),
 		},


### PR DESCRIPTION
## Summary

- All CI jobs were failing immediately with `panic: assignment to entry in nil map`
- Root cause: BuildKit v0.29 calls `maps.Clone(opt.FrontendAttrs)` then `maps.Copy(result, cacheOpt.frontendAttrs)` — when `FrontendAttrs` is nil and cache options are set (`CACHE_BUCKET=docstore-ci-cache` in prod), `maps.Clone(nil)` returns nil and `maps.Copy` panics writing to it
- Fix: pre-initialize `FrontendAttrs` to an empty map in `solveOpt`

## Test plan

- [ ] PR merges and ci-worker image is rebuilt/redeployed
- [ ] Run `python3 scripts/ci-bench.py --n 10` — expect jobs to pass instead of failing with panic
- [ ] Confirm GCS cache (`docstore-ci-cache`) is being read/written (faster subsequent runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)