### PR TITLE
deploy: switch ci-worker strategy from Recreate to RollingUpdate

### DIFF
--- a/deploy/k8s/ci-worker.yaml
+++ b/deploy/k8s/ci-worker.yaml
@@ -28,10 +28,14 @@ metadata:
   namespace: docstore-ci
 spec:
   replicas: 3
-  # Recreate: terminate all old pods before starting new ones. Fastest
-  # strategy for a tight node pool — no surge capacity needed.
+  # RollingUpdate: allows the autoscaler (KEDA) to add/remove replicas without
+  # killing running workers. Recreate would terminate all pods on any replica
+  # count change, interrupting in-flight builds.
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 3
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: ci-worker


### PR DESCRIPTION
## Summary

- `Recreate` kills **all** pods before starting new ones — any replica count change from KEDA would interrupt in-flight builds
- Switch to `RollingUpdate` with `maxSurge=3` / `maxUnavailable=0`: new pods come up before old ones are terminated, so running jobs are never killed during a scale event or deploy
- Prerequisite for KEDA autoscaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)