### PR TITLE
fix(executor): declare /src as explicit output mount for HTTP source

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -234,10 +234,14 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check) Che
 		var srcMount llb.State
 		if isHTTP {
 			httpSrc := llb.HTTP(source, llb.Filename("source.tar"))
+			// /src must be declared as an explicit output mount (via llb.AddMount with
+			// llb.Scratch() as the base) so that GetMount("/src") returns the populated
+			// state. Without it, GetMount returns nil and the golang step sees an empty /src.
 			srcMount = llb.Image("busybox:latest").
 				Run(
-					llb.Args([]string{"sh", "-c", "mkdir -p /src && tar -xf /archive/source.tar -C /src"}),
+					llb.Args([]string{"sh", "-c", "tar -xf /archive/source.tar -C /src"}),
 					llb.AddMount("/archive", httpSrc),
+					llb.AddMount("/src", llb.Scratch()),
 				).GetMount("/src")
 		} else if isLocal {
 			srcMount = llb.Local("src")


### PR DESCRIPTION
## Summary

- All CI jobs were failing with \`go build ./...\` reporting \`directory prefix . does not contain main module\`
- Root cause: BuildKit's \`GetMount()\` **only returns output for explicitly declared mounts**. The busybox extraction step wrote to \`/src\` via \`tar\`, but \`/src\` was never added with \`llb.AddMount\`, so \`GetMount(\"/src\")\` returned \`nil\`
- The golang check step then received a nil/empty \`srcMount\` and \`ls -la /src\` showed an empty directory
- Fix: add \`llb.AddMount(\"/src\", llb.Scratch())\` to the busybox step so BuildKit tracks \`/src\` as an explicit output mount

## Debugging trail

1. All jobs failed with \`panic: assignment to entry in nil map\` → fixed in #214  
2. All jobs failed with \`unknown cache exporter: "gcs"\` → fixed in #217  
3. All jobs failed with \`directory prefix . does not contain main module\` → this PR

## Test plan

- [ ] Merge + deploy
- [ ] Run \`python3 scripts/ci-bench.py --n 10 --seq 26\` — expect all 10 to pass
- [ ] Measure throughput and latency for the benchmark report

🤖 Generated with [Claude Code](https://claude.com/claude-code)