### PR TITLE
docs: fix subscription documentation inaccuracies from #225 review

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -500,7 +500,7 @@ Create a webhook subscription.
 
 ### `GET /subscriptions`
 
-List all subscriptions. Global admin only.
+List subscriptions. Global admins see all subscriptions; non-admin authenticated users see only their own.
 
 **Response 200:**
 ```json
@@ -511,12 +511,12 @@ A non-null `suspended_at` field means the subscription was automatically suspend
 
 ### `DELETE /subscriptions/{id}`
 
-Delete a subscription. Global admin only.
+Delete a subscription. Global admin or the subscription creator.
 
 **Response 204.**
 
 ### `POST /subscriptions/{id}/resume`
 
-Resume a suspended subscription. Global admin only. Clears `suspended_at` and resets `failure_count` to 0.
+Resume a suspended subscription. Global admin or the subscription creator. Clears `suspended_at` and resets `failure_count` to 0.
 
 **Response 204.**

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -357,19 +357,19 @@ Subscription management via the CLI requires the appropriate role (reader+ for r
 Create a webhook subscription.
 
 ```
-ds subscriptions create --url <url> [--repo <owner/name>] [--events <type1,type2,...>] [--secret <secret>]
+ds subscriptions create --url <url> [--repo <owner/name>] [--event-types <type1,type2,...>] [--secret <secret>]
 ```
 
 - `--url` — Required. HTTPS endpoint to deliver events to.
 - `--repo` — Scope to a specific repo. Omit for a global subscription (admin-only).
-- `--events` — Comma-separated list of event types to receive. Omit to receive all types.
+- `--event-types` — Comma-separated list of event types to receive. Omit to receive all types.
 - `--secret` — HMAC-SHA256 signing secret. When set, deliveries include `X-DocStore-Signature: sha256=<hmac>`.
 
 ```bash
 # Repo-scoped, specific event types, with HMAC signing
 ds subscriptions create \
   --repo acme/platform \
-  --events com.docstore.commit.created,com.docstore.branch.merged \
+  --event-types com.docstore.commit.created,com.docstore.branch.merged \
   --url https://hooks.example.com/docstore \
   --secret my-hmac-secret
 
@@ -385,7 +385,7 @@ List all subscriptions.
 ds subscriptions list
 ```
 
-Prints each subscription's ID, repo scope, event filter, URL, status, and failure count. Suspended subscriptions are marked `[suspended]`.
+Prints a table with columns: ID, REPO (`(all)` for global subscriptions), BACKEND, SUSPENDED (the suspension timestamp, or `no` if active).
 
 ### `ds subscriptions delete`
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -135,6 +135,9 @@ Every event is a CloudEvents 1.0 JSON object:
 }
 ```
 
+When a role is revoked rather than granted, `role` is an empty string (`""`).
+
+
 ---
 
 ## SSE streaming
@@ -221,9 +224,9 @@ Webhook subscriptions provide durable, retried delivery to an HTTPS endpoint. Th
 |---|---|
 | Create subscription (repo-scoped, `repo` field set) | Reader+ on the target repo |
 | Create subscription (global, `repo` field omitted) | Global admin |
-| List subscriptions | Global admin |
-| Delete subscription | Global admin |
-| Resume a suspended subscription | Global admin |
+| List subscriptions | Global admin (all) or any authenticated user (own) |
+| Delete subscription | Global admin or subscription creator |
+| Resume a suspended subscription | Global admin or subscription creator |
 
 ### Event filtering
 
@@ -236,7 +239,9 @@ A subscription receives events based on two optional filters. Both must match fo
 
 ### HMAC-SHA256 request signing
 
-When a subscription is created with a non-empty `secret` in its config, every webhook delivery includes an `X-DocStore-Signature` header:
+Every webhook delivery is an HTTP POST with `Content-Type: application/cloudevents+json`.
+
+When a subscription is created with a non-empty `secret` in its config, every webhook delivery also includes an `X-DocStore-Signature` header:
 
 ```
 X-DocStore-Signature: sha256=<hex-encoded-hmac-sha256>
@@ -278,6 +283,8 @@ def verify(body: bytes, secret: str, header: str) -> bool:
 
 Always use a constant-time comparison (`hmac.Equal` / `hmac.compare_digest`) to prevent timing attacks.
 
+> **Secret storage:** The `secret` value is stored and returned in plaintext. To rotate a secret, delete the subscription and recreate it with a new secret value.
+
 ### Retry and suspend policy
 
 | Behavior | Detail |
@@ -287,6 +294,7 @@ Always use a constant-time comparison (`hmac.Equal` / `hmac.compare_digest`) to 
 | Retry backoff | Exponential: 1 s, 2 s, 4 s, 8 s, …, capped at 1 hour |
 | Max attempts | 10 per outbox row |
 | Auto-suspend | After 10 failed attempts the subscription is suspended and no further events are sent |
+| `failure_count` field | Counts the number of times the subscription has been auto-suspended, not the total number of individual failed delivery attempts |
 | Resume | `POST /subscriptions/{id}/resume` clears the suspension and resets the failure counter |
 | Outbox retention | Delivered rows are deleted after 7 days |
 
@@ -328,7 +336,6 @@ Content-Type: application/json
   "config": {"url": "https://hooks.example.com/docstore", "secret": "my-hmac-secret"},
   "created_at": "2024-06-01T12:00:00Z",
   "created_by": "alice@example.com",
-  "suspended_at": null,
   "failure_count": 0
 }
 ```
@@ -352,7 +359,6 @@ GET /subscriptions
       "config": {"url": "https://hooks.example.com/docstore"},
       "created_at": "2024-06-01T12:00:00Z",
       "created_by": "alice@example.com",
-      "suspended_at": null,
       "failure_count": 0
     }
   ]
@@ -443,7 +449,7 @@ Subscription management is also available via the `ds` CLI:
 # Repo-scoped, specific event types, with HMAC secret
 ds subscriptions create \
   --repo acme/platform \
-  --events com.docstore.commit.created,com.docstore.branch.merged \
+  --event-types com.docstore.commit.created,com.docstore.branch.merged \
   --url https://hooks.example.com/docstore \
   --secret my-hmac-secret
 


### PR DESCRIPTION
## Summary

- **Auth table** (`events.md`): List/Delete/Resume subscriptions no longer say "Global admin" only — non-admins can list their own; creators can delete/resume their own
- **`api-reference.md`**: Update `GET /subscriptions`, `DELETE /subscriptions/{id}`, `POST /subscriptions/{id}/resume` to match actual auth rules
- **`--events` → `--event-types`**: Rename flag in all examples across `events.md` and `cli-reference.md`
- **Remove `suspended_at: null`**: Field is `omitempty`, absent when nil — removed from all JSON examples
- **`ds subscriptions list` columns**: Fix output description to actual columns: ID, REPO (`(all)` for global), BACKEND, SUSPENDED (date or `no`)
- **Content-Type note**: Webhook deliveries use `Content-Type: application/cloudevents+json`
- **`failure_count` clarification**: Counts auto-suspension events, not total individual delivery failures
- **`com.docstore.role.changed`**: Note that `role` is empty string when a role is revoked
- **HMAC secret plaintext**: Note secret is stored/returned in plaintext; rotate by delete+recreate

## Test plan

- [ ] Review diff for correctness against actual server behaviour (all changes are docs only, no code changes)
- [ ] Verify `--event-types` matches actual CLI flag name in `cmd/ds`

Closes part of #225 (doc review follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)