### PR TITLE
feat(executor): log per-vertex timing on completion

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -155,6 +155,15 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check) Che
 			for _, vlog := range status.Logs {
 				logBuf.Write(vlog.Data)
 			}
+			for _, v := range status.Vertexes {
+				if v.Completed != nil && v.Started != nil {
+					slog.Info("vertex complete",
+						"check", check.Name,
+						"vertex", v.Name,
+						"duration_ms", v.Completed.Sub(*v.Started).Milliseconds(),
+					)
+				}
+			}
 		}
 	}()
 


### PR DESCRIPTION
## Summary

- In the `runCheck` collect goroutine, read `status.Vertexes` alongside `status.Logs`
- For each vertex with both `Started` and `Completed` set, emit `slog.Info("vertex complete", "check", ..., "vertex", ..., "duration_ms", ...)`
- No new dependencies; uses the `log/slog` package already imported

## Test plan

- [ ] `go test ./... -count=1` passes (verified locally)
- [ ] `go build ./...` and `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)