### PR TITLE
feat(ci-worker): add KEDA autoscaling with PostgreSQL queue trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,9 +160,19 @@ jobs:
           DIGEST=$(jq -r '."containerimage.digest"' /tmp/ci-worker-metadata.json)
           echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
+      - name: Install KEDA via Helm
+        run: |
+          helm repo add kedacore https://kedacore.github.io/charts
+          helm repo update
+          helm upgrade --install keda kedacore/keda \
+            --namespace keda \
+            --create-namespace \
+            --wait
+
       - name: Deploy ci-worker to GKE
         run: |
           kubectl apply -f deploy/k8s/ci-worker.yaml
+          kubectl apply -f deploy/k8s/ci-worker-scaledobject.yaml
           kubectl set image deployment/ci-worker \
             ci-worker=us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-worker@${{ steps.build.outputs.digest }} \
             -n docstore-ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,6 +160,8 @@ jobs:
           DIGEST=$(jq -r '."containerimage.digest"' /tmp/ci-worker-metadata.json)
           echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
+      - uses: azure/setup-helm@v4
+
       - name: Install KEDA via Helm
         run: |
           helm repo add kedacore https://kedacore.github.io/charts
@@ -172,8 +174,9 @@ jobs:
       - name: Deploy ci-worker to GKE
         run: |
           kubectl apply -f deploy/k8s/ci-worker.yaml
-          kubectl apply -f deploy/k8s/ci-worker-scaledobject.yaml
           kubectl set image deployment/ci-worker \
             ci-worker=us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-worker@${{ steps.build.outputs.digest }} \
             -n docstore-ci
           kubectl rollout status deployment/ci-worker -n docstore-ci --timeout=600s
+          kubectl apply -f deploy/k8s/ci-worker-scaledobject.yaml
+          kubectl wait --for=condition=Ready scaledobject/ci-worker -n docstore-ci --timeout=60s

--- a/cmd/ci-scheduler/main.go
+++ b/cmd/ci-scheduler/main.go
@@ -46,6 +46,7 @@ type ciJobStore interface {
 	InsertCIJob(ctx context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerBaseBranch, triggerProposalID string) (*model.CIJob, error)
 	GetCIJob(ctx context.Context, id string) (*model.CIJob, error)
 	ReapStaleCIJobs(ctx context.Context) ([]model.CIJob, error)
+	CountQueuedCIJobs(ctx context.Context) (int64, error)
 }
 
 // ---------------------------------------------------------------------------
@@ -468,12 +469,25 @@ func (s *scheduler) handleGetLogs(w http.ResponseWriter, r *http.Request) {
 // HTTP mux
 // ---------------------------------------------------------------------------
 
+// handleQueueDepth returns the current number of queued CI jobs as JSON.
+// Used by the KEDA metrics-api scaler to drive autoscaling of ci-worker.
+func (s *scheduler) handleQueueDepth(w http.ResponseWriter, r *http.Request) {
+	n, err := s.store.CountQueuedCIJobs(r.Context())
+	if err != nil {
+		http.Error(w, "failed to count queued jobs", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, `{"queue_depth":%d}`, n)
+}
+
 func newMux(sched *scheduler) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /webhook", sched.handleWebhook)
 	mux.HandleFunc("POST /run", sched.handleRun)
 	mux.HandleFunc("GET /run/{id}", sched.handleGetRun)
 	mux.HandleFunc("GET /run/{id}/logs/{check}", sched.handleGetLogs)
+	mux.HandleFunc("GET /queue-depth", sched.handleQueueDepth)
 	return mux
 }
 

--- a/cmd/ci-scheduler/main_test.go
+++ b/cmd/ci-scheduler/main_test.go
@@ -56,6 +56,10 @@ func (s *stubStore) ReapStaleCIJobs(_ context.Context) ([]model.CIJob, error) {
 	return s.reapJobs, s.reapErr
 }
 
+func (s *stubStore) CountQueuedCIJobs(_ context.Context) (int64, error) {
+	return int64(len(s.insertedJobs)), nil
+}
+
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
@@ -793,6 +797,10 @@ func (s *countingStore) ReapStaleCIJobs(_ context.Context) ([]model.CIJob, error
 	defer s.mu.Unlock()
 	s.reapCalls++
 	return s.reapJobs, s.reapErr
+}
+
+func (s *countingStore) CountQueuedCIJobs(_ context.Context) (int64, error) {
+	return 0, nil
 }
 
 func (s *countingStore) calls() int {

--- a/cmd/ci-scheduler/main_test.go
+++ b/cmd/ci-scheduler/main_test.go
@@ -28,6 +28,7 @@ type stubStore struct {
 	getErr       error
 	reapJobs     []model.CIJob
 	reapErr      error
+	queueDepth   int64
 }
 
 func (s *stubStore) InsertCIJob(_ context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerBaseBranch, triggerProposalID string) (*model.CIJob, error) {
@@ -57,7 +58,7 @@ func (s *stubStore) ReapStaleCIJobs(_ context.Context) ([]model.CIJob, error) {
 }
 
 func (s *stubStore) CountQueuedCIJobs(_ context.Context) (int64, error) {
-	return int64(len(s.insertedJobs)), nil
+	return s.queueDepth, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1231,4 +1232,48 @@ func TestStartCronRunner_StopsOnContextCancellation(t *testing.T) {
 	// Brief sleep to allow the goroutine to exit gracefully.
 	time.Sleep(10 * time.Millisecond)
 	// No assertion beyond "did not panic or deadlock".
+}
+
+// ---------------------------------------------------------------------------
+// Tests: GET /queue-depth — KEDA metrics-api scaler endpoint
+// ---------------------------------------------------------------------------
+
+// TestHandleQueueDepth verifies that GET /queue-depth returns HTTP 200 and the
+// exact JSON body {"queue_depth":N}. This locks the contract that KEDA depends
+// on via valueLocation: "queue_depth" in the ScaledObject.
+func TestHandleQueueDepth(t *testing.T) {
+	stub := &stubStore{queueDepth: 7}
+	sched := &scheduler{store: stub}
+	mux := newMux(sched)
+
+	req := httptest.NewRequest(http.MethodGet, "/queue-depth", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	want := `{"queue_depth":7}`
+	if got := strings.TrimSpace(w.Body.String()); got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}
+
+// TestHandleQueueDepth_ZeroDepth verifies the response when no jobs are queued.
+func TestHandleQueueDepth_ZeroDepth(t *testing.T) {
+	stub := &stubStore{queueDepth: 0}
+	sched := &scheduler{store: stub}
+	mux := newMux(sched)
+
+	req := httptest.NewRequest(http.MethodGet, "/queue-depth", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	want := `{"queue_depth":0}`
+	if got := strings.TrimSpace(w.Body.String()); got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
 }

--- a/deploy/k8s/ci-worker-scaledobject.yaml
+++ b/deploy/k8s/ci-worker-scaledobject.yaml
@@ -1,20 +1,13 @@
 # KEDA autoscaling for ci-worker.
 #
-# TriggerAuthentication pulls the PostgreSQL connection string from the
-# existing ci-scheduler Secret so KEDA can query the ci_jobs table.
-# ScaledObject scales the ci-worker Deployment between 3 and 10 replicas
-# based on the number of queued jobs.
----
-apiVersion: keda.sh/v1alpha1
-kind: TriggerAuthentication
-metadata:
-  name: ci-worker-db-auth
-  namespace: docstore-ci
-spec:
-  secretTargetRef:
-  - parameter: connection
-    name: ci-scheduler
-    key: database-url
+# Uses the metrics-api trigger pointing at the ci-scheduler /queue-depth
+# endpoint, which returns {"queue_depth": N}. This avoids the Cloud SQL Proxy
+# problem: KEDA's operator runs in its own pod without a sidecar, so it
+# cannot use the localhost:5432 DATABASE_URL. The ci-scheduler already has
+# proxy access and can serve the count directly over HTTP.
+#
+# ScaledObject scales the ci-worker Deployment between 3 and 10 replicas.
+# targetValue: "1" means one replica per queued job (1:1 scaling).
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -27,11 +20,10 @@ spec:
   minReplicaCount: 3
   maxReplicaCount: 10
   pollingInterval: 10
-  cooldownPeriod: 30
+  cooldownPeriod: 300
   triggers:
-  - type: postgresql
+  - type: metrics-api
     metadata:
-      query: "SELECT COUNT(*) FROM ci_jobs WHERE status = 'queued'"
-      targetQueryValue: "1"
-    authenticationRef:
-      name: ci-worker-db-auth
+      targetValue: "1"
+      url: "http://ci-scheduler.docstore-ci.svc.cluster.local:8080/queue-depth"
+      valueLocation: "queue_depth"

--- a/deploy/k8s/ci-worker-scaledobject.yaml
+++ b/deploy/k8s/ci-worker-scaledobject.yaml
@@ -1,0 +1,37 @@
+# KEDA autoscaling for ci-worker.
+#
+# TriggerAuthentication pulls the PostgreSQL connection string from the
+# existing ci-scheduler Secret so KEDA can query the ci_jobs table.
+# ScaledObject scales the ci-worker Deployment between 3 and 10 replicas
+# based on the number of queued jobs.
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: ci-worker-db-auth
+  namespace: docstore-ci
+spec:
+  secretTargetRef:
+  - parameter: connection
+    name: ci-scheduler
+    key: database-url
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: ci-worker
+  namespace: docstore-ci
+spec:
+  scaleTargetRef:
+    name: ci-worker
+  minReplicaCount: 3
+  maxReplicaCount: 10
+  pollingInterval: 10
+  cooldownPeriod: 30
+  triggers:
+  - type: postgresql
+    metadata:
+      query: "SELECT COUNT(*) FROM ci_jobs WHERE status = 'queued'"
+      targetQueryValue: "1"
+    authenticationRef:
+      name: ci-worker-db-auth

--- a/deploy/k8s/ci-worker.yaml
+++ b/deploy/k8s/ci-worker.yaml
@@ -27,7 +27,7 @@ metadata:
   name: ci-worker
   namespace: docstore-ci
 spec:
-  replicas: 3
+  # replicas is intentionally omitted — KEDA manages the replica count.
   # RollingUpdate: allows the autoscaler (KEDA) to add/remove replicas without
   # killing running workers. Recreate would terminate all pods on any replica
   # count change, interrupting in-flight builds.

--- a/internal/db/ci_jobs.go
+++ b/internal/db/ci_jobs.go
@@ -160,6 +160,18 @@ func (s *Store) CompleteCIJob(ctx context.Context, id, status string, logURL, er
 	return nil
 }
 
+// CountQueuedCIJobs returns the number of ci_jobs with status 'queued'.
+func (s *Store) CountQueuedCIJobs(ctx context.Context) (int64, error) {
+	var n int64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM ci_jobs WHERE status = 'queued'`,
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count queued ci jobs: %w", err)
+	}
+	return n, nil
+}
+
 // ReapStaleCIJobs resets claimed jobs that have not sent a heartbeat in the
 // last 2 minutes back to 'queued' so another worker can pick them up.
 func (s *Store) ReapStaleCIJobs(ctx context.Context) ([]model.CIJob, error) {


### PR DESCRIPTION
## Summary

- Installs KEDA via Helm (`kedacore/keda`) in the `build-and-deploy-ci-worker` deploy workflow step before the worker is deployed
- Adds `deploy/k8s/ci-worker-scaledobject.yaml` containing:
  - `TriggerAuthentication` referencing the `database-url` key from the existing `ci-scheduler` Secret in `docstore-ci` namespace
  - `ScaledObject` targeting the `ci-worker` Deployment with min=3, max=10 replicas, pollingInterval=10s, cooldownPeriod=30s, and a PostgreSQL trigger querying `SELECT COUNT(*) FROM ci_jobs WHERE status = 'queued'` with targetQueryValue=1
- Applies `ci-worker-scaledobject.yaml` alongside `ci-worker.yaml` in the deploy step

Closes #222

## Test plan

- [x] All Go tests pass locally (`go test ./... -count=1`)
- [ ] Verify KEDA installs cleanly in the `keda` namespace on first deploy
- [ ] Confirm `ScaledObject` enters `Ready` state after deploy
- [ ] Confirm replica count scales up when queued jobs > 3 and back down during idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)