### PR TITLE
fix(deploy): make KEDA Helm install idempotent and reliable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,6 +160,16 @@ jobs:
           DIGEST=$(jq -r '."containerimage.digest"' /tmp/ci-worker-metadata.json)
           echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
+      - name: Install KEDA via Helm
+        run: |
+          helm repo add kedacore https://kedacore.github.io/charts
+          helm repo update
+          helm upgrade --install keda kedacore/keda \
+            --namespace keda \
+            --create-namespace \
+            --wait \
+            --timeout 180s
+
       - name: Deploy ci-worker to GKE
         run: |
           kubectl delete deployment ci-worker --ignore-not-found -n docstore-ci


### PR DESCRIPTION
## Summary

- Adds a dedicated **Install KEDA via Helm** step to the `build-and-deploy-ci-worker` job
- Replaces any prior `helm install` usage with `helm upgrade --install`, making the step idempotent on both fresh clusters and re-runs
- `--wait --timeout 180s` ensures the KEDA operator and CRDs are fully ready before the ScaledJob manifest is applied
- `--create-namespace` handles the `keda` namespace if it doesn't exist yet

## Why

`helm install` fails if the release already exists, leaving KEDA in a broken state with incomplete RBAC. This caused the keda-operator to crash for 20+ hours due to missing permissions on secrets and leases in the `keda` namespace.

## Test plan

- [ ] Verify workflow runs cleanly on next push to `main`
- [ ] Confirm `helm upgrade --install` exits 0 when KEDA is already installed (idempotency)
- [ ] Confirm ScaledJob patch step succeeds after KEDA install

🤖 Generated with [Claude Code](https://claude.com/claude-code)