### PR TITLE
fix: TUI issue tracker bugs (BUG-1, TUI-1, TUI-2, TUI-4)

### DIFF
--- a/internal/tui/issuedetail.go
+++ b/internal/tui/issuedetail.go
@@ -114,12 +114,20 @@ func (m issueDetailModel) Update(msg tea.Msg) (issueDetailModel, tea.Cmd) {
 			return m, loadIssueDetail(m.client, m.issue.Number)
 		}
 
+	case issueReopenedMsg:
+		if msg.err != nil {
+			m.statusMsg = styleError.Render("Reopen failed: " + msg.err.Error())
+		} else {
+			m.loading = true
+			return m, loadIssueDetail(m.client, m.issue.Number)
+		}
+
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "esc", "b":
 			m.goBack = true
 
-		case "Q", "ctrl+c":
+		case "q", "ctrl+c":
 			m.quit = true
 
 		case "c":
@@ -134,6 +142,11 @@ func (m issueDetailModel) Update(msg tea.Msg) (issueDetailModel, tea.Cmd) {
 				m.showCloseOverlay = true
 				m.closeOverlay = newIssueCloseOverlay(m.client, m.issue.Number)
 				return m, m.closeOverlay.Init()
+			}
+
+		case "r":
+			if m.issue != nil && m.issue.State == model.IssueStateClosed {
+				return m, reopenIssueCmd(m.client, m.issue.Number)
 			}
 		}
 	}
@@ -220,8 +233,12 @@ func (m issueDetailModel) View() string {
 		sb.WriteString("\n")
 	} else {
 		helpText := "  c comment · esc/b back"
-		if m.issue != nil && m.issue.State == model.IssueStateOpen && !m.loading {
-			helpText = "  c comment · x close · esc/b back"
+		if m.issue != nil && !m.loading {
+			if m.issue.State == model.IssueStateOpen {
+				helpText = "  c comment · x close · esc/b back"
+			} else {
+				helpText = "  c comment · r reopen · esc/b back"
+			}
 		}
 		sb.WriteString(styleHelp.Render(helpText))
 	}

--- a/internal/tui/issueoverlay.go
+++ b/internal/tui/issueoverlay.go
@@ -138,7 +138,18 @@ func (m issueOverlayModel) updateCreate(msg tea.Msg) (issueOverlayModel, tea.Cmd
 			return m, nil
 
 		case "enter":
+			if m.focus == issueFocusBody {
+				// Pass enter through to textarea so it inserts a newline.
+				break
+			}
 			if !m.submitting && m.titleInput.Value() != "" {
+				m.submitting = true
+				return m, createIssueCmd(m.client, m.titleInput.Value(), m.bodyArea.Value())
+			}
+			return m, nil
+
+		case "ctrl+enter":
+			if m.focus == issueFocusBody && !m.submitting && m.titleInput.Value() != "" {
 				m.submitting = true
 				return m, createIssueCmd(m.client, m.titleInput.Value(), m.bodyArea.Value())
 			}
@@ -271,7 +282,11 @@ func (m issueOverlayModel) viewCreate() string {
 		sb.WriteString("  Creating...\n")
 	}
 
-	sb.WriteString(styleHelp.Render("  tab toggle · enter submit · esc cancel"))
+	if m.focus == issueFocusBody {
+		sb.WriteString(styleHelp.Render("  tab toggle · ctrl+enter submit · esc cancel"))
+	} else {
+		sb.WriteString(styleHelp.Render("  tab toggle · enter submit · esc cancel"))
+	}
 	return sb.String()
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -301,6 +301,11 @@ type issueCommentCreatedMsg struct {
 	err error
 }
 
+type issueReopenedMsg struct {
+	issue *model.Issue
+	err   error
+}
+
 // branchSummary holds a branch plus its review/check summary.
 type branchSummary struct {
 	branch   model.Branch
@@ -680,10 +685,11 @@ func loadIssues(c *tuiClient, state string) tea.Cmd {
 		}
 		defer resp.Body.Close()
 
-		var issues []model.Issue
-		if err := c.decodeJSON(resp, &issues); err != nil {
+		var envelope model.ListIssuesResponse
+		if err := c.decodeJSON(resp, &envelope); err != nil {
 			return issuesLoadedMsg{err: fmt.Errorf("loading issues: %w", err)}
 		}
+		issues := envelope.Issues
 		if issues == nil {
 			issues = []model.Issue{}
 		}
@@ -709,10 +715,11 @@ func loadIssueDetail(c *tuiClient, number int64) tea.Cmd {
 			return issueDetailLoadedMsg{err: err}
 		}
 		defer cResp.Body.Close()
-		var comments []model.IssueComment
-		if err := c.decodeJSON(cResp, &comments); err != nil {
+		var commentsEnv model.ListIssueCommentsResponse
+		if err := c.decodeJSON(cResp, &commentsEnv); err != nil {
 			return issueDetailLoadedMsg{err: fmt.Errorf("loading comments: %w", err)}
 		}
+		comments := commentsEnv.Comments
 		if comments == nil {
 			comments = []model.IssueComment{}
 		}
@@ -722,10 +729,11 @@ func loadIssueDetail(c *tuiClient, number int64) tea.Cmd {
 			return issueDetailLoadedMsg{err: err}
 		}
 		defer rResp.Body.Close()
-		var refs []model.IssueRef
-		if err := c.decodeJSON(rResp, &refs); err != nil {
+		var refsEnv model.ListIssueRefsResponse
+		if err := c.decodeJSON(rResp, &refsEnv); err != nil {
 			return issueDetailLoadedMsg{err: fmt.Errorf("loading refs: %w", err)}
 		}
+		refs := refsEnv.Refs
 		if refs == nil {
 			refs = []model.IssueRef{}
 		}
@@ -780,6 +788,30 @@ func closeIssueCmd(c *tuiClient, number int64, reason model.IssueCloseReason) te
 			return issueClosedMsg{issue: &iss}
 		}
 		return issueClosedMsg{}
+	}
+}
+
+func reopenIssueCmd(c *tuiClient, number int64) tea.Cmd {
+	return func() tea.Msg {
+		path := fmt.Sprintf("/issues/%d/reopen", number)
+		resp, err := c.postJSON(path, nil)
+		if err != nil {
+			return issueReopenedMsg{err: err}
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+			var errResp model.ErrorResponse
+			json.NewDecoder(resp.Body).Decode(&errResp)
+			return issueReopenedMsg{err: fmt.Errorf("server error: %s", errResp.Error)}
+		}
+
+		var iss model.Issue
+		if resp.StatusCode == http.StatusOK {
+			json.NewDecoder(resp.Body).Decode(&iss)
+			return issueReopenedMsg{issue: &iss}
+		}
+		return issueReopenedMsg{}
 	}
 }
 


### PR DESCRIPTION
## Summary

- **BUG-1 (Critical)**: Fix `loadIssues`/`loadIssueDetail` to decode server envelope responses (`ListIssuesResponse`, `ListIssueCommentsResponse`, `ListIssueRefsResponse`) instead of decoding directly into raw slices — fixes the always-empty issue list
- **TUI-1**: Change quit key in `issuedetail.go` from `"Q"` to `"q"` to match the rest of the TUI
- **TUI-2**: When focus is on the body textarea in the create-issue overlay, pass `enter` through to the textarea for newlines; use `ctrl+enter` to submit. Help text updates dynamically based on focus
- **TUI-4**: Add `"r"` keybinding in issue detail view to reopen closed issues; add `reopenIssueCmd`/`issueReopenedMsg` in `model.go`; show `"r reopen"` in help text when issue is closed

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./... -count=1` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)