### PR TITLE
feat: issue tracker CLI — ds issues command group (#233)

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -91,7 +91,19 @@ commands:
   subscriptions                                          List subscriptions
   subscriptions create --url <url> --secret <s> [--repo <r>] [--event-types t1,t2]  Create a subscription
   subscriptions delete <id>                              Delete a subscription
-  subscriptions resume <id>                              Resume a suspended subscription`
+  subscriptions resume <id>                              Resume a suspended subscription
+
+  issues [--state open|closed|all] [--author <identity>]    List issues (default: open)
+  issues list [--state open|closed|all] [--author <identity>]  List issues
+  issues create --title <title> [--body <markdown>]          Create an issue
+  issues show <number>                                       Show issue details, comments, and refs
+  issues close <number> [--reason completed|not_planned|duplicate]  Close an issue
+  issues reopen <number>                                     Reopen a closed issue
+  issues comment add <number> --body <markdown>              Add a comment to an issue
+  issues comment edit <number> <comment-id> --body <markdown>  Edit an issue comment
+  issues refs <number>                                       List cross-refs for an issue
+  issues tie <number> --proposal <uuid>                      Tie a proposal to an issue
+  issues tie <number> --commit <seq>                         Tie a commit to an issue`
 
 func main() {
 	if len(os.Args) < 2 {
@@ -883,6 +895,219 @@ func main() {
 			os.Exit(1)
 		}
 		return
+
+	case "issues":
+		if len(args) < 2 {
+			err = app.IssueList("open", "")
+		} else {
+			switch args[1] {
+			case "list":
+				state := "open"
+				author := ""
+				for i := 2; i < len(args); i++ {
+					switch args[i] {
+					case "--state":
+						if i+1 < len(args) {
+							state = args[i+1]
+							i++
+						}
+					case "--author":
+						if i+1 < len(args) {
+							author = args[i+1]
+							i++
+						}
+					}
+				}
+				err = app.IssueList(state, author)
+			case "create":
+				title := ""
+				body := ""
+				for i := 2; i < len(args); i++ {
+					switch args[i] {
+					case "--title":
+						if i+1 < len(args) {
+							title = args[i+1]
+							i++
+						}
+					case "--body":
+						if i+1 < len(args) {
+							body = args[i+1]
+							i++
+						}
+					}
+				}
+				if title == "" {
+					fmt.Fprintln(os.Stderr, "usage: ds issues create --title <title> [--body <markdown>]")
+					os.Exit(1)
+				}
+				err = app.IssueCreate(title, body)
+			case "show":
+				if len(args) < 3 {
+					fmt.Fprintln(os.Stderr, "usage: ds issues show <number>")
+					os.Exit(1)
+				}
+				n, parseErr := strconv.ParseInt(args[2], 10, 64)
+				if parseErr != nil {
+					fmt.Fprintf(os.Stderr, "error: invalid issue number: %s\n", args[2])
+					os.Exit(1)
+				}
+				err = app.IssueShow(n)
+			case "close":
+				if len(args) < 3 {
+					fmt.Fprintln(os.Stderr, "usage: ds issues close <number> [--reason completed|not_planned|duplicate]")
+					os.Exit(1)
+				}
+				n, parseErr := strconv.ParseInt(args[2], 10, 64)
+				if parseErr != nil {
+					fmt.Fprintf(os.Stderr, "error: invalid issue number: %s\n", args[2])
+					os.Exit(1)
+				}
+				reason := ""
+				for i := 3; i < len(args); i++ {
+					if args[i] == "--reason" && i+1 < len(args) {
+						reason = args[i+1]
+						i++
+					}
+				}
+				err = app.IssueClose(n, reason)
+			case "reopen":
+				if len(args) < 3 {
+					fmt.Fprintln(os.Stderr, "usage: ds issues reopen <number>")
+					os.Exit(1)
+				}
+				n, parseErr := strconv.ParseInt(args[2], 10, 64)
+				if parseErr != nil {
+					fmt.Fprintf(os.Stderr, "error: invalid issue number: %s\n", args[2])
+					os.Exit(1)
+				}
+				err = app.IssueReopen(n)
+			case "comment":
+				if len(args) < 3 {
+					fmt.Fprintln(os.Stderr, "usage: ds issues comment add|edit ...")
+					os.Exit(1)
+				}
+				switch args[2] {
+				case "add":
+					if len(args) < 4 {
+						fmt.Fprintln(os.Stderr, "usage: ds issues comment add <number> --body <markdown>")
+						os.Exit(1)
+					}
+					n, parseErr := strconv.ParseInt(args[3], 10, 64)
+					if parseErr != nil {
+						fmt.Fprintf(os.Stderr, "error: invalid issue number: %s\n", args[3])
+						os.Exit(1)
+					}
+					body := ""
+					for i := 4; i < len(args); i++ {
+						if args[i] == "--body" && i+1 < len(args) {
+							body = args[i+1]
+							i++
+						}
+					}
+					if body == "" {
+						fmt.Fprintln(os.Stderr, "usage: ds issues comment add <number> --body <markdown>")
+						os.Exit(1)
+					}
+					err = app.IssueCommentAdd(n, body)
+				case "edit":
+					if len(args) < 5 {
+						fmt.Fprintln(os.Stderr, "usage: ds issues comment edit <number> <comment-id> --body <markdown>")
+						os.Exit(1)
+					}
+					n, parseErr := strconv.ParseInt(args[3], 10, 64)
+					if parseErr != nil {
+						fmt.Fprintf(os.Stderr, "error: invalid issue number: %s\n", args[3])
+						os.Exit(1)
+					}
+					commentID := args[4]
+					body := ""
+					for i := 5; i < len(args); i++ {
+						if args[i] == "--body" && i+1 < len(args) {
+							body = args[i+1]
+							i++
+						}
+					}
+					if body == "" {
+						fmt.Fprintln(os.Stderr, "usage: ds issues comment edit <number> <comment-id> --body <markdown>")
+						os.Exit(1)
+					}
+					err = app.IssueCommentEdit(n, commentID, body)
+				default:
+					fmt.Fprintf(os.Stderr, "unknown issues comment subcommand: %s\n", args[2])
+					fmt.Fprintln(os.Stderr, usage)
+					os.Exit(1)
+				}
+			case "refs":
+				if len(args) < 3 {
+					fmt.Fprintln(os.Stderr, "usage: ds issues refs <number>")
+					os.Exit(1)
+				}
+				n, parseErr := strconv.ParseInt(args[2], 10, 64)
+				if parseErr != nil {
+					fmt.Fprintf(os.Stderr, "error: invalid issue number: %s\n", args[2])
+					os.Exit(1)
+				}
+				err = app.IssueRefs(n)
+			case "tie":
+				if len(args) < 3 {
+					fmt.Fprintln(os.Stderr, "usage: ds issues tie <number> --proposal <uuid> | --commit <seq>")
+					os.Exit(1)
+				}
+				n, parseErr := strconv.ParseInt(args[2], 10, 64)
+				if parseErr != nil {
+					fmt.Fprintf(os.Stderr, "error: invalid issue number: %s\n", args[2])
+					os.Exit(1)
+				}
+				refType := ""
+				refID := ""
+				for i := 3; i < len(args); i++ {
+					switch args[i] {
+					case "--proposal":
+						if i+1 < len(args) {
+							refType = "proposal"
+							refID = args[i+1]
+							i++
+						}
+					case "--commit":
+						if i+1 < len(args) {
+							refType = "commit"
+							refID = args[i+1]
+							i++
+						}
+					}
+				}
+				if refType == "" || refID == "" {
+					fmt.Fprintln(os.Stderr, "usage: ds issues tie <number> --proposal <uuid> | --commit <seq>")
+					os.Exit(1)
+				}
+				err = app.IssueTie(n, refType, refID)
+			default:
+				// Default: treat as "issues list" but check if it looks like flags
+				if strings.HasPrefix(args[1], "--") {
+					state := "open"
+					author := ""
+					for i := 1; i < len(args); i++ {
+						switch args[i] {
+						case "--state":
+							if i+1 < len(args) {
+								state = args[i+1]
+								i++
+							}
+						case "--author":
+							if i+1 < len(args) {
+								author = args[i+1]
+								i++
+							}
+						}
+					}
+					err = app.IssueList(state, author)
+				} else {
+					fmt.Fprintf(os.Stderr, "unknown issues subcommand: %s\n", args[1])
+					fmt.Fprintln(os.Stderr, usage)
+					os.Exit(1)
+				}
+			}
+		}
 
 	case "subscriptions":
 		if len(args) < 2 {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -17,6 +17,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -3089,5 +3090,289 @@ func (a *App) SubscriptionResume(id string) error {
 		return a.readError(resp)
 	}
 	fmt.Fprintf(a.Out, "Resumed subscription '%s'\n", id)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Issue management
+// ---------------------------------------------------------------------------
+
+// IssueList lists issues for the repo.
+// state defaults to "open" if empty.
+func (a *App) IssueList(state, author string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	if state == "" {
+		state = "open"
+	}
+	q := url.Values{}
+	q.Set("state", state)
+	if author != "" {
+		q.Set("author", author)
+	}
+	resp, err := a.httpGet(cfg, repoBase(cfg)+"/issues?"+q.Encode())
+	if err != nil {
+		return fmt.Errorf("fetching issues: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var r model.ListIssuesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	if len(r.Issues) == 0 {
+		fmt.Fprintf(a.Out, "No %s issues\n", state)
+		return nil
+	}
+	fmt.Fprintf(a.Out, "%-6s  %-40s  %-30s  %-8s  %s\n", "NUMBER", "TITLE", "AUTHOR", "STATE", "CREATED")
+	for _, iss := range r.Issues {
+		title := iss.Title
+		if len(title) > 38 {
+			title = title[:37] + "…"
+		}
+		fmt.Fprintf(a.Out, "%-6d  %-40s  %-30s  %-8s  %s\n",
+			iss.Number, title, iss.Author, string(iss.State),
+			iss.CreatedAt.Format(time.RFC3339))
+	}
+	return nil
+}
+
+// IssueCreate creates a new issue.
+func (a *App) IssueCreate(title, body string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	if title == "" {
+		return fmt.Errorf("--title is required")
+	}
+	req := model.CreateIssueRequest{
+		Title: title,
+		Body:  body,
+	}
+	resp, err := a.postJSON(cfg, repoBase(cfg)+"/issues", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var r model.CreateIssueResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "Created issue #%d\n", r.Number)
+	return nil
+}
+
+// IssueShow shows details for a single issue, including comments and refs.
+func (a *App) IssueShow(number int64) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	base := repoBase(cfg) + "/issues/" + strconv.FormatInt(number, 10)
+
+	resp, err := a.httpGet(cfg, base)
+	if err != nil {
+		return fmt.Errorf("fetching issue: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var iss model.Issue
+	if err := json.NewDecoder(resp.Body).Decode(&iss); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	fmt.Fprintf(a.Out, "Issue #%d: %s\n", iss.Number, iss.Title)
+	fmt.Fprintf(a.Out, "State:   %s\n", string(iss.State))
+	fmt.Fprintf(a.Out, "Author:  %s\n", iss.Author)
+	fmt.Fprintf(a.Out, "Created: %s\n", iss.CreatedAt.Format(time.RFC3339))
+	if iss.CloseReason != nil {
+		fmt.Fprintf(a.Out, "Closed:  %s\n", string(*iss.CloseReason))
+	}
+	if iss.Body != "" {
+		fmt.Fprintf(a.Out, "\n%s\n", iss.Body)
+	}
+
+	resp2, err := a.httpGet(cfg, base+"/comments")
+	if err != nil {
+		return fmt.Errorf("fetching comments: %w", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode == http.StatusOK {
+		var cr model.ListIssueCommentsResponse
+		if err := json.NewDecoder(resp2.Body).Decode(&cr); err == nil && len(cr.Comments) > 0 {
+			fmt.Fprintf(a.Out, "\nComments (%d):\n", len(cr.Comments))
+			for _, c := range cr.Comments {
+				fmt.Fprintf(a.Out, "  [%s] %s: %s\n", c.CreatedAt.Format("2006-01-02"), c.Author, c.Body)
+			}
+		}
+	}
+
+	resp3, err := a.httpGet(cfg, base+"/refs")
+	if err != nil {
+		return fmt.Errorf("fetching refs: %w", err)
+	}
+	defer resp3.Body.Close()
+	if resp3.StatusCode == http.StatusOK {
+		var rr model.ListIssueRefsResponse
+		if err := json.NewDecoder(resp3.Body).Decode(&rr); err == nil && len(rr.Refs) > 0 {
+			fmt.Fprintf(a.Out, "\nRefs (%d):\n", len(rr.Refs))
+			for _, ref := range rr.Refs {
+				fmt.Fprintf(a.Out, "  %s: %s\n", string(ref.RefType), ref.RefID)
+			}
+		}
+	}
+
+	return nil
+}
+
+// IssueClose closes an issue.
+func (a *App) IssueClose(number int64, reason string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	if reason == "" {
+		reason = string(model.IssueCloseReasonCompleted)
+	}
+	req := model.CloseIssueRequest{Reason: model.IssueCloseReason(reason)}
+	resp, err := a.postJSON(cfg, repoBase(cfg)+"/issues/"+strconv.FormatInt(number, 10)+"/close", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Closed issue #%d\n", number)
+	return nil
+}
+
+// IssueReopen reopens a closed issue.
+func (a *App) IssueReopen(number int64) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	resp, err := a.postJSON(cfg, repoBase(cfg)+"/issues/"+strconv.FormatInt(number, 10)+"/reopen", model.ReopenIssueRequest{})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Reopened issue #%d\n", number)
+	return nil
+}
+
+// IssueCommentAdd adds a comment to an issue.
+func (a *App) IssueCommentAdd(number int64, body string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	if body == "" {
+		return fmt.Errorf("--body is required")
+	}
+	req := model.CreateIssueCommentRequest{Body: body}
+	resp, err := a.postJSON(cfg, repoBase(cfg)+"/issues/"+strconv.FormatInt(number, 10)+"/comments", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var r model.CreateIssueCommentResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	fmt.Fprintf(a.Out, "Added comment %s\n", r.ID)
+	return nil
+}
+
+// IssueCommentEdit edits an existing issue comment.
+// issueNumber is required to construct the URL path.
+func (a *App) IssueCommentEdit(issueNumber int64, commentID, body string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	if body == "" {
+		return fmt.Errorf("--body is required")
+	}
+	req := model.UpdateIssueCommentRequest{Body: body}
+	urlPath := repoBase(cfg) + "/issues/" + strconv.FormatInt(issueNumber, 10) + "/comments/" + url.PathEscape(commentID)
+	resp, err := a.patchJSON(cfg, urlPath, req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Updated comment %s\n", commentID)
+	return nil
+}
+
+// IssueRefs lists cross-references for an issue.
+func (a *App) IssueRefs(number int64) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	resp, err := a.httpGet(cfg, repoBase(cfg)+"/issues/"+strconv.FormatInt(number, 10)+"/refs")
+	if err != nil {
+		return fmt.Errorf("fetching refs: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var r model.ListIssueRefsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	if len(r.Refs) == 0 {
+		fmt.Fprintf(a.Out, "No refs for issue #%d\n", number)
+		return nil
+	}
+	fmt.Fprintf(a.Out, "%-10s  %-36s  %s\n", "TYPE", "REF_ID", "CREATED")
+	for _, ref := range r.Refs {
+		fmt.Fprintf(a.Out, "%-10s  %-36s  %s\n",
+			string(ref.RefType), ref.RefID, ref.CreatedAt.Format(time.RFC3339))
+	}
+	return nil
+}
+
+// IssueTie ties a proposal or commit ref to an issue.
+func (a *App) IssueTie(number int64, refType, refID string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	req := model.AddIssueRefRequest{
+		RefType: model.IssueRefType(refType),
+		RefID:   refID,
+	}
+	resp, err := a.postJSON(cfg, repoBase(cfg)+"/issues/"+strconv.FormatInt(number, 10)+"/refs", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Tied %s %s to issue #%d\n", refType, refID, number)
 	return nil
 }

--- a/internal/cli/e2e_test.go
+++ b/internal/cli/e2e_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -656,5 +657,133 @@ func TestRolesSet_InvalidRole(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "role must be one of") {
 		t.Errorf("expected role validation error, got: %v", err)
+	}
+}
+
+// TestIssues_EndToEnd exercises the full issue lifecycle against a real server.
+func TestIssues_EndToEnd(t *testing.T) {
+	t.Parallel()
+	srv := newRealServer(t)
+	app, out := newTestApp(t, srv)
+
+	// Set up workspace config.
+	if err := os.MkdirAll(filepath.Join(app.Dir, configDir), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.saveConfig(&Config{Remote: srv.URL, Repo: "default/default", Branch: "main", Author: "test@example.com"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create an issue.
+	out.Reset()
+	if err := app.IssueCreate("Fix the widget", "This widget is broken."); err != nil {
+		t.Fatalf("IssueCreate: %v", err)
+	}
+	createOut := out.String()
+	if !strings.Contains(createOut, "Created issue #") {
+		t.Fatalf("expected creation message, got: %s", createOut)
+	}
+	// Parse issue number from "Created issue #N\n".
+	var issueNum int64
+	if _, scanErr := fmt.Sscanf(createOut, "Created issue #%d", &issueNum); scanErr != nil {
+		t.Fatalf("could not parse issue number from: %s", createOut)
+	}
+
+	// List issues — should appear.
+	out.Reset()
+	if err := app.IssueList("open", ""); err != nil {
+		t.Fatalf("IssueList: %v", err)
+	}
+	if !strings.Contains(out.String(), "Fix the widget") {
+		t.Errorf("expected issue in listing, got: %s", out.String())
+	}
+
+	// Show issue.
+	out.Reset()
+	if err := app.IssueShow(issueNum); err != nil {
+		t.Fatalf("IssueShow: %v", err)
+	}
+	showOut := out.String()
+	if !strings.Contains(showOut, "Fix the widget") {
+		t.Errorf("expected issue title in show output, got: %s", showOut)
+	}
+	if !strings.Contains(showOut, "This widget is broken.") {
+		t.Errorf("expected issue body in show output, got: %s", showOut)
+	}
+
+	// Add a comment.
+	out.Reset()
+	if err := app.IssueCommentAdd(issueNum, "I can reproduce this."); err != nil {
+		t.Fatalf("IssueCommentAdd: %v", err)
+	}
+	if !strings.Contains(out.String(), "Added comment ") {
+		t.Errorf("expected added comment message, got: %s", out.String())
+	}
+	// Parse comment ID.
+	commentOut := out.String()
+	commentID := strings.TrimSpace(strings.TrimPrefix(commentOut, "Added comment "))
+
+	// Edit the comment.
+	out.Reset()
+	if err := app.IssueCommentEdit(issueNum, commentID, "I can reproduce this consistently."); err != nil {
+		t.Fatalf("IssueCommentEdit: %v", err)
+	}
+	if !strings.Contains(out.String(), "Updated comment "+commentID) {
+		t.Errorf("expected update message, got: %s", out.String())
+	}
+
+	// Tie a proposal ref.
+	out.Reset()
+	proposalUUID := "00000000-0000-0000-0000-000000000001"
+	if err := app.IssueTie(issueNum, "proposal", proposalUUID); err != nil {
+		t.Fatalf("IssueTie: %v", err)
+	}
+	if !strings.Contains(out.String(), "Tied proposal") {
+		t.Errorf("expected tie message, got: %s", out.String())
+	}
+
+	// List refs.
+	out.Reset()
+	if err := app.IssueRefs(issueNum); err != nil {
+		t.Fatalf("IssueRefs: %v", err)
+	}
+	if !strings.Contains(out.String(), proposalUUID) {
+		t.Errorf("expected proposal UUID in refs, got: %s", out.String())
+	}
+
+	// Close the issue.
+	out.Reset()
+	if err := app.IssueClose(issueNum, "completed"); err != nil {
+		t.Fatalf("IssueClose: %v", err)
+	}
+	if !strings.Contains(out.String(), "Closed issue #") {
+		t.Errorf("expected close message, got: %s", out.String())
+	}
+
+	// List open issues — should be empty now.
+	out.Reset()
+	if err := app.IssueList("open", ""); err != nil {
+		t.Fatalf("IssueList after close: %v", err)
+	}
+	if strings.Contains(out.String(), "Fix the widget") {
+		t.Errorf("expected issue to be absent from open list, got: %s", out.String())
+	}
+
+	// Reopen the issue.
+	out.Reset()
+	if err := app.IssueReopen(issueNum); err != nil {
+		t.Fatalf("IssueReopen: %v", err)
+	}
+	if !strings.Contains(out.String(), "Reopened issue #") {
+		t.Errorf("expected reopen message, got: %s", out.String())
+	}
+
+	// List open issues again — should appear.
+	out.Reset()
+	if err := app.IssueList("open", ""); err != nil {
+		t.Fatalf("IssueList after reopen: %v", err)
+	}
+	if !strings.Contains(out.String(), "Fix the widget") {
+		t.Errorf("expected issue back in open list, got: %s", out.String())
 	}
 }


### PR DESCRIPTION
## Summary

- Implements the full `ds issues` command group (list, create, show, close, reopen, comment add/edit, refs, tie) in `internal/cli/app.go` and wires it in `cmd/ds/main.go`
- Adds server-side HTTP handlers for all issue endpoints in `internal/server/handlers.go` with routing in `handleReposPrefix`
- Adds RBAC rules to `internal/server/middleware.go` (writer+ for all mutations, reader+ for GETs via existing catch-all)
- Adds `TestIssues_EndToEnd` e2e test covering the full lifecycle against a real Postgres-backed server

## Endpoints wired

| Endpoint | Method | CLI command |
|---|---|---|
| `/repos/{repo}/-/issues` | GET | `ds issues list` |
| `/repos/{repo}/-/issues` | POST | `ds issues create` |
| `/repos/{repo}/-/issues/{number}` | GET | `ds issues show` |
| `/repos/{repo}/-/issues/{number}/close` | POST | `ds issues close` |
| `/repos/{repo}/-/issues/{number}/reopen` | POST | `ds issues reopen` |
| `/repos/{repo}/-/issues/{number}/comments` | GET/POST | `ds issues comment add` / shown in `ds issues show` |
| `/repos/{repo}/-/issues/{number}/comments/{id}` | PATCH | `ds issues comment edit` |
| `/repos/{repo}/-/issues/{number}/refs` | GET/POST | `ds issues refs` / `ds issues tie` |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all packages pass
- [x] `TestIssues_EndToEnd` covers create → list → show → comment add/edit → tie → close → reopen

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)