### PR TITLE
feat: issue tracker — HTTP handlers, routes, events, and mention parsing

### DIFF
--- a/internal/events/types/issue.go
+++ b/internal/events/types/issue.go
@@ -1,0 +1,73 @@
+package types
+
+// IssueOpened is emitted when a new issue is opened.
+type IssueOpened struct {
+	Repo    string `json:"repo"`
+	IssueID string `json:"issue_id"`
+	Number  int64  `json:"number"`
+	Author  string `json:"author"`
+}
+
+func (e IssueOpened) Type() string   { return "com.docstore.issue.opened" }
+func (e IssueOpened) Source() string { return "/repos/" + e.Repo }
+func (e IssueOpened) Data() any      { return e }
+
+// IssueClosed is emitted when an issue is closed.
+type IssueClosed struct {
+	Repo     string `json:"repo"`
+	IssueID  string `json:"issue_id"`
+	Number   int64  `json:"number"`
+	Reason   string `json:"reason"`
+	ClosedBy string `json:"closed_by"`
+}
+
+func (e IssueClosed) Type() string   { return "com.docstore.issue.closed" }
+func (e IssueClosed) Source() string { return "/repos/" + e.Repo }
+func (e IssueClosed) Data() any      { return e }
+
+// IssueReopened is emitted when an issue is reopened.
+type IssueReopened struct {
+	Repo    string `json:"repo"`
+	IssueID string `json:"issue_id"`
+	Number  int64  `json:"number"`
+}
+
+func (e IssueReopened) Type() string   { return "com.docstore.issue.reopened" }
+func (e IssueReopened) Source() string { return "/repos/" + e.Repo }
+func (e IssueReopened) Data() any      { return e }
+
+// IssueUpdated is emitted when an issue is updated.
+type IssueUpdated struct {
+	Repo    string `json:"repo"`
+	IssueID string `json:"issue_id"`
+	Number  int64  `json:"number"`
+}
+
+func (e IssueUpdated) Type() string   { return "com.docstore.issue.updated" }
+func (e IssueUpdated) Source() string { return "/repos/" + e.Repo }
+func (e IssueUpdated) Data() any      { return e }
+
+// IssueCommentCreated is emitted when a comment is added to an issue.
+type IssueCommentCreated struct {
+	Repo      string `json:"repo"`
+	IssueID   string `json:"issue_id"`
+	Number    int64  `json:"number"`
+	CommentID string `json:"comment_id"`
+	Author    string `json:"author"`
+}
+
+func (e IssueCommentCreated) Type() string   { return "com.docstore.issue.comment.created" }
+func (e IssueCommentCreated) Source() string { return "/repos/" + e.Repo }
+func (e IssueCommentCreated) Data() any      { return e }
+
+// IssueCommentUpdated is emitted when a comment is updated.
+type IssueCommentUpdated struct {
+	Repo      string `json:"repo"`
+	IssueID   string `json:"issue_id"`
+	Number    int64  `json:"number"`
+	CommentID string `json:"comment_id"`
+}
+
+func (e IssueCommentUpdated) Type() string   { return "com.docstore.issue.comment.updated" }
+func (e IssueCommentUpdated) Source() string { return "/repos/" + e.Repo }
+func (e IssueCommentUpdated) Data() any      { return e }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -208,11 +209,21 @@ func (s *server) handleReposPrefix(w http.ResponseWriter, r *http.Request) {
 		}
 
 	case strings.HasPrefix(endpoint, "commit/"):
-		if r.Method == http.MethodGet {
-			r.SetPathValue("sequence", strings.TrimPrefix(endpoint, "commit/"))
-			s.handleGetCommit(w, r)
+		rest := strings.TrimPrefix(endpoint, "commit/")
+		if strings.HasSuffix(rest, "/issues") {
+			r.SetPathValue("sequence", strings.TrimSuffix(rest, "/issues"))
+			if r.Method == http.MethodGet {
+				s.handleCommitIssues(w, r)
+			} else {
+				writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			}
 		} else {
-			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			if r.Method == http.MethodGet {
+				r.SetPathValue("sequence", rest)
+				s.handleGetCommit(w, r)
+			} else {
+				writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			}
 		}
 
 	case strings.HasPrefix(endpoint, "file/"):
@@ -284,6 +295,14 @@ func (s *server) handleReposPrefix(w http.ResponseWriter, r *http.Request) {
 			} else {
 				writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 			}
+		} else if strings.HasSuffix(rest, "/issues") {
+			proposalID := strings.TrimSuffix(rest, "/issues")
+			r.SetPathValue("proposalID", proposalID)
+			if r.Method == http.MethodGet {
+				s.handleProposalIssues(w, r)
+			} else {
+				writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			}
 		} else {
 			r.SetPathValue("proposalID", rest)
 			switch r.Method {
@@ -294,6 +313,84 @@ func (s *server) handleReposPrefix(w http.ResponseWriter, r *http.Request) {
 			default:
 				writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 			}
+		}
+
+	case endpoint == "issues":
+		switch r.Method {
+		case http.MethodGet:
+			s.handleListIssues(w, r)
+		case http.MethodPost:
+			s.handleCreateIssue(w, r)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+
+	case strings.HasPrefix(endpoint, "issues/"):
+		rest := strings.TrimPrefix(endpoint, "issues/")
+		parts := strings.SplitN(rest, "/", 3)
+		r.SetPathValue("number", parts[0])
+		switch len(parts) {
+		case 1:
+			// issues/{number}
+			switch r.Method {
+			case http.MethodGet:
+				s.handleGetIssue(w, r)
+			case http.MethodPatch:
+				s.handleUpdateIssue(w, r)
+			default:
+				writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			}
+		case 2:
+			switch parts[1] {
+			case "close":
+				if r.Method == http.MethodPost {
+					s.handleCloseIssue(w, r)
+				} else {
+					writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+				}
+			case "reopen":
+				if r.Method == http.MethodPost {
+					s.handleReopenIssue(w, r)
+				} else {
+					writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+				}
+			case "comments":
+				switch r.Method {
+				case http.MethodGet:
+					s.handleListIssueComments(w, r)
+				case http.MethodPost:
+					s.handleCreateIssueComment(w, r)
+				default:
+					writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+				}
+			case "refs":
+				switch r.Method {
+				case http.MethodGet:
+					s.handleListIssueRefs(w, r)
+				case http.MethodPost:
+					s.handleAddIssueRef(w, r)
+				default:
+					writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+				}
+			default:
+				writeError(w, http.StatusNotFound, "not found")
+			}
+		case 3:
+			if parts[1] == "comments" {
+				r.SetPathValue("commentID", parts[2])
+				switch r.Method {
+				case http.MethodPatch:
+					s.handleUpdateIssueComment(w, r)
+				case http.MethodDelete:
+					s.handleDeleteIssueComment(w, r)
+				default:
+					writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+				}
+			} else {
+				writeError(w, http.StatusNotFound, "not found")
+			}
+		default:
+			writeError(w, http.StatusNotFound, "not found")
 		}
 
 	default:
@@ -1698,6 +1795,7 @@ func (s *server) handleCreateProposal(w http.ResponseWriter, r *http.Request) {
 		Author:     author,
 		Sequence:   headSeq,
 	})
+	s.upsertProposalMentionRefs(r.Context(), repo, p.ID, req.Description)
 	slog.Info("proposal opened", "repo", repo, "branch", req.Branch, "proposal_id", p.ID, "author", author)
 	writeJSON(w, http.StatusCreated, model.CreateProposalResponse{ID: p.ID})
 }
@@ -1802,6 +1900,9 @@ func (s *server) handleUpdateProposal(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, "internal server error")
 		}
 		return
+	}
+	if req.Description != nil {
+		s.upsertProposalMentionRefs(r.Context(), repo, proposalID, *req.Description)
 	}
 	writeJSON(w, http.StatusOK, p)
 }
@@ -2711,4 +2812,555 @@ func (s *server) streamSSE(w http.ResponseWriter, r *http.Request, repo string) 
 			flusher.Flush()
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Issue handlers
+// ---------------------------------------------------------------------------
+
+var (
+	reMentionProposal = regexp.MustCompile(`\bproposal:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\b`)
+	reMentionCommit   = regexp.MustCompile(`\bcommit:(\d+)\b`)
+	reMentionIssue    = regexp.MustCompile(`#(\d+)`)
+)
+
+// parseMentions extracts cross-reference mentions from a text body.
+// Returns proposal UUIDs, commit sequence numbers, and issue numbers.
+func parseMentions(body string) (proposalIDs []string, commitSeqs []int64, issueNums []int64) {
+	for _, m := range reMentionProposal.FindAllStringSubmatch(body, -1) {
+		proposalIDs = append(proposalIDs, m[1])
+	}
+	for _, m := range reMentionCommit.FindAllStringSubmatch(body, -1) {
+		if n, err := strconv.ParseInt(m[1], 10, 64); err == nil {
+			commitSeqs = append(commitSeqs, n)
+		}
+	}
+	for _, m := range reMentionIssue.FindAllStringSubmatch(body, -1) {
+		if n, err := strconv.ParseInt(m[1], 10, 64); err == nil {
+			issueNums = append(issueNums, n)
+		}
+	}
+	return
+}
+
+// upsertIssueBodyRefs creates issue_refs on issueNum for proposal and commit
+// mentions found in body, ignoring duplicate and not-found errors.
+func (s *server) upsertIssueBodyRefs(ctx context.Context, repo string, issueNum int64, body string) {
+	proposalIDs, commitSeqs, _ := parseMentions(body)
+	for _, pid := range proposalIDs {
+		_, err := s.commitStore.CreateIssueRef(ctx, repo, issueNum, model.IssueRefTypeProposal, pid)
+		if err != nil && !errors.Is(err, db.ErrIssueRefExists) && !errors.Is(err, db.ErrIssueNotFound) {
+			slog.Warn("upsert issue ref", "repo", repo, "issue", issueNum, "ref_type", "proposal", "ref_id", pid, "error", err)
+		}
+	}
+	for _, seq := range commitSeqs {
+		refID := strconv.FormatInt(seq, 10)
+		_, err := s.commitStore.CreateIssueRef(ctx, repo, issueNum, model.IssueRefTypeCommit, refID)
+		if err != nil && !errors.Is(err, db.ErrIssueRefExists) && !errors.Is(err, db.ErrIssueNotFound) {
+			slog.Warn("upsert issue ref", "repo", repo, "issue", issueNum, "ref_type", "commit", "ref_id", refID, "error", err)
+		}
+	}
+}
+
+// upsertProposalMentionRefs creates issue_refs for issues mentioned in a proposal body.
+// When a proposal body contains "#N", an issue_ref of type "proposal" pointing at proposalID
+// is upserted on issue N.
+func (s *server) upsertProposalMentionRefs(ctx context.Context, repo, proposalID, body string) {
+	_, _, issueNums := parseMentions(body)
+	for _, num := range issueNums {
+		_, err := s.commitStore.CreateIssueRef(ctx, repo, num, model.IssueRefTypeProposal, proposalID)
+		if err != nil && !errors.Is(err, db.ErrIssueRefExists) && !errors.Is(err, db.ErrIssueNotFound) {
+			slog.Warn("upsert proposal mention ref", "repo", repo, "issue", num, "proposal", proposalID, "error", err)
+		}
+	}
+}
+
+// parseIssueNumber parses the "number" path value into an int64.
+// Writes 400 and returns false on failure.
+func parseIssueNumber(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	n, err := strconv.ParseInt(r.PathValue("number"), 10, 64)
+	if err != nil || n <= 0 {
+		writeError(w, http.StatusBadRequest, "invalid issue number")
+		return 0, false
+	}
+	return n, true
+}
+
+// handleListIssues implements GET /repos/:name/issues
+func (s *server) handleListIssues(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	state := r.URL.Query().Get("state")
+	if state == "" {
+		state = "open"
+	}
+	switch state {
+	case "open", "closed", "all":
+	default:
+		writeError(w, http.StatusBadRequest, "invalid state; must be open, closed, or all")
+		return
+	}
+	stateFilter := state
+	if state == "all" {
+		stateFilter = ""
+	}
+	authorFilter := r.URL.Query().Get("author")
+
+	issues, err := s.commitStore.ListIssues(r.Context(), repo, stateFilter, authorFilter)
+	if err != nil {
+		slog.Error("internal error", "op", "list_issues", "repo", repo, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, model.ListIssuesResponse{Issues: issues})
+}
+
+// handleCreateIssue implements POST /repos/:name/issues
+func (s *server) handleCreateIssue(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	var req model.CreateIssueRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Title == "" {
+		writeError(w, http.StatusBadRequest, "title is required")
+		return
+	}
+
+	author := IdentityFromContext(r.Context())
+	iss, err := s.commitStore.CreateIssue(r.Context(), repo, req.Title, req.Body, author, req.Labels)
+	if err != nil {
+		slog.Error("internal error", "op", "create_issue", "repo", repo, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	s.upsertIssueBodyRefs(r.Context(), repo, iss.Number, req.Body)
+	s.emit(r.Context(), evtypes.IssueOpened{Repo: repo, IssueID: iss.ID, Number: iss.Number, Author: author})
+	slog.Info("issue opened", "repo", repo, "number", iss.Number, "author", author)
+	writeJSON(w, http.StatusCreated, model.CreateIssueResponse{ID: iss.ID, Number: iss.Number})
+}
+
+// handleGetIssue implements GET /repos/:name/issues/:number
+func (s *server) handleGetIssue(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	number, ok := parseIssueNumber(w, r)
+	if !ok {
+		return
+	}
+
+	iss, err := s.commitStore.GetIssue(r.Context(), repo, number)
+	if err != nil {
+		if errors.Is(err, db.ErrIssueNotFound) {
+			writeError(w, http.StatusNotFound, "issue not found")
+		} else {
+			slog.Error("internal error", "op", "get_issue", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, iss)
+}
+
+// handleUpdateIssue implements PATCH /repos/:name/issues/:number
+func (s *server) handleUpdateIssue(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	number, ok := parseIssueNumber(w, r)
+	if !ok {
+		return
+	}
+
+	identity := IdentityFromContext(r.Context())
+	role := RoleFromContext(r.Context())
+
+	existing, err := s.commitStore.GetIssue(r.Context(), repo, number)
+	if err != nil {
+		if errors.Is(err, db.ErrIssueNotFound) {
+			writeError(w, http.StatusNotFound, "issue not found")
+		} else {
+			slog.Error("internal error", "op", "update_issue", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	if existing.Author != identity && role != model.RoleMaintainer && role != model.RoleAdmin {
+		writeError(w, http.StatusForbidden, "forbidden: must be issue author or maintainer")
+		return
+	}
+
+	var req model.UpdateIssueRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	var labelsPtr *[]string
+	if req.Labels != nil {
+		labelsPtr = &req.Labels
+	}
+	iss, err := s.commitStore.UpdateIssue(r.Context(), repo, number, req.Title, req.Body, labelsPtr)
+	if err != nil {
+		if errors.Is(err, db.ErrIssueNotFound) {
+			writeError(w, http.StatusNotFound, "issue not found")
+		} else {
+			slog.Error("internal error", "op", "update_issue", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	if req.Body != nil {
+		s.upsertIssueBodyRefs(r.Context(), repo, number, *req.Body)
+	}
+	s.emit(r.Context(), evtypes.IssueUpdated{Repo: repo, IssueID: iss.ID, Number: iss.Number})
+	writeJSON(w, http.StatusOK, iss)
+}
+
+// handleCloseIssue implements POST /repos/:name/issues/:number/close
+func (s *server) handleCloseIssue(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	number, ok := parseIssueNumber(w, r)
+	if !ok {
+		return
+	}
+
+	identity := IdentityFromContext(r.Context())
+	role := RoleFromContext(r.Context())
+
+	existing, err := s.commitStore.GetIssue(r.Context(), repo, number)
+	if err != nil {
+		if errors.Is(err, db.ErrIssueNotFound) {
+			writeError(w, http.StatusNotFound, "issue not found")
+		} else {
+			slog.Error("internal error", "op", "close_issue", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	if existing.Author != identity && role != model.RoleMaintainer && role != model.RoleAdmin {
+		writeError(w, http.StatusForbidden, "forbidden: must be issue author or maintainer")
+		return
+	}
+
+	var req model.CloseIssueRequest
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&req)
+	}
+	reason := req.Reason
+	if reason == "" {
+		reason = model.IssueCloseReasonCompleted
+	}
+	switch reason {
+	case model.IssueCloseReasonCompleted, model.IssueCloseReasonNotPlanned, model.IssueCloseReasonDuplicate:
+	default:
+		writeError(w, http.StatusBadRequest, "invalid close reason")
+		return
+	}
+
+	iss, err := s.commitStore.CloseIssue(r.Context(), repo, number, reason, identity)
+	if err != nil {
+		if errors.Is(err, db.ErrIssueNotFound) {
+			writeError(w, http.StatusNotFound, "issue not found")
+		} else {
+			slog.Error("internal error", "op", "close_issue", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	s.emit(r.Context(), evtypes.IssueClosed{Repo: repo, IssueID: iss.ID, Number: iss.Number, Reason: string(reason), ClosedBy: identity})
+	slog.Info("issue closed", "repo", repo, "number", number, "by", identity)
+	writeJSON(w, http.StatusOK, iss)
+}
+
+// handleReopenIssue implements POST /repos/:name/issues/:number/reopen
+func (s *server) handleReopenIssue(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	number, ok := parseIssueNumber(w, r)
+	if !ok {
+		return
+	}
+
+	iss, err := s.commitStore.ReopenIssue(r.Context(), repo, number)
+	if err != nil {
+		if errors.Is(err, db.ErrIssueNotFound) {
+			writeError(w, http.StatusNotFound, "issue not found")
+		} else {
+			slog.Error("internal error", "op", "reopen_issue", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	s.emit(r.Context(), evtypes.IssueReopened{Repo: repo, IssueID: iss.ID, Number: iss.Number})
+	slog.Info("issue reopened", "repo", repo, "number", number)
+	writeJSON(w, http.StatusOK, iss)
+}
+
+// handleListIssueComments implements GET /repos/:name/issues/:number/comments
+func (s *server) handleListIssueComments(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	number, ok := parseIssueNumber(w, r)
+	if !ok {
+		return
+	}
+
+	comments, err := s.commitStore.ListIssueComments(r.Context(), repo, number)
+	if err != nil {
+		slog.Error("internal error", "op", "list_issue_comments", "repo", repo, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, model.ListIssueCommentsResponse{Comments: comments})
+}
+
+// handleCreateIssueComment implements POST /repos/:name/issues/:number/comments
+func (s *server) handleCreateIssueComment(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	number, ok := parseIssueNumber(w, r)
+	if !ok {
+		return
+	}
+
+	var req model.CreateIssueCommentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Body == "" {
+		writeError(w, http.StatusBadRequest, "body is required")
+		return
+	}
+
+	author := IdentityFromContext(r.Context())
+	c, err := s.commitStore.CreateIssueComment(r.Context(), repo, number, req.Body, author)
+	if err != nil {
+		if errors.Is(err, db.ErrIssueNotFound) {
+			writeError(w, http.StatusNotFound, "issue not found")
+		} else {
+			slog.Error("internal error", "op", "create_issue_comment", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	s.upsertIssueBodyRefs(r.Context(), repo, number, req.Body)
+	s.emit(r.Context(), evtypes.IssueCommentCreated{Repo: repo, IssueID: c.IssueID, Number: number, CommentID: c.ID, Author: author})
+	slog.Info("issue comment created", "repo", repo, "issue", number, "comment", c.ID, "author", author)
+	writeJSON(w, http.StatusCreated, model.CreateIssueCommentResponse{ID: c.ID})
+}
+
+// handleUpdateIssueComment implements PATCH /repos/:name/issues/:number/comments/:commentID
+func (s *server) handleUpdateIssueComment(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	number, ok := parseIssueNumber(w, r)
+	if !ok {
+		return
+	}
+
+	commentID := r.PathValue("commentID")
+	identity := IdentityFromContext(r.Context())
+	role := RoleFromContext(r.Context())
+
+	existing, err := s.commitStore.GetIssueComment(r.Context(), repo, commentID)
+	if err != nil {
+		if errors.Is(err, db.ErrIssueCommentNotFound) {
+			writeError(w, http.StatusNotFound, "comment not found")
+		} else {
+			slog.Error("internal error", "op", "update_issue_comment", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	if existing.Author != identity && role != model.RoleMaintainer && role != model.RoleAdmin {
+		writeError(w, http.StatusForbidden, "forbidden: must be comment author or maintainer")
+		return
+	}
+
+	var req model.UpdateIssueCommentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Body == "" {
+		writeError(w, http.StatusBadRequest, "body is required")
+		return
+	}
+
+	c, err := s.commitStore.UpdateIssueComment(r.Context(), repo, commentID, req.Body)
+	if err != nil {
+		if errors.Is(err, db.ErrIssueCommentNotFound) {
+			writeError(w, http.StatusNotFound, "comment not found")
+		} else {
+			slog.Error("internal error", "op", "update_issue_comment", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	s.upsertIssueBodyRefs(r.Context(), repo, number, req.Body)
+	s.emit(r.Context(), evtypes.IssueCommentUpdated{Repo: repo, IssueID: c.IssueID, Number: number, CommentID: c.ID})
+	writeJSON(w, http.StatusOK, c)
+}
+
+// handleDeleteIssueComment implements DELETE /repos/:name/issues/:number/comments/:commentID
+func (s *server) handleDeleteIssueComment(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	if _, ok := parseIssueNumber(w, r); !ok {
+		return
+	}
+
+	commentID := r.PathValue("commentID")
+	if err := s.commitStore.DeleteIssueComment(r.Context(), repo, commentID); err != nil {
+		if errors.Is(err, db.ErrIssueCommentNotFound) {
+			writeError(w, http.StatusNotFound, "comment not found")
+		} else {
+			slog.Error("internal error", "op", "delete_issue_comment", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleListIssueRefs implements GET /repos/:name/issues/:number/refs
+func (s *server) handleListIssueRefs(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	number, ok := parseIssueNumber(w, r)
+	if !ok {
+		return
+	}
+
+	refs, err := s.commitStore.ListIssueRefs(r.Context(), repo, number)
+	if err != nil {
+		slog.Error("internal error", "op", "list_issue_refs", "repo", repo, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, model.ListIssueRefsResponse{Refs: refs})
+}
+
+// handleAddIssueRef implements POST /repos/:name/issues/:number/refs
+func (s *server) handleAddIssueRef(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	number, ok := parseIssueNumber(w, r)
+	if !ok {
+		return
+	}
+
+	var req model.AddIssueRefRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	switch req.RefType {
+	case model.IssueRefTypeProposal, model.IssueRefTypeCommit:
+	default:
+		writeError(w, http.StatusBadRequest, "invalid ref_type; must be proposal or commit")
+		return
+	}
+	if req.RefID == "" {
+		writeError(w, http.StatusBadRequest, "ref_id is required")
+		return
+	}
+
+	ref, err := s.commitStore.CreateIssueRef(r.Context(), repo, number, req.RefType, req.RefID)
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrIssueNotFound):
+			writeError(w, http.StatusNotFound, "issue not found")
+		case errors.Is(err, db.ErrIssueRefExists):
+			writeError(w, http.StatusConflict, "ref already exists")
+		default:
+			slog.Error("internal error", "op", "add_issue_ref", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+	writeJSON(w, http.StatusCreated, model.AddIssueRefResponse{ID: ref.ID})
+}
+
+// handleProposalIssues implements GET /repos/:name/proposals/:proposalID/issues
+func (s *server) handleProposalIssues(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	proposalID := r.PathValue("proposalID")
+	issues, err := s.commitStore.ListIssuesByRef(r.Context(), repo, model.IssueRefTypeProposal, proposalID)
+	if err != nil {
+		slog.Error("internal error", "op", "proposal_issues", "repo", repo, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, model.ListIssuesResponse{Issues: issues})
+}
+
+// handleCommitIssues implements GET /repos/:name/commit/:sequence/issues
+func (s *server) handleCommitIssues(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	seqStr := r.PathValue("sequence")
+	issues, err := s.commitStore.ListIssuesByRef(r.Context(), repo, model.IssueRefTypeCommit, seqStr)
+	if err != nil {
+		slog.Error("internal error", "op", "commit_issues", "repo", repo, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, model.ListIssuesResponse{Issues: issues})
 }

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -1912,3 +1912,255 @@ func TestIntegrationReleases(t *testing.T) {
 		t.Errorf("expected only v2.0 remaining, got %+v", listBody2.Releases)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Issue integration tests
+// ---------------------------------------------------------------------------
+
+func TestIntegrationIssues(t *testing.T) {
+	t.Parallel()
+	database := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seed(t, database)
+
+	handler := server.New(dbpkg.NewStore(database), database, "alice@example.com", "alice@example.com")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	base := srv.URL + "/repos/default/default/-"
+
+	doReq := func(method, url, body string) *http.Response {
+		t.Helper()
+		var req *http.Request
+		var err error
+		if body != "" {
+			req, err = http.NewRequest(method, url, strings.NewReader(body))
+		} else {
+			req, err = http.NewRequest(method, url, nil)
+		}
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", method, url, err)
+		}
+		return resp
+	}
+
+	// CREATE issue.
+	createResp := doReq(http.MethodPost, base+"/issues",
+		`{"title":"bug: crash on startup","body":"commit:1 is the culprit"}`)
+	defer createResp.Body.Close()
+	if createResp.StatusCode != http.StatusCreated {
+		t.Fatalf("create issue: expected 201, got %d", createResp.StatusCode)
+	}
+	var created struct {
+		ID     string `json:"id"`
+		Number int64  `json:"number"`
+	}
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Number != 1 {
+		t.Errorf("expected issue number 1, got %d", created.Number)
+	}
+
+	// GET issue.
+	getResp := doReq(http.MethodGet, base+"/issues/1", "")
+	defer getResp.Body.Close()
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("get issue: expected 200, got %d", getResp.StatusCode)
+	}
+	var got struct {
+		Number int64  `json:"number"`
+		Title  string `json:"title"`
+		State  string `json:"state"`
+	}
+	if err := json.NewDecoder(getResp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if got.Title != "bug: crash on startup" {
+		t.Errorf("expected title 'bug: crash on startup', got %q", got.Title)
+	}
+	if got.State != "open" {
+		t.Errorf("expected state open, got %q", got.State)
+	}
+
+	// LIST issues (default: open).
+	listResp := doReq(http.MethodGet, base+"/issues", "")
+	defer listResp.Body.Close()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("list issues: expected 200, got %d", listResp.StatusCode)
+	}
+	var issueList struct {
+		Issues []struct {
+			Number int64 `json:"number"`
+		} `json:"issues"`
+	}
+	if err := json.NewDecoder(listResp.Body).Decode(&issueList); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(issueList.Issues) != 1 {
+		t.Errorf("expected 1 issue, got %d", len(issueList.Issues))
+	}
+
+	// REFS: body mentioned commit:1, so a commit ref should have been auto-created.
+	refsResp := doReq(http.MethodGet, base+"/issues/1/refs", "")
+	defer refsResp.Body.Close()
+	if refsResp.StatusCode != http.StatusOK {
+		t.Fatalf("list refs: expected 200, got %d", refsResp.StatusCode)
+	}
+	var refList struct {
+		Refs []struct {
+			RefType string `json:"ref_type"`
+			RefID   string `json:"ref_id"`
+		} `json:"refs"`
+	}
+	if err := json.NewDecoder(refsResp.Body).Decode(&refList); err != nil {
+		t.Fatalf("decode refs response: %v", err)
+	}
+	if len(refList.Refs) != 1 || refList.Refs[0].RefType != "commit" || refList.Refs[0].RefID != "1" {
+		t.Errorf("expected one commit ref for seq 1, got %+v", refList.Refs)
+	}
+
+	// CLOSE issue.
+	closeResp := doReq(http.MethodPost, base+"/issues/1/close", `{"reason":"completed"}`)
+	defer closeResp.Body.Close()
+	if closeResp.StatusCode != http.StatusOK {
+		t.Fatalf("close issue: expected 200, got %d", closeResp.StatusCode)
+	}
+	var closed struct {
+		State string `json:"state"`
+	}
+	if err := json.NewDecoder(closeResp.Body).Decode(&closed); err != nil {
+		t.Fatalf("decode close response: %v", err)
+	}
+	if closed.State != "closed" {
+		t.Errorf("expected state closed, got %q", closed.State)
+	}
+
+	// LIST: should be empty for default open filter.
+	listClosed := doReq(http.MethodGet, base+"/issues", "")
+	defer listClosed.Body.Close()
+	if err := json.NewDecoder(listClosed.Body).Decode(&issueList); err != nil {
+		t.Fatalf("decode list closed: %v", err)
+	}
+	if len(issueList.Issues) != 0 {
+		t.Errorf("expected 0 open issues after close, got %d", len(issueList.Issues))
+	}
+
+	// REOPEN issue.
+	reopenResp := doReq(http.MethodPost, base+"/issues/1/reopen", "")
+	defer reopenResp.Body.Close()
+	if reopenResp.StatusCode != http.StatusOK {
+		t.Fatalf("reopen issue: expected 200, got %d", reopenResp.StatusCode)
+	}
+	var reopened struct {
+		State string `json:"state"`
+	}
+	if err := json.NewDecoder(reopenResp.Body).Decode(&reopened); err != nil {
+		t.Fatalf("decode reopen response: %v", err)
+	}
+	if reopened.State != "open" {
+		t.Errorf("expected state open after reopen, got %q", reopened.State)
+	}
+
+	// CREATE comment.
+	commentResp := doReq(http.MethodPost, base+"/issues/1/comments", `{"body":"this is a comment"}`)
+	defer commentResp.Body.Close()
+	if commentResp.StatusCode != http.StatusCreated {
+		t.Fatalf("create comment: expected 201, got %d", commentResp.StatusCode)
+	}
+	var commentCreated struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(commentResp.Body).Decode(&commentCreated); err != nil {
+		t.Fatalf("decode comment create: %v", err)
+	}
+	if commentCreated.ID == "" {
+		t.Error("expected non-empty comment ID")
+	}
+
+	// LIST comments.
+	listCommentsResp := doReq(http.MethodGet, base+"/issues/1/comments", "")
+	defer listCommentsResp.Body.Close()
+	if listCommentsResp.StatusCode != http.StatusOK {
+		t.Fatalf("list comments: expected 200, got %d", listCommentsResp.StatusCode)
+	}
+	var commentList struct {
+		Comments []struct {
+			ID   string `json:"id"`
+			Body string `json:"body"`
+		} `json:"comments"`
+	}
+	if err := json.NewDecoder(listCommentsResp.Body).Decode(&commentList); err != nil {
+		t.Fatalf("decode comment list: %v", err)
+	}
+	if len(commentList.Comments) != 1 {
+		t.Errorf("expected 1 comment, got %d", len(commentList.Comments))
+	}
+
+	// UPDATE comment.
+	updateCommentResp := doReq(http.MethodPatch,
+		base+"/issues/1/comments/"+commentCreated.ID,
+		`{"body":"updated comment"}`)
+	defer updateCommentResp.Body.Close()
+	if updateCommentResp.StatusCode != http.StatusOK {
+		t.Fatalf("update comment: expected 200, got %d", updateCommentResp.StatusCode)
+	}
+
+	// ADD explicit ref.
+	addRefResp := doReq(http.MethodPost, base+"/issues/1/refs",
+		`{"ref_type":"commit","ref_id":"2"}`)
+	defer addRefResp.Body.Close()
+	if addRefResp.StatusCode != http.StatusCreated {
+		t.Fatalf("add ref: expected 201, got %d", addRefResp.StatusCode)
+	}
+
+	// LIST refs: now 2 (commit:1 from body + commit:2 from explicit).
+	refsResp2 := doReq(http.MethodGet, base+"/issues/1/refs", "")
+	defer refsResp2.Body.Close()
+	var refList2 struct {
+		Refs []struct{ RefType, RefID string } `json:"refs"`
+	}
+	if err := json.NewDecoder(refsResp2.Body).Decode(&refList2); err != nil {
+		t.Fatalf("decode refs2: %v", err)
+	}
+	if len(refList2.Refs) != 2 {
+		t.Errorf("expected 2 refs, got %d", len(refList2.Refs))
+	}
+
+	// COMMIT issues reverse lookup.
+	commitIssuesResp := doReq(http.MethodGet, base+"/commit/1/issues", "")
+	defer commitIssuesResp.Body.Close()
+	if commitIssuesResp.StatusCode != http.StatusOK {
+		t.Fatalf("commit issues: expected 200, got %d", commitIssuesResp.StatusCode)
+	}
+	var commitIssueList struct {
+		Issues []struct{ Number int64 `json:"number"` } `json:"issues"`
+	}
+	if err := json.NewDecoder(commitIssuesResp.Body).Decode(&commitIssueList); err != nil {
+		t.Fatalf("decode commit issues: %v", err)
+	}
+	if len(commitIssueList.Issues) != 1 || commitIssueList.Issues[0].Number != 1 {
+		t.Errorf("expected issue 1 in commit/1/issues, got %+v", commitIssueList.Issues)
+	}
+
+	// DELETE comment.
+	delCommentResp := doReq(http.MethodDelete,
+		base+"/issues/1/comments/"+commentCreated.ID, "")
+	defer delCommentResp.Body.Close()
+	if delCommentResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete comment: expected 204, got %d", delCommentResp.StatusCode)
+	}
+
+	// GET: 404 for unknown issue.
+	notFoundResp := doReq(http.MethodGet, base+"/issues/999", "")
+	defer notFoundResp.Body.Close()
+	if notFoundResp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for unknown issue, got %d", notFoundResp.StatusCode)
+	}
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -277,6 +277,24 @@ func roleAllows(role model.RoleType, method, subPath string, r *http.Request) bo
 		return role == model.RoleWriter || role == model.RoleMaintainer || role == model.RoleAdmin
 	}
 
+	// Issue endpoints.
+	// POST /issues — writer+.
+	if method == http.MethodPost && subPath == "issues" {
+		return role == model.RoleWriter || role == model.RoleMaintainer || role == model.RoleAdmin
+	}
+	// POST /issues/* (close, reopen, comments, refs) — writer+.
+	if method == http.MethodPost && strings.HasPrefix(subPath, "issues/") {
+		return role == model.RoleWriter || role == model.RoleMaintainer || role == model.RoleAdmin
+	}
+	// PATCH /issues/* — writer+ minimum; handler additionally checks author or maintainer.
+	if method == http.MethodPatch && strings.HasPrefix(subPath, "issues/") {
+		return role == model.RoleWriter || role == model.RoleMaintainer || role == model.RoleAdmin
+	}
+	// DELETE /issues/* — maintainer+.
+	if method == http.MethodDelete && strings.HasPrefix(subPath, "issues/") {
+		return role == model.RoleMaintainer || role == model.RoleAdmin
+	}
+
 	// POST /branch, /merge, /rebase — maintainer+.
 	if method == http.MethodPost && (subPath == "branch" || subPath == "merge" || subPath == "rebase") {
 		return role == model.RoleMaintainer || role == model.RoleAdmin


### PR DESCRIPTION
## Summary

- Adds all issue/comment/ref HTTP handlers with full RBAC, event emission, and mention parsing (implements #233)
- New `internal/events/types/issue.go` with 6 event types following `proposal.go` pattern
- `parseMentions` helper auto-creates `issue_refs` for `proposal:UUID` / `commit:N` in issue bodies; proposal bodies mentioning `#N` auto-link those issues
- RBAC rules added to `middleware.go` for issue paths (writer+ for mutations, maintainer+ for DELETE)
- Route dispatch wired in `handleReposPrefix`: `issues/*`, `commit/{seq}/issues`, `proposals/{id}/issues`

## Test plan

- [x] All existing tests pass (`go test ./... -count=1`)
- [x] `TestIntegrationIssues` covers: create, get, list, close, reopen, comment CRUD, auto-ref from body mention, explicit ref add, commit/issues reverse lookup, 404 for unknown issue
- [x] `go build ./...` and `go vet ./...` clean

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)