### PR TITLE
perf(tui): parallelize file content fetches and add diff unit tests

### DIFF
--- a/internal/tui/branchdetail_test.go
+++ b/internal/tui/branchdetail_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/dlorenc/docstore/internal/model"
@@ -65,5 +66,289 @@ func TestDiffFiles_EmptyBaseTree(t *testing.T) {
 	}
 	if files[0].changeType != "~" {
 		t.Errorf("want '~' when base tree is empty, got %q", files[0].changeType)
+	}
+}
+
+// --- lcsLineDiff tests ---
+
+func lcsKinds(hunks []diffHunkLine) string {
+	var b strings.Builder
+	for _, h := range hunks {
+		b.WriteByte(h.kind)
+	}
+	return b.String()
+}
+
+func TestLcsLineDiff_IdenticalFiles(t *testing.T) {
+	lines := []string{"a", "b", "c"}
+	hunks := lcsLineDiff(lines, lines)
+	if len(hunks) != 3 {
+		t.Fatalf("want 3 hunks, got %d", len(hunks))
+	}
+	for _, h := range hunks {
+		if h.kind != ' ' {
+			t.Errorf("want all context lines, got kind %q", h.kind)
+		}
+	}
+}
+
+func TestLcsLineDiff_CompletelyDifferent(t *testing.T) {
+	base := []string{"a", "b", "c"}
+	head := []string{"x", "y", "z"}
+	hunks := lcsLineDiff(base, head)
+	kinds := lcsKinds(hunks)
+	if strings.ContainsAny(kinds, " ") {
+		t.Errorf("want no common lines, kinds: %q", kinds)
+	}
+	deletes := strings.Count(kinds, "-")
+	adds := strings.Count(kinds, "+")
+	if deletes != 3 {
+		t.Errorf("want 3 deletes, got %d", deletes)
+	}
+	if adds != 3 {
+		t.Errorf("want 3 adds, got %d", adds)
+	}
+}
+
+func TestLcsLineDiff_SingleLineChangeInMiddle(t *testing.T) {
+	base := []string{"a", "old", "c"}
+	head := []string{"a", "new", "c"}
+	hunks := lcsLineDiff(base, head)
+	// LCS is ["a","c"]; middle produces one delete and one add (order depends on
+	// the traceback direction, which emits '+' before '-' in this case).
+	if len(hunks) != 4 {
+		t.Fatalf("want 4 hunks, got %d: %v", len(hunks), hunks)
+	}
+	if hunks[0].kind != ' ' || hunks[0].text != "a" {
+		t.Errorf("hunk[0]: want context 'a', got %q %q", hunks[0].kind, hunks[0].text)
+	}
+	// Middle two hunks are one delete and one add (order: '+' then '-').
+	kinds12 := string([]byte{hunks[1].kind, hunks[2].kind})
+	if kinds12 != "+-" && kinds12 != "-+" {
+		t.Errorf("hunk[1..2]: want one '+' and one '-', got %q", kinds12)
+	}
+	texts := map[string]bool{hunks[1].text: true, hunks[2].text: true}
+	if !texts["old"] || !texts["new"] {
+		t.Errorf("hunk[1..2]: want texts 'old' and 'new', got %q %q", hunks[1].text, hunks[2].text)
+	}
+	if hunks[3].kind != ' ' || hunks[3].text != "c" {
+		t.Errorf("hunk[3]: want context 'c', got %q %q", hunks[3].kind, hunks[3].text)
+	}
+}
+
+func TestLcsLineDiff_AddedLinesOnly(t *testing.T) {
+	base := []string{"a", "b"}
+	head := []string{"a", "b", "c", "d"}
+	hunks := lcsLineDiff(base, head)
+	kinds := lcsKinds(hunks)
+	if strings.Count(kinds, "+") != 2 {
+		t.Errorf("want 2 adds, kinds: %q", kinds)
+	}
+	if strings.Count(kinds, "-") != 0 {
+		t.Errorf("want 0 deletes, kinds: %q", kinds)
+	}
+	if strings.Count(kinds, " ") != 2 {
+		t.Errorf("want 2 context lines, kinds: %q", kinds)
+	}
+}
+
+func TestLcsLineDiff_DeletedLinesOnly(t *testing.T) {
+	base := []string{"a", "b", "c", "d"}
+	head := []string{"a", "b"}
+	hunks := lcsLineDiff(base, head)
+	kinds := lcsKinds(hunks)
+	if strings.Count(kinds, "-") != 2 {
+		t.Errorf("want 2 deletes, kinds: %q", kinds)
+	}
+	if strings.Count(kinds, "+") != 0 {
+		t.Errorf("want 0 adds, kinds: %q", kinds)
+	}
+	if strings.Count(kinds, " ") != 2 {
+		t.Errorf("want 2 context lines, kinds: %q", kinds)
+	}
+}
+
+func TestLcsLineDiff_EmptyBase(t *testing.T) {
+	head := []string{"x", "y", "z"}
+	hunks := lcsLineDiff(nil, head)
+	if len(hunks) != 3 {
+		t.Fatalf("want 3 hunks, got %d", len(hunks))
+	}
+	for _, h := range hunks {
+		if h.kind != '+' {
+			t.Errorf("want all adds, got %q", h.kind)
+		}
+	}
+}
+
+func TestLcsLineDiff_EmptyHead(t *testing.T) {
+	base := []string{"x", "y", "z"}
+	hunks := lcsLineDiff(base, nil)
+	if len(hunks) != 3 {
+		t.Fatalf("want 3 hunks, got %d", len(hunks))
+	}
+	for _, h := range hunks {
+		if h.kind != '-' {
+			t.Errorf("want all deletes, got %q", h.kind)
+		}
+	}
+}
+
+func TestLcsLineDiff_BothEmpty(t *testing.T) {
+	hunks := lcsLineDiff(nil, nil)
+	if len(hunks) != 0 {
+		t.Errorf("want 0 hunks for both empty, got %d", len(hunks))
+	}
+}
+
+// --- computeFileDiff tests ---
+
+func TestComputeFileDiff_AddedFile(t *testing.T) {
+	head := []byte("line1\nline2\n")
+	data := computeFileDiff(nil, head, "+")
+	if data.err != "" {
+		t.Fatalf("unexpected error: %q", data.err)
+	}
+	if len(data.hunks) != 2 {
+		t.Fatalf("want 2 hunks, got %d", len(data.hunks))
+	}
+	for _, h := range data.hunks {
+		if h.kind != '+' {
+			t.Errorf("want all adds for added file, got %q", h.kind)
+		}
+	}
+	if data.hunks[0].text != "line1" || data.hunks[1].text != "line2" {
+		t.Errorf("unexpected texts: %v", data.hunks)
+	}
+}
+
+func TestComputeFileDiff_DeletedFile(t *testing.T) {
+	base := []byte("line1\nline2\n")
+	data := computeFileDiff(base, nil, "-")
+	if data.err != "" {
+		t.Fatalf("unexpected error: %q", data.err)
+	}
+	if len(data.hunks) != 2 {
+		t.Fatalf("want 2 hunks, got %d", len(data.hunks))
+	}
+	for _, h := range data.hunks {
+		if h.kind != '-' {
+			t.Errorf("want all deletes for deleted file, got %q", h.kind)
+		}
+	}
+}
+
+func TestComputeFileDiff_ModifiedFile(t *testing.T) {
+	base := []byte("a\nb\nc\n")
+	head := []byte("a\nB\nc\n")
+	data := computeFileDiff(base, head, "~")
+	if data.err != "" {
+		t.Fatalf("unexpected error: %q", data.err)
+	}
+	// Expect: ' a', '-b', '+B', ' c'
+	if len(data.hunks) != 4 {
+		t.Fatalf("want 4 hunks, got %d", len(data.hunks))
+	}
+}
+
+func TestComputeFileDiff_TooLarge(t *testing.T) {
+	// Build slices exceeding 4000 combined lines.
+	bigLine := strings.Repeat("x", 10)
+	base := []byte(strings.Repeat(bigLine+"\n", 2001))
+	head := []byte(strings.Repeat(bigLine+"\n", 2001))
+	data := computeFileDiff(base, head, "~")
+	if data.err == "" {
+		t.Error("want error for too-large file, got none")
+	}
+	if !strings.Contains(data.err, "too large") {
+		t.Errorf("want 'too large' in error, got %q", data.err)
+	}
+}
+
+func TestComputeFileDiff_EmptyFiles(t *testing.T) {
+	// Both empty, modified.
+	data := computeFileDiff(nil, nil, "~")
+	if data.err != "" {
+		t.Errorf("unexpected error for empty~empty: %q", data.err)
+	}
+	if len(data.hunks) != 0 {
+		t.Errorf("want 0 hunks for empty~empty, got %d", len(data.hunks))
+	}
+
+	// Empty head added file.
+	data = computeFileDiff(nil, nil, "+")
+	if data.err != "" {
+		t.Errorf("unexpected error for empty+: %q", data.err)
+	}
+	if len(data.hunks) != 0 {
+		t.Errorf("want 0 hunks for empty added file, got %d", len(data.hunks))
+	}
+
+	// Empty base deleted file.
+	data = computeFileDiff(nil, nil, "-")
+	if data.err != "" {
+		t.Errorf("unexpected error for empty-: %q", data.err)
+	}
+	if len(data.hunks) != 0 {
+		t.Errorf("want 0 hunks for empty deleted file, got %d", len(data.hunks))
+	}
+}
+
+// --- Edge case tests ---
+
+func TestLcsLineDiff_WhitespaceOnlyLines(t *testing.T) {
+	base := []string{"   ", "\t", "   "}
+	head := []string{"   ", "X", "   "}
+	hunks := lcsLineDiff(base, head)
+	kinds := lcsKinds(hunks)
+	if strings.Count(kinds, "-") != 1 || strings.Count(kinds, "+") != 1 {
+		t.Errorf("want 1 delete and 1 add, got kinds %q", kinds)
+	}
+	if strings.Count(kinds, " ") != 2 {
+		t.Errorf("want 2 context lines, got kinds %q", kinds)
+	}
+}
+
+func TestLcsLineDiff_SingleLineFiles(t *testing.T) {
+	// Same single line.
+	hunks := lcsLineDiff([]string{"hello"}, []string{"hello"})
+	if len(hunks) != 1 || hunks[0].kind != ' ' {
+		t.Errorf("want 1 context hunk, got %v", hunks)
+	}
+
+	// Different single lines.
+	hunks = lcsLineDiff([]string{"hello"}, []string{"world"})
+	kinds := lcsKinds(hunks)
+	if strings.Count(kinds, "-") != 1 || strings.Count(kinds, "+") != 1 {
+		t.Errorf("want 1 delete + 1 add, got %q", kinds)
+	}
+}
+
+func TestComputeFileDiff_TrailingNewlineDifferences(t *testing.T) {
+	// File with trailing newline vs without.
+	withNewline := []byte("line1\nline2\n")
+	withoutNewline := []byte("line1\nline2")
+	data := computeFileDiff(withNewline, withoutNewline, "~")
+	if data.err != "" {
+		t.Fatalf("unexpected error: %q", data.err)
+	}
+	// Both should produce 2 lines after splitLines trims trailing empty.
+	// Content is identical so all context.
+	for _, h := range data.hunks {
+		if h.kind != ' ' {
+			t.Errorf("trailing newline diff should produce context lines, got %q", h.kind)
+		}
+	}
+}
+
+func TestComputeFileDiff_SingleLineFiles(t *testing.T) {
+	base := []byte("only\n")
+	head := []byte("only\n")
+	data := computeFileDiff(base, head, "~")
+	if data.err != "" {
+		t.Fatalf("unexpected error: %q", data.err)
+	}
+	if len(data.hunks) != 1 || data.hunks[0].kind != ' ' {
+		t.Errorf("want 1 context hunk for identical single-line files, got %v", data.hunks)
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -419,7 +420,11 @@ func loadBranchDetail(c *tuiClient, branchName string) tea.Cmd {
 
 		// Fetch file content for each non-binary changed file so the diff tab
 		// can render inline diffs when the user expands a file.
+		// Fetches run in parallel (max 5 concurrent) to avoid sequential latency.
 		fileContents := make(map[string]fileDiffData, len(diff.BranchChanges))
+		var fcMu sync.Mutex
+		sem := make(chan struct{}, 5)
+		var wg sync.WaitGroup
 		for _, entry := range diff.BranchChanges {
 			if entry.Binary {
 				continue
@@ -431,36 +436,49 @@ func loadBranchDetail(c *tuiClient, branchName string) tea.Cmd {
 				changeType = "+"
 			}
 
-			var baseBytes, headBytes []byte
+			entry := entry // capture loop variable
+			ct := changeType
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
 
-			// Fetch head content when the file exists at head.
-			if entry.VersionID != nil && headSeq > 0 {
-				path := "/file/" + entry.Path + "?branch=" + url.QueryEscape(branchName) +
-					"&at=" + strconv.FormatInt(headSeq, 10)
-				if fResp, fErr := c.get(path); fErr == nil {
-					var fr model.FileResponse
-					if decErr := c.decodeJSON(fResp, &fr); decErr == nil {
-						headBytes = fr.Content
+				var baseBytes, headBytes []byte
+
+				// Fetch head content when the file exists at head.
+				if entry.VersionID != nil && headSeq > 0 {
+					path := "/file/" + entry.Path + "?branch=" + url.QueryEscape(branchName) +
+						"&at=" + strconv.FormatInt(headSeq, 10)
+					if fResp, fErr := c.get(path); fErr == nil {
+						var fr model.FileResponse
+						if decErr := c.decodeJSON(fResp, &fr); decErr == nil {
+							headBytes = fr.Content
+						}
+						fResp.Body.Close()
 					}
-					fResp.Body.Close()
 				}
-			}
 
-			// Fetch base content when the file existed before the branch changes.
-			if baseTreePaths[entry.Path] && baseSeq > 0 {
-				path := "/file/" + entry.Path + "?branch=" + url.QueryEscape(branchName) +
-					"&at=" + strconv.FormatInt(baseSeq, 10)
-				if fResp, fErr := c.get(path); fErr == nil {
-					var fr model.FileResponse
-					if decErr := c.decodeJSON(fResp, &fr); decErr == nil {
-						baseBytes = fr.Content
+				// Fetch base content when the file existed before the branch changes.
+				if baseTreePaths[entry.Path] && baseSeq > 0 {
+					path := "/file/" + entry.Path + "?branch=" + url.QueryEscape(branchName) +
+						"&at=" + strconv.FormatInt(baseSeq, 10)
+					if fResp, fErr := c.get(path); fErr == nil {
+						var fr model.FileResponse
+						if decErr := c.decodeJSON(fResp, &fr); decErr == nil {
+							baseBytes = fr.Content
+						}
+						fResp.Body.Close()
 					}
-					fResp.Body.Close()
 				}
-			}
 
-			fileContents[entry.Path] = computeFileDiff(baseBytes, headBytes, changeType)
+				result := computeFileDiff(baseBytes, headBytes, ct)
+				fcMu.Lock()
+				fileContents[entry.Path] = result
+				fcMu.Unlock()
+			}()
 		}
+		wg.Wait()
 
 		return branchDetailLoadedMsg{
 			diff:          &diff,


### PR DESCRIPTION
## Summary

- **Parallel file fetches**: `loadBranchDetail` now fetches file content for changed files concurrently (max 5 goroutines) using `sync.WaitGroup` + buffered channel semaphore + `sync.Mutex`. For a branch with 30 files at 100ms/fetch, load time drops from ~3s to ~600ms.
- **Diff unit tests**: Added 17 tests in `branchdetail_test.go` covering `lcsLineDiff` and `computeFileDiff` — identical files, completely different, single-line change, add-only, delete-only, empty inputs, added/deleted/modified/too-large files, whitespace-only lines, single-line files, trailing newline differences.

## Test plan

- [x] `go test ./... -count=1` — all packages pass
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)