### PR TITLE
fix(executor): switch BuildKit cache from gcs to registry backend

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -379,7 +379,7 @@ func main() {
 	store := db.NewStore(sqlDB)
 
 	// Build executor.
-	cacheBucket := os.Getenv("CACHE_BUCKET")
+	cacheBucket := os.Getenv("CACHE_REF")
 	exec, err := executor.New(buildkitAddr, cacheBucket)
 	if err != nil {
 		slog.Error("connect to buildkitd", "error", err)

--- a/deploy/k8s/ci-worker.yaml
+++ b/deploy/k8s/ci-worker.yaml
@@ -74,8 +74,8 @@ spec:
           value: gcs
         - name: LOG_BUCKET
           value: docstore-ci-logs
-        - name: CACHE_BUCKET
-          value: docstore-ci-cache
+        - name: CACHE_REF
+          value: us-central1-docker.pkg.dev/dlorenc-chainguard/images/buildcache
         ports:
         - containerPort: 8081
         resources:

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -49,18 +49,19 @@ type CheckResult struct {
 
 // Executor translates a Config into an LLB DAG and dispatches it to buildkitd.
 type Executor struct {
-	client      *client.Client
-	cacheBucket string // empty = no cache
+	client    *client.Client
+	cacheRef  string // registry image ref for BuildKit cache; empty = no cache
 }
 
 // New creates an Executor connected to the buildkitd at buildkitAddr.
-// cacheBucket is an optional GCS bucket name for BuildKit cache; pass "" to disable.
-func New(buildkitAddr, cacheBucket string) (*Executor, error) {
+// cacheRef is an optional registry image reference used for BuildKit registry cache;
+// pass "" to disable. Example: "us-central1-docker.pkg.dev/myproject/images/buildcache".
+func New(buildkitAddr, cacheRef string) (*Executor, error) {
 	c, err := client.New(context.Background(), buildkitAddr)
 	if err != nil {
 		return nil, fmt.Errorf("connect to buildkitd at %s: %w", buildkitAddr, err)
 	}
-	return &Executor{client: c, cacheBucket: cacheBucket}, nil
+	return &Executor{client: c, cacheRef: cacheRef}, nil
 }
 
 // Run executes all checks in cfg in parallel against the given source.
@@ -186,18 +187,16 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check) Che
 			"src": source,
 		}
 	}
-	if e.cacheBucket != "" {
+	if e.cacheRef != "" {
 		solveOpt.CacheImports = []client.CacheOptionsEntry{
-			{Type: "gcs", Attrs: map[string]string{
-				"bucket": e.cacheBucket,
-				"prefix": "buildkit-cache/",
+			{Type: "registry", Attrs: map[string]string{
+				"ref": e.cacheRef,
 			}},
 		}
 		solveOpt.CacheExports = []client.CacheOptionsEntry{
-			{Type: "gcs", Attrs: map[string]string{
-				"bucket": e.cacheBucket,
-				"prefix": "buildkit-cache/",
-				"mode":   "max",
+			{Type: "registry", Attrs: map[string]string{
+				"ref":  e.cacheRef,
+				"mode": "max",
 			}},
 		}
 	}


### PR DESCRIPTION
## Summary

- BuildKit v0.29 has no `gcs` cache exporter — every job was failing with `unknown cache exporter: "gcs"`
- BuildKit's built-in cache backends are: `registry`, `local`, `inline`, `s3`, `azblob`, `gha`
- Switch to `registry` type, which pushes/pulls cache layers to/from Artifact Registry
- Rename env var `CACHE_BUCKET` → `CACHE_REF` (full image ref, e.g. `us-central1-docker.pkg.dev/dlorenc-chainguard/images/buildcache`)
- Keep `mode=max` to cache all intermediate layers for maximum hit rate

## Deployment change needed

Update ci-worker deployment env:
- Remove: `CACHE_BUCKET=docstore-ci-cache`
- Add: `CACHE_REF=us-central1-docker.pkg.dev/dlorenc-chainguard/images/buildcache`

## Test plan

- [ ] PR merges and ci-worker redeploys
- [ ] Run `python3 scripts/ci-bench.py --n 10` — expect jobs to pass
- [ ] Second run should be faster due to warm registry cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)