### PR TITLE
ci: remove KEDA Helm install step from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,17 +160,6 @@ jobs:
           DIGEST=$(jq -r '."containerimage.digest"' /tmp/ci-worker-metadata.json)
           echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
-      - uses: azure/setup-helm@v4
-
-      - name: Install KEDA via Helm
-        run: |
-          helm repo add kedacore https://kedacore.github.io/charts
-          helm repo update
-          helm upgrade --install keda kedacore/keda \
-            --namespace keda \
-            --create-namespace \
-            --wait
-
       - name: Deploy ci-worker to GKE
         run: |
           kubectl apply -f deploy/k8s/ci-worker.yaml


### PR DESCRIPTION
## Summary

- Removes the `azure/setup-helm` action step and `Install KEDA via Helm` step from the `build-and-deploy-ci-worker` job
- KEDA is cluster infrastructure that should be installed once as a one-time setup, not on every push to main
- The `kubectl apply` of `ci-worker-scaledobject.yaml` (line 181) remains — that is the only per-deploy step needed

## Root Cause

Since PR #223 added KEDA autoscaling, the deploy workflow has been failing on every push to main. The `helm upgrade --install keda` step tries to patch the `keda-operator` ClusterRole, but the `docstore-deployer` service account lacks `container.clusterRoles.update` permission.

## Test plan

- [ ] Verify the deploy workflow succeeds on the next push to main after merge
- [ ] Confirm KEDA ScaledObject is still applied per-deploy (line 181 unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)