### PR TITLE
feat(executor): add automatic BuildKit cache mounts for common package managers

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -264,6 +264,11 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check) Che
 				llb.Args([]string{"sh", "-c", step}),
 				llb.WithCustomName(check.Name + ": " + step),
 				llb.AddMount("/src", srcMount),
+				llb.AddMount("/go/pkg/mod", llb.Scratch(), llb.AsPersistentCacheDir("go-mod", llb.CacheMountShared)),
+				llb.AddMount("/root/.cache/go-build", llb.Scratch(), llb.AsPersistentCacheDir("go-build", llb.CacheMountShared)),
+				llb.AddMount("/root/.npm", llb.Scratch(), llb.AsPersistentCacheDir("npm", llb.CacheMountShared)),
+				llb.AddMount("/root/.cache/pip", llb.Scratch(), llb.AsPersistentCacheDir("pip", llb.CacheMountShared)),
+				llb.AddMount("/usr/local/cargo/registry", llb.Scratch(), llb.AsPersistentCacheDir("cargo-registry", llb.CacheMountShared)),
 			}
 			runOpts = append(runOpts, envOpts...)
 			exec := state.Run(runOpts...)


### PR DESCRIPTION
## Summary

- Adds persistent cache mounts for `/go/pkg/mod`, `/root/.cache/go-build`, `/root/.npm`, `/root/.cache/pip`, and `/usr/local/cargo/registry` to every CI step
- All mounts use `llb.CacheMountShared` and `llb.Scratch()` as the source — injected unconditionally for every step, no image detection logic
- Cache mounts are shared across concurrent builds and persist between runs, speeding up Go, Node, Python, and Rust builds

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` passes — all packages green including `internal/executor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)