### PR TITLE
feat(cli): add 'ds subscriptions' command group

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -923,7 +923,10 @@ func main() {
 					fmt.Fprintln(os.Stderr, "usage: ds subscriptions create --url <url> --secret <secret> [--repo <repo>] [--event-types t1,t2]")
 					os.Exit(1)
 				}
-				err = app.SubscriptionCreate(repo, eventTypes, webhookURL, secret)
+				if secret == "" {
+					fmt.Fprintln(os.Stderr, "warning: --secret is empty; subscription will have no HMAC signing key")
+				}
+				err = app.SubscriptionCreate(webhookURL, secret, repo, eventTypes)
 			case "delete":
 				if len(args) < 3 {
 					fmt.Fprintln(os.Stderr, "usage: ds subscriptions delete <id>")

--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -86,7 +86,12 @@ commands:
   proposal list [--state open|closed|merged]             List proposals
   proposal close <id>                                    Close a proposal
 
-  ci run [--check <name>] [--trigger push|proposal|proposal_synchronized] [--base-branch <branch>] [--buildkit <addr>]  Run CI checks locally`
+  ci run [--check <name>] [--trigger push|proposal|proposal_synchronized] [--base-branch <branch>] [--buildkit <addr>]  Run CI checks locally
+
+  subscriptions                                          List subscriptions
+  subscriptions create --url <url> --secret <s> [--repo <r>] [--event-types t1,t2]  Create a subscription
+  subscriptions delete <id>                              Delete a subscription
+  subscriptions resume <id>                              Resume a suspended subscription`
 
 func main() {
 	if len(os.Args) < 2 {
@@ -878,6 +883,65 @@ func main() {
 			os.Exit(1)
 		}
 		return
+
+	case "subscriptions":
+		if len(args) < 2 {
+			err = app.SubscriptionList()
+		} else {
+			switch args[1] {
+			case "create":
+				webhookURL := ""
+				secret := ""
+				var repo *string
+				var eventTypes []string
+				for i := 2; i < len(args); i++ {
+					switch args[i] {
+					case "--url":
+						if i+1 < len(args) {
+							webhookURL = args[i+1]
+							i++
+						}
+					case "--secret":
+						if i+1 < len(args) {
+							secret = args[i+1]
+							i++
+						}
+					case "--repo":
+						if i+1 < len(args) {
+							r := args[i+1]
+							repo = &r
+							i++
+						}
+					case "--event-types":
+						if i+1 < len(args) {
+							eventTypes = strings.Split(args[i+1], ",")
+							i++
+						}
+					}
+				}
+				if webhookURL == "" {
+					fmt.Fprintln(os.Stderr, "usage: ds subscriptions create --url <url> --secret <secret> [--repo <repo>] [--event-types t1,t2]")
+					os.Exit(1)
+				}
+				err = app.SubscriptionCreate(repo, eventTypes, webhookURL, secret)
+			case "delete":
+				if len(args) < 3 {
+					fmt.Fprintln(os.Stderr, "usage: ds subscriptions delete <id>")
+					os.Exit(1)
+				}
+				err = app.SubscriptionDelete(args[2])
+			case "resume":
+				if len(args) < 3 {
+					fmt.Fprintln(os.Stderr, "usage: ds subscriptions resume <id>")
+					os.Exit(1)
+				}
+				err = app.SubscriptionResume(args[2])
+			default:
+				fmt.Fprintf(os.Stderr, "unknown subscriptions subcommand: %s\n", args[1])
+				fmt.Fprintln(os.Stderr, usage)
+				os.Exit(1)
+			}
+		}
 
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", cmd)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -2992,7 +2992,7 @@ func (a *App) ProposalClose(proposalID string) error {
 // ---------------------------------------------------------------------------
 
 // SubscriptionCreate creates a new webhook subscription.
-func (a *App) SubscriptionCreate(repo *string, eventTypes []string, webhookURL, secret string) error {
+func (a *App) SubscriptionCreate(webhookURL, secret string, repo *string, eventTypes []string) error {
 	remote, err := a.loadRemote()
 	if err != nil {
 		return err
@@ -3080,12 +3080,12 @@ func (a *App) SubscriptionResume(id string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := a.doPOSTJSON(remote+"/subscriptions/"+url.PathEscape(id)+"/resume", nil)
+	resp, err := a.doPOSTJSON(remote+"/subscriptions/"+url.PathEscape(id)+"/resume", struct{}{})
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+	if resp.StatusCode != http.StatusNoContent {
 		return a.readError(resp)
 	}
 	fmt.Fprintf(a.Out, "Resumed subscription '%s'\n", id)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -2986,3 +2986,108 @@ func (a *App) ProposalClose(proposalID string) error {
 	fmt.Fprintf(a.Out, "Proposal %s closed\n", proposalID)
 	return nil
 }
+
+// ---------------------------------------------------------------------------
+// Subscription management
+// ---------------------------------------------------------------------------
+
+// SubscriptionCreate creates a new webhook subscription.
+func (a *App) SubscriptionCreate(repo *string, eventTypes []string, webhookURL, secret string) error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	webhookConfig, err := json.Marshal(map[string]string{"url": webhookURL, "secret": secret})
+	if err != nil {
+		return fmt.Errorf("encoding webhook config: %w", err)
+	}
+	req := model.CreateSubscriptionRequest{
+		Repo:       repo,
+		EventTypes: eventTypes,
+		Backend:    "webhook",
+		Config:     json.RawMessage(webhookConfig),
+	}
+	resp, err := a.doPOSTJSON(remote+"/subscriptions", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var sub model.EventSubscription
+	if err := json.NewDecoder(resp.Body).Decode(&sub); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "Created subscription '%s'\n", sub.ID)
+	return nil
+}
+
+// SubscriptionList lists all webhook subscriptions.
+func (a *App) SubscriptionList() error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doGET(remote + "/subscriptions")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var r model.ListSubscriptionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "%-36s  %-20s  %-10s  %s\n", "ID", "REPO", "BACKEND", "SUSPENDED")
+	for _, sub := range r.Subscriptions {
+		repo := "(all)"
+		if sub.Repo != nil {
+			repo = *sub.Repo
+		}
+		suspended := "no"
+		if sub.SuspendedAt != nil {
+			suspended = sub.SuspendedAt.Format("2006-01-02")
+		}
+		fmt.Fprintf(a.Out, "%-36s  %-20s  %-10s  %s\n", sub.ID, repo, sub.Backend, suspended)
+	}
+	return nil
+}
+
+// SubscriptionDelete deletes a subscription by ID.
+func (a *App) SubscriptionDelete(id string) error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doDELETE(remote + "/subscriptions/" + url.PathEscape(id))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Deleted subscription '%s'\n", id)
+	return nil
+}
+
+// SubscriptionResume resumes a suspended subscription by ID.
+func (a *App) SubscriptionResume(id string) error {
+	remote, err := a.loadRemote()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doPOSTJSON(remote+"/subscriptions/"+url.PathEscape(id)+"/resume", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Resumed subscription '%s'\n", id)
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds `SubscriptionCreate`, `SubscriptionList`, `SubscriptionDelete`, `SubscriptionResume` methods to `internal/cli/app.go`, following the existing `Orgs`/`Roles` pattern (using `loadRemote()` since subscriptions are server-level endpoints)
- Adds `subscriptions` dispatch block in `cmd/ds/main.go` with `create` (flags: `--url`, `--secret`, `--repo`, `--event-types`), `delete <id>`, and `resume <id>` subcommands; bare `subscriptions` lists all
- Implements Part 2 of issue #225

## Test plan

- [x] `go build ./cmd/ds/...` passes cleanly
- [x] `go test ./... -count=1` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)