### PR TITLE
ci: remove KEDA Helm install step re-added by #258

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,16 +160,6 @@ jobs:
           DIGEST=$(jq -r '."containerimage.digest"' /tmp/ci-worker-metadata.json)
           echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
-      - name: Install KEDA via Helm
-        run: |
-          helm repo add kedacore https://kedacore.github.io/charts
-          helm repo update
-          helm upgrade --install keda kedacore/keda \
-            --namespace keda \
-            --create-namespace \
-            --wait \
-            --timeout 180s
-
       - name: Deploy ci-worker to GKE
         run: |
           kubectl delete deployment ci-worker --ignore-not-found -n docstore-ci


### PR DESCRIPTION
## Summary

- Removes the `Install KEDA via Helm` step from `build-and-deploy-ci-worker` that was re-added by #258
- No `azure/setup-helm` step was present (it was not re-added)
- KEDA is already installed in the cluster; the `docstore-deployer` service account lacks the cluster-scope permissions (`validatingWebhookConfigurations`, `clusterRoles`) required to run `helm upgrade --install keda`
- Deploy was green after #256 (ScaledJob) and #257; #258 broke it by adding back the Helm install

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./... -count=1` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)