### PR TITLE
feat: issue tracker foundation — schema, API types, DB store

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -692,6 +692,145 @@ type ListSubscriptionsResponse struct {
 }
 
 // ---------------------------------------------------------------------------
+// Issues
+// ---------------------------------------------------------------------------
+
+// IssueState represents the lifecycle state of an issue.
+type IssueState string
+
+const (
+	IssueStateOpen   IssueState = "open"
+	IssueStateClosed IssueState = "closed"
+)
+
+// IssueCloseReason represents why an issue was closed.
+type IssueCloseReason string
+
+const (
+	IssueCloseReasonCompleted  IssueCloseReason = "completed"
+	IssueCloseReasonNotPlanned IssueCloseReason = "not_planned"
+	IssueCloseReasonDuplicate  IssueCloseReason = "duplicate"
+)
+
+// IssueRefType represents the kind of cross-reference attached to an issue.
+type IssueRefType string
+
+const (
+	IssueRefTypeProposal IssueRefType = "proposal"
+	IssueRefTypeCommit   IssueRefType = "commit"
+)
+
+// Issue is a repo-scoped bug report or feature request.
+type Issue struct {
+	ID          string            `json:"id"`
+	Repo        string            `json:"repo"`
+	Number      int64             `json:"number"`
+	Title       string            `json:"title"`
+	Body        string            `json:"body,omitempty"`
+	Author      string            `json:"author"`
+	State       IssueState        `json:"state"`
+	CloseReason *IssueCloseReason `json:"close_reason,omitempty"`
+	ClosedBy    *string           `json:"closed_by,omitempty"`
+	Labels      []string          `json:"labels"`
+	CreatedAt   time.Time         `json:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"`
+}
+
+// IssueComment is a comment on an issue.
+type IssueComment struct {
+	ID        string     `json:"id"`
+	IssueID   string     `json:"issue_id"`
+	Repo      string     `json:"repo"`
+	Body      string     `json:"body"`
+	Author    string     `json:"author"`
+	CreatedAt time.Time  `json:"created_at"`
+	EditedAt  *time.Time `json:"edited_at,omitempty"`
+}
+
+// IssueRef is a cross-reference from an issue to a proposal or commit.
+type IssueRef struct {
+	ID        string       `json:"id"`
+	IssueID   string       `json:"issue_id"`
+	Repo      string       `json:"repo"`
+	RefType   IssueRefType `json:"ref_type"`
+	RefID     string       `json:"ref_id"`
+	CreatedAt time.Time    `json:"created_at"`
+}
+
+// CreateIssueRequest is the body for POST /repos/:name/issues.
+type CreateIssueRequest struct {
+	Title  string   `json:"title"`
+	Body   string   `json:"body,omitempty"`
+	Labels []string `json:"labels,omitempty"`
+}
+
+// CreateIssueResponse is the response for POST /repos/:name/issues.
+type CreateIssueResponse struct {
+	ID     string `json:"id"`
+	Number int64  `json:"number"`
+}
+
+// UpdateIssueRequest is the body for PATCH /repos/:name/issues/:number.
+type UpdateIssueRequest struct {
+	Title  *string  `json:"title,omitempty"`
+	Body   *string  `json:"body,omitempty"`
+	Labels []string `json:"labels,omitempty"`
+}
+
+// CloseIssueRequest is the body for POST /repos/:name/issues/:number/close.
+type CloseIssueRequest struct {
+	Reason IssueCloseReason `json:"reason"`
+}
+
+// ReopenIssueRequest is the body for POST /repos/:name/issues/:number/reopen.
+// Currently empty but defined for forward compatibility.
+type ReopenIssueRequest struct{}
+
+// ListIssuesResponse is the response for GET /repos/:name/issues.
+type ListIssuesResponse struct {
+	Issues []Issue `json:"issues"`
+}
+
+// IssueResponse is the response for GET /repos/:name/issues/:number.
+type IssueResponse = Issue
+
+// CreateIssueCommentRequest is the body for POST /repos/:name/issues/:number/comments.
+type CreateIssueCommentRequest struct {
+	Body string `json:"body"`
+}
+
+// CreateIssueCommentResponse is the response for POST /repos/:name/issues/:number/comments.
+type CreateIssueCommentResponse struct {
+	ID string `json:"id"`
+}
+
+// UpdateIssueCommentRequest is the body for PATCH /repos/:name/issues/comments/:id.
+type UpdateIssueCommentRequest struct {
+	Body string `json:"body"`
+}
+
+// ListIssueCommentsResponse is the response for GET /repos/:name/issues/:number/comments.
+type ListIssueCommentsResponse struct {
+	Comments []IssueComment `json:"comments"`
+}
+
+// AddIssueRefRequest is the body for POST /repos/:name/issues/:number/refs.
+type AddIssueRefRequest struct {
+	RefType IssueRefType `json:"ref_type"`
+	RefID   string       `json:"ref_id"`
+}
+
+// AddIssueRefResponse is the response for POST /repos/:name/issues/:number/refs.
+type AddIssueRefResponse struct {
+	ID string `json:"id"`
+}
+
+// ListIssueRefsResponse is the response for GET /repos/:name/issues/:number/refs.
+type ListIssueRefsResponse struct {
+	Refs []IssueRef `json:"refs"`
+}
+
+// ---------------------------------------------------------------------------
 // Errors
 // ---------------------------------------------------------------------------
 

--- a/api/types.go
+++ b/api/types.go
@@ -732,6 +732,7 @@ type Issue struct {
 	CloseReason *IssueCloseReason `json:"close_reason,omitempty"`
 	ClosedBy    *string           `json:"closed_by,omitempty"`
 	Labels      []string          `json:"labels"`
+	ClosedAt    *time.Time        `json:"closed_at,omitempty"`
 	CreatedAt   time.Time         `json:"created_at"`
 	UpdatedAt   time.Time         `json:"updated_at"`
 }

--- a/internal/db/issues.go
+++ b/internal/db/issues.go
@@ -1,0 +1,488 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+)
+
+// Sentinel errors for issue operations.
+var (
+	ErrIssueNotFound        = fmt.Errorf("issue not found")
+	ErrIssueCommentNotFound = fmt.Errorf("issue comment not found")
+	ErrIssueRefExists       = fmt.Errorf("issue ref already exists")
+)
+
+// scanIssue scans one issues row into a model.Issue.
+func scanIssue(row interface{ Scan(...any) error }) (*model.Issue, error) {
+	var iss model.Issue
+	var body sql.NullString
+	var closeReason sql.NullString
+	var closedBy sql.NullString
+	if err := row.Scan(
+		&iss.ID, &iss.Repo, &iss.Number, &iss.Title, &body,
+		&iss.Author, &iss.State, &closeReason, &closedBy,
+		pq.Array(&iss.Labels), &iss.CreatedAt, &iss.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	if body.Valid {
+		iss.Body = body.String
+	}
+	if closeReason.Valid {
+		r := model.IssueCloseReason(closeReason.String)
+		iss.CloseReason = &r
+	}
+	if closedBy.Valid {
+		iss.ClosedBy = &closedBy.String
+	}
+	if iss.Labels == nil {
+		iss.Labels = []string{}
+	}
+	return &iss, nil
+}
+
+const issueColumns = `id::text, repo, number, title, body, author, state::text,
+	close_reason::text, closed_by, labels, created_at, updated_at`
+
+// CreateIssue inserts a new issue, allocating a per-repo issue number atomically.
+func (s *Store) CreateIssue(ctx context.Context, repo, title, body, author string, labels []string) (*model.Issue, error) {
+	if labels == nil {
+		labels = []string{}
+	}
+	id := uuid.New().String()
+	var nullBody sql.NullString
+	if body != "" {
+		nullBody = sql.NullString{String: body, Valid: true}
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create issue: begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Lock the repo row to serialize number allocation.
+	_, err = tx.ExecContext(ctx, `SELECT 1 FROM repos WHERE name = $1 FOR UPDATE`, repo)
+	if err != nil {
+		return nil, fmt.Errorf("create issue: lock repo: %w", err)
+	}
+
+	var number int64
+	err = tx.QueryRowContext(ctx,
+		`SELECT COALESCE(MAX(number), 0) + 1 FROM issues WHERE repo = $1`,
+		repo,
+	).Scan(&number)
+	if err != nil {
+		return nil, fmt.Errorf("create issue: allocate number: %w", err)
+	}
+
+	var iss model.Issue
+	iss.ID = id
+	iss.Repo = repo
+	iss.Number = number
+	iss.Title = title
+	iss.Body = body
+	iss.Author = author
+	iss.State = model.IssueStateOpen
+	iss.Labels = labels
+
+	err = tx.QueryRowContext(ctx,
+		`INSERT INTO issues (id, repo, number, title, body, author, labels)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)
+		 RETURNING created_at, updated_at`,
+		id, repo, number, title, nullBody, author, pq.Array(labels),
+	).Scan(&iss.CreatedAt, &iss.UpdatedAt)
+	if err != nil {
+		if isForeignKeyViolation(err) {
+			return nil, ErrRepoNotFound
+		}
+		return nil, fmt.Errorf("create issue: insert: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("create issue: commit: %w", err)
+	}
+	return &iss, nil
+}
+
+// GetIssue returns a single issue by repo and issue number.
+// Returns ErrIssueNotFound if no matching issue exists.
+func (s *Store) GetIssue(ctx context.Context, repo string, number int64) (*model.Issue, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+issueColumns+` FROM issues WHERE repo = $1 AND number = $2`,
+		repo, number,
+	)
+	iss, err := scanIssue(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrIssueNotFound
+		}
+		return nil, fmt.Errorf("get issue: %w", err)
+	}
+	return iss, nil
+}
+
+// ListIssues returns issues for a repo ordered by number DESC.
+// stateFilter, if non-empty, restricts to that state. authorFilter, if non-empty, restricts to that author.
+func (s *Store) ListIssues(ctx context.Context, repo, stateFilter, authorFilter string) ([]model.Issue, error) {
+	q := `SELECT ` + issueColumns + ` FROM issues WHERE repo = $1`
+	args := []interface{}{repo}
+	if stateFilter != "" {
+		args = append(args, stateFilter)
+		q += fmt.Sprintf(" AND state = $%d::issue_state", len(args))
+	}
+	if authorFilter != "" {
+		args = append(args, authorFilter)
+		q += fmt.Sprintf(" AND author = $%d", len(args))
+	}
+	q += " ORDER BY number DESC"
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list issues: %w", err)
+	}
+	defer rows.Close()
+
+	var issues []model.Issue
+	for rows.Next() {
+		iss, err := scanIssue(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list issues: scan: %w", err)
+		}
+		issues = append(issues, *iss)
+	}
+	if issues == nil {
+		issues = []model.Issue{}
+	}
+	return issues, rows.Err()
+}
+
+// UpdateIssue updates the title and/or body of an issue.
+// Returns ErrIssueNotFound if no matching issue exists.
+func (s *Store) UpdateIssue(ctx context.Context, repo string, number int64, title, body *string) (*model.Issue, error) {
+	if title == nil && body == nil {
+		return s.GetIssue(ctx, repo, number)
+	}
+
+	setClauses := []string{"updated_at = now()"}
+	args := []interface{}{}
+	argIdx := 1
+
+	if title != nil {
+		setClauses = append(setClauses, fmt.Sprintf("title = $%d", argIdx))
+		args = append(args, *title)
+		argIdx++
+	}
+	if body != nil {
+		setClauses = append(setClauses, fmt.Sprintf("body = $%d", argIdx))
+		args = append(args, *body)
+		argIdx++
+	}
+
+	setSQL := setClauses[0]
+	for _, c := range setClauses[1:] {
+		setSQL += ", " + c
+	}
+
+	args = append(args, repo, number)
+	repoIdx := argIdx
+	numIdx := argIdx + 1
+
+	row := s.db.QueryRowContext(ctx,
+		fmt.Sprintf(`UPDATE issues SET %s WHERE repo = $%d AND number = $%d RETURNING `+issueColumns, setSQL, repoIdx, numIdx),
+		args...,
+	)
+	iss, err := scanIssue(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrIssueNotFound
+		}
+		return nil, fmt.Errorf("update issue: %w", err)
+	}
+	return iss, nil
+}
+
+// CloseIssue sets the issue state to 'closed' with a reason and the closer's identity.
+// Returns ErrIssueNotFound if no matching issue exists.
+func (s *Store) CloseIssue(ctx context.Context, repo string, number int64, reason model.IssueCloseReason, closedBy string) (*model.Issue, error) {
+	row := s.db.QueryRowContext(ctx,
+		`UPDATE issues
+		 SET state = 'closed', close_reason = $3::issue_close_reason, closed_by = $4, updated_at = now()
+		 WHERE repo = $1 AND number = $2
+		 RETURNING `+issueColumns,
+		repo, number, string(reason), closedBy,
+	)
+	iss, err := scanIssue(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrIssueNotFound
+		}
+		return nil, fmt.Errorf("close issue: %w", err)
+	}
+	return iss, nil
+}
+
+// ReopenIssue sets the issue state back to 'open', clearing close_reason and closed_by.
+// Returns ErrIssueNotFound if no matching issue exists.
+func (s *Store) ReopenIssue(ctx context.Context, repo string, number int64) (*model.Issue, error) {
+	row := s.db.QueryRowContext(ctx,
+		`UPDATE issues
+		 SET state = 'open', close_reason = NULL, closed_by = NULL, updated_at = now()
+		 WHERE repo = $1 AND number = $2
+		 RETURNING `+issueColumns,
+		repo, number,
+	)
+	iss, err := scanIssue(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrIssueNotFound
+		}
+		return nil, fmt.Errorf("reopen issue: %w", err)
+	}
+	return iss, nil
+}
+
+// ---------------------------------------------------------------------------
+// Issue comments
+// ---------------------------------------------------------------------------
+
+const issueCommentColumns = `id::text, issue_id::text, repo, body, author, created_at, edited_at`
+
+func scanIssueComment(row interface{ Scan(...any) error }) (*model.IssueComment, error) {
+	var c model.IssueComment
+	var editedAt sql.NullTime
+	if err := row.Scan(&c.ID, &c.IssueID, &c.Repo, &c.Body, &c.Author, &c.CreatedAt, &editedAt); err != nil {
+		return nil, err
+	}
+	if editedAt.Valid {
+		c.EditedAt = &editedAt.Time
+	}
+	return &c, nil
+}
+
+// CreateIssueComment inserts a new comment on an issue identified by repo+number.
+// Returns ErrIssueNotFound if the issue does not exist.
+func (s *Store) CreateIssueComment(ctx context.Context, repo string, number int64, body, author string) (*model.IssueComment, error) {
+	// Resolve issue_id from repo+number.
+	var issueID string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id::text FROM issues WHERE repo = $1 AND number = $2`,
+		repo, number,
+	).Scan(&issueID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrIssueNotFound
+		}
+		return nil, fmt.Errorf("create issue comment: resolve issue: %w", err)
+	}
+
+	id := uuid.New().String()
+	row := s.db.QueryRowContext(ctx,
+		`INSERT INTO issue_comments (id, issue_id, repo, body, author)
+		 VALUES ($1, $2::uuid, $3, $4, $5)
+		 RETURNING `+issueCommentColumns,
+		id, issueID, repo, body, author,
+	)
+	c, err := scanIssueComment(row)
+	if err != nil {
+		return nil, fmt.Errorf("create issue comment: %w", err)
+	}
+	return c, nil
+}
+
+// GetIssueComment returns a single comment by ID within the given repo.
+// Returns ErrIssueCommentNotFound if no matching comment exists.
+func (s *Store) GetIssueComment(ctx context.Context, repo, id string) (*model.IssueComment, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+issueCommentColumns+` FROM issue_comments WHERE repo = $1 AND id = $2::uuid`,
+		repo, id,
+	)
+	c, err := scanIssueComment(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrIssueCommentNotFound
+		}
+		return nil, fmt.Errorf("get issue comment: %w", err)
+	}
+	return c, nil
+}
+
+// ListIssueComments returns all comments on an issue identified by repo+number, ordered by created_at ASC.
+func (s *Store) ListIssueComments(ctx context.Context, repo string, number int64) ([]model.IssueComment, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+issueCommentColumns+`
+		 FROM issue_comments
+		 WHERE repo = $1 AND issue_id = (SELECT id FROM issues WHERE repo = $1 AND number = $2)
+		 ORDER BY created_at ASC`,
+		repo, number,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list issue comments: %w", err)
+	}
+	defer rows.Close()
+
+	var comments []model.IssueComment
+	for rows.Next() {
+		c, err := scanIssueComment(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list issue comments: scan: %w", err)
+		}
+		comments = append(comments, *c)
+	}
+	if comments == nil {
+		comments = []model.IssueComment{}
+	}
+	return comments, rows.Err()
+}
+
+// UpdateIssueComment updates the body of a comment and sets edited_at = now().
+// Returns ErrIssueCommentNotFound if no matching comment exists.
+func (s *Store) UpdateIssueComment(ctx context.Context, repo, id, body string) (*model.IssueComment, error) {
+	row := s.db.QueryRowContext(ctx,
+		`UPDATE issue_comments SET body = $3, edited_at = now()
+		 WHERE repo = $1 AND id = $2::uuid
+		 RETURNING `+issueCommentColumns,
+		repo, id, body,
+	)
+	c, err := scanIssueComment(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrIssueCommentNotFound
+		}
+		return nil, fmt.Errorf("update issue comment: %w", err)
+	}
+	return c, nil
+}
+
+// DeleteIssueComment deletes a comment by ID within the given repo.
+// Returns ErrIssueCommentNotFound if no matching comment exists.
+func (s *Store) DeleteIssueComment(ctx context.Context, repo, id string) error {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM issue_comments WHERE repo = $1 AND id = $2::uuid`,
+		repo, id,
+	)
+	if err != nil {
+		return fmt.Errorf("delete issue comment: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("delete issue comment: rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrIssueCommentNotFound
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Issue refs
+// ---------------------------------------------------------------------------
+
+const issueRefColumns = `id::text, issue_id::text, repo, ref_type::text, ref_id, created_at`
+
+func scanIssueRef(row interface{ Scan(...any) error }) (*model.IssueRef, error) {
+	var r model.IssueRef
+	if err := row.Scan(&r.ID, &r.IssueID, &r.Repo, &r.RefType, &r.RefID, &r.CreatedAt); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+// CreateIssueRef attaches a cross-reference to an issue identified by repo+number.
+// Returns ErrIssueNotFound if the issue does not exist.
+// Returns ErrIssueRefExists if the (issue_id, ref_type, ref_id) combination already exists.
+func (s *Store) CreateIssueRef(ctx context.Context, repo string, number int64, refType model.IssueRefType, refID string) (*model.IssueRef, error) {
+	var issueID string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id::text FROM issues WHERE repo = $1 AND number = $2`,
+		repo, number,
+	).Scan(&issueID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrIssueNotFound
+		}
+		return nil, fmt.Errorf("create issue ref: resolve issue: %w", err)
+	}
+
+	id := uuid.New().String()
+	row := s.db.QueryRowContext(ctx,
+		`INSERT INTO issue_refs (id, issue_id, repo, ref_type, ref_id)
+		 VALUES ($1, $2::uuid, $3, $4::issue_ref_type, $5)
+		 RETURNING `+issueRefColumns,
+		id, issueID, repo, string(refType), refID,
+	)
+	r, err := scanIssueRef(row)
+	if err != nil {
+		if isDuplicateKeyError(err) {
+			return nil, ErrIssueRefExists
+		}
+		return nil, fmt.Errorf("create issue ref: %w", err)
+	}
+	return r, nil
+}
+
+// ListIssueRefs returns all refs attached to an issue identified by repo+number,
+// ordered by created_at ASC.
+func (s *Store) ListIssueRefs(ctx context.Context, repo string, number int64) ([]model.IssueRef, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+issueRefColumns+`
+		 FROM issue_refs
+		 WHERE repo = $1 AND issue_id = (SELECT id FROM issues WHERE repo = $1 AND number = $2)
+		 ORDER BY created_at ASC`,
+		repo, number,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list issue refs: %w", err)
+	}
+	defer rows.Close()
+
+	var refs []model.IssueRef
+	for rows.Next() {
+		r, err := scanIssueRef(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list issue refs: scan: %w", err)
+		}
+		refs = append(refs, *r)
+	}
+	if refs == nil {
+		refs = []model.IssueRef{}
+	}
+	return refs, rows.Err()
+}
+
+// ListIssuesByRef returns issues in a repo that have a ref matching (refType, refID),
+// ordered by issue number ASC.
+func (s *Store) ListIssuesByRef(ctx context.Context, repo string, refType model.IssueRefType, refID string) ([]model.Issue, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+issueColumns+`
+		 FROM issues
+		 WHERE id IN (
+		     SELECT issue_id FROM issue_refs
+		     WHERE repo = $1 AND ref_type = $2::issue_ref_type AND ref_id = $3
+		 )
+		 ORDER BY number ASC`,
+		repo, string(refType), refID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list issues by ref: %w", err)
+	}
+	defer rows.Close()
+
+	var issues []model.Issue
+	for rows.Next() {
+		iss, err := scanIssue(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list issues by ref: scan: %w", err)
+		}
+		issues = append(issues, *iss)
+	}
+	if issues == nil {
+		issues = []model.Issue{}
+	}
+	return issues, rows.Err()
+}

--- a/internal/db/issues.go
+++ b/internal/db/issues.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/google/uuid"
@@ -23,10 +24,11 @@ func scanIssue(row interface{ Scan(...any) error }) (*model.Issue, error) {
 	var body sql.NullString
 	var closeReason sql.NullString
 	var closedBy sql.NullString
+	var closedAt sql.NullTime
 	if err := row.Scan(
 		&iss.ID, &iss.Repo, &iss.Number, &iss.Title, &body,
 		&iss.Author, &iss.State, &closeReason, &closedBy,
-		pq.Array(&iss.Labels), &iss.CreatedAt, &iss.UpdatedAt,
+		pq.Array(&iss.Labels), &closedAt, &iss.CreatedAt, &iss.UpdatedAt,
 	); err != nil {
 		return nil, err
 	}
@@ -40,6 +42,9 @@ func scanIssue(row interface{ Scan(...any) error }) (*model.Issue, error) {
 	if closedBy.Valid {
 		iss.ClosedBy = &closedBy.String
 	}
+	if closedAt.Valid {
+		iss.ClosedAt = &closedAt.Time
+	}
 	if iss.Labels == nil {
 		iss.Labels = []string{}
 	}
@@ -47,7 +52,7 @@ func scanIssue(row interface{ Scan(...any) error }) (*model.Issue, error) {
 }
 
 const issueColumns = `id::text, repo, number, title, body, author, state::text,
-	close_reason::text, closed_by, labels, created_at, updated_at`
+	close_reason::text, closed_by, labels, closed_at, created_at, updated_at`
 
 // CreateIssue inserts a new issue, allocating a per-repo issue number atomically.
 func (s *Store) CreateIssue(ctx context.Context, repo, title, body, author string, labels []string) (*model.Issue, error) {
@@ -162,10 +167,10 @@ func (s *Store) ListIssues(ctx context.Context, repo, stateFilter, authorFilter 
 	return issues, rows.Err()
 }
 
-// UpdateIssue updates the title and/or body of an issue.
+// UpdateIssue updates the title, body, and/or labels of an issue.
 // Returns ErrIssueNotFound if no matching issue exists.
-func (s *Store) UpdateIssue(ctx context.Context, repo string, number int64, title, body *string) (*model.Issue, error) {
-	if title == nil && body == nil {
+func (s *Store) UpdateIssue(ctx context.Context, repo string, number int64, title, body *string, labels *[]string) (*model.Issue, error) {
+	if title == nil && body == nil && labels == nil {
 		return s.GetIssue(ctx, repo, number)
 	}
 
@@ -183,11 +188,13 @@ func (s *Store) UpdateIssue(ctx context.Context, repo string, number int64, titl
 		args = append(args, *body)
 		argIdx++
 	}
-
-	setSQL := setClauses[0]
-	for _, c := range setClauses[1:] {
-		setSQL += ", " + c
+	if labels != nil {
+		setClauses = append(setClauses, fmt.Sprintf("labels = $%d", argIdx))
+		args = append(args, pq.Array(*labels))
+		argIdx++
 	}
+
+	setSQL := strings.Join(setClauses, ", ")
 
 	args = append(args, repo, number)
 	repoIdx := argIdx
@@ -212,7 +219,7 @@ func (s *Store) UpdateIssue(ctx context.Context, repo string, number int64, titl
 func (s *Store) CloseIssue(ctx context.Context, repo string, number int64, reason model.IssueCloseReason, closedBy string) (*model.Issue, error) {
 	row := s.db.QueryRowContext(ctx,
 		`UPDATE issues
-		 SET state = 'closed', close_reason = $3::issue_close_reason, closed_by = $4, updated_at = now()
+		 SET state = 'closed', close_reason = $3::issue_close_reason, closed_by = $4, closed_at = now(), updated_at = now()
 		 WHERE repo = $1 AND number = $2
 		 RETURNING `+issueColumns,
 		repo, number, string(reason), closedBy,
@@ -232,7 +239,7 @@ func (s *Store) CloseIssue(ctx context.Context, repo string, number int64, reaso
 func (s *Store) ReopenIssue(ctx context.Context, repo string, number int64) (*model.Issue, error) {
 	row := s.db.QueryRowContext(ctx,
 		`UPDATE issues
-		 SET state = 'open', close_reason = NULL, closed_by = NULL, updated_at = now()
+		 SET state = 'open', close_reason = NULL, closed_by = NULL, closed_at = NULL, updated_at = now()
 		 WHERE repo = $1 AND number = $2
 		 RETURNING `+issueColumns,
 		repo, number,

--- a/internal/db/migrations/000013_issues.down.sql
+++ b/internal/db/migrations/000013_issues.down.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS issue_refs;
+DROP TABLE IF EXISTS issue_comments;
+DROP TABLE IF EXISTS issues;
+
+DROP TYPE IF EXISTS issue_ref_type;
+DROP TYPE IF EXISTS issue_close_reason;
+DROP TYPE IF EXISTS issue_state;

--- a/internal/db/migrations/000013_issues.up.sql
+++ b/internal/db/migrations/000013_issues.up.sql
@@ -13,6 +13,7 @@ CREATE TABLE issues (
     close_reason issue_close_reason,
     closed_by    TEXT,
     labels       TEXT[] NOT NULL DEFAULT '{}',
+    closed_at    TIMESTAMPTZ,
     created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
     UNIQUE (repo, number)
@@ -39,7 +40,6 @@ CREATE TABLE issue_refs (
 );
 
 CREATE INDEX issues_repo_state   ON issues (repo, state);
-CREATE INDEX issues_repo_number  ON issues (repo, number);
 CREATE INDEX issue_comments_issue_id ON issue_comments (issue_id);
 CREATE INDEX issue_refs_issue_id ON issue_refs (issue_id);
 CREATE INDEX issue_refs_repo_ref ON issue_refs (repo, ref_type, ref_id);

--- a/internal/db/migrations/000013_issues.up.sql
+++ b/internal/db/migrations/000013_issues.up.sql
@@ -1,0 +1,45 @@
+CREATE TYPE issue_state AS ENUM ('open', 'closed');
+CREATE TYPE issue_close_reason AS ENUM ('completed', 'not_planned', 'duplicate');
+CREATE TYPE issue_ref_type AS ENUM ('proposal', 'commit');
+
+CREATE TABLE issues (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    repo         TEXT NOT NULL REFERENCES repos(name),
+    number       BIGINT NOT NULL,
+    title        TEXT NOT NULL,
+    body         TEXT,
+    author       TEXT NOT NULL,
+    state        issue_state NOT NULL DEFAULT 'open',
+    close_reason issue_close_reason,
+    closed_by    TEXT,
+    labels       TEXT[] NOT NULL DEFAULT '{}',
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (repo, number)
+);
+
+CREATE TABLE issue_comments (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    issue_id   UUID NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
+    repo       TEXT NOT NULL REFERENCES repos(name),
+    body       TEXT NOT NULL,
+    author     TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    edited_at  TIMESTAMPTZ
+);
+
+CREATE TABLE issue_refs (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    issue_id   UUID NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
+    repo       TEXT NOT NULL REFERENCES repos(name),
+    ref_type   issue_ref_type NOT NULL,
+    ref_id     TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (issue_id, ref_type, ref_id)
+);
+
+CREATE INDEX issues_repo_state   ON issues (repo, state);
+CREATE INDEX issues_repo_number  ON issues (repo, number);
+CREATE INDEX issue_comments_issue_id ON issue_comments (issue_id);
+CREATE INDEX issue_refs_issue_id ON issue_refs (issue_id);
+CREATE INDEX issue_refs_repo_ref ON issue_refs (repo, ref_type, ref_id);

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -87,4 +87,18 @@ type CreateProposalRequest = api.CreateProposalRequest
 type CreateProposalResponse = api.CreateProposalResponse
 type UpdateProposalRequest = api.UpdateProposalRequest
 
+type CreateIssueRequest = api.CreateIssueRequest
+type CreateIssueResponse = api.CreateIssueResponse
+type UpdateIssueRequest = api.UpdateIssueRequest
+type CloseIssueRequest = api.CloseIssueRequest
+type ListIssuesResponse = api.ListIssuesResponse
+type IssueResponse = api.IssueResponse
+type CreateIssueCommentRequest = api.CreateIssueCommentRequest
+type CreateIssueCommentResponse = api.CreateIssueCommentResponse
+type UpdateIssueCommentRequest = api.UpdateIssueCommentRequest
+type ListIssueCommentsResponse = api.ListIssueCommentsResponse
+type AddIssueRefRequest = api.AddIssueRefRequest
+type AddIssueRefResponse = api.AddIssueRefResponse
+type ListIssueRefsResponse = api.ListIssueRefsResponse
+
 type ErrorResponse = api.ErrorResponse

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -91,6 +91,7 @@ type CreateIssueRequest = api.CreateIssueRequest
 type CreateIssueResponse = api.CreateIssueResponse
 type UpdateIssueRequest = api.UpdateIssueRequest
 type CloseIssueRequest = api.CloseIssueRequest
+type ReopenIssueRequest = api.ReopenIssueRequest
 type ListIssuesResponse = api.ListIssuesResponse
 type IssueResponse = api.IssueResponse
 type CreateIssueCommentRequest = api.CreateIssueCommentRequest

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -79,6 +79,32 @@ const (
 	ProposalMerged = api.ProposalMerged
 )
 
+type IssueState = api.IssueState
+
+const (
+	IssueStateOpen   = api.IssueStateOpen
+	IssueStateClosed = api.IssueStateClosed
+)
+
+type IssueCloseReason = api.IssueCloseReason
+
+const (
+	IssueCloseReasonCompleted  = api.IssueCloseReasonCompleted
+	IssueCloseReasonNotPlanned = api.IssueCloseReasonNotPlanned
+	IssueCloseReasonDuplicate  = api.IssueCloseReasonDuplicate
+)
+
+type IssueRefType = api.IssueRefType
+
+const (
+	IssueRefTypeProposal = api.IssueRefTypeProposal
+	IssueRefTypeCommit   = api.IssueRefTypeCommit
+)
+
+type Issue = api.Issue
+type IssueComment = api.IssueComment
+type IssueRef = api.IssueRef
+
 // ---------------------------------------------------------------------------
 // Internal-only types — not part of the HTTP wire surface.
 // ---------------------------------------------------------------------------

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -120,6 +120,26 @@ type WriteStore interface {
 	UpdateProposal(ctx context.Context, repo, proposalID string, title, description *string) (*model.Proposal, error)
 	CloseProposal(ctx context.Context, repo, proposalID string) error
 	MergeProposal(ctx context.Context, repo, branch string) (*model.Proposal, error)
+
+	// Issue management
+	CreateIssue(ctx context.Context, repo, title, body, author string, labels []string) (*model.Issue, error)
+	GetIssue(ctx context.Context, repo string, number int64) (*model.Issue, error)
+	ListIssues(ctx context.Context, repo, stateFilter, authorFilter string) ([]model.Issue, error)
+	UpdateIssue(ctx context.Context, repo string, number int64, title, body *string) (*model.Issue, error)
+	CloseIssue(ctx context.Context, repo string, number int64, reason model.IssueCloseReason, closedBy string) (*model.Issue, error)
+	ReopenIssue(ctx context.Context, repo string, number int64) (*model.Issue, error)
+
+	// Issue comment management
+	CreateIssueComment(ctx context.Context, repo string, number int64, body, author string) (*model.IssueComment, error)
+	GetIssueComment(ctx context.Context, repo, id string) (*model.IssueComment, error)
+	ListIssueComments(ctx context.Context, repo string, number int64) ([]model.IssueComment, error)
+	UpdateIssueComment(ctx context.Context, repo, id, body string) (*model.IssueComment, error)
+	DeleteIssueComment(ctx context.Context, repo, id string) error
+
+	// Issue ref management
+	CreateIssueRef(ctx context.Context, repo string, number int64, refType model.IssueRefType, refID string) (*model.IssueRef, error)
+	ListIssueRefs(ctx context.Context, repo string, number int64) ([]model.IssueRef, error)
+	ListIssuesByRef(ctx context.Context, repo string, refType model.IssueRefType, refID string) ([]model.Issue, error)
 }
 
 // CommitStore is an alias for backward compatibility with tests.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -125,7 +125,7 @@ type WriteStore interface {
 	CreateIssue(ctx context.Context, repo, title, body, author string, labels []string) (*model.Issue, error)
 	GetIssue(ctx context.Context, repo string, number int64) (*model.Issue, error)
 	ListIssues(ctx context.Context, repo, stateFilter, authorFilter string) ([]model.Issue, error)
-	UpdateIssue(ctx context.Context, repo string, number int64, title, body *string) (*model.Issue, error)
+	UpdateIssue(ctx context.Context, repo string, number int64, title, body *string, labels *[]string) (*model.Issue, error)
 	CloseIssue(ctx context.Context, repo string, number int64, reason model.IssueCloseReason, closedBy string) (*model.Issue, error)
 	ReopenIssue(ctx context.Context, repo string, number int64) (*model.Issue, error)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -434,6 +434,49 @@ func (m *mockStore) DeleteReviewComment(ctx context.Context, repo, id string) er
 	return db.ErrCommentNotFound
 }
 
+func (m *mockStore) CreateIssue(_ context.Context, _, _, _, _ string, _ []string) (*model.Issue, error) {
+	return nil, errors.New("not implemented")
+}
+func (m *mockStore) GetIssue(_ context.Context, _ string, _ int64) (*model.Issue, error) {
+	return nil, db.ErrIssueNotFound
+}
+func (m *mockStore) ListIssues(_ context.Context, _, _, _ string) ([]model.Issue, error) {
+	return []model.Issue{}, nil
+}
+func (m *mockStore) UpdateIssue(_ context.Context, _ string, _ int64, _, _ *string) (*model.Issue, error) {
+	return nil, db.ErrIssueNotFound
+}
+func (m *mockStore) CloseIssue(_ context.Context, _ string, _ int64, _ model.IssueCloseReason, _ string) (*model.Issue, error) {
+	return nil, db.ErrIssueNotFound
+}
+func (m *mockStore) ReopenIssue(_ context.Context, _ string, _ int64) (*model.Issue, error) {
+	return nil, db.ErrIssueNotFound
+}
+func (m *mockStore) CreateIssueComment(_ context.Context, _ string, _ int64, _, _ string) (*model.IssueComment, error) {
+	return nil, errors.New("not implemented")
+}
+func (m *mockStore) GetIssueComment(_ context.Context, _, _ string) (*model.IssueComment, error) {
+	return nil, db.ErrIssueCommentNotFound
+}
+func (m *mockStore) ListIssueComments(_ context.Context, _ string, _ int64) ([]model.IssueComment, error) {
+	return []model.IssueComment{}, nil
+}
+func (m *mockStore) UpdateIssueComment(_ context.Context, _, _, _ string) (*model.IssueComment, error) {
+	return nil, db.ErrIssueCommentNotFound
+}
+func (m *mockStore) DeleteIssueComment(_ context.Context, _, _ string) error {
+	return db.ErrIssueCommentNotFound
+}
+func (m *mockStore) CreateIssueRef(_ context.Context, _ string, _ int64, _ model.IssueRefType, _ string) (*model.IssueRef, error) {
+	return nil, errors.New("not implemented")
+}
+func (m *mockStore) ListIssueRefs(_ context.Context, _ string, _ int64) ([]model.IssueRef, error) {
+	return []model.IssueRef{}, nil
+}
+func (m *mockStore) ListIssuesByRef(_ context.Context, _ string, _ model.IssueRefType, _ string) ([]model.Issue, error) {
+	return []model.Issue{}, nil
+}
+
 func TestHealthEndpoint(t *testing.T) {
 	// /healthz is exempt from IAP auth, so devIdentity="" is fine here.
 	srv := New(nil, nil, "", "")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -443,7 +443,7 @@ func (m *mockStore) GetIssue(_ context.Context, _ string, _ int64) (*model.Issue
 func (m *mockStore) ListIssues(_ context.Context, _, _, _ string) ([]model.Issue, error) {
 	return []model.Issue{}, nil
 }
-func (m *mockStore) UpdateIssue(_ context.Context, _ string, _ int64, _, _ *string) (*model.Issue, error) {
+func (m *mockStore) UpdateIssue(_ context.Context, _ string, _ int64, _, _ *string, _ *[]string) (*model.Issue, error) {
 	return nil, db.ErrIssueNotFound
 }
 func (m *mockStore) CloseIssue(_ context.Context, _ string, _ int64, _ model.IssueCloseReason, _ string) (*model.Issue, error) {


### PR DESCRIPTION
## Summary

- **Migration 000013**: `issue_state`, `issue_close_reason`, `issue_ref_type` enums; `issues`, `issue_comments`, `issue_refs` tables with all required indexes
- **`api/types.go`**: `Issue`, `IssueComment`, `IssueRef` domain structs plus all request/response types (`CreateIssueRequest`, `UpdateIssueRequest`, `CloseIssueRequest`, `CreateIssueCommentRequest`, `UpdateIssueCommentRequest`, `AddIssueRefRequest`, list/response wrappers)
- **`internal/db/issues.go`**: full SQL store — `CreateIssue` (transaction + `SELECT FOR UPDATE` on `repos` row for safe number allocation), `GetIssue`, `ListIssues`, `UpdateIssue`, `CloseIssue`, `ReopenIssue`; comments CRUD; refs `CreateIssueRef`, `ListIssueRefs`, `ListIssuesByRef`
- **`internal/model`**: re-exports all new types as aliases (matching existing pattern)
- **`server.go` `WriteStore`**: declares all new issue interface methods
- **`server_test.go` `mockStore`**: no-op stubs so existing tests compile

Closes #233 (phase 1 — foundation only; handlers to follow)

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)