### PR TITLE
fix: issue tracker authz, idempotency, and validation bugs

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -2821,7 +2822,7 @@ func (s *server) streamSSE(w http.ResponseWriter, r *http.Request, repo string) 
 var (
 	reMentionProposal = regexp.MustCompile(`\bproposal:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\b`)
 	reMentionCommit   = regexp.MustCompile(`\bcommit:(\d+)\b`)
-	reMentionIssue    = regexp.MustCompile(`#(\d+)`)
+	reMentionIssue    = regexp.MustCompile(`(?:^|[^&\w])#(\d+)`)
 )
 
 // parseMentions extracts cross-reference mentions from a text body.
@@ -3064,9 +3065,17 @@ func (s *server) handleCloseIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if existing.State == model.IssueStateClosed {
+		writeError(w, http.StatusConflict, "issue is already closed")
+		return
+	}
+
 	var req model.CloseIssueRequest
 	if r.Body != nil {
-		_ = json.NewDecoder(r.Body).Decode(&req)
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			writeError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
 	}
 	reason := req.Reason
 	if reason == "" {
@@ -3104,6 +3113,30 @@ func (s *server) handleReopenIssue(w http.ResponseWriter, r *http.Request) {
 
 	number, ok := parseIssueNumber(w, r)
 	if !ok {
+		return
+	}
+
+	identity := IdentityFromContext(r.Context())
+	role := RoleFromContext(r.Context())
+
+	existing, err := s.commitStore.GetIssue(r.Context(), repo, number)
+	if err != nil {
+		if errors.Is(err, db.ErrIssueNotFound) {
+			writeError(w, http.StatusNotFound, "issue not found")
+		} else {
+			slog.Error("internal error", "op", "reopen_issue", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	if existing.Author != identity && role != model.RoleMaintainer && role != model.RoleAdmin {
+		writeError(w, http.StatusForbidden, "forbidden: must be issue author or maintainer")
+		return
+	}
+
+	if existing.State == model.IssueStateOpen {
+		writeError(w, http.StatusConflict, "issue is already open")
 		return
 	}
 
@@ -3211,6 +3244,21 @@ func (s *server) handleUpdateIssueComment(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	issue, err := s.commitStore.GetIssue(r.Context(), repo, number)
+	if err != nil {
+		if errors.Is(err, db.ErrIssueNotFound) {
+			writeError(w, http.StatusNotFound, "comment not found")
+		} else {
+			slog.Error("internal error", "op", "update_issue_comment", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+	if existing.IssueID != issue.ID {
+		writeError(w, http.StatusNotFound, "comment not found")
+		return
+	}
+
 	if existing.Author != identity && role != model.RoleMaintainer && role != model.RoleAdmin {
 		writeError(w, http.StatusForbidden, "forbidden: must be comment author or maintainer")
 		return
@@ -3249,11 +3297,46 @@ func (s *server) handleDeleteIssueComment(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if _, ok := parseIssueNumber(w, r); !ok {
+	number, ok := parseIssueNumber(w, r)
+	if !ok {
 		return
 	}
 
 	commentID := r.PathValue("commentID")
+	identity := IdentityFromContext(r.Context())
+	role := RoleFromContext(r.Context())
+
+	existing, err := s.commitStore.GetIssueComment(r.Context(), repo, commentID)
+	if err != nil {
+		if errors.Is(err, db.ErrIssueCommentNotFound) {
+			writeError(w, http.StatusNotFound, "comment not found")
+		} else {
+			slog.Error("internal error", "op", "delete_issue_comment", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	issue, err := s.commitStore.GetIssue(r.Context(), repo, number)
+	if err != nil {
+		if errors.Is(err, db.ErrIssueNotFound) {
+			writeError(w, http.StatusNotFound, "comment not found")
+		} else {
+			slog.Error("internal error", "op", "delete_issue_comment", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+	if existing.IssueID != issue.ID {
+		writeError(w, http.StatusNotFound, "comment not found")
+		return
+	}
+
+	if existing.Author != identity && role != model.RoleMaintainer && role != model.RoleAdmin {
+		writeError(w, http.StatusForbidden, "forbidden: must be comment author or maintainer")
+		return
+	}
+
 	if err := s.commitStore.DeleteIssueComment(r.Context(), repo, commentID); err != nil {
 		if errors.Is(err, db.ErrIssueCommentNotFound) {
 			writeError(w, http.StatusNotFound, "comment not found")
@@ -3356,6 +3439,10 @@ func (s *server) handleCommitIssues(w http.ResponseWriter, r *http.Request) {
 	}
 
 	seqStr := r.PathValue("sequence")
+	if _, err := strconv.ParseInt(seqStr, 10, 64); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid sequence number")
+		return
+	}
 	issues, err := s.commitStore.ListIssuesByRef(r.Context(), repo, model.IssueRefTypeCommit, seqStr)
 	if err != nil {
 		slog.Error("internal error", "op", "commit_issues", "repo", repo, "error", err)


### PR DESCRIPTION
## Summary

- **BUG-2**: `handleDeleteIssueComment` — fetch comment first, check caller is author or maintainer before deleting (was completely unguarded)
- **BUG-3**: `handleReopenIssue` — fetch existing issue and apply same authz check as `handleCloseIssue` (author or maintainer+)
- **BUG-4**: `handleCommitIssues` — validate sequence path param with `strconv.ParseInt`, return 400 on invalid input
- **SEC-1**: `handleCloseIssue` — body decode now returns 400 on JSON error for non-empty bodies (was silently discarding errors with `_ =`)
- **SEC-2**: `handleCloseIssue` returns 409 if issue is already closed; `handleReopenIssue` returns 409 if issue is already open
- **CONS-2**: `reMentionIssue` regex changed from `#(\d+)` to `(?:^|[^&\w])#(\d+)` to avoid matching mid-word (e.g. `&#123;`)
- **CONS-6**: `handleUpdateIssueComment` and `handleDeleteIssueComment` now verify the fetched comment's `IssueID` matches the issue for the number in the URL, returning 404 if not

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)