### PR TITLE
fix: address review issues from issue #225 changes

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -889,6 +889,8 @@ func main() {
 			err = app.SubscriptionList()
 		} else {
 			switch args[1] {
+			case "list":
+				err = app.SubscriptionList()
 			case "create":
 				webhookURL := ""
 				secret := ""

--- a/internal/db/store_gap_test.go
+++ b/internal/db/store_gap_test.go
@@ -406,3 +406,44 @@ func TestGetSubscription_NotFound(t *testing.T) {
 		t.Errorf("expected ErrSubscriptionNotFound, got %v", err)
 	}
 }
+
+func TestListSubscriptionsByCreator_FiltersCorrectly(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	config, _ := json.Marshal(map[string]string{"url": "https://example.com/hook"})
+
+	// Create a subscription for alice.
+	if _, err := s.CreateSubscription(ctx, model.CreateSubscriptionRequest{
+		Backend:   "webhook",
+		Config:    config,
+		CreatedBy: "alice@example.com",
+	}); err != nil {
+		t.Fatalf("create alice subscription: %v", err)
+	}
+
+	// Create a subscription for bob.
+	if _, err := s.CreateSubscription(ctx, model.CreateSubscriptionRequest{
+		Backend:   "webhook",
+		Config:    config,
+		CreatedBy: "bob@example.com",
+	}); err != nil {
+		t.Fatalf("create bob subscription: %v", err)
+	}
+
+	// ListSubscriptionsByCreator for alice should return only alice's subscription.
+	subs, err := s.ListSubscriptionsByCreator(ctx, "alice@example.com")
+	if err != nil {
+		t.Fatalf("list by creator: %v", err)
+	}
+	for _, sub := range subs {
+		if sub.CreatedBy != "alice@example.com" {
+			t.Errorf("expected only alice's subscriptions, got created_by=%q", sub.CreatedBy)
+		}
+	}
+	if len(subs) == 0 {
+		t.Error("expected at least one subscription for alice")
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2462,7 +2462,7 @@ func (s *server) handleCreateSubscription(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if req.Backend != "webhook" {
-		writeError(w, http.StatusBadRequest, "only backend='webhook' is supported in Milestone 1")
+		writeError(w, http.StatusBadRequest, "only backend='webhook' is supported")
 		return
 	}
 	if len(req.Config) == 0 {

--- a/internal/server/handlers_gap_test.go
+++ b/internal/server/handlers_gap_test.go
@@ -265,7 +265,12 @@ func TestHandleCreateSubscription_InvalidURL(t *testing.T) {
 }
 
 func TestHandleCreateSubscription_Success(t *testing.T) {
-	srv := New(&mockStore{}, nil, devID, devID)
+	ms := &mockStore{
+		createSubscriptionFn: func(_ context.Context, req model.CreateSubscriptionRequest) (*model.EventSubscription, error) {
+			return &model.EventSubscription{ID: "test-sub-id", Backend: req.Backend, CreatedBy: req.CreatedBy}, nil
+		},
+	}
+	srv := New(ms, nil, devID, devID)
 	body, _ := json.Marshal(map[string]interface{}{
 		"backend": "webhook",
 		"config":  map[string]string{"url": "https://example.com/hook", "secret": "s3cr3t"},
@@ -283,6 +288,9 @@ func TestHandleCreateSubscription_Success(t *testing.T) {
 	}
 	if sub.Backend != "webhook" {
 		t.Errorf("expected backend webhook, got %q", sub.Backend)
+	}
+	if sub.CreatedBy != devID {
+		t.Errorf("expected created_by %q, got %q", devID, sub.CreatedBy)
 	}
 }
 
@@ -776,5 +784,37 @@ func TestHandleResumeSubscription_NonAdmin_NotFound(t *testing.T) {
 	srv.ServeHTTP(rec, req)
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for not-found on non-admin resume, got %d", rec.Code)
+	}
+}
+
+// 13. Non-admin caller, listSubscriptionsByCreatorFn returns an error → 500.
+func TestHandleListSubscriptions_NonAdmin_StoreError(t *testing.T) {
+	ms := &mockStore{
+		listSubscriptionsByCreatorFn: func(_ context.Context, createdBy string) ([]model.EventSubscription, error) {
+			return nil, errors.New("db unavailable")
+		},
+	}
+	srv := New(ms, nil, devID, "admin@other.com")
+	req := httptest.NewRequest(http.MethodGet, "/subscriptions", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for non-admin store error on list, got %d", rec.Code)
+	}
+}
+
+// 14. Config sent as a JSON array → 400.
+func TestHandleCreateSubscription_InvalidConfigType(t *testing.T) {
+	srv := New(&mockStore{}, nil, devID, devID)
+	body, _ := json.Marshal(map[string]interface{}{
+		"backend": "webhook",
+		"config":  []int{1, 2, 3},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/subscriptions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for array config, got %d; body: %s", rec.Code, rec.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

- **P0 bug fix**: `ds subscriptions list` now works — added `case "list":` to the subscriptions switch in `cmd/ds/main.go` that calls `app.SubscriptionList()`
- **P3 cleanup**: Removed "in Milestone 1" from the unsupported backend error message in `handlers.go`
- **P3 tests**: Added `TestListSubscriptionsByCreator_FiltersCorrectly` in `internal/db/store_gap_test.go` — verifies store-level filtering by creator
- **P3 tests**: Added `TestHandleListSubscriptions_NonAdmin_StoreError` — non-admin path, store error → 500
- **P3 tests**: Updated `TestHandleCreateSubscription_Success` — mock now echoes `req.CreatedBy`, asserts `sub.CreatedBy == devID`
- **P3 tests**: Added `TestHandleCreateSubscription_InvalidConfigType` — config sent as JSON array → 400

## Test plan

- [x] `go test ./internal/server/... ./cmd/ds/... -count=1` passes
- [x] `go test ./internal/db/... -run TestListSubscriptionsByCreator -count=1` passes
- [x] `go build ./...` and `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)