### PR TITLE
feat: issue tracker TUI views and HTTP API handlers

### DIFF
--- a/internal/tui/branchlist.go
+++ b/internal/tui/branchlist.go
@@ -16,6 +16,7 @@ type branchListModel struct {
 	loading    bool
 	err        error
 	openBranch string
+	openIssues bool
 	quit       bool
 
 	refreshing    bool
@@ -66,6 +67,9 @@ func (m branchListModel) Update(msg tea.Msg) (branchListModel, tea.Cmd) {
 				m.openBranch = m.branches[m.cursor].branch.Name
 			}
 
+		case "i":
+			m.openIssues = true
+
 		case "R":
 			m.loading = true
 			m.refreshing = true
@@ -113,11 +117,11 @@ func (m branchListModel) View() string {
 
 	sb.WriteString("\n")
 	if m.refreshing {
-		sb.WriteString(styleHelp.Render("  j/k navigate · enter open · R refresh · q quit  ↻ refreshing…"))
+		sb.WriteString(styleHelp.Render("  j/k navigate · enter open · i issues · R refresh · q quit  ↻ refreshing…"))
 	} else if !m.lastRefreshed.IsZero() {
-		sb.WriteString(styleHelp.Render("  j/k navigate · enter open · R refresh · q quit  · last refreshed at " + m.lastRefreshed.Format("15:04:05")))
+		sb.WriteString(styleHelp.Render("  j/k navigate · enter open · i issues · R refresh · q quit  · last refreshed at " + m.lastRefreshed.Format("15:04:05")))
 	} else {
-		sb.WriteString(styleHelp.Render("  j/k navigate · enter open · R refresh · q quit"))
+		sb.WriteString(styleHelp.Render("  j/k navigate · enter open · i issues · R refresh · q quit"))
 	}
 
 	return sb.String()

--- a/internal/tui/issuedetail.go
+++ b/internal/tui/issuedetail.go
@@ -1,0 +1,230 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// issueDetailModel shows the full detail of a single issue.
+type issueDetailModel struct {
+	client      *tuiClient
+	issue       *model.Issue
+	comments    []model.IssueComment
+	refs        []model.IssueRef
+	loading     bool
+	err         error
+	goBack      bool
+	quit        bool
+	statusMsg   string
+
+	showCommentOverlay bool
+	commentOverlay     issueOverlayModel
+	showCloseOverlay   bool
+	closeOverlay       issueOverlayModel
+}
+
+func newIssueDetailModel(client *tuiClient, issue *model.Issue) issueDetailModel {
+	return issueDetailModel{
+		client:  client,
+		issue:   issue,
+		loading: true,
+	}
+}
+
+func (m issueDetailModel) Init() tea.Cmd {
+	return loadIssueDetail(m.client, m.issue.Number)
+}
+
+func (m issueDetailModel) Update(msg tea.Msg) (issueDetailModel, tea.Cmd) {
+	if m.showCommentOverlay {
+		switch msg := msg.(type) {
+		case tea.KeyMsg:
+			if msg.String() == "esc" {
+				m.showCommentOverlay = false
+				return m, nil
+			}
+			if msg.String() == "ctrl+c" {
+				m.quit = true
+				return m, tea.Quit
+			}
+		case issueCommentCreatedMsg:
+			if msg.err == nil {
+				m.showCommentOverlay = false
+				m.loading = true
+				return m, loadIssueDetail(m.client, m.issue.Number)
+			}
+		}
+		var cmd tea.Cmd
+		m.commentOverlay, cmd = m.commentOverlay.Update(msg)
+		if m.commentOverlay.submitted {
+			m.showCommentOverlay = false
+			m.loading = true
+			return m, loadIssueDetail(m.client, m.issue.Number)
+		}
+		return m, cmd
+	}
+
+	if m.showCloseOverlay {
+		switch msg := msg.(type) {
+		case tea.KeyMsg:
+			if msg.String() == "esc" {
+				m.showCloseOverlay = false
+				return m, nil
+			}
+			if msg.String() == "ctrl+c" {
+				m.quit = true
+				return m, tea.Quit
+			}
+		case issueClosedMsg:
+			if msg.err == nil {
+				m.showCloseOverlay = false
+				m.loading = true
+				return m, loadIssueDetail(m.client, m.issue.Number)
+			}
+		}
+		var cmd tea.Cmd
+		m.closeOverlay, cmd = m.closeOverlay.Update(msg)
+		if m.closeOverlay.submitted {
+			m.showCloseOverlay = false
+			m.loading = true
+			return m, loadIssueDetail(m.client, m.issue.Number)
+		}
+		return m, cmd
+	}
+
+	switch msg := msg.(type) {
+	case issueDetailLoadedMsg:
+		m.loading = false
+		m.err = msg.err
+		if msg.err == nil {
+			m.issue = msg.issue
+			m.comments = msg.comments
+			m.refs = msg.refs
+		}
+
+	case issueClosedMsg:
+		if msg.err != nil {
+			m.statusMsg = styleError.Render("Close failed: " + msg.err.Error())
+		} else {
+			m.loading = true
+			return m, loadIssueDetail(m.client, m.issue.Number)
+		}
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc", "b":
+			m.goBack = true
+
+		case "Q", "ctrl+c":
+			m.quit = true
+
+		case "c":
+			if m.issue != nil {
+				m.showCommentOverlay = true
+				m.commentOverlay = newIssueCommentOverlay(m.client, m.issue.Number)
+				return m, m.commentOverlay.Init()
+			}
+
+		case "x":
+			if m.issue != nil && m.issue.State == model.IssueStateOpen {
+				m.showCloseOverlay = true
+				m.closeOverlay = newIssueCloseOverlay(m.client, m.issue.Number)
+				return m, m.closeOverlay.Init()
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m issueDetailModel) View() string {
+	var sb strings.Builder
+
+	if m.issue == nil {
+		sb.WriteString("  Loading...\n")
+		return sb.String()
+	}
+
+	stateStyled := ""
+	if m.issue.State == model.IssueStateOpen {
+		stateStyled = styleApproved.Render("[open]")
+	} else {
+		stateStyled = styleStale.Render("[closed]")
+	}
+	title := fmt.Sprintf("#%d  %s  %s", m.issue.Number, m.issue.Title, stateStyled)
+	sb.WriteString(styleTitle.Render(title) + "\n")
+	sb.WriteString(strings.Repeat("─", 60) + "\n")
+
+	if m.loading {
+		sb.WriteString("  Loading...\n")
+	} else if m.err != nil {
+		sb.WriteString(styleError.Render("  Error: "+m.err.Error()) + "\n")
+	} else {
+		sb.WriteString(fmt.Sprintf("  Author:  %s\n", m.issue.Author))
+		sb.WriteString(fmt.Sprintf("  Created: %s\n", m.issue.CreatedAt.Format("2006-01-02 15:04:05")))
+		if m.issue.CloseReason != nil {
+			sb.WriteString(fmt.Sprintf("  Reason:  %s\n", string(*m.issue.CloseReason)))
+		}
+		if m.issue.ClosedBy != nil {
+			sb.WriteString(fmt.Sprintf("  Closed by: %s\n", *m.issue.ClosedBy))
+		}
+		if len(m.issue.Labels) > 0 {
+			sb.WriteString(fmt.Sprintf("  Labels:  %s\n", strings.Join(m.issue.Labels, ", ")))
+		}
+
+		if m.issue.Body != "" {
+			sb.WriteString("\n")
+			sb.WriteString(styleHeader.Render("  Description") + "\n")
+			for _, line := range strings.Split(m.issue.Body, "\n") {
+				sb.WriteString("  " + line + "\n")
+			}
+		}
+
+		if len(m.comments) > 0 {
+			sb.WriteString("\n")
+			sb.WriteString(styleHeader.Render(fmt.Sprintf("  Comments (%d)", len(m.comments))) + "\n")
+			sb.WriteString(strings.Repeat("─", 40) + "\n")
+			for _, c := range m.comments {
+				sb.WriteString(fmt.Sprintf("  %s  %s\n",
+					styleModified.Render(c.Author),
+					c.CreatedAt.Format("2006-01-02 15:04"),
+				))
+				for _, line := range strings.Split(c.Body, "\n") {
+					sb.WriteString("    " + line + "\n")
+				}
+				sb.WriteString("\n")
+			}
+		}
+
+		if len(m.refs) > 0 {
+			sb.WriteString(styleHeader.Render(fmt.Sprintf("  References (%d)", len(m.refs))) + "\n")
+			for _, ref := range m.refs {
+				sb.WriteString(fmt.Sprintf("  %s  %s\n", string(ref.RefType), ref.RefID))
+			}
+		}
+	}
+
+	if m.statusMsg != "" {
+		sb.WriteString("\n  " + m.statusMsg + "\n")
+	}
+
+	sb.WriteString("\n")
+	if m.showCommentOverlay {
+		sb.WriteString(styleBorder.Render(m.commentOverlay.View()))
+		sb.WriteString("\n")
+	} else if m.showCloseOverlay {
+		sb.WriteString(styleBorder.Render(m.closeOverlay.View()))
+		sb.WriteString("\n")
+	} else {
+		helpText := "  c comment · esc/b back"
+		if m.issue != nil && m.issue.State == model.IssueStateOpen && !m.loading {
+			helpText = "  c comment · x close · esc/b back"
+		}
+		sb.WriteString(styleHelp.Render(helpText))
+	}
+
+	return sb.String()
+}

--- a/internal/tui/issueoverlay.go
+++ b/internal/tui/issueoverlay.go
@@ -1,0 +1,324 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+type issueOverlayMode int
+
+const (
+	overlayCreateIssue issueOverlayMode = iota
+	overlayCloseIssue
+	overlayAddComment
+)
+
+// closeReasons lists the valid close reasons in display order.
+var closeReasons = []model.IssueCloseReason{
+	model.IssueCloseReasonCompleted,
+	model.IssueCloseReasonNotPlanned,
+	model.IssueCloseReasonDuplicate,
+}
+
+type issueFocus int
+
+const (
+	issueFocusTitle issueFocus = iota
+	issueFocusBody
+)
+
+// issueOverlayModel handles create issue, close issue, and add comment overlays.
+type issueOverlayModel struct {
+	client      *tuiClient
+	mode        issueOverlayMode
+	issueNumber int64
+
+	// create mode fields
+	titleInput textinput.Model
+	bodyArea   textarea.Model
+	focus      issueFocus
+
+	// close mode fields
+	reasonIdx int
+
+	submitting bool
+	err        error
+	submitted  bool
+}
+
+func newIssueCreateOverlay(client *tuiClient) issueOverlayModel {
+	ti := textinput.New()
+	ti.Placeholder = "Issue title (required)"
+	ti.Focus()
+	ti.Width = 48
+
+	ta := textarea.New()
+	ta.Placeholder = "Description (optional)"
+	ta.SetWidth(48)
+	ta.SetHeight(4)
+
+	return issueOverlayModel{
+		client:     client,
+		mode:       overlayCreateIssue,
+		titleInput: ti,
+		bodyArea:   ta,
+		focus:      issueFocusTitle,
+	}
+}
+
+func newIssueCloseOverlay(client *tuiClient, issueNumber int64) issueOverlayModel {
+	return issueOverlayModel{
+		client:      client,
+		mode:        overlayCloseIssue,
+		issueNumber: issueNumber,
+	}
+}
+
+func newIssueCommentOverlay(client *tuiClient, issueNumber int64) issueOverlayModel {
+	ta := textarea.New()
+	ta.Placeholder = "Comment body (required)"
+	ta.SetWidth(48)
+	ta.SetHeight(4)
+	ta.Focus()
+
+	return issueOverlayModel{
+		client:      client,
+		mode:        overlayAddComment,
+		issueNumber: issueNumber,
+		bodyArea:    ta,
+	}
+}
+
+func (m issueOverlayModel) Init() tea.Cmd {
+	switch m.mode {
+	case overlayCreateIssue:
+		return textinput.Blink
+	case overlayAddComment:
+		return textarea.Blink
+	}
+	return nil
+}
+
+func (m issueOverlayModel) Update(msg tea.Msg) (issueOverlayModel, tea.Cmd) {
+	switch m.mode {
+	case overlayCreateIssue:
+		return m.updateCreate(msg)
+	case overlayCloseIssue:
+		return m.updateClose(msg)
+	case overlayAddComment:
+		return m.updateComment(msg)
+	}
+	return m, nil
+}
+
+func (m issueOverlayModel) updateCreate(msg tea.Msg) (issueOverlayModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			return m, nil
+
+		case "tab":
+			m.focus = (m.focus + 1) % 2
+			m.titleInput.Blur()
+			m.bodyArea.Blur()
+			switch m.focus {
+			case issueFocusTitle:
+				m.titleInput.Focus()
+				return m, textinput.Blink
+			case issueFocusBody:
+				m.bodyArea.Focus()
+				return m, textarea.Blink
+			}
+			return m, nil
+
+		case "enter":
+			if !m.submitting && m.titleInput.Value() != "" {
+				m.submitting = true
+				return m, createIssueCmd(m.client, m.titleInput.Value(), m.bodyArea.Value())
+			}
+			return m, nil
+		}
+
+	case issueCreatedMsg:
+		m.submitting = false
+		if msg.err != nil {
+			m.err = msg.err
+		} else {
+			m.submitted = true
+		}
+		return m, nil
+	}
+
+	var cmd tea.Cmd
+	switch m.focus {
+	case issueFocusTitle:
+		m.titleInput, cmd = m.titleInput.Update(msg)
+	case issueFocusBody:
+		m.bodyArea, cmd = m.bodyArea.Update(msg)
+	}
+	return m, cmd
+}
+
+func (m issueOverlayModel) updateClose(msg tea.Msg) (issueOverlayModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			return m, nil
+
+		case "j", "down":
+			if m.reasonIdx < len(closeReasons)-1 {
+				m.reasonIdx++
+			}
+			return m, nil
+
+		case "k", "up":
+			if m.reasonIdx > 0 {
+				m.reasonIdx--
+			}
+			return m, nil
+
+		case "enter":
+			if !m.submitting {
+				m.submitting = true
+				return m, closeIssueCmd(m.client, m.issueNumber, closeReasons[m.reasonIdx])
+			}
+			return m, nil
+		}
+
+	case issueClosedMsg:
+		m.submitting = false
+		if msg.err != nil {
+			m.err = msg.err
+		} else {
+			m.submitted = true
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m issueOverlayModel) updateComment(msg tea.Msg) (issueOverlayModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			return m, nil
+
+		case "enter":
+			if !m.submitting && m.bodyArea.Value() != "" {
+				m.submitting = true
+				return m, createIssueCommentCmd(m.client, m.issueNumber, m.bodyArea.Value())
+			}
+			return m, nil
+		}
+
+	case issueCommentCreatedMsg:
+		m.submitting = false
+		if msg.err != nil {
+			m.err = msg.err
+		} else {
+			m.submitted = true
+		}
+		return m, nil
+	}
+
+	var cmd tea.Cmd
+	m.bodyArea, cmd = m.bodyArea.Update(msg)
+	return m, cmd
+}
+
+func (m issueOverlayModel) View() string {
+	switch m.mode {
+	case overlayCreateIssue:
+		return m.viewCreate()
+	case overlayCloseIssue:
+		return m.viewClose()
+	case overlayAddComment:
+		return m.viewComment()
+	}
+	return ""
+}
+
+func (m issueOverlayModel) viewCreate() string {
+	var sb strings.Builder
+
+	sb.WriteString(styleTitle.Render("New Issue") + "\n\n")
+
+	titleLabel := "  Title:  "
+	if m.focus == issueFocusTitle {
+		titleLabel = styleApproved.Render(titleLabel)
+	}
+	sb.WriteString(titleLabel + m.titleInput.View() + "\n\n")
+
+	bodyLabel := "  Body:\n"
+	if m.focus == issueFocusBody {
+		bodyLabel = styleApproved.Render("  Body:\n")
+	}
+	sb.WriteString(bodyLabel)
+	sb.WriteString("  " + m.bodyArea.View() + "\n\n")
+
+	if m.err != nil {
+		sb.WriteString(styleError.Render("  Error: "+m.err.Error()) + "\n\n")
+	}
+	if m.submitting {
+		sb.WriteString("  Creating...\n")
+	}
+
+	sb.WriteString(styleHelp.Render("  tab toggle · enter submit · esc cancel"))
+	return sb.String()
+}
+
+func (m issueOverlayModel) viewClose() string {
+	var sb strings.Builder
+
+	sb.WriteString(styleTitle.Render("Close Issue") + "\n\n")
+	sb.WriteString("  Select reason:\n\n")
+
+	for i, r := range closeReasons {
+		radio := "( ) "
+		if i == m.reasonIdx {
+			radio = "(•) "
+		}
+		label := "  " + radio + string(r)
+		if i == m.reasonIdx {
+			sb.WriteString(styleSelected.Render(label) + "\n")
+		} else {
+			sb.WriteString(label + "\n")
+		}
+	}
+
+	sb.WriteString("\n")
+	if m.err != nil {
+		sb.WriteString(styleError.Render("  Error: "+m.err.Error()) + "\n\n")
+	}
+	if m.submitting {
+		sb.WriteString("  Closing...\n")
+	}
+
+	sb.WriteString(styleHelp.Render("  j/k navigate · enter confirm · esc cancel"))
+	return sb.String()
+}
+
+func (m issueOverlayModel) viewComment() string {
+	var sb strings.Builder
+
+	sb.WriteString(styleTitle.Render("Add Comment") + "\n\n")
+	sb.WriteString("  " + m.bodyArea.View() + "\n\n")
+
+	if m.err != nil {
+		sb.WriteString(styleError.Render("  Error: "+m.err.Error()) + "\n\n")
+	}
+	if m.submitting {
+		sb.WriteString("  Submitting...\n")
+	}
+
+	sb.WriteString(styleHelp.Render("  enter submit · esc cancel"))
+	return sb.String()
+}

--- a/internal/tui/issueslist.go
+++ b/internal/tui/issueslist.go
@@ -1,0 +1,199 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+type issueFilter int
+
+const (
+	filterOpen issueFilter = iota
+	filterClosed
+	filterAll
+)
+
+func (f issueFilter) stateParam() string {
+	switch f {
+	case filterClosed:
+		return "closed"
+	case filterAll:
+		return ""
+	default:
+		return "open"
+	}
+}
+
+// issueListModel is the issue list screen.
+type issueListModel struct {
+	client    *tuiClient
+	issues    []model.Issue
+	filter    issueFilter
+	cursor    int
+	loading   bool
+	err       error
+	openIssue *model.Issue
+	goBack    bool
+	quit      bool
+
+	showCreateOverlay bool
+	createOverlay     issueOverlayModel
+}
+
+func newIssueListModel(client *tuiClient) issueListModel {
+	return issueListModel{
+		client:  client,
+		filter:  filterOpen,
+		loading: true,
+	}
+}
+
+func (m issueListModel) Init() tea.Cmd {
+	return loadIssues(m.client, m.filter.stateParam())
+}
+
+func (m issueListModel) Update(msg tea.Msg) (issueListModel, tea.Cmd) {
+	if m.showCreateOverlay {
+		switch msg := msg.(type) {
+		case tea.KeyMsg:
+			if msg.String() == "esc" {
+				m.showCreateOverlay = false
+				return m, nil
+			}
+			if msg.String() == "ctrl+c" {
+				m.quit = true
+				return m, tea.Quit
+			}
+		case issueCreatedMsg:
+			if msg.err == nil {
+				m.showCreateOverlay = false
+				m.loading = true
+				return m, loadIssues(m.client, m.filter.stateParam())
+			}
+		}
+		var cmd tea.Cmd
+		m.createOverlay, cmd = m.createOverlay.Update(msg)
+		if m.createOverlay.submitted {
+			m.showCreateOverlay = false
+			m.loading = true
+			return m, loadIssues(m.client, m.filter.stateParam())
+		}
+		return m, cmd
+	}
+
+	switch msg := msg.(type) {
+	case issuesLoadedMsg:
+		m.loading = false
+		m.err = msg.err
+		m.issues = msg.issues
+		if m.cursor >= len(m.issues) {
+			m.cursor = 0
+		}
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "ctrl+c":
+			m.quit = true
+
+		case "i", "esc":
+			m.goBack = true
+
+		case "j", "down":
+			if m.cursor < len(m.issues)-1 {
+				m.cursor++
+			}
+
+		case "k", "up":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+
+		case "enter":
+			if len(m.issues) > 0 {
+				issue := m.issues[m.cursor]
+				m.openIssue = &issue
+			}
+
+		case "tab":
+			m.filter = (m.filter + 1) % 3
+			m.loading = true
+			m.cursor = 0
+			return m, loadIssues(m.client, m.filter.stateParam())
+
+		case "n":
+			m.showCreateOverlay = true
+			m.createOverlay = newIssueCreateOverlay(m.client)
+			return m, m.createOverlay.Init()
+		}
+	}
+	return m, nil
+}
+
+func (m issueListModel) View() string {
+	var sb strings.Builder
+
+	sb.WriteString(styleTitle.Render("Issues — "+m.client.repo) + "\n\n")
+
+	// Filter tabs.
+	filterLabels := []string{"Open", "Closed", "All"}
+	parts := make([]string, len(filterLabels))
+	for i, label := range filterLabels {
+		if issueFilter(i) == m.filter {
+			parts[i] = styleTabActive.Render(label)
+		} else {
+			parts[i] = styleTabInactive.Render(label)
+		}
+	}
+	sb.WriteString(" " + strings.Join(parts, "  ") + "\n")
+	sb.WriteString(strings.Repeat("─", 60) + "\n")
+
+	if m.loading {
+		sb.WriteString("  Loading...\n")
+	} else if m.err != nil {
+		sb.WriteString(styleError.Render("  Error: "+m.err.Error()) + "\n")
+	} else if len(m.issues) == 0 {
+		sb.WriteString("  No " + filterLabels[m.filter] + " issues.\n")
+	} else {
+		header := fmt.Sprintf("  %-5s %-40s %-15s", "#", "TITLE", "AUTHOR")
+		sb.WriteString(styleHeader.Render(header) + "\n")
+
+		for i, iss := range m.issues {
+			stateTag := ""
+			if m.filter == filterAll {
+				if iss.State == model.IssueStateOpen {
+					stateTag = styleApproved.Render("[open]  ")
+				} else {
+					stateTag = styleStale.Render("[closed]")
+				}
+			}
+			line := fmt.Sprintf("%-5d %-40s %-15s",
+				iss.Number,
+				truncate(iss.Title, 40),
+				truncate(iss.Author, 15),
+			)
+			prefix := "  "
+			if m.filter == filterAll {
+				line = stateTag + " " + line
+			}
+			if i == m.cursor {
+				sb.WriteString(styleSelected.Render(prefix+line) + "\n")
+			} else {
+				sb.WriteString(prefix + line + "\n")
+			}
+		}
+	}
+
+	sb.WriteString("\n")
+	if m.showCreateOverlay {
+		sb.WriteString(styleBorder.Render(m.createOverlay.View()))
+		sb.WriteString("\n")
+	} else {
+		sb.WriteString(styleHelp.Render("  j/k navigate · enter open · tab filter · n new · i/esc back · q quit"))
+	}
+
+	return sb.String()
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -22,6 +22,8 @@ type view int
 const (
 	viewBranchList view = iota
 	viewBranchDetail
+	viewIssueList
+	viewIssueDetail
 )
 
 // tuiClient wraps HTTP calls for the TUI.
@@ -123,6 +125,8 @@ type topModel struct {
 
 	branchList   branchListModel
 	branchDetail branchDetailModel
+	issueList    issueListModel
+	issueDetail  issueDetailModel
 }
 
 // newTopModel creates the initial top-level model.
@@ -151,6 +155,12 @@ func (m topModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.activeView = viewBranchDetail
 			return m, m.branchDetail.Init()
 		}
+		if m.branchList.openIssues {
+			m.branchList.openIssues = false
+			m.issueList = newIssueListModel(m.client)
+			m.activeView = viewIssueList
+			return m, m.issueList.Init()
+		}
 		if m.branchList.quit {
 			return m, tea.Quit
 		}
@@ -170,6 +180,41 @@ func (m topModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 		return m, cmd
+
+	case viewIssueList:
+		newList, cmd := m.issueList.Update(msg)
+		m.issueList = newList
+
+		if m.issueList.openIssue != nil {
+			issue := m.issueList.openIssue
+			m.issueList.openIssue = nil
+			m.issueDetail = newIssueDetailModel(m.client, issue)
+			m.activeView = viewIssueDetail
+			return m, m.issueDetail.Init()
+		}
+		if m.issueList.goBack {
+			m.issueList.goBack = false
+			m.activeView = viewBranchList
+			return m, m.branchList.Init()
+		}
+		if m.issueList.quit {
+			return m, tea.Quit
+		}
+		return m, cmd
+
+	case viewIssueDetail:
+		newDetail, cmd := m.issueDetail.Update(msg)
+		m.issueDetail = newDetail
+
+		if m.issueDetail.goBack {
+			m.issueDetail.goBack = false
+			m.activeView = viewIssueList
+			return m, m.issueList.Init()
+		}
+		if m.issueDetail.quit {
+			return m, tea.Quit
+		}
+		return m, cmd
 	}
 	return m, nil
 }
@@ -180,6 +225,10 @@ func (m topModel) View() string {
 		return m.branchList.View()
 	case viewBranchDetail:
 		return m.branchDetail.View()
+	case viewIssueList:
+		return m.issueList.View()
+	case viewIssueDetail:
+		return m.issueDetail.View()
 	}
 	return ""
 }
@@ -221,6 +270,34 @@ type proposalOpenedMsg struct {
 }
 
 type proposalClosedMsg struct {
+	err error
+}
+
+type issuesLoadedMsg struct {
+	issues []model.Issue
+	err    error
+}
+
+type issueDetailLoadedMsg struct {
+	issue    *model.Issue
+	comments []model.IssueComment
+	refs     []model.IssueRef
+	err      error
+}
+
+type issueCreatedMsg struct {
+	id     string
+	number int64
+	err    error
+}
+
+type issueClosedMsg struct {
+	issue *model.Issue
+	err   error
+}
+
+type issueCommentCreatedMsg struct {
+	id  string
 	err error
 }
 
@@ -586,5 +663,144 @@ func submitReview(c *tuiClient, branchName, status, body string) tea.Cmd {
 		var r model.CreateReviewResponse
 		json.NewDecoder(resp.Body).Decode(&r)
 		return reviewSubmittedMsg{id: r.ID}
+	}
+}
+
+// --- Issue commands ---
+
+func loadIssues(c *tuiClient, state string) tea.Cmd {
+	return func() tea.Msg {
+		path := "/issues"
+		if state != "" {
+			path += "?state=" + state
+		}
+		resp, err := c.get(path)
+		if err != nil {
+			return issuesLoadedMsg{err: err}
+		}
+		defer resp.Body.Close()
+
+		var issues []model.Issue
+		if err := c.decodeJSON(resp, &issues); err != nil {
+			return issuesLoadedMsg{err: fmt.Errorf("loading issues: %w", err)}
+		}
+		if issues == nil {
+			issues = []model.Issue{}
+		}
+		return issuesLoadedMsg{issues: issues}
+	}
+}
+
+func loadIssueDetail(c *tuiClient, number int64) tea.Cmd {
+	return func() tea.Msg {
+		issPath := fmt.Sprintf("/issues/%d", number)
+		iResp, err := c.get(issPath)
+		if err != nil {
+			return issueDetailLoadedMsg{err: err}
+		}
+		defer iResp.Body.Close()
+		var iss model.Issue
+		if err := c.decodeJSON(iResp, &iss); err != nil {
+			return issueDetailLoadedMsg{err: fmt.Errorf("loading issue: %w", err)}
+		}
+
+		cResp, err := c.get(fmt.Sprintf("/issues/%d/comments", number))
+		if err != nil {
+			return issueDetailLoadedMsg{err: err}
+		}
+		defer cResp.Body.Close()
+		var comments []model.IssueComment
+		if err := c.decodeJSON(cResp, &comments); err != nil {
+			return issueDetailLoadedMsg{err: fmt.Errorf("loading comments: %w", err)}
+		}
+		if comments == nil {
+			comments = []model.IssueComment{}
+		}
+
+		rResp, err := c.get(fmt.Sprintf("/issues/%d/refs", number))
+		if err != nil {
+			return issueDetailLoadedMsg{err: err}
+		}
+		defer rResp.Body.Close()
+		var refs []model.IssueRef
+		if err := c.decodeJSON(rResp, &refs); err != nil {
+			return issueDetailLoadedMsg{err: fmt.Errorf("loading refs: %w", err)}
+		}
+		if refs == nil {
+			refs = []model.IssueRef{}
+		}
+
+		return issueDetailLoadedMsg{issue: &iss, comments: comments, refs: refs}
+	}
+}
+
+func createIssueCmd(c *tuiClient, title, body string) tea.Cmd {
+	return func() tea.Msg {
+		req := model.CreateIssueRequest{
+			Title: title,
+			Body:  body,
+		}
+		resp, err := c.postJSON("/issues", req)
+		if err != nil {
+			return issueCreatedMsg{err: err}
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+			var errResp model.ErrorResponse
+			json.NewDecoder(resp.Body).Decode(&errResp)
+			return issueCreatedMsg{err: fmt.Errorf("server error: %s", errResp.Error)}
+		}
+
+		var r model.CreateIssueResponse
+		json.NewDecoder(resp.Body).Decode(&r)
+		return issueCreatedMsg{id: r.ID, number: r.Number}
+	}
+}
+
+func closeIssueCmd(c *tuiClient, number int64, reason model.IssueCloseReason) tea.Cmd {
+	return func() tea.Msg {
+		req := model.CloseIssueRequest{Reason: reason}
+		path := fmt.Sprintf("/issues/%d/close", number)
+		resp, err := c.postJSON(path, req)
+		if err != nil {
+			return issueClosedMsg{err: err}
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+			var errResp model.ErrorResponse
+			json.NewDecoder(resp.Body).Decode(&errResp)
+			return issueClosedMsg{err: fmt.Errorf("server error: %s", errResp.Error)}
+		}
+
+		var iss model.Issue
+		if resp.StatusCode == http.StatusOK {
+			json.NewDecoder(resp.Body).Decode(&iss)
+			return issueClosedMsg{issue: &iss}
+		}
+		return issueClosedMsg{}
+	}
+}
+
+func createIssueCommentCmd(c *tuiClient, number int64, body string) tea.Cmd {
+	return func() tea.Msg {
+		req := model.CreateIssueCommentRequest{Body: body}
+		path := fmt.Sprintf("/issues/%d/comments", number)
+		resp, err := c.postJSON(path, req)
+		if err != nil {
+			return issueCommentCreatedMsg{err: err}
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+			var errResp model.ErrorResponse
+			json.NewDecoder(resp.Body).Decode(&errResp)
+			return issueCommentCreatedMsg{err: fmt.Errorf("server error: %s", errResp.Error)}
+		}
+
+		var r model.CreateIssueCommentResponse
+		json.NewDecoder(resp.Body).Decode(&r)
+		return issueCommentCreatedMsg{id: r.ID}
 	}
 }


### PR DESCRIPTION
## Summary

- **New TUI views** (`internal/tui/`): issue list, issue detail, and issue overlay (create/close/comment) following the existing Bubble Tea patterns (branchlist, branchdetail, proposaloverlay)
- **New HTTP handlers** (`internal/server/handlers.go`): 7 issue API endpoints wired into the existing `handleReposPrefix` dispatcher
- **Navigation**: `i` from branch list → issue list; `enter` → issue detail; `esc/b` → back at each level

### TUI navigation
| Screen | Key | Action |
|--------|-----|--------|
| Branch list | `i` | Open issue list |
| Issue list | `tab` | Cycle open/closed/all filter |
| Issue list | `j/k` | Navigate |
| Issue list | `enter` | Open issue detail |
| Issue list | `n` | Create new issue overlay |
| Issue list | `i/esc` | Back to branch list |
| Issue detail | `c` | Add comment overlay |
| Issue detail | `x` | Close issue overlay (open issues only) |
| Issue detail | `esc/b` | Back to issue list |

### HTTP endpoints added
- `GET /-/issues?state=open|closed` — list issues
- `GET /-/issues/:number` — get issue
- `POST /-/issues` — create issue
- `POST /-/issues/:number/close` — close with reason
- `GET /-/issues/:number/comments` — list comments
- `POST /-/issues/:number/comments` — add comment
- `GET /-/issues/:number/refs` — list cross-references

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all packages pass

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)