### PR TITLE
feat(server): subscription auth relaxation (issue #225)

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2249,6 +2249,47 @@ func (s *Store) ListSubscriptions(ctx context.Context) ([]model.EventSubscriptio
 	return subs, nil
 }
 
+// ListSubscriptionsByCreator returns all event subscriptions created by the given identity.
+func (s *Store) ListSubscriptionsByCreator(ctx context.Context, createdBy string) ([]model.EventSubscription, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, repo, event_types, backend, config, created_at, created_by, suspended_at, failure_count
+		FROM event_subscriptions
+		WHERE created_by = $1
+		ORDER BY created_at`, createdBy)
+	if err != nil {
+		return nil, fmt.Errorf("list subscriptions by creator: %w", err)
+	}
+	defer rows.Close()
+
+	var subs []model.EventSubscription
+	for rows.Next() {
+		var sub model.EventSubscription
+		var repo sql.NullString
+		var eventTypes pq.StringArray
+		var suspendedAt sql.NullTime
+		var configBytes []byte
+		if err := rows.Scan(&sub.ID, &repo, &eventTypes, &sub.Backend,
+			&configBytes, &sub.CreatedAt, &sub.CreatedBy, &suspendedAt, &sub.FailureCount); err != nil {
+			return nil, fmt.Errorf("scan subscription: %w", err)
+		}
+		if repo.Valid {
+			sub.Repo = &repo.String
+		}
+		if len(eventTypes) > 0 {
+			sub.EventTypes = []string(eventTypes)
+		}
+		if suspendedAt.Valid {
+			sub.SuspendedAt = &suspendedAt.Time
+		}
+		sub.Config = json.RawMessage(configBytes)
+		subs = append(subs, sub)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate subscriptions: %w", err)
+	}
+	return subs, nil
+}
+
 // DeleteSubscription deletes a subscription by ID.
 func (s *Store) DeleteSubscription(ctx context.Context, id string) error {
 	res, err := s.db.ExecContext(ctx,

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2175,6 +2175,39 @@ func (s *Store) CreateSubscription(ctx context.Context, req model.CreateSubscrip
 	return sub, nil
 }
 
+// GetSubscription returns a single event subscription by ID.
+// Returns ErrSubscriptionNotFound if no subscription with that ID exists.
+func (s *Store) GetSubscription(ctx context.Context, id string) (*model.EventSubscription, error) {
+	var sub model.EventSubscription
+	var repo sql.NullString
+	var eventTypes pq.StringArray
+	var suspendedAt sql.NullTime
+	var configBytes []byte
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, repo, event_types, backend, config, created_at, created_by, suspended_at, failure_count
+		FROM event_subscriptions
+		WHERE id = $1`, id).Scan(
+		&sub.ID, &repo, &eventTypes, &sub.Backend,
+		&configBytes, &sub.CreatedAt, &sub.CreatedBy, &suspendedAt, &sub.FailureCount)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrSubscriptionNotFound
+		}
+		return nil, fmt.Errorf("get subscription: %w", err)
+	}
+	if repo.Valid {
+		sub.Repo = &repo.String
+	}
+	if len(eventTypes) > 0 {
+		sub.EventTypes = []string(eventTypes)
+	}
+	if suspendedAt.Valid {
+		sub.SuspendedAt = &suspendedAt.Time
+	}
+	sub.Config = json.RawMessage(configBytes)
+	return &sub, nil
+}
+
 // ListSubscriptions returns all event subscriptions. If repo is non-nil,
 // only subscriptions matching that repo (or global ones) are returned.
 func (s *Store) ListSubscriptions(ctx context.Context) ([]model.EventSubscription, error) {

--- a/internal/db/store_gap_test.go
+++ b/internal/db/store_gap_test.go
@@ -363,3 +363,46 @@ func TestResumeSubscription_NotFound(t *testing.T) {
 		t.Errorf("expected ErrSubscriptionNotFound, got %v", err)
 	}
 }
+
+func TestGetSubscription_Found(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	config, _ := json.Marshal(map[string]string{"url": "https://example.com/hook"})
+	created, err := s.CreateSubscription(ctx, model.CreateSubscriptionRequest{
+		Backend:   "webhook",
+		Config:    config,
+		CreatedBy: "admin@example.com",
+	})
+	if err != nil {
+		t.Fatalf("create subscription: %v", err)
+	}
+
+	got, err := s.GetSubscription(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("get subscription: %v", err)
+	}
+	if got.ID != created.ID {
+		t.Errorf("expected id %q, got %q", created.ID, got.ID)
+	}
+	if got.Backend != "webhook" {
+		t.Errorf("expected backend webhook, got %q", got.Backend)
+	}
+	if got.CreatedBy != "admin@example.com" {
+		t.Errorf("expected created_by admin@example.com, got %q", got.CreatedBy)
+	}
+}
+
+func TestGetSubscription_NotFound(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	_, err := s.GetSubscription(ctx, "00000000-0000-0000-0000-000000000000")
+	if !errors.Is(err, ErrSubscriptionNotFound) {
+		t.Errorf("expected ErrSubscriptionNotFound, got %v", err)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2448,12 +2448,10 @@ func (s *server) handleChain(w http.ResponseWriter, r *http.Request) {
 // Event subscription handlers (admin only)
 // ---------------------------------------------------------------------------
 
-// handleCreateSubscription implements POST /subscriptions
+// handleCreateSubscription implements POST /subscriptions.
+// Global admin may create subscriptions of any scope. Non-admin users may create
+// repo-scoped subscriptions only if they have at least reader access to that repo.
 func (s *server) handleCreateSubscription(w http.ResponseWriter, r *http.Request) {
-	if !s.requireGlobalAdmin(w, r) {
-		return
-	}
-
 	var req model.CreateSubscriptionRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
@@ -2492,7 +2490,20 @@ func (s *server) handleCreateSubscription(w http.ResponseWriter, r *http.Request
 		slog.Warn("subscription created without webhook secret", "url", webhookURL)
 	}
 
-	req.CreatedBy = IdentityFromContext(r.Context())
+	identity := IdentityFromContext(r.Context())
+	isAdmin := s.globalAdmin != "" && identity == s.globalAdmin
+	if !isAdmin {
+		// Non-admin may only create repo-scoped subscriptions for repos they can read.
+		if req.Repo == nil || *req.Repo == "" {
+			writeError(w, http.StatusForbidden, "forbidden: global admin required for global subscriptions")
+			return
+		}
+		if !s.requireRepoReadAccess(w, r, *req.Repo) {
+			return
+		}
+	}
+
+	req.CreatedBy = identity
 
 	sub, err := s.commitStore.CreateSubscription(r.Context(), req)
 	if err != nil {
@@ -2505,11 +2516,12 @@ func (s *server) handleCreateSubscription(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusCreated, sub)
 }
 
-// handleListSubscriptions implements GET /subscriptions
+// handleListSubscriptions implements GET /subscriptions.
+// Global admin sees all subscriptions. Non-admin users see only subscriptions
+// they created (filtered by CreatedBy == identity).
 func (s *server) handleListSubscriptions(w http.ResponseWriter, r *http.Request) {
-	if !s.requireGlobalAdmin(w, r) {
-		return
-	}
+	identity := IdentityFromContext(r.Context())
+	isAdmin := s.globalAdmin != "" && identity == s.globalAdmin
 
 	subs, err := s.commitStore.ListSubscriptions(r.Context())
 	if err != nil {
@@ -2520,16 +2532,45 @@ func (s *server) handleListSubscriptions(w http.ResponseWriter, r *http.Request)
 	if subs == nil {
 		subs = []model.EventSubscription{}
 	}
+	// Non-admin users only see subscriptions they created.
+	if !isAdmin {
+		filtered := make([]model.EventSubscription, 0, len(subs))
+		for _, sub := range subs {
+			if sub.CreatedBy == identity {
+				filtered = append(filtered, sub)
+			}
+		}
+		subs = filtered
+	}
 	writeJSON(w, http.StatusOK, model.ListSubscriptionsResponse{Subscriptions: subs})
 }
 
-// handleDeleteSubscription implements DELETE /subscriptions/{id}
+// handleDeleteSubscription implements DELETE /subscriptions/{id}.
+// Global admin may delete any subscription. The subscription creator may also delete it.
 func (s *server) handleDeleteSubscription(w http.ResponseWriter, r *http.Request) {
-	if !s.requireGlobalAdmin(w, r) {
-		return
-	}
+	identity := IdentityFromContext(r.Context())
+	isAdmin := s.globalAdmin != "" && identity == s.globalAdmin
 
 	id := r.PathValue("id")
+
+	if !isAdmin {
+		sub, err := s.commitStore.GetSubscription(r.Context(), id)
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrSubscriptionNotFound):
+				writeError(w, http.StatusNotFound, "subscription not found")
+			default:
+				slog.Error("internal error", "op", "get_subscription", "id", id, "error", err)
+				writeError(w, http.StatusInternalServerError, "internal server error")
+			}
+			return
+		}
+		if sub.CreatedBy != identity {
+			writeError(w, http.StatusForbidden, "forbidden: not subscription creator")
+			return
+		}
+	}
+
 	if err := s.commitStore.DeleteSubscription(r.Context(), id); err != nil {
 		switch {
 		case errors.Is(err, db.ErrSubscriptionNotFound):
@@ -2541,17 +2582,36 @@ func (s *server) handleDeleteSubscription(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	slog.Info("subscription deleted", "id", id, "by", IdentityFromContext(r.Context()))
+	slog.Info("subscription deleted", "id", id, "by", identity)
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// handleResumeSubscription implements POST /subscriptions/{id}/resume
+// handleResumeSubscription implements POST /subscriptions/{id}/resume.
+// Global admin may resume any subscription. The subscription creator may also resume it.
 func (s *server) handleResumeSubscription(w http.ResponseWriter, r *http.Request) {
-	if !s.requireGlobalAdmin(w, r) {
-		return
-	}
+	identity := IdentityFromContext(r.Context())
+	isAdmin := s.globalAdmin != "" && identity == s.globalAdmin
 
 	id := r.PathValue("id")
+
+	if !isAdmin {
+		sub, err := s.commitStore.GetSubscription(r.Context(), id)
+		if err != nil {
+			switch {
+			case errors.Is(err, db.ErrSubscriptionNotFound):
+				writeError(w, http.StatusNotFound, "subscription not found")
+			default:
+				slog.Error("internal error", "op", "get_subscription", "id", id, "error", err)
+				writeError(w, http.StatusInternalServerError, "internal server error")
+			}
+			return
+		}
+		if sub.CreatedBy != identity {
+			writeError(w, http.StatusForbidden, "forbidden: not subscription creator")
+			return
+		}
+	}
+
 	if err := s.commitStore.ResumeSubscription(r.Context(), id); err != nil {
 		switch {
 		case errors.Is(err, db.ErrSubscriptionNotFound):
@@ -2563,7 +2623,7 @@ func (s *server) handleResumeSubscription(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	slog.Info("subscription resumed", "id", id, "by", IdentityFromContext(r.Context()))
+	slog.Info("subscription resumed", "id", id, "by", identity)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2445,7 +2445,7 @@ func (s *server) handleChain(w http.ResponseWriter, r *http.Request) {
 }
 
 // ---------------------------------------------------------------------------
-// Event subscription handlers (admin only)
+// Event subscription handlers (delegated auth: admin for global scope, creator for own subscriptions)
 // ---------------------------------------------------------------------------
 
 // handleCreateSubscription implements POST /subscriptions.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2518,12 +2518,18 @@ func (s *server) handleCreateSubscription(w http.ResponseWriter, r *http.Request
 
 // handleListSubscriptions implements GET /subscriptions.
 // Global admin sees all subscriptions. Non-admin users see only subscriptions
-// they created (filtered by CreatedBy == identity).
+// they created (queried directly by created_by at the store level).
 func (s *server) handleListSubscriptions(w http.ResponseWriter, r *http.Request) {
 	identity := IdentityFromContext(r.Context())
 	isAdmin := s.globalAdmin != "" && identity == s.globalAdmin
 
-	subs, err := s.commitStore.ListSubscriptions(r.Context())
+	var subs []model.EventSubscription
+	var err error
+	if isAdmin {
+		subs, err = s.commitStore.ListSubscriptions(r.Context())
+	} else {
+		subs, err = s.commitStore.ListSubscriptionsByCreator(r.Context(), identity)
+	}
 	if err != nil {
 		slog.Error("internal error", "op", "list_subscriptions", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal server error")
@@ -2531,16 +2537,6 @@ func (s *server) handleListSubscriptions(w http.ResponseWriter, r *http.Request)
 	}
 	if subs == nil {
 		subs = []model.EventSubscription{}
-	}
-	// Non-admin users only see subscriptions they created.
-	if !isAdmin {
-		filtered := make([]model.EventSubscription, 0, len(subs))
-		for _, sub := range subs {
-			if sub.CreatedBy == identity {
-				filtered = append(filtered, sub)
-			}
-		}
-		subs = filtered
 	}
 	writeJSON(w, http.StatusOK, model.ListSubscriptionsResponse{Subscriptions: subs})
 }

--- a/internal/server/handlers_gap_test.go
+++ b/internal/server/handlers_gap_test.go
@@ -166,9 +166,9 @@ func TestHandleGetOrg_StoreError(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRequireGlobalAdmin_NotConfigured(t *testing.T) {
-	// globalAdmin empty → 403.
+	// globalAdmin empty → 403 on global-admin-only endpoints (e.g. GET /events).
 	srv := New(&mockStore{}, nil, devID, "") // no global admin
-	req := httptest.NewRequest(http.MethodGet, "/subscriptions", nil)
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
@@ -177,9 +177,9 @@ func TestRequireGlobalAdmin_NotConfigured(t *testing.T) {
 }
 
 func TestRequireGlobalAdmin_WrongIdentity(t *testing.T) {
-	// identity (devID = "test@example.com") != globalAdmin → 403.
+	// identity (devID = "test@example.com") != globalAdmin → 403 on global-admin-only endpoints.
 	srv := New(&mockStore{}, nil, devID, "admin@other.com")
-	req := httptest.NewRequest(http.MethodGet, "/subscriptions", nil)
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
@@ -377,13 +377,14 @@ func TestHandleListSubscriptions_Empty(t *testing.T) {
 	}
 }
 
-func TestHandleListSubscriptions_NonAdmin_Forbidden(t *testing.T) {
+func TestHandleListSubscriptions_NonAdmin_Allowed(t *testing.T) {
+	// Non-admin gets 200 with filtered (own) subscriptions, not 403.
 	srv := New(&mockStore{}, nil, devID, "admin@other.com")
 	req := httptest.NewRequest(http.MethodGet, "/subscriptions", nil)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
-	if rec.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 }
 
@@ -433,7 +434,13 @@ func TestHandleDeleteSubscription_NotFound(t *testing.T) {
 }
 
 func TestHandleDeleteSubscription_NonAdmin_Forbidden(t *testing.T) {
-	srv := New(&mockStore{}, nil, devID, "admin@other.com")
+	// Non-admin trying to delete a subscription they did not create → 403.
+	ms := &mockStore{
+		getSubscriptionFn: func(_ context.Context, id string) (*model.EventSubscription, error) {
+			return &model.EventSubscription{ID: id, Backend: "webhook", CreatedBy: "other@example.com"}, nil
+		},
+	}
+	srv := New(ms, nil, devID, "admin@other.com")
 	req := httptest.NewRequest(http.MethodDelete, "/subscriptions/sub-1", nil)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -488,7 +495,13 @@ func TestHandleResumeSubscription_NotFound(t *testing.T) {
 }
 
 func TestHandleResumeSubscription_NonAdmin_Forbidden(t *testing.T) {
-	srv := New(&mockStore{}, nil, devID, "admin@other.com")
+	// Non-admin trying to resume a subscription they did not create → 403.
+	ms := &mockStore{
+		getSubscriptionFn: func(_ context.Context, id string) (*model.EventSubscription, error) {
+			return &model.EventSubscription{ID: id, Backend: "webhook", CreatedBy: "other@example.com"}, nil
+		},
+	}
+	srv := New(ms, nil, devID, "admin@other.com")
 	req := httptest.NewRequest(http.MethodPost, "/subscriptions/sub-1/resume", nil)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -534,5 +547,170 @@ func TestHandleSSEGlobalEvents_NoBroker_ServiceUnavailable(t *testing.T) {
 	srv.ServeHTTP(rec, req)
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503 (no broker), got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Subscription auth relaxation tests (issue #225)
+// ---------------------------------------------------------------------------
+
+// 1. Non-admin with repo access can create a repo-scoped subscription.
+func TestHandleCreateSubscription_RepoScoped_NonAdmin_Success(t *testing.T) {
+	ms := &mockStore{
+		getRoleFn: func(_ context.Context, repo, identity string) (*model.Role, error) {
+			return &model.Role{Identity: identity, Role: model.RoleReader}, nil
+		},
+	}
+	srv := New(ms, nil, devID, "admin@other.com")
+	repoName := "myorg/myrepo"
+	body, _ := json.Marshal(map[string]interface{}{
+		"repo":    repoName,
+		"backend": "webhook",
+		"config":  map[string]string{"url": "https://example.com/hook", "secret": "s3cr3t"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for repo-scoped non-admin, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// 2. Non-admin without repo access cannot create a repo-scoped subscription.
+func TestHandleCreateSubscription_RepoScoped_NoRepoAccess_Forbidden(t *testing.T) {
+	// Default mockStore.getRoleFn returns db.ErrRoleNotFound → no access.
+	srv := New(&mockStore{}, nil, devID, "admin@other.com")
+	repoName := "myorg/myrepo"
+	body, _ := json.Marshal(map[string]interface{}{
+		"repo":    repoName,
+		"backend": "webhook",
+		"config":  map[string]string{"url": "https://example.com/hook"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for no repo access, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// 3. Non-admin sees only subscriptions they created.
+func TestHandleListSubscriptions_NonAdmin_FiltersToOwn(t *testing.T) {
+	ms := &mockStore{
+		listSubscriptionsFn: func(_ context.Context) ([]model.EventSubscription, error) {
+			return []model.EventSubscription{
+				{ID: "sub-1", Backend: "webhook", CreatedBy: devID},
+				{ID: "sub-2", Backend: "webhook", CreatedBy: "other@example.com"},
+			}, nil
+		},
+	}
+	srv := New(ms, nil, devID, "admin@other.com")
+	req := httptest.NewRequest(http.MethodGet, "/subscriptions", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp model.ListSubscriptionsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Subscriptions) != 1 {
+		t.Errorf("expected 1 subscription (own), got %d", len(resp.Subscriptions))
+	}
+	if len(resp.Subscriptions) == 1 && resp.Subscriptions[0].ID != "sub-1" {
+		t.Errorf("expected sub-1, got %q", resp.Subscriptions[0].ID)
+	}
+}
+
+// 4. Global admin sees all subscriptions, not just their own.
+func TestHandleListSubscriptions_Admin_SeesAll(t *testing.T) {
+	ms := &mockStore{
+		listSubscriptionsFn: func(_ context.Context) ([]model.EventSubscription, error) {
+			return []model.EventSubscription{
+				{ID: "sub-1", Backend: "webhook", CreatedBy: devID},
+				{ID: "sub-2", Backend: "webhook", CreatedBy: "other@example.com"},
+			}, nil
+		},
+	}
+	srv := New(ms, nil, devID, devID) // devID is global admin
+	req := httptest.NewRequest(http.MethodGet, "/subscriptions", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp model.ListSubscriptionsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Subscriptions) != 2 {
+		t.Errorf("expected 2 subscriptions (all), got %d", len(resp.Subscriptions))
+	}
+}
+
+// 5. Subscription creator (non-admin) can delete their own subscription.
+func TestHandleDeleteSubscription_Creator_Success(t *testing.T) {
+	ms := &mockStore{
+		getSubscriptionFn: func(_ context.Context, id string) (*model.EventSubscription, error) {
+			return &model.EventSubscription{ID: id, Backend: "webhook", CreatedBy: devID}, nil
+		},
+	}
+	srv := New(ms, nil, devID, "admin@other.com")
+	req := httptest.NewRequest(http.MethodDelete, "/subscriptions/sub-1", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 for creator delete, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// 6. Non-creator non-admin cannot delete someone else's subscription.
+func TestHandleDeleteSubscription_NotCreator_Forbidden(t *testing.T) {
+	ms := &mockStore{
+		getSubscriptionFn: func(_ context.Context, id string) (*model.EventSubscription, error) {
+			return &model.EventSubscription{ID: id, Backend: "webhook", CreatedBy: "other@example.com"}, nil
+		},
+	}
+	srv := New(ms, nil, devID, "admin@other.com")
+	req := httptest.NewRequest(http.MethodDelete, "/subscriptions/sub-1", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-creator delete, got %d", rec.Code)
+	}
+}
+
+// 7. Subscription creator (non-admin) can resume their own subscription.
+func TestHandleResumeSubscription_Creator_Success(t *testing.T) {
+	ms := &mockStore{
+		getSubscriptionFn: func(_ context.Context, id string) (*model.EventSubscription, error) {
+			return &model.EventSubscription{ID: id, Backend: "webhook", CreatedBy: devID}, nil
+		},
+	}
+	srv := New(ms, nil, devID, "admin@other.com")
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions/sub-1/resume", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 for creator resume, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// 8. Non-creator non-admin cannot resume someone else's subscription.
+func TestHandleResumeSubscription_NotCreator_Forbidden(t *testing.T) {
+	ms := &mockStore{
+		getSubscriptionFn: func(_ context.Context, id string) (*model.EventSubscription, error) {
+			return &model.EventSubscription{ID: id, Backend: "webhook", CreatedBy: "other@example.com"}, nil
+		},
+	}
+	srv := New(ms, nil, devID, "admin@other.com")
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions/sub-1/resume", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-creator resume, got %d", rec.Code)
 	}
 }

--- a/internal/server/handlers_gap_test.go
+++ b/internal/server/handlers_gap_test.go
@@ -286,8 +286,8 @@ func TestHandleCreateSubscription_Success(t *testing.T) {
 	}
 }
 
-func TestHandleCreateSubscription_NonAdmin_Forbidden(t *testing.T) {
-	// devID != global admin → 403.
+func TestHandleCreateSubscription_NonAdmin_GlobalScope_Forbidden(t *testing.T) {
+	// Non-admin caller with no repo field: tests the 'no repo field on non-admin' path → 403.
 	srv := New(&mockStore{}, nil, devID, "admin@other.com")
 	body, _ := json.Marshal(map[string]interface{}{
 		"backend": "webhook",
@@ -596,13 +596,13 @@ func TestHandleCreateSubscription_RepoScoped_NoRepoAccess_Forbidden(t *testing.T
 	}
 }
 
-// 3. Non-admin sees only subscriptions they created.
+// 3. Non-admin sees only subscriptions they created (via store-level query).
 func TestHandleListSubscriptions_NonAdmin_FiltersToOwn(t *testing.T) {
 	ms := &mockStore{
-		listSubscriptionsFn: func(_ context.Context) ([]model.EventSubscription, error) {
+		listSubscriptionsByCreatorFn: func(_ context.Context, createdBy string) ([]model.EventSubscription, error) {
+			// Store returns only the caller's subscriptions.
 			return []model.EventSubscription{
-				{ID: "sub-1", Backend: "webhook", CreatedBy: devID},
-				{ID: "sub-2", Backend: "webhook", CreatedBy: "other@example.com"},
+				{ID: "sub-1", Backend: "webhook", CreatedBy: createdBy},
 			}, nil
 		},
 	}
@@ -712,5 +712,69 @@ func TestHandleResumeSubscription_NotCreator_Forbidden(t *testing.T) {
 	srv.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("expected 403 for non-creator resume, got %d", rec.Code)
+	}
+}
+
+// 9. Non-admin caller, GetSubscription returns generic error → 500 for delete.
+func TestHandleDeleteSubscription_NonAdmin_StoreError(t *testing.T) {
+	ms := &mockStore{
+		getSubscriptionFn: func(_ context.Context, id string) (*model.EventSubscription, error) {
+			return nil, errors.New("db connection reset")
+		},
+	}
+	srv := New(ms, nil, devID, "admin@other.com")
+	req := httptest.NewRequest(http.MethodDelete, "/subscriptions/sub-1", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for store error on non-admin delete, got %d", rec.Code)
+	}
+}
+
+// 10. Non-admin caller, GetSubscription returns generic error → 500 for resume.
+func TestHandleResumeSubscription_NonAdmin_StoreError(t *testing.T) {
+	ms := &mockStore{
+		getSubscriptionFn: func(_ context.Context, id string) (*model.EventSubscription, error) {
+			return nil, errors.New("db connection reset")
+		},
+	}
+	srv := New(ms, nil, devID, "admin@other.com")
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions/sub-1/resume", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for store error on non-admin resume, got %d", rec.Code)
+	}
+}
+
+// 11. Non-admin caller, GetSubscription returns ErrSubscriptionNotFound → 404 for delete.
+func TestHandleDeleteSubscription_NonAdmin_NotFound(t *testing.T) {
+	ms := &mockStore{
+		getSubscriptionFn: func(_ context.Context, id string) (*model.EventSubscription, error) {
+			return nil, db.ErrSubscriptionNotFound
+		},
+	}
+	srv := New(ms, nil, devID, "admin@other.com")
+	req := httptest.NewRequest(http.MethodDelete, "/subscriptions/sub-1", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for not-found on non-admin delete, got %d", rec.Code)
+	}
+}
+
+// 12. Non-admin caller, GetSubscription returns ErrSubscriptionNotFound → 404 for resume.
+func TestHandleResumeSubscription_NonAdmin_NotFound(t *testing.T) {
+	ms := &mockStore{
+		getSubscriptionFn: func(_ context.Context, id string) (*model.EventSubscription, error) {
+			return nil, db.ErrSubscriptionNotFound
+		},
+	}
+	srv := New(ms, nil, devID, "admin@other.com")
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions/sub-1/resume", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for not-found on non-admin resume, got %d", rec.Code)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -109,6 +109,7 @@ type WriteStore interface {
 	CreateSubscription(ctx context.Context, req model.CreateSubscriptionRequest) (*model.EventSubscription, error)
 	GetSubscription(ctx context.Context, id string) (*model.EventSubscription, error)
 	ListSubscriptions(ctx context.Context) ([]model.EventSubscription, error)
+	ListSubscriptionsByCreator(ctx context.Context, createdBy string) ([]model.EventSubscription, error)
 	DeleteSubscription(ctx context.Context, id string) error
 	ResumeSubscription(ctx context.Context, id string) error
 
@@ -202,7 +203,7 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 	//   GET  /repos/acme/myrepo          (bare: GET/DELETE a repo)
 	inner.Handle("/repos/", http.HandlerFunc(s.handleReposPrefix))
 
-	// Event subscription management (global, admin only).
+	// Event subscription management (delegated auth: admin for global, creator for own).
 	inner.HandleFunc("POST /subscriptions", s.handleCreateSubscription)
 	inner.HandleFunc("GET /subscriptions", s.handleListSubscriptions)
 	inner.HandleFunc("DELETE /subscriptions/{id}", s.handleDeleteSubscription)
@@ -323,11 +324,17 @@ func (s *server) requireGlobalAdmin(w http.ResponseWriter, r *http.Request) bool
 
 // requireRepoReadAccess checks that the current identity has at least reader
 // access to repo (any assigned role counts). Returns false and writes 403 if not.
+// Returns 500 for unexpected store errors.
 func (s *server) requireRepoReadAccess(w http.ResponseWriter, r *http.Request, repo string) bool {
 	identity := IdentityFromContext(r.Context())
 	_, err := s.commitStore.GetRole(r.Context(), repo, identity)
 	if err != nil {
-		writeError(w, http.StatusForbidden, "forbidden: no access to repo")
+		if errors.Is(err, db.ErrRoleNotFound) {
+			writeError(w, http.StatusForbidden, "forbidden: no access to repo")
+		} else {
+			slog.Error("internal error", "op", "get_role", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
 		return false
 	}
 	return true

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -107,6 +107,7 @@ type WriteStore interface {
 
 	// Event subscription management
 	CreateSubscription(ctx context.Context, req model.CreateSubscriptionRequest) (*model.EventSubscription, error)
+	GetSubscription(ctx context.Context, id string) (*model.EventSubscription, error)
 	ListSubscriptions(ctx context.Context) ([]model.EventSubscription, error)
 	DeleteSubscription(ctx context.Context, id string) error
 	ResumeSubscription(ctx context.Context, id string) error
@@ -315,6 +316,18 @@ func (s *server) requireGlobalAdmin(w http.ResponseWriter, r *http.Request) bool
 	identity := IdentityFromContext(r.Context())
 	if identity != s.globalAdmin {
 		writeError(w, http.StatusForbidden, "forbidden: global admin required")
+		return false
+	}
+	return true
+}
+
+// requireRepoReadAccess checks that the current identity has at least reader
+// access to repo (any assigned role counts). Returns false and writes 403 if not.
+func (s *server) requireRepoReadAccess(w http.ResponseWriter, r *http.Request, repo string) bool {
+	identity := IdentityFromContext(r.Context())
+	_, err := s.commitStore.GetRole(r.Context(), repo, identity)
+	if err != nil {
+		writeError(w, http.StatusForbidden, "forbidden: no access to repo")
 		return false
 	}
 	return true

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -66,10 +66,11 @@ type mockStore struct {
 	getReviewCommentFn    func(ctx context.Context, repo, id string) (*model.ReviewComment, error)
 	deleteReviewCommentFn func(ctx context.Context, repo, id string) error
 
-	createSubscriptionFn func(ctx context.Context, req model.CreateSubscriptionRequest) (*model.EventSubscription, error)
-	listSubscriptionsFn  func(ctx context.Context) ([]model.EventSubscription, error)
-	deleteSubscriptionFn func(ctx context.Context, id string) error
-	resumeSubscriptionFn func(ctx context.Context, id string) error
+	createSubscriptionFn  func(ctx context.Context, req model.CreateSubscriptionRequest) (*model.EventSubscription, error)
+	getSubscriptionFn     func(ctx context.Context, id string) (*model.EventSubscription, error)
+	listSubscriptionsFn   func(ctx context.Context) ([]model.EventSubscription, error)
+	deleteSubscriptionFn  func(ctx context.Context, id string) error
+	resumeSubscriptionFn  func(ctx context.Context, id string) error
 }
 
 func (m *mockStore) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
@@ -343,6 +344,13 @@ func (m *mockStore) CreateSubscription(ctx context.Context, req model.CreateSubs
 		return m.createSubscriptionFn(ctx, req)
 	}
 	return &model.EventSubscription{ID: "test-sub-id", Backend: req.Backend}, nil
+}
+
+func (m *mockStore) GetSubscription(ctx context.Context, id string) (*model.EventSubscription, error) {
+	if m.getSubscriptionFn != nil {
+		return m.getSubscriptionFn(ctx, id)
+	}
+	return nil, db.ErrSubscriptionNotFound
 }
 
 func (m *mockStore) ListSubscriptions(ctx context.Context) ([]model.EventSubscription, error) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -66,11 +66,12 @@ type mockStore struct {
 	getReviewCommentFn    func(ctx context.Context, repo, id string) (*model.ReviewComment, error)
 	deleteReviewCommentFn func(ctx context.Context, repo, id string) error
 
-	createSubscriptionFn  func(ctx context.Context, req model.CreateSubscriptionRequest) (*model.EventSubscription, error)
-	getSubscriptionFn     func(ctx context.Context, id string) (*model.EventSubscription, error)
-	listSubscriptionsFn   func(ctx context.Context) ([]model.EventSubscription, error)
-	deleteSubscriptionFn  func(ctx context.Context, id string) error
-	resumeSubscriptionFn  func(ctx context.Context, id string) error
+	createSubscriptionFn             func(ctx context.Context, req model.CreateSubscriptionRequest) (*model.EventSubscription, error)
+	getSubscriptionFn                func(ctx context.Context, id string) (*model.EventSubscription, error)
+	listSubscriptionsFn              func(ctx context.Context) ([]model.EventSubscription, error)
+	listSubscriptionsByCreatorFn     func(ctx context.Context, createdBy string) ([]model.EventSubscription, error)
+	deleteSubscriptionFn             func(ctx context.Context, id string) error
+	resumeSubscriptionFn             func(ctx context.Context, id string) error
 }
 
 func (m *mockStore) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
@@ -356,6 +357,13 @@ func (m *mockStore) GetSubscription(ctx context.Context, id string) (*model.Even
 func (m *mockStore) ListSubscriptions(ctx context.Context) ([]model.EventSubscription, error) {
 	if m.listSubscriptionsFn != nil {
 		return m.listSubscriptionsFn(ctx)
+	}
+	return []model.EventSubscription{}, nil
+}
+
+func (m *mockStore) ListSubscriptionsByCreator(ctx context.Context, createdBy string) ([]model.EventSubscription, error) {
+	if m.listSubscriptionsByCreatorFn != nil {
+		return m.listSubscriptionsByCreatorFn(ctx, createdBy)
 	}
 	return []model.EventSubscription{}, nil
 }


### PR DESCRIPTION
## Summary

- Add `GetSubscription(ctx, id)` to `WriteStore` interface and implement in `internal/db/store.go` (SELECT WHERE id=$1, ErrSubscriptionNotFound on no rows)
- Add `GetSubscriptionFn` mock field and `GetSubscription` method to `server_test.go` mockStore
- Add `requireRepoReadAccess` helper in `server.go` (checks any repo role = read access)
- Relax `handleCreateSubscription`: global admin creates any scope; non-admin creates repo-scoped only if they have repo read access
- Relax `handleListSubscriptions`: global admin sees all; non-admin filtered to `CreatedBy == identity`
- Relax `handleDeleteSubscription`: global admin or subscription creator can delete
- Relax `handleResumeSubscription`: global admin or subscription creator can resume
- Add 8 handler tests and 2 db store tests covering the new behavior
- Update 5 existing tests that assumed strict admin-only semantics

## Test plan

- [x] `go test ./... -count=1` passes (all packages green)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] New tests: `TestHandleCreateSubscription_RepoScoped_NonAdmin_Success`, `TestHandleCreateSubscription_RepoScoped_NoRepoAccess_Forbidden`, `TestHandleListSubscriptions_NonAdmin_FiltersToOwn`, `TestHandleListSubscriptions_Admin_SeesAll`, `TestHandleDeleteSubscription_Creator_Success`, `TestHandleDeleteSubscription_NotCreator_Forbidden`, `TestHandleResumeSubscription_Creator_Success`, `TestHandleResumeSubscription_NotCreator_Forbidden`
- [x] New store tests: `TestGetSubscription_Found`, `TestGetSubscription_NotFound`

🤖 Generated with [Claude Code](https://claude.com/claude-code)