### PR TITLE
fix(ci-worker): signal cloud-sql-proxy to exit so ScaledJob pods complete

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -365,15 +365,25 @@ func main() {
 	}
 	waitCancel()
 
-	// Connect to Postgres.
+	// Connect to Postgres — retry to allow cloud-sql-proxy sidecar time to start.
 	sqlDB, err := sql.Open("postgres", dbURL)
 	if err != nil {
 		slog.Error("open db", "error", err)
 		os.Exit(1)
 	}
-	if err := sqlDB.Ping(); err != nil {
-		slog.Error("ping db", "error", err)
-		os.Exit(1)
+	{
+		dbCtx, dbCancel := context.WithTimeout(ctx, 2*time.Minute)
+		for {
+			if err := sqlDB.PingContext(dbCtx); err == nil {
+				break
+			} else if dbCtx.Err() != nil {
+				slog.Error("ping db: timed out waiting for cloud-sql-proxy", "error", err)
+				os.Exit(1)
+			}
+			slog.Info("waiting for db", "error", err)
+			time.Sleep(2 * time.Second)
+		}
+		dbCancel()
 	}
 	defer sqlDB.Close()
 	store := db.NewStore(sqlDB)

--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	exec2 "os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -484,4 +485,10 @@ func main() {
 	shutdownCtx, shutdownCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer shutdownCancel()
 	_ = logHTTP.Shutdown(shutdownCtx)
+
+	// Signal cloud-sql-proxy sidecar to exit so the Job pod reaches Succeeded.
+	// Requires shareProcessNamespace: true on the pod spec.
+	if out, err := exec2.Command("pkill", "-TERM", "cloud-sql-proxy").CombinedOutput(); err != nil {
+		slog.Info("cloud-sql-proxy not signalled (not running?)", "output", string(out))
+	}
 }

--- a/deploy/k8s/ci-worker.yaml
+++ b/deploy/k8s/ci-worker.yaml
@@ -32,6 +32,7 @@ spec:
     template:
       spec:
         restartPolicy: Never
+        shareProcessNamespace: true
         serviceAccountName: ci-worker
         runtimeClassName: kata-clh
         nodeSelector:


### PR DESCRIPTION
## Summary

With ScaledJob, a pod only reaches `Succeeded` when **all** containers exit. The cloud-sql-proxy sidecar runs indefinitely, preventing Job completion and leaving queue items stuck in `claimed` state.

Fix:
- Add `shareProcessNamespace: true` to the pod spec so the ci-worker process can signal the sidecar
- Send `SIGTERM` to cloud-sql-proxy at the end of `main` so the pod exits cleanly

## Root Cause

ScaledJob pods must reach `Succeeded` for KEDA to decrement the queue depth counter. A stuck sidecar blocks this, causing queue items to never be freed.

## Test plan
- [ ] ScaledJob pods reach `Succeeded` state after job completes
- [ ] Queue items are no longer stuck in `claimed` state

🤖 Generated with [Claude Code](https://claude.com/claude-code)