### PR TITLE
feat: agent context assembly endpoint

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -834,6 +834,26 @@ type ListIssueRefsResponse struct {
 }
 
 // ---------------------------------------------------------------------------
+// GET /repos/:name/-/branch/:branch/agent-context
+// ---------------------------------------------------------------------------
+
+// AgentContextResponse is the response for GET /repos/:name/-/branch/:branch/agent-context.
+// It bundles diff, reviews, check runs, proposals, linked issues, file ownership,
+// recent commits, policy results, and mergeability in one atomic snapshot for LLM agents.
+type AgentContextResponse struct {
+	Branch        Branch              `json:"branch"`
+	Diff          DiffResponse        `json:"diff"`
+	Reviews       []Review            `json:"reviews"`
+	CheckRuns     []CheckRun          `json:"check_runs"`
+	Proposals     []Proposal          `json:"proposals"`
+	LinkedIssues  []Issue             `json:"linked_issues"`
+	FileOwnership map[string][]string `json:"file_ownership"`
+	RecentCommits []ChainEntry        `json:"recent_commits"`
+	Policies      []PolicyResult      `json:"policies"`
+	Mergeable     bool                `json:"mergeable"`
+}
+
+// ---------------------------------------------------------------------------
 // Errors
 // ---------------------------------------------------------------------------
 

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -102,4 +102,6 @@ type AddIssueRefRequest = api.AddIssueRefRequest
 type AddIssueRefResponse = api.AddIssueRefResponse
 type ListIssueRefsResponse = api.ListIssueRefsResponse
 
+type AgentContextResponse = api.AgentContextResponse
+
 type ErrorResponse = api.ErrorResponse

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -273,6 +273,9 @@ func (s *server) handleReposPrefix(w http.ResponseWriter, r *http.Request) {
 				if strings.HasSuffix(bpath, "/status") {
 					branchName := strings.TrimSuffix(bpath, "/status")
 					s.handleBranchStatus(w, r, repoName, branchName)
+				} else if strings.HasSuffix(bpath, "/agent-context") {
+					branchName := strings.TrimSuffix(bpath, "/agent-context")
+					s.handleAgentContext(w, r, repoName, branchName)
 				} else {
 					r.SetPathValue("branch", bpath)
 					s.handleBranchGet(w, r)
@@ -2243,6 +2246,260 @@ func (s *server) handleBranchStatus(w http.ResponseWriter, r *http.Request, repo
 		Mergeable: mergeable,
 		Policies:  results,
 		AutoMerge: branchInfo.AutoMerge,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Agent context handler
+// ---------------------------------------------------------------------------
+
+// handleAgentContext implements GET /repos/:name/-/branch/:branch/agent-context.
+// It assembles all branch review context in a single atomic response for LLM agents,
+// following the same assembly logic as handleBranchStatus.
+func (s *server) handleAgentContext(w http.ResponseWriter, r *http.Request, repo, branch string) {
+	if s.readStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "read store not available")
+		return
+	}
+
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	ctx := r.Context()
+	actor := IdentityFromContext(ctx)
+
+	// Load branch info.
+	branchInfo, err := s.readStore.GetBranch(ctx, repo, branch)
+	if err != nil {
+		slog.Error("internal error", "op", "agent_context_branch", "repo", repo, "branch", branch, "error", err)
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if branchInfo == nil {
+		writeError(w, http.StatusNotFound, "branch not found")
+		return
+	}
+
+	// Load diff.
+	diff, err := s.readStore.GetDiff(ctx, repo, branch)
+	if err != nil {
+		slog.Error("internal error", "op", "agent_context_diff", "repo", repo, "branch", branch, "error", err)
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if diff == nil {
+		diff = &store.DiffResult{}
+	}
+
+	// Load reviews filtered to current head sequence.
+	reviews, err := s.commitStore.ListReviews(ctx, repo, branch, &branchInfo.HeadSequence)
+	if err != nil {
+		slog.Error("internal error", "op", "agent_context_reviews", "repo", repo, "branch", branch, "error", err)
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if reviews == nil {
+		reviews = []model.Review{}
+	}
+
+	// Load check runs filtered to current head sequence.
+	checkRuns, err := s.commitStore.ListCheckRuns(ctx, repo, branch, &branchInfo.HeadSequence)
+	if err != nil {
+		slog.Error("internal error", "op", "agent_context_checks", "repo", repo, "branch", branch, "error", err)
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if checkRuns == nil {
+		checkRuns = []model.CheckRun{}
+	}
+
+	// Load the open proposal for this branch (if any).
+	openState := model.ProposalOpen
+	proposalPtrs, err := s.commitStore.ListProposals(ctx, repo, &openState, &branch)
+	if err != nil {
+		slog.Error("internal error", "op", "agent_context_proposals", "repo", repo, "branch", branch, "error", err)
+		writeError(w, http.StatusInternalServerError, "query failed")
+		return
+	}
+	proposals := make([]model.Proposal, len(proposalPtrs))
+	for i, p := range proposalPtrs {
+		proposals[i] = *p
+	}
+
+	// Load linked issues from the first open proposal (if one exists).
+	linkedIssues := []model.Issue{}
+	if len(proposalPtrs) > 0 {
+		linkedIssues, err = s.commitStore.ListIssuesByRef(ctx, repo, model.IssueRefTypeProposal, proposalPtrs[0].ID)
+		if err != nil {
+			slog.Error("internal error", "op", "agent_context_issues", "repo", repo, "branch", branch, "error", err)
+			writeError(w, http.StatusInternalServerError, "query failed")
+			return
+		}
+		if linkedIssues == nil {
+			linkedIssues = []model.Issue{}
+		}
+	}
+
+	// Collect recent commits on this branch via the chain.
+	// Cap to the last 50 sequences to bound the query range.
+	const maxCommitRange = int64(50)
+	recentCommits := []store.ChainEntry{}
+	if branchInfo.HeadSequence > branchInfo.BaseSequence {
+		from := branchInfo.BaseSequence + 1
+		if branchInfo.HeadSequence-from+1 > maxCommitRange {
+			from = branchInfo.HeadSequence - maxCommitRange + 1
+		}
+		chainEntries, err := s.readStore.GetChain(ctx, repo, from, branchInfo.HeadSequence)
+		if err != nil {
+			slog.Error("internal error", "op", "agent_context_commits", "repo", repo, "branch", branch, "error", err)
+			writeError(w, http.StatusInternalServerError, "query failed")
+			return
+		}
+		for _, e := range chainEntries {
+			if e.Branch == branch {
+				recentCommits = append(recentCommits, e)
+			}
+		}
+	}
+
+	// Collect changed paths for ownership resolution.
+	var changedPaths []string
+	for _, e := range diff.BranchChanges {
+		changedPaths = append(changedPaths, e.Path)
+	}
+
+	// Load policies and resolve file ownership.
+	fileOwnership := make(map[string][]string)
+	policyResults := []model.PolicyResult{}
+	mergeable := true
+
+	if s.policyCache != nil {
+		engine, owners, err := s.policyCache.Load(ctx, repo, s.readStore)
+		if err != nil {
+			slog.Error("policy cache load error", "op", "agent_context", "repo", repo, "error", err)
+			writeError(w, http.StatusInternalServerError, "policy evaluation error")
+			return
+		}
+		if engine != nil {
+			// Resolve file ownership per changed path.
+			for _, p := range changedPaths {
+				fileOwnership[p] = policy.ResolveOwners(owners, p)
+			}
+
+			// Get actor roles for policy input.
+			actorRoles := []string{}
+			if role, err := s.commitStore.GetRole(ctx, repo, actor); err == nil && role != nil {
+				actorRoles = []string{string(role.Role)}
+			}
+
+			// Build proposal input for policy evaluation.
+			var proposalInput *policy.ProposalInput
+			if len(proposalPtrs) > 0 {
+				p := proposalPtrs[0]
+				proposalInput = &policy.ProposalInput{
+					ID:         p.ID,
+					BaseBranch: p.BaseBranch,
+					Title:      p.Title,
+					State:      string(p.State),
+				}
+			}
+
+			// Build review and check inputs.
+			reviewInputs := make([]policy.ReviewInput, len(reviews))
+			for i, rev := range reviews {
+				reviewInputs[i] = policy.ReviewInput{
+					Reviewer: rev.Reviewer,
+					Status:   string(rev.Status),
+					Sequence: rev.Sequence,
+				}
+			}
+			checkInputs := make([]policy.CheckRunInput, len(checkRuns))
+			for i, cr := range checkRuns {
+				checkInputs[i] = policy.CheckRunInput{
+					CheckName: cr.CheckName,
+					Status:    string(cr.Status),
+					Sequence:  cr.Sequence,
+				}
+			}
+			resolvedOwners := make(map[string][]string)
+			for _, p := range changedPaths {
+				resolvedOwners[p] = policy.ResolveOwners(owners, p)
+			}
+
+			input := policy.Input{
+				Actor:        actor,
+				ActorRoles:   actorRoles,
+				Action:       "merge",
+				Repo:         repo,
+				Branch:       branch,
+				Draft:        branchInfo.Draft,
+				ChangedPaths: changedPaths,
+				Reviews:      reviewInputs,
+				CheckRuns:    checkInputs,
+				Owners:       resolvedOwners,
+				HeadSeq:      branchInfo.HeadSequence,
+				BaseSeq:      branchInfo.BaseSequence,
+				Proposal:     proposalInput,
+			}
+
+			results, err := engine.Evaluate(ctx, input)
+			if err != nil {
+				slog.Error("policy evaluation error", "op", "agent_context", "repo", repo, "branch", branch, "error", err)
+				writeError(w, http.StatusInternalServerError, "policy evaluation error")
+				return
+			}
+			if results != nil {
+				policyResults = results
+			}
+			for _, res := range policyResults {
+				if !res.Pass {
+					mergeable = false
+					break
+				}
+			}
+		}
+	}
+
+	// Convert diff from store types to API types.
+	diffResp := model.DiffResponse{
+		BranchChanges: make([]model.DiffEntry, len(diff.BranchChanges)),
+		MainChanges:   make([]model.DiffEntry, len(diff.MainChanges)),
+	}
+	for i, e := range diff.BranchChanges {
+		diffResp.BranchChanges[i] = model.DiffEntry{Path: e.Path, VersionID: e.VersionID, Binary: e.Binary}
+	}
+	for i, e := range diff.MainChanges {
+		diffResp.MainChanges[i] = model.DiffEntry{Path: e.Path, VersionID: e.VersionID, Binary: e.Binary}
+	}
+	for _, c := range diff.Conflicts {
+		diffResp.Conflicts = append(diffResp.Conflicts, model.ConflictEntry{
+			Path:            c.Path,
+			MainVersionID:   c.MainVersionID,
+			BranchVersionID: c.BranchVersionID,
+		})
+	}
+
+	branchResp := model.Branch{
+		Name:         branchInfo.Name,
+		HeadSequence: branchInfo.HeadSequence,
+		BaseSequence: branchInfo.BaseSequence,
+		Status:       model.BranchStatus(branchInfo.Status),
+		Draft:        branchInfo.Draft,
+		AutoMerge:    branchInfo.AutoMerge,
+	}
+
+	writeJSON(w, http.StatusOK, model.AgentContextResponse{
+		Branch:        branchResp,
+		Diff:          diffResp,
+		Reviews:       reviews,
+		CheckRuns:     checkRuns,
+		Proposals:     proposals,
+		LinkedIssues:  linkedIssues,
+		FileOwnership: fileOwnership,
+		RecentCommits: recentCommits,
+		Policies:      policyResults,
+		Mergeable:     mergeable,
 	})
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -72,6 +72,9 @@ type mockStore struct {
 	listSubscriptionsByCreatorFn     func(ctx context.Context, createdBy string) ([]model.EventSubscription, error)
 	deleteSubscriptionFn             func(ctx context.Context, id string) error
 	resumeSubscriptionFn             func(ctx context.Context, id string) error
+
+	listProposalsFn   func(ctx context.Context, repo string, state *model.ProposalState, branch *string) ([]*model.Proposal, error)
+	listIssuesByRefFn func(ctx context.Context, repo string, refType model.IssueRefType, refID string) ([]model.Issue, error)
 }
 
 func (m *mockStore) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
@@ -394,7 +397,10 @@ func (m *mockStore) GetProposal(_ context.Context, _, _ string) (*model.Proposal
 	return nil, db.ErrProposalNotFound
 }
 
-func (m *mockStore) ListProposals(_ context.Context, _ string, _ *model.ProposalState, _ *string) ([]*model.Proposal, error) {
+func (m *mockStore) ListProposals(ctx context.Context, repo string, state *model.ProposalState, branch *string) ([]*model.Proposal, error) {
+	if m.listProposalsFn != nil {
+		return m.listProposalsFn(ctx, repo, state, branch)
+	}
 	return []*model.Proposal{}, nil
 }
 
@@ -477,7 +483,10 @@ func (m *mockStore) CreateIssueRef(_ context.Context, _ string, _ int64, _ model
 func (m *mockStore) ListIssueRefs(_ context.Context, _ string, _ int64) ([]model.IssueRef, error) {
 	return []model.IssueRef{}, nil
 }
-func (m *mockStore) ListIssuesByRef(_ context.Context, _ string, _ model.IssueRefType, _ string) ([]model.Issue, error) {
+func (m *mockStore) ListIssuesByRef(ctx context.Context, repo string, refType model.IssueRefType, refID string) ([]model.Issue, error) {
+	if m.listIssuesByRefFn != nil {
+		return m.listIssuesByRefFn(ctx, repo, refType, refID)
+	}
 	return []model.Issue{}, nil
 }
 
@@ -3563,5 +3572,240 @@ func TestHandleArchive_BranchNotFound(t *testing.T) {
 	h.ServeHTTP(w, req)
 	if w.Code != http.StatusNotFound {
 		t.Errorf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Agent context handler tests
+// ---------------------------------------------------------------------------
+
+// TestAgentContext_NoReadStore verifies 503 when the server has no read store.
+func TestAgentContext_NoReadStore(t *testing.T) {
+	srv := New(nil, nil, devID, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/feature/x/agent-context", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestAgentContext_BranchNotFound verifies 404 when the branch does not exist.
+func TestAgentContext_BranchNotFound(t *testing.T) {
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
+			return nil, nil
+		},
+	}
+	ms := &mockStore{
+		listReviewsFn:   func(_ context.Context, _, _ string, _ *int64) ([]model.Review, error) { return nil, nil },
+		listCheckRunsFn: func(_ context.Context, _, _ string, _ *int64) ([]model.CheckRun, error) { return nil, nil },
+	}
+	srv := newTestHandler(ms, rs, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/nonexistent/agent-context", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestAgentContext_Bootstrap verifies that the endpoint returns 200 with a
+// complete response when no policies are defined (bootstrap mode).
+func TestAgentContext_Bootstrap(t *testing.T) {
+	vid := "v1"
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, branch string) (*store.BranchInfo, error) {
+			return &store.BranchInfo{
+				Name:         branch,
+				HeadSequence: 3,
+				BaseSequence: 1,
+				Status:       "active",
+				Draft:        false,
+			}, nil
+		},
+		getDiffFn: func(_ context.Context, _, _ string) (*store.DiffResult, error) {
+			return &store.DiffResult{
+				BranchChanges: []store.DiffEntry{{Path: "foo.go", VersionID: &vid}},
+			}, nil
+		},
+		getChainFn: func(_ context.Context, _ string, from, to int64) ([]store.ChainEntry, error) {
+			return []store.ChainEntry{
+				{Sequence: 2, Branch: "feature/x", Author: "alice", Message: "add foo"},
+				{Sequence: 3, Branch: "feature/x", Author: "alice", Message: "fix foo"},
+			}, nil
+		},
+	}
+	ms := &mockStore{
+		listReviewsFn: func(_ context.Context, _, _ string, _ *int64) ([]model.Review, error) {
+			return []model.Review{{ID: "r1", Branch: "feature/x", Reviewer: "bob", Status: model.ReviewApproved}}, nil
+		},
+		listCheckRunsFn: func(_ context.Context, _, _ string, _ *int64) ([]model.CheckRun, error) {
+			return []model.CheckRun{{ID: "c1", CheckName: "ci", Status: model.CheckRunPassed}}, nil
+		},
+	}
+	// nil policy cache → bootstrap mode
+	srv := newTestHandler(ms, rs, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/feature/x/agent-context", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.AgentContextResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Branch.Name != "feature/x" {
+		t.Errorf("expected branch name feature/x, got %q", resp.Branch.Name)
+	}
+	if resp.Branch.HeadSequence != 3 {
+		t.Errorf("expected head_sequence 3, got %d", resp.Branch.HeadSequence)
+	}
+	if len(resp.Diff.BranchChanges) != 1 || resp.Diff.BranchChanges[0].Path != "foo.go" {
+		t.Errorf("unexpected diff: %+v", resp.Diff)
+	}
+	if len(resp.Reviews) != 1 || resp.Reviews[0].ID != "r1" {
+		t.Errorf("unexpected reviews: %+v", resp.Reviews)
+	}
+	if len(resp.CheckRuns) != 1 || resp.CheckRuns[0].CheckName != "ci" {
+		t.Errorf("unexpected check_runs: %+v", resp.CheckRuns)
+	}
+	if len(resp.RecentCommits) != 2 {
+		t.Errorf("expected 2 recent commits, got %d: %+v", len(resp.RecentCommits), resp.RecentCommits)
+	}
+	if !resp.Mergeable {
+		t.Error("expected mergeable=true in bootstrap mode")
+	}
+	if len(resp.Policies) != 0 {
+		t.Errorf("expected no policies in bootstrap mode, got: %+v", resp.Policies)
+	}
+}
+
+// TestAgentContext_PolicyDeny verifies that a failing policy sets mergeable=false.
+func TestAgentContext_PolicyDeny(t *testing.T) {
+	engine := mustBuildEngine(t, "require_review", `
+package docstore.require_review
+default allow = false
+default reason = "a review is required"
+`)
+
+	ms := &mockStore{
+		listReviewsFn:   func(_ context.Context, _, _ string, _ *int64) ([]model.Review, error) { return nil, nil },
+		listCheckRunsFn: func(_ context.Context, _, _ string, _ *int64) ([]model.CheckRun, error) { return nil, nil },
+	}
+	pc := &mockPolicyCache{
+		loadFn: func(_ context.Context, _ string, _ policy.ReadStore) (*policy.Engine, map[string][]string, error) {
+			return engine, nil, nil
+		},
+	}
+	rs := &mockReadStore{}
+
+	srv := newTestHandler(ms, rs, pc)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/feature/x/agent-context", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.AgentContextResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Mergeable {
+		t.Error("expected mergeable=false with denying policy")
+	}
+	if len(resp.Policies) != 1 || resp.Policies[0].Pass {
+		t.Errorf("expected 1 failing policy, got: %+v", resp.Policies)
+	}
+}
+
+// TestAgentContext_PolicyAllow verifies that an allowing policy sets mergeable=true.
+func TestAgentContext_PolicyAllow(t *testing.T) {
+	engine := mustBuildEngine(t, "always_allow", `
+package docstore.always_allow
+default allow = true
+`)
+
+	ms := &mockStore{
+		listReviewsFn:   func(_ context.Context, _, _ string, _ *int64) ([]model.Review, error) { return nil, nil },
+		listCheckRunsFn: func(_ context.Context, _, _ string, _ *int64) ([]model.CheckRun, error) { return nil, nil },
+	}
+	pc := &mockPolicyCache{
+		loadFn: func(_ context.Context, _ string, _ policy.ReadStore) (*policy.Engine, map[string][]string, error) {
+			return engine, nil, nil
+		},
+	}
+	rs := &mockReadStore{}
+
+	srv := newTestHandler(ms, rs, pc)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/feature/x/agent-context", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.AgentContextResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Mergeable {
+		t.Errorf("expected mergeable=true with allowing policy, policies: %+v", resp.Policies)
+	}
+}
+
+// TestAgentContext_LinkedIssues verifies that linked issues are included when a
+// proposal exists for the branch.
+func TestAgentContext_LinkedIssues(t *testing.T) {
+	proposalID := "prop-1"
+	ms := &mockStore{
+		listReviewsFn:   func(_ context.Context, _, _ string, _ *int64) ([]model.Review, error) { return nil, nil },
+		listCheckRunsFn: func(_ context.Context, _, _ string, _ *int64) ([]model.CheckRun, error) { return nil, nil },
+		listProposalsFn: func(_ context.Context, _ string, _ *model.ProposalState, _ *string) ([]*model.Proposal, error) {
+			return []*model.Proposal{
+				{ID: proposalID, Branch: "feature/x", BaseBranch: "main", Title: "my proposal", State: model.ProposalOpen},
+			}, nil
+		},
+		listIssuesByRefFn: func(_ context.Context, _ string, refType model.IssueRefType, refID string) ([]model.Issue, error) {
+			if refType != model.IssueRefTypeProposal || refID != proposalID {
+				return nil, nil
+			}
+			return []model.Issue{{ID: "issue-1", Number: 42, Title: "Fix bug"}}, nil
+		},
+	}
+	rs := &mockReadStore{}
+	srv := newTestHandler(ms, rs, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/feature/x/agent-context", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp model.AgentContextResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Proposals) != 1 || resp.Proposals[0].ID != proposalID {
+		t.Errorf("expected 1 proposal with ID %q, got: %+v", proposalID, resp.Proposals)
+	}
+	if len(resp.LinkedIssues) != 1 || resp.LinkedIssues[0].Number != 42 {
+		t.Errorf("expected 1 linked issue with number 42, got: %+v", resp.LinkedIssues)
 	}
 }


### PR DESCRIPTION
## Summary

- Implements issue #252: adds `GET /repos/{owner}/{name}/-/branch/{branch}/agent-context` endpoint
- Returns a single aggregated document with diff, reviews, check runs, proposals, linked issues, file ownership, recent commits, policy results, and mergeability status
- Follows `handleBranchStatus` patterns — validates repo, assembles merge input, evaluates policies
- Caps recent commits to last 50 sequence range to bound query cost

## Changes

- `api/types.go`: new `AgentContextResponse` struct
- `internal/model/api.go`: alias for `AgentContextResponse`
- `internal/server/handlers.go`: new `handleAgentContext()` handler + wire into dispatcher
- `internal/server/server_test.go`: 6 new tests (no readStore, branch not found, bootstrap mode, policy deny, policy allow, linked issues)

## Test plan

- [x] `go test ./... -count=1` — all tests pass
- [x] `go build ./...` — clean build
- [x] `go vet ./...` — no issues
- [x] `TestAgentContext_NoReadStore` — 503 without read store
- [x] `TestAgentContext_BranchNotFound` — 404 for missing branch
- [x] `TestAgentContext_Bootstrap` — 200 with full response in bootstrap mode
- [x] `TestAgentContext_PolicyDeny` — mergeable=false with denying policy
- [x] `TestAgentContext_PolicyAllow` — mergeable=true with allowing policy
- [x] `TestAgentContext_LinkedIssues` — linked issues populated from proposal ref

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)