### PR TITLE
test: add contract coverage for /branches response envelope

### DIFF
--- a/cmd/ci-scheduler/contract_test.go
+++ b/cmd/ci-scheduler/contract_test.go
@@ -1,0 +1,89 @@
+package main
+
+// contract_test.go — cross-package contract test for the /branches wire format.
+//
+// Regression: a previous commit changed fetchBranchHead to decode
+// model.BranchesResponse{"branches":[...]} while the real server handler
+// returns a bare []Branch JSON array. Both sides were wrong in sync so CI
+// stayed green; this test catches the mismatch going forward.
+//
+// The test spins up a real internal/server handler (not a hand-rolled mock),
+// calls GET /repos/.../branches, and feeds the response body into the
+// fetchBranchHead decoder. It fails if either side changes the envelope
+// without the other following.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/server"
+	"github.com/dlorenc/docstore/internal/store"
+)
+
+// contractWriteStore is a minimal WriteStore stub for the contract test.
+// Only GetRepo and HasAdmin are overridden; the embedded nil interface panics
+// if any other method is called, making unintended call paths immediately obvious.
+type contractWriteStore struct {
+	server.WriteStore // nil — panics if any unimplemented method is invoked
+}
+
+func (w *contractWriteStore) GetRepo(_ context.Context, name string) (*model.Repo, error) {
+	return &model.Repo{Name: name}, nil
+}
+
+// HasAdmin returns (false, nil) so the bootstrap-admin grant fires and the
+// request gets admin access without needing a real role entry.
+func (w *contractWriteStore) HasAdmin(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+
+// contractReadStore is a minimal ReadStore stub for the contract test.
+// Only ListBranches is overridden; handleBranches only calls that method.
+type contractReadStore struct {
+	server.ReadStore // nil — panics if any unimplemented method is invoked
+	branches         []store.BranchInfo
+}
+
+func (r *contractReadStore) ListBranches(_ context.Context, _, _ string, _, _ bool) ([]store.BranchInfo, error) {
+	return r.branches, nil
+}
+
+// TestBranchesEndpointContract verifies that the real server handler and the
+// fetchBranchHead decoder agree on the response envelope for GET /-/branches.
+//
+// The test will fail if:
+//   - the server wraps the array (e.g. {"branches":[...]}) — fetchBranchHead
+//     decodes into an empty []Branch and "main" is not found;
+//   - fetchBranchHead wraps the decode target (e.g. BranchesResponse) — the
+//     bare-array JSON from the server fails to decode into the struct.
+func TestBranchesEndpointContract(t *testing.T) {
+	const wantSeq = int64(77)
+
+	testBranches := []store.BranchInfo{
+		{Name: "main", HeadSequence: wantSeq, Status: "active"},
+		{Name: "feat/other", HeadSequence: 3, Status: "active"},
+	}
+
+	// Spin up a real internal/server handler with minimal test doubles.
+	// devIdentity == bootstrapAdmin so the request is granted admin access
+	// without a real role entry in the store.
+	ws := &contractWriteStore{}
+	rs := &contractReadStore{branches: testBranches}
+	handler := server.NewWithReadStore(ws, rs, "contractdev", "contractdev")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// fetchBranchHead builds the URL itself, so only docstoreURL is needed.
+	sched := &scheduler{docstoreURL: srv.URL, httpClient: &http.Client{}}
+
+	seq, err := sched.fetchBranchHead(context.Background(), "testrepo", "main")
+	if err != nil {
+		t.Fatalf("fetchBranchHead failed (likely envelope mismatch): %v", err)
+	}
+	if seq != wantSeq {
+		t.Errorf("head sequence = %d, want %d", seq, wantSeq)
+	}
+}

--- a/cmd/ci-scheduler/main_test.go
+++ b/cmd/ci-scheduler/main_test.go
@@ -604,6 +604,7 @@ func newDocstoreServer(t *testing.T, ciYAML string, branches []map[string]any, p
 			}
 			json.NewEncoder(w).Encode(fileResp{Path: ".docstore/ci.yaml", Content: []byte(ciYAML)}) //nolint:errcheck
 		case strings.Contains(r.URL.Path, "/-/branches"):
+			// Bare array — must match real server format. See TestBranchesEndpointContract.
 			json.NewEncoder(w).Encode(branches) //nolint:errcheck
 		case strings.Contains(r.URL.Path, "/-/proposals"):
 			json.NewEncoder(w).Encode(proposals) //nolint:errcheck
@@ -840,6 +841,7 @@ func newScheduleDocstoreServer(t *testing.T, repoNames []string, headSeq int64, 
 			}
 			json.NewEncoder(w).Encode(fileResp{Path: ".docstore/ci.yaml", Content: []byte(ciYAML)}) //nolint:errcheck
 		case strings.Contains(r.URL.Path, "/-/branches"):
+			// Bare array — must match real server format. See TestBranchesEndpointContract.
 			json.NewEncoder(w).Encode([]map[string]any{ //nolint:errcheck
 				{"name": "main", "head_sequence": headSeq},
 			})
@@ -854,6 +856,13 @@ func newScheduleDocstoreServer(t *testing.T, repoNames []string, headSeq int64, 
 // ---------------------------------------------------------------------------
 
 func TestFetchBranchHead_HappyPath(t *testing.T) {
+	// NOTE: this mock returns a bare JSON array — NOT a wrapped struct like
+	// {"branches":[...]}. The format must match the real server handler in
+	// internal/server/handlers.go (handleBranches). TestBranchesEndpointContract
+	// in contract_test.go enforces this cross-package contract automatically.
+	// Regression: a previous commit decoded model.BranchesResponse here while
+	// the server was returning a bare array; both sides were wrong in sync so
+	// CI stayed green for months before the mismatch was discovered.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode([]map[string]any{ //nolint:errcheck

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -146,6 +146,22 @@ type WriteStore interface {
 // CommitStore is an alias for backward compatibility with tests.
 type CommitStore = WriteStore
 
+// ReadStore is the read-only data access interface used by the server's GET handlers.
+// It is exported so external test packages can inject test doubles for contract tests.
+type ReadStore = readStore
+
+// NewWithReadStore constructs a handler with explicitly injected read and write stores.
+// Intended for contract tests outside this package that need to verify the server's
+// wire format against clients that consume the API (e.g. cmd/ci-scheduler).
+func NewWithReadStore(ws WriteStore, rs ReadStore, devIdentity, bootstrapAdmin string) http.Handler {
+	s := &server{
+		commitStore: ws,
+		readStore:   rs,
+		policyCache: policy.NewCache(),
+	}
+	return s.buildHandler(devIdentity, bootstrapAdmin, ws)
+}
+
 // New returns an http.Handler with all routes registered.
 // devIdentity, if non-empty, bypasses IAP JWT validation (for local dev/testing).
 // bootstrapAdmin, if non-empty, has admin access to any repo with no existing admin.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1127,6 +1127,16 @@ func TestHandleBranches_DraftFilter(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
 	}
+	// Assert the response is a bare []store.BranchInfo, not a wrapped envelope.
+	// This catches any change that wraps the array (e.g. {"branches":[...]})
+	// which would break clients like cmd/ci-scheduler that decode the bare array.
+	var branches []store.BranchInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &branches); err != nil {
+		t.Fatalf("response body not decodeable as []store.BranchInfo (envelope mismatch?): %v\nbody: %s", err, rec.Body.String())
+	}
+	if len(branches) == 0 {
+		t.Fatal("expected at least one branch in decoded response")
+	}
 	if !gotOnlyDraft {
 		t.Error("expected onlyDraft=true to be passed to store")
 	}
@@ -1138,6 +1148,11 @@ func TestHandleBranches_DraftFilter(t *testing.T) {
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
+	// Assert response shape for second request too.
+	var branches2 []store.BranchInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &branches2); err != nil {
+		t.Fatalf("second response body not decodeable as []store.BranchInfo: %v", err)
+	}
 	if !gotIncludeDraft {
 		t.Error("expected includeDraft=true to be passed to store")
 	}


### PR DESCRIPTION
## Summary

- Adds `TestBranchesEndpointContract` in `cmd/ci-scheduler/contract_test.go`: spins up a real `internal/server` handler via new `server.NewWithReadStore`, calls `GET /-/branches`, and feeds the response through `fetchBranchHead` — fails if either side changes the JSON envelope without the other following
- Adds response shape assertion to `TestHandleBranches_DraftFilter` in `internal/server/server_test.go`: decodes response body as `[]store.BranchInfo` so any wrapping struct breaks the test
- Adds comments to all branches mocks in `cmd/ci-scheduler/main_test.go` noting the bare-array contract and referencing the contract test

Prevents regression of the BranchesResponse wrapping bug fixed in #255. Both the server handler and the ci-scheduler decoder were wrong in sync, so CI stayed green for months before the mismatch was discovered.

## Test plan

- [x] `go test ./cmd/ci-scheduler/... ./internal/server/... -count=1` passes locally
- [x] `go build ./...` and `go vet ./...` clean
- [ ] Verify `TestBranchesEndpointContract` fails if `fetchBranchHead` is reverted to decode `model.BranchesResponse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)