### PR TITLE
fix(executor): reject path traversal in local source paths

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -125,6 +126,25 @@ func (e *Executor) Close() error {
 
 // runCheck executes a single check and returns its result.
 func (e *Executor) runCheck(ctx context.Context, source string, check Check) CheckResult {
+	isHTTP := strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://")
+	isLocal := source != "" && !isHTTP
+
+	// Validate local path: clean it and reject any path that still contains
+	// ".." segments after cleaning, which indicates a path traversal attempt.
+	if isLocal {
+		cleaned := filepath.Clean(source)
+		for _, seg := range strings.Split(cleaned, string(filepath.Separator)) {
+			if seg == ".." {
+				return CheckResult{
+					Name:   check.Name,
+					Status: "failed",
+					Logs:   fmt.Sprintf("invalid source path %q: path traversal not allowed", source),
+				}
+			}
+		}
+		source = cleaned
+	}
+
 	var logBuf bytes.Buffer
 	ch := make(chan *client.SolveStatus)
 
@@ -153,9 +173,6 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check) Che
 	if dockerCfg != nil {
 		ap.AuthConfigProvider = authprovider.LoadAuthConfig(dockerCfg)
 	}
-
-	isHTTP := strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://")
-	isLocal := source != "" && !isHTTP
 
 	solveOpt := client.SolveOpt{
 		Session: []session.Attachable{

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -407,6 +407,33 @@ func TestLocalPathSource(t *testing.T) {
 	}
 }
 
+// TestPathTraversalRejected verifies that a source path containing ".." segments
+// is rejected with status "failed" before any buildkitd interaction.
+func TestPathTraversalRejected(t *testing.T) {
+	exec := newExecutor(t)
+
+	cfg := executor.Config{
+		Checks: []executor.Check{
+			{Name: "ci/test", Image: "alpine", Steps: []string{"echo hi"}},
+		},
+	}
+
+	results, err := exec.Run(context.Background(), "../../etc/passwd", cfg, ciconfig.TriggerContext{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.Status != "failed" {
+		t.Errorf("expected status failed for path traversal, got %s (logs: %s)", r.Status, r.Logs)
+	}
+	if !strings.Contains(r.Logs, "path traversal") {
+		t.Errorf("expected path traversal error in logs, got: %s", r.Logs)
+	}
+}
+
 // TestLogCapture verifies that stdout and stderr from steps both appear in
 // the Logs field.
 func TestLogCapture(t *testing.T) {


### PR DESCRIPTION
## Summary

- Apply `filepath.Clean()` to local source paths in `runCheck()` before any DB or buildkit access
- Reject paths that still contain `..` segments after cleaning, returning a `CheckResult` with `status: "failed"` and a clear error message
- Validation runs before goroutine setup to avoid any resource leaks on early return

## Test plan

- [ ] `TestPathTraversalRejected` — passes `../../etc/passwd` as source, asserts `status == "failed"` and logs contain `"path traversal"`
- [ ] Full test suite passes: `go test ./... -count=1` (all packages green)
- [ ] `go build ./... && go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)