### PR TITLE
fix(ci-worker): retry DB ping to allow cloud-sql-proxy sidecar startup

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -365,15 +365,25 @@ func main() {
 	}
 	waitCancel()
 
-	// Connect to Postgres.
+	// Connect to Postgres — retry to allow cloud-sql-proxy sidecar time to start.
 	sqlDB, err := sql.Open("postgres", dbURL)
 	if err != nil {
 		slog.Error("open db", "error", err)
 		os.Exit(1)
 	}
-	if err := sqlDB.Ping(); err != nil {
-		slog.Error("ping db", "error", err)
-		os.Exit(1)
+	{
+		dbCtx, dbCancel := context.WithTimeout(ctx, 2*time.Minute)
+		for {
+			if err := sqlDB.PingContext(dbCtx); err == nil {
+				break
+			} else if dbCtx.Err() != nil {
+				slog.Error("ping db: timed out waiting for cloud-sql-proxy", "error", err)
+				os.Exit(1)
+			}
+			slog.Info("waiting for db", "error", err)
+			time.Sleep(2 * time.Second)
+		}
+		dbCancel()
 	}
 	defer sqlDB.Close()
 	store := db.NewStore(sqlDB)


### PR DESCRIPTION
## Summary

With the ScaledJob approach (#256), fresh pods start with no grace period. The ci-worker was immediately failing on DB connection refused before the cloud-sql-proxy sidecar was ready.

Add a 2-minute retry loop for the DB ping, matching the existing pattern used for buildkitd/dockerd startup waits.

## Root Cause

ScaledJob creates fresh Job pods per queue item. Unlike a long-running Deployment, there's no pre-warmed sidecar — cloud-sql-proxy needs a moment to initialize on each new pod.

## Test plan
- [ ] ScaledJob pods no longer fail immediately on fresh start
- [ ] DB connections succeed once cloud-sql-proxy sidecar is ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)