### PR TITLE
feat: auto-merge — merge branches automatically when CI and policies pass

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -122,6 +122,7 @@ type Branch struct {
 	BaseSequence int64        `json:"base_sequence"`
 	Status       BranchStatus `json:"status"`
 	Draft        bool         `json:"draft"`
+	AutoMerge    bool         `json:"auto_merge"`
 }
 
 // Role maps an identity to a coarse-grained permission level on a repo.
@@ -318,6 +319,7 @@ type PolicyResult struct {
 type BranchStatusResponse struct {
 	Mergeable bool           `json:"mergeable"`
 	Policies  []PolicyResult `json:"policies"`
+	AutoMerge bool           `json:"auto_merge"`
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/docstore/main.go
+++ b/cmd/docstore/main.go
@@ -13,10 +13,13 @@ import (
 
 	_ "github.com/lib/pq"
 
+	"github.com/dlorenc/docstore/internal/automerge"
 	"github.com/dlorenc/docstore/internal/blob"
 	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/events"
+	"github.com/dlorenc/docstore/internal/policy"
 	"github.com/dlorenc/docstore/internal/server"
+	"github.com/dlorenc/docstore/internal/store"
 )
 
 func main() {
@@ -139,6 +142,13 @@ func main() {
 
 	srv := server.NewWithBroker(commitStore, database, bs, broker, *devIdentity, *bootstrapAdmin)
 
+	// Start the auto-merge worker. It subscribes to check.reported and
+	// review.submitted events and merges branches with auto_merge=true.
+	readStore := store.New(database)
+	autoMergeWorker := automerge.New(broker, commitStore, readStore, policy.NewCache())
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	go autoMergeWorker.Run(workerCtx)
+
 	httpServer := &http.Server{
 		Addr:         ":" + port,
 		Handler:      srv,
@@ -162,8 +172,9 @@ func main() {
 	<-quit
 	logger.Info("shutting down")
 
-	// Stop the outbox dispatcher.
+	// Stop the outbox dispatcher and auto-merge worker.
 	dispatchCancel()
+	workerCancel()
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer shutdownCancel()

--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -33,6 +33,8 @@ commands:
   resolve <path>                                  Resolve a merge/rebase conflict
   verify                                          Verify commit chain integrity
   ready                                           Mark current branch as ready (not draft)
+  auto-merge enable [--branch <name>]             Enable auto-merge for the current branch
+  auto-merge disable [--branch <name>]            Disable auto-merge for the current branch
   branches [--status active|merged|abandoned] [--draft] [--include-draft]  List branches
   reviews [--branch <name>]                       List reviews for a branch
   review --status approved|rejected [--body "…"] [--branch <name>]  Submit a review
@@ -715,6 +717,29 @@ func main() {
 
 	case "ready":
 		err = app.Ready()
+
+	case "auto-merge":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: ds auto-merge enable|disable [--branch <name>]")
+			os.Exit(1)
+		}
+		subCmd := args[1]
+		branch := ""
+		for i := 2; i < len(args); i++ {
+			if args[i] == "--branch" && i+1 < len(args) {
+				branch = args[i+1]
+				i++
+			}
+		}
+		switch subCmd {
+		case "enable":
+			err = app.AutoMergeEnable(branch)
+		case "disable":
+			err = app.AutoMergeDisable(branch)
+		default:
+			fmt.Fprintf(os.Stderr, "unknown auto-merge subcommand: %s\n", subCmd)
+			os.Exit(1)
+		}
 
 	case "purge":
 		olderThan := ""

--- a/internal/automerge/worker.go
+++ b/internal/automerge/worker.go
@@ -1,0 +1,157 @@
+// Package automerge implements the auto-merge worker. When a branch has
+// auto_merge=true, the worker listens for check.reported and review.submitted
+// events and attempts a merge whenever policies are satisfied.
+package automerge
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/events"
+	evtypes "github.com/dlorenc/docstore/internal/events/types"
+	mergeutil "github.com/dlorenc/docstore/internal/merge"
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// Store is the minimal interface required by the worker for write operations.
+// *db.Store satisfies this interface.
+type Store interface {
+	// Branch writes
+	SetBranchAutoMerge(ctx context.Context, repo, name string, autoMerge bool) error
+	// Merge
+	Merge(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error)
+	MergeProposal(ctx context.Context, repo, branch string) (*model.Proposal, error)
+	// Policy input assembly (satisfies mergeutil.QueryStore)
+	ListReviews(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error)
+	ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error)
+	ListProposals(ctx context.Context, repo string, state *model.ProposalState, branch *string) ([]*model.Proposal, error)
+	GetRole(ctx context.Context, repo, identity string) (*model.Role, error)
+}
+
+// Worker subscribes to check.reported and review.submitted events and
+// attempts an auto-merge when a branch has auto_merge=true.
+type Worker struct {
+	broker      *events.Broker
+	store       Store
+	readStore   mergeutil.ReadStore
+	policyCache mergeutil.PolicyCache
+}
+
+// New creates a new Worker. If broker, store, or readStore are nil the worker
+// will do nothing (safe no-op for tests that don't wire events).
+func New(broker *events.Broker, st Store, rs mergeutil.ReadStore, pc mergeutil.PolicyCache) *Worker {
+	return &Worker{
+		broker:      broker,
+		store:       st,
+		readStore:   rs,
+		policyCache: pc,
+	}
+}
+
+// Run starts the event loop. It blocks until ctx is cancelled.
+func (w *Worker) Run(ctx context.Context) {
+	if w.broker == nil || w.store == nil || w.readStore == nil {
+		return
+	}
+
+	ch, unsub := w.broker.Subscribe("*", []string{
+		"com.docstore.check.reported",
+		"com.docstore.review.submitted",
+	})
+	defer unsub()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			var repo, branch string
+			switch e := ev.(type) {
+			case evtypes.CheckReported:
+				repo, branch = e.Repo, e.Branch
+			case evtypes.ReviewSubmitted:
+				repo, branch = e.Repo, e.Branch
+			default:
+				continue
+			}
+			w.tryAutoMerge(ctx, repo, branch)
+		}
+	}
+}
+
+// tryAutoMerge checks whether the branch should be auto-merged and attempts
+// the merge if all conditions are met.
+func (w *Worker) tryAutoMerge(ctx context.Context, repo, branch string) {
+	info, err := w.readStore.GetBranch(ctx, repo, branch)
+	if err != nil {
+		slog.Error("auto-merge: get branch failed", "repo", repo, "branch", branch, "error", err)
+		return
+	}
+	if info == nil {
+		return // branch not found
+	}
+	if !info.AutoMerge || info.Draft || info.Status != "active" {
+		return
+	}
+
+	denied, err := mergeutil.EvaluatePolicy(ctx, w.policyCache, w.readStore, w.store, repo, branch, "auto-merge")
+	if err != nil {
+		slog.Error("auto-merge: policy evaluation failed", "repo", repo, "branch", branch, "error", err)
+		return
+	}
+	if denied != nil {
+		// Policies not yet satisfied — will retry on next event.
+		return
+	}
+
+	resp, conflicts, err := w.store.Merge(ctx, model.MergeRequest{
+		Repo:   repo,
+		Branch: branch,
+		Author: "auto-merge",
+	})
+	if err != nil {
+		if errors.Is(err, db.ErrMergeConflict) {
+			slog.Warn("auto-merge: conflict detected, disabling auto-merge",
+				"repo", repo, "branch", branch, "conflicts", len(conflicts))
+			if clearErr := w.store.SetBranchAutoMerge(ctx, repo, branch, false); clearErr != nil {
+				slog.Warn("auto-merge: failed to clear auto_merge flag", "repo", repo, "branch", branch, "error", clearErr)
+			}
+			w.broker.Emit(ctx, evtypes.BranchAutoMergeFailed{
+				Repo:   repo,
+				Branch: branch,
+				Reason: "merge conflict",
+			})
+		} else if errors.Is(err, db.ErrBranchDraft) || errors.Is(err, db.ErrBranchNotActive) || errors.Is(err, db.ErrBranchNotFound) {
+			// Branch state changed between check and merge — nothing to do.
+			slog.Info("auto-merge: branch no longer mergeable", "repo", repo, "branch", branch, "error", err)
+		} else {
+			slog.Error("auto-merge: merge failed", "repo", repo, "branch", branch, "error", err)
+		}
+		return
+	}
+
+	// Best-effort: transition any open proposal to merged.
+	if mp, mergeProposalErr := w.store.MergeProposal(ctx, repo, branch); mergeProposalErr != nil {
+		slog.Warn("auto-merge: failed to merge proposal", "repo", repo, "branch", branch, "error", mergeProposalErr)
+	} else if mp != nil {
+		w.broker.Emit(ctx, evtypes.ProposalMerged{
+			Repo:       repo,
+			Branch:     branch,
+			BaseBranch: mp.BaseBranch,
+			ProposalID: mp.ID,
+		})
+	}
+
+	w.broker.Emit(ctx, evtypes.BranchMerged{
+		Repo:     repo,
+		Branch:   branch,
+		Sequence: resp.Sequence,
+		MergedBy: "auto-merge",
+	})
+	slog.Info("auto-merge: branch merged", "repo", repo, "branch", branch, "sequence", resp.Sequence)
+}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -583,6 +583,67 @@ func (a *App) Ready() error {
 	return nil
 }
 
+// AutoMergeEnable enables auto-merge on the current (or specified) branch.
+// When all CI checks pass and merge policies are satisfied, the branch will
+// be merged automatically.
+func (a *App) AutoMergeEnable(branch string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	if branch == "" {
+		branch = cfg.Branch
+	}
+	if branch == "" || branch == "main" {
+		return fmt.Errorf("no branch checked out (or on main)")
+	}
+
+	resp, err := a.postJSON(cfg, repoBase(cfg)+"/branch/"+branch+"/auto-merge", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return a.readError(resp)
+	}
+
+	fmt.Fprintf(a.Out, "Auto-merge enabled for branch '%s'\n", branch)
+	return nil
+}
+
+// AutoMergeDisable disables auto-merge on the current (or specified) branch.
+func (a *App) AutoMergeDisable(branch string) error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	if branch == "" {
+		branch = cfg.Branch
+	}
+	if branch == "" || branch == "main" {
+		return fmt.Errorf("no branch checked out (or on main)")
+	}
+
+	req, err := http.NewRequest("DELETE", repoBase(cfg)+"/branch/"+branch+"/auto-merge", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-DocStore-Identity", cfg.Author)
+	resp, err := a.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return a.readError(resp)
+	}
+
+	fmt.Fprintf(a.Out, "Auto-merge disabled for branch '%s'\n", branch)
+	return nil
+}
+
 // Checkout switches to an existing branch and syncs files from the server.
 func (a *App) Checkout(branch string) error {
 	cfg, err := a.loadConfig()

--- a/internal/db/migrations/000014_auto_merge.down.sql
+++ b/internal/db/migrations/000014_auto_merge.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE branches DROP COLUMN auto_merge;

--- a/internal/db/migrations/000014_auto_merge.up.sql
+++ b/internal/db/migrations/000014_auto_merge.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE branches ADD COLUMN auto_merge BOOLEAN NOT NULL DEFAULT false;

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -629,6 +629,28 @@ func (s *Store) UpdateBranchDraft(ctx context.Context, repo, name string, draft 
 	return nil
 }
 
+// SetBranchAutoMerge sets the auto_merge flag on a branch.
+// Returns ErrBranchNotFound if the branch does not exist.
+func (s *Store) SetBranchAutoMerge(ctx context.Context, repo, name string, autoMerge bool) error {
+	res, err := s.db.ExecContext(ctx,
+		"UPDATE branches SET auto_merge = $1 WHERE repo = $2 AND name = $3",
+		autoMerge, repo, name,
+	)
+	if err != nil {
+		slog.Error("set branch auto_merge failed", "repo", repo, "branch", name, "error", err)
+		return fmt.Errorf("set branch auto_merge: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrBranchNotFound
+	}
+	slog.Info("branch auto_merge updated", "repo", repo, "branch", name, "auto_merge", autoMerge)
+	return nil
+}
+
 // Merge merges a branch into main. It detects conflicts (paths changed on
 // both the branch and main since the branch's base_sequence) and either
 // aborts with conflict details or fast-forwards main.

--- a/internal/events/broker.go
+++ b/internal/events/broker.go
@@ -83,15 +83,19 @@ func (b *Broker) fanOutSSE(e Event) {
 	repo := repoFromSource(e.Source())
 
 	// Collect the set of matching subscriber keys.
+	// Also check global wildcard keys ("*/*" and "*/<type>") so that
+	// subscribers using repo="*" receive events from all repos.
 	wildcardKey := repo + "/*"
 	typeKey := repo + "/" + e.Type()
+	globalWildcardKey := "*/*"
+	globalTypeKey := "*/" + e.Type()
 
 	b.mu.RLock()
 	// Collect unique channels (a subscriber might appear under both keys theoretically,
 	// but our Subscribe logic ensures each channel is under exactly one set of keys).
 	seen := make(map[chan Event]struct{})
 	var targets []chan Event
-	for _, k := range []string{wildcardKey, typeKey} {
+	for _, k := range []string{wildcardKey, typeKey, globalWildcardKey, globalTypeKey} {
 		for _, ch := range b.subs[k] {
 			if _, ok := seen[ch]; !ok {
 				seen[ch] = struct{}{}

--- a/internal/events/types/auto_merge.go
+++ b/internal/events/types/auto_merge.go
@@ -1,0 +1,35 @@
+package types
+
+// BranchAutoMergeEnabled is emitted when auto-merge is enabled on a branch.
+type BranchAutoMergeEnabled struct {
+	Repo      string `json:"repo"`
+	Branch    string `json:"branch"`
+	EnabledBy string `json:"enabled_by"`
+}
+
+func (e BranchAutoMergeEnabled) Type() string   { return "com.docstore.branch.automerge.enabled" }
+func (e BranchAutoMergeEnabled) Source() string { return "/repos/" + e.Repo }
+func (e BranchAutoMergeEnabled) Data() any      { return e }
+
+// BranchAutoMergeDisabled is emitted when auto-merge is disabled on a branch.
+type BranchAutoMergeDisabled struct {
+	Repo       string `json:"repo"`
+	Branch     string `json:"branch"`
+	DisabledBy string `json:"disabled_by"`
+}
+
+func (e BranchAutoMergeDisabled) Type() string   { return "com.docstore.branch.automerge.disabled" }
+func (e BranchAutoMergeDisabled) Source() string { return "/repos/" + e.Repo }
+func (e BranchAutoMergeDisabled) Data() any      { return e }
+
+// BranchAutoMergeFailed is emitted when auto-merge fails (e.g. due to a conflict).
+// The auto_merge flag is cleared on the branch when this event is emitted.
+type BranchAutoMergeFailed struct {
+	Repo   string `json:"repo"`
+	Branch string `json:"branch"`
+	Reason string `json:"reason"`
+}
+
+func (e BranchAutoMergeFailed) Type() string   { return "com.docstore.branch.automerge.failed" }
+func (e BranchAutoMergeFailed) Source() string { return "/repos/" + e.Repo }
+func (e BranchAutoMergeFailed) Data() any      { return e }

--- a/internal/merge/policy.go
+++ b/internal/merge/policy.go
@@ -1,0 +1,168 @@
+// Package merge provides shared merge policy evaluation logic used by both
+// the HTTP handler and the auto-merge worker.
+package merge
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/policy"
+	"github.com/dlorenc/docstore/internal/store"
+)
+
+// ReadStore is the minimal interface for reading branch and diff data.
+// *store.Store satisfies this interface.
+type ReadStore interface {
+	GetBranch(ctx context.Context, repo, branch string) (*store.BranchInfo, error)
+	GetDiff(ctx context.Context, repo, branch string) (*store.DiffResult, error)
+	MaterializeTree(ctx context.Context, repo, branch string, atSeq *int64, limit int, afterPath string) ([]store.TreeEntry, error)
+	GetFile(ctx context.Context, repo, branch, path string, atSeq *int64) (*store.FileContent, error)
+}
+
+// QueryStore is the minimal interface for querying reviews, checks, proposals, and roles.
+// *db.Store satisfies this interface.
+type QueryStore interface {
+	ListReviews(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error)
+	ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64) ([]model.CheckRun, error)
+	ListProposals(ctx context.Context, repo string, state *model.ProposalState, branch *string) ([]*model.Proposal, error)
+	GetRole(ctx context.Context, repo, identity string) (*model.Role, error)
+}
+
+// PolicyCache loads OPA engines for a given repo.
+// *policy.Cache satisfies this interface.
+type PolicyCache interface {
+	Load(ctx context.Context, repo string, st policy.ReadStore) (*policy.Engine, map[string][]string, error)
+}
+
+// AssembleInput gathers all data needed for OPA policy evaluation.
+// Returns nil, nil if the branch does not exist (callers should surface the 404).
+// owners is the raw directory→owners map from the policy cache; it is resolved
+// per changed path before being placed on the Input.
+func AssembleInput(ctx context.Context, rs ReadStore, qs QueryStore, repo, branch, actor string, owners map[string][]string) (*policy.Input, error) {
+	branchInfo, err := rs.GetBranch(ctx, repo, branch)
+	if err != nil {
+		return nil, fmt.Errorf("get branch info: %w", err)
+	}
+	if branchInfo == nil {
+		return nil, nil // branch not found
+	}
+
+	diff, err := rs.GetDiff(ctx, repo, branch)
+	if err != nil {
+		return nil, fmt.Errorf("get diff: %w", err)
+	}
+	var changedPaths []string
+	if diff != nil {
+		for _, e := range diff.BranchChanges {
+			changedPaths = append(changedPaths, e.Path)
+		}
+	}
+
+	reviews, err := qs.ListReviews(ctx, repo, branch, &branchInfo.HeadSequence)
+	if err != nil {
+		return nil, fmt.Errorf("list reviews: %w", err)
+	}
+	checkRuns, err := qs.ListCheckRuns(ctx, repo, branch, &branchInfo.HeadSequence)
+	if err != nil {
+		return nil, fmt.Errorf("list check runs: %w", err)
+	}
+
+	openState := model.ProposalOpen
+	proposals, err := qs.ListProposals(ctx, repo, &openState, &branch)
+	if err != nil {
+		return nil, fmt.Errorf("list proposals: %w", err)
+	}
+	var proposalInput *policy.ProposalInput
+	if len(proposals) > 0 {
+		p := proposals[0]
+		proposalInput = &policy.ProposalInput{
+			ID:         p.ID,
+			BaseBranch: p.BaseBranch,
+			Title:      p.Title,
+			State:      string(p.State),
+		}
+	}
+
+	actorRoles := []string{}
+	if r, err := qs.GetRole(ctx, repo, actor); err == nil && r != nil {
+		actorRoles = []string{string(r.Role)}
+	}
+
+	reviewInputs := make([]policy.ReviewInput, len(reviews))
+	for i, rev := range reviews {
+		reviewInputs[i] = policy.ReviewInput{
+			Reviewer: rev.Reviewer,
+			Status:   string(rev.Status),
+			Sequence: rev.Sequence,
+		}
+	}
+	checkInputs := make([]policy.CheckRunInput, len(checkRuns))
+	for i, cr := range checkRuns {
+		checkInputs[i] = policy.CheckRunInput{
+			CheckName: cr.CheckName,
+			Status:    string(cr.Status),
+			Sequence:  cr.Sequence,
+		}
+	}
+
+	resolvedOwners := make(map[string][]string)
+	for _, p := range changedPaths {
+		resolvedOwners[p] = policy.ResolveOwners(owners, p)
+	}
+
+	return &policy.Input{
+		Actor:        actor,
+		ActorRoles:   actorRoles,
+		Action:       "merge",
+		Repo:         repo,
+		Branch:       branch,
+		Draft:        branchInfo.Draft,
+		ChangedPaths: changedPaths,
+		Reviews:      reviewInputs,
+		CheckRuns:    checkInputs,
+		Owners:       resolvedOwners,
+		HeadSeq:      branchInfo.HeadSequence,
+		BaseSeq:      branchInfo.BaseSequence,
+		Proposal:     proposalInput,
+	}, nil
+}
+
+// EvaluatePolicy evaluates all OPA policies for a pending merge.
+// Returns failing PolicyResults (non-nil means denied), or nil if allowed.
+// Returns an error only for unexpected infrastructure failures.
+// When cache or rs are nil, or no policies exist, the merge is allowed.
+func EvaluatePolicy(ctx context.Context, cache PolicyCache, rs ReadStore, qs QueryStore, repo, branch, actor string) ([]model.PolicyResult, error) {
+	if cache == nil || rs == nil {
+		return nil, nil
+	}
+
+	engine, owners, err := cache.Load(ctx, repo, rs)
+	if err != nil {
+		return nil, err
+	}
+	if engine == nil {
+		return nil, nil // bootstrap mode
+	}
+
+	input, err := AssembleInput(ctx, rs, qs, repo, branch, actor, owners)
+	if err != nil {
+		return nil, err
+	}
+	if input == nil {
+		return nil, nil // branch not found — let caller surface the error
+	}
+
+	results, err := engine.Evaluate(ctx, *input)
+	if err != nil {
+		return nil, fmt.Errorf("evaluate policies: %w", err)
+	}
+
+	var denied []model.PolicyResult
+	for _, r := range results {
+		if !r.Pass {
+			denied = append(denied, r)
+		}
+	}
+	return denied, nil
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/events"
 	evtypes "github.com/dlorenc/docstore/internal/events/types"
+	mergeutil "github.com/dlorenc/docstore/internal/merge"
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/policy"
 	"github.com/dlorenc/docstore/internal/store"
@@ -249,23 +250,36 @@ func (s *server) handleReposPrefix(w http.ResponseWriter, r *http.Request) {
 
 	case strings.HasPrefix(endpoint, "branch/"):
 		bpath := strings.TrimPrefix(endpoint, "branch/")
-		switch r.Method {
-		case http.MethodDelete:
-			r.SetPathValue("bname", bpath)
-			s.handleDeleteBranch(w, r)
-		case http.MethodPatch:
-			r.SetPathValue("bname", bpath)
-			s.handleUpdateBranch(w, r)
-		case http.MethodGet:
-			if strings.HasSuffix(bpath, "/status") {
-				branchName := strings.TrimSuffix(bpath, "/status")
-				s.handleBranchStatus(w, r, repoName, branchName)
-			} else {
-				r.SetPathValue("branch", bpath)
-				s.handleBranchGet(w, r)
+		if strings.HasSuffix(bpath, "/auto-merge") {
+			branchName := strings.TrimSuffix(bpath, "/auto-merge")
+			r.SetPathValue("bname", branchName)
+			switch r.Method {
+			case http.MethodPost:
+				s.handleEnableAutoMerge(w, r)
+			case http.MethodDelete:
+				s.handleDisableAutoMerge(w, r)
+			default:
+				writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 			}
-		default:
-			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		} else {
+			switch r.Method {
+			case http.MethodDelete:
+				r.SetPathValue("bname", bpath)
+				s.handleDeleteBranch(w, r)
+			case http.MethodPatch:
+				r.SetPathValue("bname", bpath)
+				s.handleUpdateBranch(w, r)
+			case http.MethodGet:
+				if strings.HasSuffix(bpath, "/status") {
+					branchName := strings.TrimSuffix(bpath, "/status")
+					s.handleBranchStatus(w, r, repoName, branchName)
+				} else {
+					r.SetPathValue("branch", bpath)
+					s.handleBranchGet(w, r)
+				}
+			default:
+				writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			}
 		}
 
 	case endpoint == "events":
@@ -1558,6 +1572,69 @@ func (s *server) handleUpdateBranch(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, model.UpdateBranchResponse{Name: bname, Draft: req.Draft})
 }
 
+// handleEnableAutoMerge implements POST /repos/:name/-/branch/:bname/auto-merge (writer+)
+// Enables auto-merge on the branch. When all policies are satisfied and CI checks
+// pass, the branch will be automatically merged.
+func (s *server) handleEnableAutoMerge(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	bname := r.PathValue("bname")
+
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+	if bname == "main" {
+		writeError(w, http.StatusBadRequest, "cannot enable auto-merge on branch 'main'")
+		return
+	}
+
+	if err := s.commitStore.SetBranchAutoMerge(r.Context(), repo, bname, true); err != nil {
+		switch {
+		case errors.Is(err, db.ErrBranchNotFound):
+			writeError(w, http.StatusNotFound, "branch not found")
+		default:
+			slog.Error("internal error", "op", "enable_auto_merge", "repo", repo, "branch", bname, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	identity := IdentityFromContext(r.Context())
+	s.emit(r.Context(), evtypes.BranchAutoMergeEnabled{Repo: repo, Branch: bname, EnabledBy: identity})
+	slog.Info("auto-merge enabled", "repo", repo, "branch", bname, "by", identity)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleDisableAutoMerge implements DELETE /repos/:name/-/branch/:bname/auto-merge (writer+)
+// Disables auto-merge on the branch.
+func (s *server) handleDisableAutoMerge(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	bname := r.PathValue("bname")
+
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+	if bname == "main" {
+		writeError(w, http.StatusBadRequest, "cannot disable auto-merge on branch 'main'")
+		return
+	}
+
+	if err := s.commitStore.SetBranchAutoMerge(r.Context(), repo, bname, false); err != nil {
+		switch {
+		case errors.Is(err, db.ErrBranchNotFound):
+			writeError(w, http.StatusNotFound, "branch not found")
+		default:
+			slog.Error("internal error", "op", "disable_auto_merge", "repo", repo, "branch", bname, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	identity := IdentityFromContext(r.Context())
+	s.emit(r.Context(), evtypes.BranchAutoMergeDisabled{Repo: repo, Branch: bname, DisabledBy: identity})
+	slog.Info("auto-merge disabled", "repo", repo, "branch", bname, "by", identity)
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // handleDeleteBranch implements DELETE /repos/:name/branch/{bname}
 func (s *server) handleDeleteBranch(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
@@ -2068,99 +2145,7 @@ func (s *server) handleMerge(w http.ResponseWriter, r *http.Request) {
 // directory→owners map from the policy cache; it is resolved per changed path
 // before being placed on the Input.
 func (s *server) assembleMergeInput(ctx context.Context, repo, branch, actor string, owners map[string][]string) (*policy.Input, error) {
-	// Collect branch info for head/base sequence.
-	branchInfo, err := s.readStore.GetBranch(ctx, repo, branch)
-	if err != nil {
-		return nil, fmt.Errorf("get branch info: %w", err)
-	}
-	if branchInfo == nil {
-		return nil, nil // branch not found
-	}
-
-	// Collect changed paths.
-	diff, err := s.readStore.GetDiff(ctx, repo, branch)
-	if err != nil {
-		return nil, fmt.Errorf("get diff: %w", err)
-	}
-	var changedPaths []string
-	if diff != nil {
-		for _, e := range diff.BranchChanges {
-			changedPaths = append(changedPaths, e.Path)
-		}
-	}
-
-	// Collect reviews filtered to the current head sequence (stale reviews excluded).
-	reviews, err := s.commitStore.ListReviews(ctx, repo, branch, &branchInfo.HeadSequence)
-	if err != nil {
-		return nil, fmt.Errorf("list reviews: %w", err)
-	}
-	checkRuns, err := s.commitStore.ListCheckRuns(ctx, repo, branch, &branchInfo.HeadSequence)
-	if err != nil {
-		return nil, fmt.Errorf("list check runs: %w", err)
-	}
-
-	// Fetch the open proposal for this branch (nil if none exists).
-	openState := model.ProposalOpen
-	proposals, err := s.commitStore.ListProposals(ctx, repo, &openState, &branch)
-	if err != nil {
-		return nil, fmt.Errorf("list proposals: %w", err)
-	}
-	var proposalInput *policy.ProposalInput
-	if len(proposals) > 0 {
-		p := proposals[0]
-		proposalInput = &policy.ProposalInput{
-			ID:         p.ID,
-			BaseBranch: p.BaseBranch,
-			Title:      p.Title,
-			State:      string(p.State),
-		}
-	}
-
-	// Look up actor roles (empty slice if not assigned).
-	actorRoles := []string{}
-	if r, err := s.commitStore.GetRole(ctx, repo, actor); err == nil && r != nil {
-		actorRoles = []string{string(r.Role)}
-	}
-
-	// Build OPA input.
-	reviewInputs := make([]policy.ReviewInput, len(reviews))
-	for i, rev := range reviews {
-		reviewInputs[i] = policy.ReviewInput{
-			Reviewer: rev.Reviewer,
-			Status:   string(rev.Status),
-			Sequence: rev.Sequence,
-		}
-	}
-	checkInputs := make([]policy.CheckRunInput, len(checkRuns))
-	for i, cr := range checkRuns {
-		checkInputs[i] = policy.CheckRunInput{
-			CheckName: cr.CheckName,
-			Status:    string(cr.Status),
-			Sequence:  cr.Sequence,
-		}
-	}
-
-	// Resolve owners per changed path so policies can use input.owners["path"].
-	resolvedOwners := make(map[string][]string)
-	for _, p := range changedPaths {
-		resolvedOwners[p] = policy.ResolveOwners(owners, p)
-	}
-
-	return &policy.Input{
-		Actor:        actor,
-		ActorRoles:   actorRoles,
-		Action:       "merge",
-		Repo:         repo,
-		Branch:       branch,
-		Draft:        branchInfo.Draft,
-		ChangedPaths: changedPaths,
-		Reviews:      reviewInputs,
-		CheckRuns:    checkInputs,
-		Owners:       resolvedOwners,
-		HeadSeq:      branchInfo.HeadSequence,
-		BaseSeq:      branchInfo.BaseSequence,
-		Proposal:     proposalInput,
-	}, nil
+	return mergeutil.AssembleInput(ctx, s.readStore, s.commitStore, repo, branch, actor, owners)
 }
 
 // evaluateMergePolicy evaluates all OPA policies for a pending merge.
@@ -2168,39 +2153,7 @@ func (s *server) assembleMergeInput(ctx context.Context, repo, branch, actor str
 // Returns an error only for unexpected infrastructure failures.
 // When readStore or policyCache are nil, or no policies exist, the merge is allowed.
 func (s *server) evaluateMergePolicy(ctx context.Context, repo, branch, actor string) ([]model.PolicyResult, error) {
-	if s.policyCache == nil || s.readStore == nil {
-		return nil, nil
-	}
-
-	engine, owners, err := s.policyCache.Load(ctx, repo, s.readStore)
-	if err != nil {
-		return nil, err
-	}
-	if engine == nil {
-		return nil, nil // bootstrap mode
-	}
-
-	input, err := s.assembleMergeInput(ctx, repo, branch, actor, owners)
-	if err != nil {
-		return nil, err
-	}
-	if input == nil {
-		return nil, nil // branch not found — let the merge handler surface the error
-	}
-
-	results, err := engine.Evaluate(ctx, *input)
-	if err != nil {
-		return nil, fmt.Errorf("evaluate policies: %w", err)
-	}
-
-	// Collect any failing policies.
-	var denied []model.PolicyResult
-	for _, r := range results {
-		if !r.Pass {
-			denied = append(denied, r)
-		}
-	}
-	return denied, nil
+	return mergeutil.EvaluatePolicy(ctx, s.policyCache, s.readStore, s.commitStore, repo, branch, actor)
 }
 
 // ---------------------------------------------------------------------------
@@ -2235,11 +2188,24 @@ func (s *server) handleBranchStatus(w http.ResponseWriter, r *http.Request, repo
 		}
 	}
 
+	// Fetch branch info to populate auto_merge in the response.
+	branchInfo, err := s.readStore.GetBranch(r.Context(), repo, branch)
+	if err != nil {
+		slog.Error("get branch error", "op", "branch_status", "repo", repo, "branch", branch, "error", err)
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if branchInfo == nil {
+		writeError(w, http.StatusNotFound, "branch not found")
+		return
+	}
+
 	if engine == nil {
 		// Bootstrap mode: no policies defined.
 		writeJSON(w, http.StatusOK, model.BranchStatusResponse{
 			Mergeable: true,
 			Policies:  []model.PolicyResult{},
+			AutoMerge: branchInfo.AutoMerge,
 		})
 		return
 	}
@@ -2276,6 +2242,7 @@ func (s *server) handleBranchStatus(w http.ResponseWriter, r *http.Request, repo
 	writeJSON(w, http.StatusOK, model.BranchStatusResponse{
 		Mergeable: mergeable,
 		Policies:  results,
+		AutoMerge: branchInfo.AutoMerge,
 	})
 }
 

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -300,6 +300,11 @@ func roleAllows(role model.RoleType, method, subPath string, r *http.Request) bo
 		return role == model.RoleMaintainer || role == model.RoleAdmin
 	}
 
+	// POST/DELETE /branch/*/auto-merge — writer+.
+	if strings.HasPrefix(subPath, "branch/") && strings.HasSuffix(subPath, "/auto-merge") {
+		return role == model.RoleWriter || role == model.RoleMaintainer || role == model.RoleAdmin
+	}
+
 	// DELETE /branch/* — maintainer+.
 	if method == http.MethodDelete && strings.HasPrefix(subPath, "branch/") {
 		return role == model.RoleMaintainer || role == model.RoleAdmin

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -69,6 +69,7 @@ type WriteStore interface {
 	Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error)
 	CreateBranch(ctx context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error)
 	UpdateBranchDraft(ctx context.Context, repo, name string, draft bool) error
+	SetBranchAutoMerge(ctx context.Context, repo, name string, autoMerge bool) error
 	Merge(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error)
 	DeleteBranch(ctx context.Context, repo, name string) error
 	Rebase(ctx context.Context, req model.RebaseRequest) (*model.RebaseResponse, []db.MergeConflict, error)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -92,6 +92,10 @@ func (m *mockStore) UpdateBranchDraft(ctx context.Context, repo, name string, dr
 	return nil
 }
 
+func (m *mockStore) SetBranchAutoMerge(ctx context.Context, repo, name string, autoMerge bool) error {
+	return nil
+}
+
 func (m *mockStore) Merge(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
 	if m.mergeFn != nil {
 		return m.mergeFn(ctx, req)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -260,6 +260,7 @@ type BranchInfo struct {
 	BaseSequence int64  `json:"base_sequence"`
 	Status       string `json:"status"`
 	Draft        bool   `json:"draft"`
+	AutoMerge    bool   `json:"auto_merge"`
 }
 
 // DiffEntry represents a file changed on a branch relative to its base.
@@ -288,9 +289,9 @@ type DiffResult struct {
 func (s *Store) GetBranch(ctx context.Context, repo, branch string) (*BranchInfo, error) {
 	var b BranchInfo
 	err := s.db.QueryRowContext(ctx,
-		"SELECT name, head_sequence, base_sequence, status, draft FROM branches WHERE repo = $1 AND name = $2",
+		"SELECT name, head_sequence, base_sequence, status, draft, auto_merge FROM branches WHERE repo = $1 AND name = $2",
 		repo, branch,
-	).Scan(&b.Name, &b.HeadSequence, &b.BaseSequence, &b.Status, &b.Draft)
+	).Scan(&b.Name, &b.HeadSequence, &b.BaseSequence, &b.Status, &b.Draft, &b.AutoMerge)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
@@ -304,7 +305,7 @@ func (s *Store) GetBranch(ctx context.Context, repo, branch string) (*BranchInfo
 // includeDraft=true includes draft branches; onlyDraft=true returns only draft branches.
 // By default (both false), draft branches are excluded.
 func (s *Store) ListBranches(ctx context.Context, repo, statusFilter string, includeDraft, onlyDraft bool) ([]BranchInfo, error) {
-	q := "SELECT name, head_sequence, base_sequence, status, draft FROM branches WHERE repo = $1"
+	q := "SELECT name, head_sequence, base_sequence, status, draft, auto_merge FROM branches WHERE repo = $1"
 	args := []interface{}{repo}
 
 	if statusFilter != "" {
@@ -328,7 +329,7 @@ func (s *Store) ListBranches(ctx context.Context, repo, statusFilter string, inc
 	var branches []BranchInfo
 	for rows.Next() {
 		var b BranchInfo
-		if err := rows.Scan(&b.Name, &b.HeadSequence, &b.BaseSequence, &b.Status, &b.Draft); err != nil {
+		if err := rows.Scan(&b.Name, &b.HeadSequence, &b.BaseSequence, &b.Status, &b.Draft, &b.AutoMerge); err != nil {
 			return nil, err
 		}
 		branches = append(branches, b)


### PR DESCRIPTION
## Summary

- Adds `auto_merge` boolean column to branches table (migration 000014)
- New `internal/merge` package extracts `evaluateMergePolicy`/`assembleMergeInput` so the HTTP handler and worker share policy evaluation logic
- New `internal/automerge` worker subscribes to `check.reported` and `review.submitted` events; when a branch has `auto_merge=true`, not draft, and all policies pass, it calls `store.Merge()` directly; on conflict it clears `auto_merge` and emits `BranchAutoMergeFailed`
- Extended broker `fanOutSSE` to check global `"*"` wildcard keys, enabling the worker (and fixing the existing `GET /events` global stream)
- New event types: `BranchAutoMergeEnabled`, `BranchAutoMergeDisabled`, `BranchAutoMergeFailed`
- HTTP handlers `POST/DELETE /repos/:name/-/branch/:bname/auto-merge` (writer+); `BranchStatusResponse` now includes `auto_merge`
- RBAC: writer+ rule for auto-merge endpoints (before the generic DELETE /branch/* maintainer+ rule)
- `Branch` and `BranchStatusResponse` API types include `auto_merge` field
- `GetBranch` and `ListBranches` in read store now select and scan `auto_merge`
- `ds auto-merge enable/disable [--branch <name>]` CLI commands

## Test plan

- [x] `go test ./... -count=1` — all tests pass
- [x] `go build ./...` — clean build
- [x] `go vet ./...` — no issues
- [ ] Integration: enable auto-merge on a branch, report a passing check, verify branch is merged automatically
- [ ] Integration: enable auto-merge, create a conflict, verify `auto_merge` is cleared and `BranchAutoMergeFailed` event is emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)