### PR TITLE
feat(ui): minimal read-only web UI

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -1,0 +1,192 @@
+// Command ui-preview boots the minimal docstore UI against in-memory fake data.
+// Run `go run ./cmd/ui-preview` and visit http://localhost:8090/ui/ to preview
+// the UI without a database.
+//
+// This command is for local preview only and is not wired into production.
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/dlorenc/docstore/api"
+	"github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/store"
+	"github.com/dlorenc/docstore/internal/ui"
+)
+
+// ---------------------------------------------------------------------------
+// Fake data
+// ---------------------------------------------------------------------------
+
+type fakeRead struct{}
+
+func (fakeRead) MaterializeTree(_ context.Context, _ , _ string, _ *int64, _ int, _ string) ([]store.TreeEntry, error) {
+	return []store.TreeEntry{
+		{Path: "README.md", VersionID: "v-readme-01", ContentHash: "sha256:a1b2c3d4e5f6a7b8c9d0"},
+		{Path: "docs/intro.md", VersionID: "v-intro-02", ContentHash: "sha256:abc123def456789abcd0"},
+		{Path: "docs/architecture.md", VersionID: "v-arch-03", ContentHash: "sha256:def456abc789123def00"},
+		{Path: "docs/guides/onboarding.md", VersionID: "v-onb-04", ContentHash: "sha256:111222333444555666ff"},
+		{Path: "policies/reviewers.rego", VersionID: "v-pol-05", ContentHash: "sha256:999888777666aaa0bbb0"},
+		{Path: "OWNERS", VersionID: "v-own-06", ContentHash: "sha256:000111222333444555aa"},
+	}, nil
+}
+
+func (fakeRead) GetFile(_ context.Context, _, _, path string, _ *int64) (*store.FileContent, error) {
+	content := map[string][]byte{
+		"README.md":                  []byte("# acme/platform\n\nShared configuration and policy for Acme Corp.\n\nSee `docs/intro.md` to get started.\n"),
+		"docs/intro.md":              []byte("# Introduction\n\nThis repo stores **versioned structured data**. All writes go\nthrough a proposal workflow with CI checks and reviewer policy gates.\n\nNew here? Read `docs/guides/onboarding.md` next.\n"),
+		"docs/architecture.md":       []byte("# Architecture\n\n- Content-addressable blob store\n- Postgres-backed branch/commit metadata\n- OPA-enforced merge policy\n- Agent-friendly JSON + minimal web UI\n"),
+		"docs/guides/onboarding.md":  []byte("# Onboarding\n\n1. `ds orgs create acme`\n2. `ds repos create acme/platform`\n3. `ds roles set acme/platform you@example.com writer`\n4. Start branching!\n"),
+		"policies/reviewers.rego":    []byte("package docstore.policy\n\n# Require at least one approval before merge.\ndeny[msg] {\n    count({r | r := input.reviews[_]; r.status == \"approved\"}) == 0\n    msg := \"at least one approval required\"\n}\n"),
+		"OWNERS":                     []byte("# Path-scoped reviewers.\n* @ajay @sam\n/policies/ @security-team\n/docs/ @docs-team\n"),
+	}
+	if c, ok := content[path]; ok {
+		return &store.FileContent{Path: path, VersionID: "v-" + path, ContentHash: "sha256:preview", Content: c, ContentType: "text/markdown"}, nil
+	}
+	return nil, nil
+}
+
+func (fakeRead) GetBranch(_ context.Context, _, _ string) (*store.BranchInfo, error) { return nil, nil }
+
+func (fakeRead) ListBranches(_ context.Context, repo, _ string, _, _ bool) ([]store.BranchInfo, error) {
+	if repo != "acme/platform" {
+		return []store.BranchInfo{{Name: "main", HeadSequence: 3, BaseSequence: 0, Status: "active"}}, nil
+	}
+	return []store.BranchInfo{
+		{Name: "main", HeadSequence: 42, BaseSequence: 0, Status: "active"},
+		{Name: "add-onboarding-guide", HeadSequence: 47, BaseSequence: 42, Status: "active"},
+		{Name: "tighten-reviewer-policy", HeadSequence: 45, BaseSequence: 42, Status: "active", AutoMerge: true},
+		{Name: "wip-refactor", HeadSequence: 44, BaseSequence: 42, Status: "active", Draft: true},
+		{Name: "bump-arch-doc", HeadSequence: 48, BaseSequence: 42, Status: "merged"},
+		{Name: "old-experiment", HeadSequence: 31, BaseSequence: 20, Status: "abandoned"},
+	}, nil
+}
+
+type fakeWrite struct{}
+
+func (fakeWrite) ListRepos(_ context.Context) ([]model.Repo, error) {
+	t := time.Now()
+	return []model.Repo{
+		{Name: "acme/platform", Owner: "acme", CreatedBy: "ajay@acme", CreatedAt: t.Add(-30 * 24 * time.Hour)},
+		{Name: "acme/policies", Owner: "acme", CreatedBy: "sam@acme", CreatedAt: t.Add(-14 * 24 * time.Hour)},
+		{Name: "acme/docs", Owner: "acme", CreatedBy: "ajay@acme", CreatedAt: t.Add(-3 * 24 * time.Hour)},
+		{Name: "beta/experiments", Owner: "beta", CreatedBy: "lee@beta", CreatedAt: t.Add(-2 * time.Hour)},
+	}, nil
+}
+
+func (fakeWrite) ListOrgs(_ context.Context) ([]model.Org, error) { return nil, nil }
+
+func (fakeWrite) GetRepo(_ context.Context, name string) (*model.Repo, error) {
+	all, _ := (fakeWrite{}).ListRepos(context.Background())
+	for _, r := range all {
+		if r.Name == name {
+			return &r, nil
+		}
+	}
+	return nil, db.ErrRepoNotFound
+}
+
+func fakeAssemble(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
+	t := time.Now()
+	vid := func(s string) *string { return &s }
+
+	switch branch {
+	case "add-onboarding-guide":
+		logURL := "https://ci.example/logs/1"
+		return &model.AgentContextResponse{
+			Branch: model.Branch{Name: branch, HeadSequence: 47, BaseSequence: 42, Status: model.BranchStatusActive},
+			Diff: model.DiffResponse{
+				BranchChanges: []model.DiffEntry{
+					{Path: "docs/guides/onboarding.md", VersionID: vid("v-onb-new")},
+					{Path: "docs/intro.md", VersionID: vid("v-intro-02b")},
+					{Path: "docs/legacy.md", VersionID: nil},
+				},
+				MainChanges: []model.DiffEntry{
+					{Path: "README.md", VersionID: vid("v-readme-02")},
+				},
+			},
+			Reviews: []model.Review{
+				{ID: "r1", Reviewer: "sam@acme", Status: model.ReviewApproved, Sequence: 47, CreatedAt: t.Add(-40 * time.Minute), Body: "LGTM, nice guide."},
+				{ID: "r2", Reviewer: "lee@acme", Status: model.ReviewDismissed, Sequence: 46, CreatedAt: t.Add(-2 * time.Hour), Body: "stale after new commits"},
+			},
+			CheckRuns: []model.CheckRun{
+				{ID: "c1", CheckName: "markdown-lint", Status: model.CheckRunPassed, Reporter: "ci", Sequence: 47, CreatedAt: t.Add(-30 * time.Minute)},
+				{ID: "c2", CheckName: "link-check", Status: model.CheckRunPending, Reporter: "ci", Sequence: 47, CreatedAt: t.Add(-10 * time.Minute), LogURL: &logURL},
+				{ID: "c3", CheckName: "spell-check", Status: model.CheckRunFailed, Reporter: "ci", Sequence: 47, CreatedAt: t.Add(-25 * time.Minute), LogURL: &logURL},
+			},
+			Proposals: []model.Proposal{
+				{ID: "p1", Branch: branch, BaseBranch: "main", Title: "docs: add onboarding guide", Description: "Fills the gap new contributors keep asking about in slack.", Author: "ajay@acme", State: model.ProposalOpen, CreatedAt: t.Add(-3 * time.Hour), UpdatedAt: t.Add(-30 * time.Minute)},
+			},
+			LinkedIssues: []model.Issue{
+				{ID: "i1", Number: 128, Title: "New contributor onboarding is unclear", Author: "new-dev@acme", State: model.IssueStateOpen, CreatedAt: t.Add(-5 * 24 * time.Hour)},
+			},
+			Policies: []model.PolicyResult{
+				{Name: "at-least-one-approval", Pass: true, Reason: "sam@acme approved"},
+				{Name: "all-checks-passed", Pass: false, Reason: "spell-check failed, link-check pending"},
+				{Name: "owner-review-required", Pass: true, Reason: "docs-team approved via sam@acme"},
+			},
+			RecentCommits: []api.ChainEntry{
+				{Sequence: 47, Branch: branch, Author: "ajay@acme", Message: "address review comments", CreatedAt: t.Add(-30 * time.Minute)},
+				{Sequence: 46, Branch: branch, Author: "ajay@acme", Message: "add architecture cross-link", CreatedAt: t.Add(-2 * time.Hour)},
+				{Sequence: 45, Branch: branch, Author: "ajay@acme", Message: "initial onboarding guide", CreatedAt: t.Add(-3 * time.Hour)},
+			},
+			Mergeable: false,
+		}, nil
+
+	case "tighten-reviewer-policy":
+		return &model.AgentContextResponse{
+			Branch: model.Branch{Name: branch, HeadSequence: 45, BaseSequence: 42, Status: model.BranchStatusActive, AutoMerge: true},
+			Diff: model.DiffResponse{
+				BranchChanges: []model.DiffEntry{{Path: "policies/reviewers.rego", VersionID: vid("v-pol-new")}},
+			},
+			Reviews: []model.Review{
+				{ID: "r3", Reviewer: "security@acme", Status: model.ReviewApproved, Sequence: 45, CreatedAt: t.Add(-1 * time.Hour)},
+			},
+			CheckRuns: []model.CheckRun{
+				{ID: "c4", CheckName: "rego-syntax", Status: model.CheckRunPassed, Reporter: "ci", Sequence: 45, CreatedAt: t.Add(-50 * time.Minute)},
+				{ID: "c5", CheckName: "policy-sim", Status: model.CheckRunPassed, Reporter: "ci", Sequence: 45, CreatedAt: t.Add(-40 * time.Minute)},
+			},
+			Policies: []model.PolicyResult{
+				{Name: "owner-review-required", Pass: true, Reason: "security-team approved"},
+				{Name: "all-checks-passed", Pass: true, Reason: "all 2 checks passed"},
+			},
+			Mergeable: true,
+		}, nil
+	}
+	return nil, &notFoundErr{}
+}
+
+type notFoundErr struct{}
+
+func (e *notFoundErr) Error() string { return "branch not found" }
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+func main() {
+	h, err := ui.NewHandler(fakeRead{}, fakeWrite{}, fakeAssemble)
+	if err != nil {
+		log.Fatalf("ui init: %v", err)
+	}
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	// Redirect bare "/" to /ui/ so the preview URL is short.
+	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/ui/", http.StatusFound)
+	})
+
+	addr := "127.0.0.1:8090"
+	log.Printf("docstore UI preview: http://%s/ui/", addr)
+	log.Printf("try: http://%s/ui/r/acme/platform", addr)
+	log.Printf("try: http://%s/ui/r/acme/platform/b/add-onboarding-guide", addr)
+	log.Printf("try: http://%s/ui/r/acme/platform/f/docs/intro.md?branch=main", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2253,96 +2253,78 @@ func (s *server) handleBranchStatus(w http.ResponseWriter, r *http.Request, repo
 // Agent context handler
 // ---------------------------------------------------------------------------
 
-// handleAgentContext implements GET /repos/:name/-/branch/:branch/agent-context.
-// It assembles all branch review context in a single atomic response for LLM agents,
-// following the same assembly logic as handleBranchStatus.
-func (s *server) handleAgentContext(w http.ResponseWriter, r *http.Request, repo, branch string) {
+// ErrAgentContextBranchNotFound is returned by assembleAgentContext when the
+// named branch does not exist on the repo. Callers translate this to 404.
+var ErrAgentContextBranchNotFound = errors.New("branch not found")
+
+// ErrAgentContextReadStoreUnavailable is returned when the server was built
+// without a read store. Callers translate this to 503.
+var ErrAgentContextReadStoreUnavailable = errors.New("read store not available")
+
+// AssembleAgentContext builds the full branch-context snapshot (diff, reviews,
+// checks, proposals, linked issues, policies, recent commits) in one pass.
+//
+// Exported so in-process consumers (e.g. the UI package) can render the same
+// view humans and agents see without going back over HTTP.
+func (s *server) AssembleAgentContext(ctx context.Context, repo, branch, actor string) (*model.AgentContextResponse, error) {
 	if s.readStore == nil {
-		writeError(w, http.StatusServiceUnavailable, "read store not available")
-		return
+		return nil, ErrAgentContextReadStoreUnavailable
 	}
 
-	if !s.validateRepo(w, r, repo) {
-		return
-	}
-
-	ctx := r.Context()
-	actor := IdentityFromContext(ctx)
-
-	// Load branch info.
 	branchInfo, err := s.readStore.GetBranch(ctx, repo, branch)
 	if err != nil {
-		slog.Error("internal error", "op", "agent_context_branch", "repo", repo, "branch", branch, "error", err)
-		writeError(w, http.StatusInternalServerError, "query failed")
-		return
+		return nil, fmt.Errorf("get branch: %w", err)
 	}
 	if branchInfo == nil {
-		writeError(w, http.StatusNotFound, "branch not found")
-		return
+		return nil, ErrAgentContextBranchNotFound
 	}
 
-	// Load diff.
 	diff, err := s.readStore.GetDiff(ctx, repo, branch)
 	if err != nil {
-		slog.Error("internal error", "op", "agent_context_diff", "repo", repo, "branch", branch, "error", err)
-		writeError(w, http.StatusInternalServerError, "query failed")
-		return
+		return nil, fmt.Errorf("get diff: %w", err)
 	}
 	if diff == nil {
 		diff = &store.DiffResult{}
 	}
 
-	// Load reviews filtered to current head sequence.
 	reviews, err := s.commitStore.ListReviews(ctx, repo, branch, &branchInfo.HeadSequence)
 	if err != nil {
-		slog.Error("internal error", "op", "agent_context_reviews", "repo", repo, "branch", branch, "error", err)
-		writeError(w, http.StatusInternalServerError, "query failed")
-		return
+		return nil, fmt.Errorf("list reviews: %w", err)
 	}
 	if reviews == nil {
 		reviews = []model.Review{}
 	}
 
-	// Load check runs filtered to current head sequence.
 	checkRuns, err := s.commitStore.ListCheckRuns(ctx, repo, branch, &branchInfo.HeadSequence)
 	if err != nil {
-		slog.Error("internal error", "op", "agent_context_checks", "repo", repo, "branch", branch, "error", err)
-		writeError(w, http.StatusInternalServerError, "query failed")
-		return
+		return nil, fmt.Errorf("list check runs: %w", err)
 	}
 	if checkRuns == nil {
 		checkRuns = []model.CheckRun{}
 	}
 
-	// Load the open proposal for this branch (if any).
 	openState := model.ProposalOpen
 	proposalPtrs, err := s.commitStore.ListProposals(ctx, repo, &openState, &branch)
 	if err != nil {
-		slog.Error("internal error", "op", "agent_context_proposals", "repo", repo, "branch", branch, "error", err)
-		writeError(w, http.StatusInternalServerError, "query failed")
-		return
+		return nil, fmt.Errorf("list proposals: %w", err)
 	}
 	proposals := make([]model.Proposal, len(proposalPtrs))
 	for i, p := range proposalPtrs {
 		proposals[i] = *p
 	}
 
-	// Load linked issues from the first open proposal (if one exists).
 	linkedIssues := []model.Issue{}
 	if len(proposalPtrs) > 0 {
 		linkedIssues, err = s.commitStore.ListIssuesByRef(ctx, repo, model.IssueRefTypeProposal, proposalPtrs[0].ID)
 		if err != nil {
-			slog.Error("internal error", "op", "agent_context_issues", "repo", repo, "branch", branch, "error", err)
-			writeError(w, http.StatusInternalServerError, "query failed")
-			return
+			return nil, fmt.Errorf("list issues by ref: %w", err)
 		}
 		if linkedIssues == nil {
 			linkedIssues = []model.Issue{}
 		}
 	}
 
-	// Collect recent commits on this branch via the chain.
-	// Cap to the last 50 sequences to bound the query range.
+	// Cap chain queries to the last 50 sequences on the branch.
 	const maxCommitRange = int64(50)
 	recentCommits := []store.ChainEntry{}
 	if branchInfo.HeadSequence > branchInfo.BaseSequence {
@@ -2352,9 +2334,7 @@ func (s *server) handleAgentContext(w http.ResponseWriter, r *http.Request, repo
 		}
 		chainEntries, err := s.readStore.GetChain(ctx, repo, from, branchInfo.HeadSequence)
 		if err != nil {
-			slog.Error("internal error", "op", "agent_context_commits", "repo", repo, "branch", branch, "error", err)
-			writeError(w, http.StatusInternalServerError, "query failed")
-			return
+			return nil, fmt.Errorf("get chain: %w", err)
 		}
 		for _, e := range chainEntries {
 			if e.Branch == branch {
@@ -2363,13 +2343,11 @@ func (s *server) handleAgentContext(w http.ResponseWriter, r *http.Request, repo
 		}
 	}
 
-	// Collect changed paths for ownership resolution.
 	var changedPaths []string
 	for _, e := range diff.BranchChanges {
 		changedPaths = append(changedPaths, e.Path)
 	}
 
-	// Load policies and resolve file ownership.
 	fileOwnership := make(map[string][]string)
 	policyResults := []model.PolicyResult{}
 	mergeable := true
@@ -2377,23 +2355,18 @@ func (s *server) handleAgentContext(w http.ResponseWriter, r *http.Request, repo
 	if s.policyCache != nil {
 		engine, owners, err := s.policyCache.Load(ctx, repo, s.readStore)
 		if err != nil {
-			slog.Error("policy cache load error", "op", "agent_context", "repo", repo, "error", err)
-			writeError(w, http.StatusInternalServerError, "policy evaluation error")
-			return
+			return nil, fmt.Errorf("policy cache load: %w", err)
 		}
 		if engine != nil {
-			// Resolve file ownership per changed path.
 			for _, p := range changedPaths {
 				fileOwnership[p] = policy.ResolveOwners(owners, p)
 			}
 
-			// Get actor roles for policy input.
 			actorRoles := []string{}
 			if role, err := s.commitStore.GetRole(ctx, repo, actor); err == nil && role != nil {
 				actorRoles = []string{string(role.Role)}
 			}
 
-			// Build proposal input for policy evaluation.
 			var proposalInput *policy.ProposalInput
 			if len(proposalPtrs) > 0 {
 				p := proposalPtrs[0]
@@ -2405,7 +2378,6 @@ func (s *server) handleAgentContext(w http.ResponseWriter, r *http.Request, repo
 				}
 			}
 
-			// Build review and check inputs.
 			reviewInputs := make([]policy.ReviewInput, len(reviews))
 			for i, rev := range reviews {
 				reviewInputs[i] = policy.ReviewInput{
@@ -2445,9 +2417,7 @@ func (s *server) handleAgentContext(w http.ResponseWriter, r *http.Request, repo
 
 			results, err := engine.Evaluate(ctx, input)
 			if err != nil {
-				slog.Error("policy evaluation error", "op", "agent_context", "repo", repo, "branch", branch, "error", err)
-				writeError(w, http.StatusInternalServerError, "policy evaluation error")
-				return
+				return nil, fmt.Errorf("policy evaluate: %w", err)
 			}
 			if results != nil {
 				policyResults = results
@@ -2461,7 +2431,6 @@ func (s *server) handleAgentContext(w http.ResponseWriter, r *http.Request, repo
 		}
 	}
 
-	// Convert diff from store types to API types.
 	diffResp := model.DiffResponse{
 		BranchChanges: make([]model.DiffEntry, len(diff.BranchChanges)),
 		MainChanges:   make([]model.DiffEntry, len(diff.MainChanges)),
@@ -2480,17 +2449,15 @@ func (s *server) handleAgentContext(w http.ResponseWriter, r *http.Request, repo
 		})
 	}
 
-	branchResp := model.Branch{
-		Name:         branchInfo.Name,
-		HeadSequence: branchInfo.HeadSequence,
-		BaseSequence: branchInfo.BaseSequence,
-		Status:       model.BranchStatus(branchInfo.Status),
-		Draft:        branchInfo.Draft,
-		AutoMerge:    branchInfo.AutoMerge,
-	}
-
-	writeJSON(w, http.StatusOK, model.AgentContextResponse{
-		Branch:        branchResp,
+	return &model.AgentContextResponse{
+		Branch: model.Branch{
+			Name:         branchInfo.Name,
+			HeadSequence: branchInfo.HeadSequence,
+			BaseSequence: branchInfo.BaseSequence,
+			Status:       model.BranchStatus(branchInfo.Status),
+			Draft:        branchInfo.Draft,
+			AutoMerge:    branchInfo.AutoMerge,
+		},
 		Diff:          diffResp,
 		Reviews:       reviews,
 		CheckRuns:     checkRuns,
@@ -2500,7 +2467,34 @@ func (s *server) handleAgentContext(w http.ResponseWriter, r *http.Request, repo
 		RecentCommits: recentCommits,
 		Policies:      policyResults,
 		Mergeable:     mergeable,
-	})
+	}, nil
+}
+
+// handleAgentContext implements GET /repos/:name/-/branch/:branch/agent-context.
+// It is a thin HTTP wrapper over AssembleAgentContext.
+func (s *server) handleAgentContext(w http.ResponseWriter, r *http.Request, repo, branch string) {
+	if s.readStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "read store not available")
+		return
+	}
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	resp, err := s.AssembleAgentContext(r.Context(), repo, branch, IdentityFromContext(r.Context()))
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrAgentContextBranchNotFound):
+			writeError(w, http.StatusNotFound, "branch not found")
+		case errors.Is(err, ErrAgentContextReadStoreUnavailable):
+			writeError(w, http.StatusServiceUnavailable, "read store not available")
+		default:
+			slog.Error("internal error", "op", "agent_context", "repo", repo, "branch", branch, "error", err)
+			writeError(w, http.StatusInternalServerError, "query failed")
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/policy"
 	"github.com/dlorenc/docstore/internal/store"
+	"github.com/dlorenc/docstore/internal/ui"
 )
 
 // readStore is the interface for all read operations used by handlers.
@@ -239,6 +240,22 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 	//   POST /repos/acme/myrepo/-/commit
 	//   GET  /repos/acme/myrepo          (bare: GET/DELETE a repo)
 	inner.Handle("/repos/", http.HandlerFunc(s.handleReposPrefix))
+
+	// Minimal read-only web UI. Registered on `inner` so it shares IAP + RBAC
+	// middleware. Only wires up when both a read store and write store are
+	// present — read-only mode still works for browsing, but we need the write
+	// store for repo/org listings.
+	if s.readStore != nil && writeStore != nil {
+		assemble := func(ctx context.Context, repo, branch string) (*model.AgentContextResponse, error) {
+			return s.AssembleAgentContext(ctx, repo, branch, IdentityFromContext(ctx))
+		}
+		uiHandler, err := ui.NewHandler(s.readStore, writeStore, assemble)
+		if err != nil {
+			slog.Error("ui init failed", "error", err)
+		} else {
+			uiHandler.Register(inner)
+		}
+	}
 
 	// Event subscription management (delegated auth: admin for global, creator for own).
 	inner.HandleFunc("POST /subscriptions", s.handleCreateSubscription)

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -1,0 +1,375 @@
+package ui
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// Page data types
+// ---------------------------------------------------------------------------
+
+type reposPage struct {
+	Orgs []orgGroup
+}
+
+type orgGroup struct {
+	Name  string
+	Repos []model.Repo
+}
+
+type branchesPage struct {
+	Repo      model.Repo
+	Active    []branchRow
+	Merged    []branchRow
+	Abandoned []branchRow
+}
+
+type branchRow struct {
+	Name         string
+	HeadSequence int64
+	BaseSequence int64
+	Draft        bool
+	AutoMerge    bool
+	Status       string
+}
+
+type branchDetailPage struct {
+	Repo            model.Repo
+	Ctx             *model.AgentContextResponse
+	Blockers        []string
+	PassedCheckCnt  int
+	PendingCheckCnt int
+	FailedCheckCnt  int
+}
+
+type filePage struct {
+	Repo      model.Repo
+	Branch    string
+	AtSeq     *int64
+	Path      string
+	File      *fileView
+	Tree      []treeRow
+	ParentDir string
+}
+
+type fileView struct {
+	Path        string
+	VersionID   string
+	ContentHash string
+	Content     []byte
+	ContentType string
+}
+
+type treeRow struct {
+	Name  string
+	Path  string
+	IsDir bool
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+// handleRepos renders the landing page listing orgs and their repos.
+func (h *Handler) handleRepos(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	repos, err := h.write.ListRepos(ctx)
+	if err != nil {
+		slog.Error("ui list repos", "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repos")
+		return
+	}
+	byOrg := map[string][]model.Repo{}
+	for _, rp := range repos {
+		byOrg[rp.Owner] = append(byOrg[rp.Owner], rp)
+	}
+	orgs := make([]orgGroup, 0, len(byOrg))
+	for name, list := range byOrg {
+		slices.SortFunc(list, func(a, b model.Repo) int { return strings.Compare(a.Name, b.Name) })
+		orgs = append(orgs, orgGroup{Name: name, Repos: list})
+	}
+	slices.SortFunc(orgs, func(a, b orgGroup) int { return strings.Compare(a.Name, b.Name) })
+
+	h.render(w, h.tmpl.repos, "layout.html", pageData{
+		Title:       "Repos",
+		Breadcrumbs: []crumb{{Label: "repos", Href: "/ui/"}},
+		Body:        reposPage{Orgs: orgs},
+	})
+}
+
+// handleBranches renders the branch list for a single repo.
+func (h *Handler) handleBranches(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	branches, err := h.read.ListBranches(ctx, repoName, "", true, false)
+	if err != nil {
+		slog.Error("ui list branches", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load branches")
+		return
+	}
+
+	page := branchesPage{Repo: *repo}
+	for _, b := range branches {
+		row := branchRow{
+			Name:         b.Name,
+			HeadSequence: b.HeadSequence,
+			BaseSequence: b.BaseSequence,
+			Draft:        b.Draft,
+			AutoMerge:    b.AutoMerge,
+			Status:       b.Status,
+		}
+		switch b.Status {
+		case "merged":
+			page.Merged = append(page.Merged, row)
+		case "abandoned":
+			page.Abandoned = append(page.Abandoned, row)
+		default:
+			page.Active = append(page.Active, row)
+		}
+	}
+
+	h.render(w, h.tmpl.branches, "layout.html", pageData{
+		Title: repoName + " / branches",
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+		},
+		Body: page,
+	})
+}
+
+// handleBranchDetail renders the diff + reviews + checks + policy view.
+func (h *Handler) handleBranchDetail(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	branch := r.PathValue("branch")
+	repoName := owner + "/" + name
+
+	repo, err := h.write.GetRepo(r.Context(), repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	if h.assemble == nil {
+		h.renderError(w, http.StatusServiceUnavailable, "agent context assembler not configured")
+		return
+	}
+	actCtx, err := h.assemble(r.Context(), repoName, branch)
+	if err != nil {
+		// Matches the sentinel message from server.ErrAgentContextBranchNotFound.
+		// We avoid importing internal/server to stay free of circular deps.
+		if strings.Contains(err.Error(), "branch not found") {
+			h.renderError(w, http.StatusNotFound, "branch not found: "+branch)
+			return
+		}
+		slog.Error("ui assemble agent context", "repo", repoName, "branch", branch, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load branch")
+		return
+	}
+
+	page := branchDetailPage{Repo: *repo, Ctx: actCtx}
+	for _, p := range actCtx.Policies {
+		if !p.Pass {
+			reason := p.Reason
+			if reason == "" {
+				reason = p.Name
+			}
+			page.Blockers = append(page.Blockers, reason)
+		}
+	}
+	for _, c := range actCtx.CheckRuns {
+		switch c.Status {
+		case model.CheckRunPassed:
+			page.PassedCheckCnt++
+		case model.CheckRunPending:
+			page.PendingCheckCnt++
+			page.Blockers = append(page.Blockers, c.CheckName+" pending")
+		case model.CheckRunFailed:
+			page.FailedCheckCnt++
+			page.Blockers = append(page.Blockers, c.CheckName+" failed")
+		}
+	}
+
+	h.render(w, h.tmpl.branchDetail, "layout.html", pageData{
+		Title: repoName + " / " + branch,
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: branch, Href: ""},
+		},
+		Body: page,
+	})
+}
+
+// handleChecksPartial returns just the checks table for HTMX polling.
+func (h *Handler) handleChecksPartial(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	branch := r.PathValue("branch")
+	repoName := owner + "/" + name
+
+	if h.assemble == nil {
+		http.Error(w, "assembler not configured", http.StatusServiceUnavailable)
+		return
+	}
+	actCtx, err := h.assemble(r.Context(), repoName, branch)
+	if err != nil {
+		slog.Error("ui assemble checks partial", "repo", repoName, "branch", branch, "error", err)
+		http.Error(w, "query failed", http.StatusInternalServerError)
+		return
+	}
+	h.render(w, h.tmpl.branchChecks, "branch_checks.html", actCtx)
+}
+
+// handleFile renders a file viewer with a sibling tree pane.
+func (h *Handler) handleFile(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	path := r.PathValue("path")
+	repoName := owner + "/" + name
+
+	branch := r.URL.Query().Get("branch")
+	if branch == "" {
+		branch = "main"
+	}
+	var atSeq *int64
+	if v := r.URL.Query().Get("at"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			h.renderError(w, http.StatusBadRequest, "invalid 'at' parameter")
+			return
+		}
+		atSeq = &n
+	}
+
+	repo, err := h.write.GetRepo(r.Context(), repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	parentDir := ""
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		parentDir = path[:i]
+	}
+
+	entries, err := h.read.MaterializeTree(r.Context(), repoName, branch, atSeq, 500, "")
+	if err != nil {
+		slog.Error("ui materialize tree", "repo", repoName, "branch", branch, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load tree")
+		return
+	}
+	tree := siblingTreeRows(entries, parentDir)
+
+	page := filePage{
+		Repo:      *repo,
+		Branch:    branch,
+		AtSeq:     atSeq,
+		Path:      path,
+		Tree:      tree,
+		ParentDir: parentDir,
+	}
+
+	if path != "" {
+		fc, err := h.read.GetFile(r.Context(), repoName, branch, path, atSeq)
+		if err != nil {
+			slog.Error("ui get file", "repo", repoName, "path", path, "error", err)
+			h.renderError(w, http.StatusInternalServerError, "could not load file")
+			return
+		}
+		if fc != nil {
+			page.File = &fileView{
+				Path:        fc.Path,
+				VersionID:   fc.VersionID,
+				ContentHash: fc.ContentHash,
+				Content:     fc.Content,
+				ContentType: fc.ContentType,
+			}
+		}
+	}
+
+	h.render(w, h.tmpl.fileView, "layout.html", pageData{
+		Title: repoName + " / " + path,
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: branch + ":" + path, Href: ""},
+		},
+		Body: page,
+	})
+}
+
+// siblingTreeRows returns the immediate children of dir within entries, with
+// synthesized directory rows for paths that have a deeper subtree.
+func siblingTreeRows(entries []store.TreeEntry, dir string) []treeRow {
+	prefix := ""
+	if dir != "" {
+		prefix = dir + "/"
+	}
+	seen := map[string]bool{}
+	var rows []treeRow
+	for _, e := range entries {
+		rest, ok := strings.CutPrefix(e.Path, prefix)
+		if !ok || rest == "" {
+			continue
+		}
+		dirName, _, hasSlash := strings.Cut(rest, "/")
+		if !hasSlash {
+			if seen[rest] {
+				continue
+			}
+			seen[rest] = true
+			rows = append(rows, treeRow{Name: rest, Path: e.Path, IsDir: false})
+			continue
+		}
+		if seen[dirName] {
+			continue
+		}
+		seen[dirName] = true
+		rows = append(rows, treeRow{Name: dirName, Path: prefix + dirName, IsDir: true})
+	}
+	slices.SortFunc(rows, func(a, b treeRow) int {
+		if a.IsDir != b.IsDir {
+			if a.IsDir {
+				return -1
+			}
+			return 1
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+	return rows
+}

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -1,0 +1,274 @@
+package ui
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"html/template"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// templateSet holds the parsed template tree. Each page has its own *Template
+// so it can define its own "content" block against the shared layout.
+type templateSet struct {
+	repos         *template.Template
+	branches      *template.Template
+	branchDetail  *template.Template
+	branchChecks  *template.Template
+	fileView      *template.Template
+	errorPage     *template.Template
+}
+
+func parseTemplates(root embed.FS) (*templateSet, error) {
+	load := func(page string) (*template.Template, error) {
+		return template.New("layout.html").
+			Funcs(funcMap()).
+			ParseFS(root, "templates/layout.html", "templates/"+page)
+	}
+	loadFragment := func(name string) (*template.Template, error) {
+		return template.New(name).
+			Funcs(funcMap()).
+			ParseFS(root, "templates/"+name)
+	}
+
+	repos, err := load("repos.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse repos: %w", err)
+	}
+	branches, err := load("branches.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse branches: %w", err)
+	}
+	// branch_detail pulls in _diff.html and branch_checks.html as partials so
+	// the initial render shows the checks table without a separate HTMX call.
+	branchDetail, err := template.New("layout.html").
+		Funcs(funcMap()).
+		ParseFS(root,
+			"templates/layout.html",
+			"templates/branch_detail.html",
+			"templates/_diff.html",
+			"templates/branch_checks.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse branch_detail: %w", err)
+	}
+	branchChecks, err := loadFragment("branch_checks.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse branch_checks: %w", err)
+	}
+	fileView, err := load("file.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse file: %w", err)
+	}
+	errorPage, err := load("error.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse error: %w", err)
+	}
+	return &templateSet{
+		repos:        repos,
+		branches:     branches,
+		branchDetail: branchDetail,
+		branchChecks: branchChecks,
+		fileView:     fileView,
+		errorPage:    errorPage,
+	}, nil
+}
+
+// render executes the named template against data and writes it to w as HTML.
+// On execution error it logs and emits a 500; templates must not panic.
+func (h *Handler) render(w http.ResponseWriter, t *template.Template, name string, data any) {
+	var buf bytes.Buffer
+	if err := t.ExecuteTemplate(&buf, name, data); err != nil {
+		slog.Error("ui render error", "template", name, "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write(buf.Bytes())
+}
+
+// renderError renders the error page with the given status.
+func (h *Handler) renderError(w http.ResponseWriter, status int, message string) {
+	var buf bytes.Buffer
+	data := pageData{
+		Title: fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Err: errorInfo{
+			Status:  status,
+			Message: message,
+		},
+	}
+	if err := h.tmpl.errorPage.ExecuteTemplate(&buf, "layout.html", data); err != nil {
+		http.Error(w, message, status)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	_, _ = w.Write(buf.Bytes())
+}
+
+// ---------------------------------------------------------------------------
+// Template data structures
+// ---------------------------------------------------------------------------
+
+type pageData struct {
+	Title       string
+	Breadcrumbs []crumb
+	Body        any
+	Err         errorInfo
+}
+
+type crumb struct {
+	Label string
+	Href  string
+}
+
+type errorInfo struct {
+	Status  int
+	Message string
+}
+
+// ---------------------------------------------------------------------------
+// Template FuncMap
+// ---------------------------------------------------------------------------
+
+func funcMap() template.FuncMap {
+	return template.FuncMap{
+		"relTime":    relTime,
+		"shortHash":  shortHash,
+		"statusClass": statusClass,
+		"diffClass":  diffClass,
+		"joinPath":   joinPath,
+		"safeContent": safeContent,
+		"hasPrefix":  strings.HasPrefix,
+		"lines":      splitLines,
+		"dict":       dict,
+		"add":        func(a, b int) int { return a + b },
+	}
+}
+
+// dict builds a map from alternating key/value pairs for template composition:
+//   {{template "x" (dict "Title" "Foo" "Rows" .Bar)}}
+func dict(kv ...any) map[string]any {
+	m := make(map[string]any, len(kv)/2)
+	for i := 0; i+1 < len(kv); i += 2 {
+		k, ok := kv[i].(string)
+		if !ok {
+			continue
+		}
+		m[k] = kv[i+1]
+	}
+	return m
+}
+
+func relTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	case d < 30*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	default:
+		return t.Format("2006-01-02")
+	}
+}
+
+func shortHash(s string) string {
+	if len(s) <= 12 {
+		return s
+	}
+	return s[:12]
+}
+
+// statusClass maps domain status strings to stable CSS class names.
+// "ok" is reserved for genuine success states (passed, approved); lifecycle
+// states like "active" and "merged" map to "neutral" so they don't compete
+// visually with the mergeable verdict on the branch detail page.
+func statusClass(s string) string {
+	switch strings.ToLower(s) {
+	case "passed", "approved", "open":
+		return "ok"
+	case "failed", "rejected", "abandoned":
+		return "bad"
+	case "pending", "dismissed", "draft":
+		return "warn"
+	case "active", "merged", "closed":
+		return "neutral"
+	default:
+		return "neutral"
+	}
+}
+
+// diffClass returns a CSS class for a diff entry based on whether it is an add,
+// delete, or modify. An entry with a nil VersionID is a deletion.
+func diffClass(versionID *string) string {
+	if versionID == nil {
+		return "del"
+	}
+	return "add"
+}
+
+func joinPath(parts ...string) string {
+	out := strings.Builder{}
+	for i, p := range parts {
+		if i > 0 {
+			out.WriteByte('/')
+		}
+		out.WriteString(p)
+	}
+	return out.String()
+}
+
+// safeContent returns the text as a safe HTML fragment if it looks like text,
+// else a placeholder. Used to avoid blowing up on binary files.
+func safeContent(b []byte) template.HTML {
+	if !isProbablyText(b) {
+		return template.HTML("<em>binary file (not shown)</em>")
+	}
+	return template.HTML(template.HTMLEscapeString(string(b)))
+}
+
+func isProbablyText(b []byte) bool {
+	if len(b) == 0 {
+		return true
+	}
+	// If any byte in the first 512 is null, treat as binary.
+	n := 512
+	if len(b) < n {
+		n = len(b)
+	}
+	for _, c := range b[:n] {
+		if c == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// splitLines returns the file content split into lines, each annotated with
+// its 1-indexed line number, for numbered rendering.
+type numberedLine struct {
+	Num  int
+	Text string
+}
+
+func splitLines(b []byte) []numberedLine {
+	if len(b) == 0 {
+		return nil
+	}
+	lines := strings.Split(strings.TrimRight(string(b), "\n"), "\n")
+	out := make([]numberedLine, len(lines))
+	for i, l := range lines {
+		out[i] = numberedLine{Num: i + 1, Text: l}
+	}
+	return out
+}
+

--- a/internal/ui/static/poll.js
+++ b/internal/ui/static/poll.js
@@ -1,0 +1,57 @@
+// Minimal polling shim used by branch_detail.html for the checks table.
+// Any element with `data-poll-url` is refreshed periodically; the server
+// returns an HTML fragment that replaces the element's innerHTML.
+(function () {
+  function attach(el) {
+    var url = el.getAttribute('data-poll-url');
+    var ms = parseInt(el.getAttribute('data-poll-interval') || '10000', 10);
+    if (!url) return;
+    setInterval(function () {
+      fetch(url, { credentials: 'same-origin' }).then(function (r) {
+        if (!r.ok) return;
+        return r.text().then(function (t) { el.innerHTML = t; });
+      }).catch(function () { /* ignore transient errors */ });
+    }, ms);
+  }
+  document.addEventListener('DOMContentLoaded', function () {
+    var els = document.querySelectorAll('[data-poll-url]');
+    for (var i = 0; i < els.length; i++) attach(els[i]);
+  });
+
+  // Theme toggle. Cycles document <html data-theme>, persists to localStorage.
+  function currentTheme() {
+    var t = document.documentElement.getAttribute('data-theme');
+    if (t === 'light' || t === 'dark') return t;
+    try { t = localStorage.getItem('ds-theme'); } catch (e) {}
+    return (t === 'light') ? 'light' : 'dark';
+  }
+  function applyTheme(t) {
+    document.documentElement.setAttribute('data-theme', t);
+    try { localStorage.setItem('ds-theme', t); } catch (e) {}
+  }
+  document.addEventListener('DOMContentLoaded', function () {
+    var btns = document.querySelectorAll('[data-theme-toggle]');
+    for (var i = 0; i < btns.length; i++) {
+      btns[i].addEventListener('click', function () {
+        applyTheme(currentTheme() === 'light' ? 'dark' : 'light');
+      });
+    }
+  });
+
+  // Branch-list filter. Hides tbody rows whose first cell text doesn't match.
+  document.addEventListener('DOMContentLoaded', function () {
+    var inputs = document.querySelectorAll('[data-branch-filter]');
+    for (var i = 0; i < inputs.length; i++) {
+      inputs[i].addEventListener('input', function (e) {
+        var q = e.target.value.trim().toLowerCase();
+        var rows = document.querySelectorAll('table.grid tbody tr');
+        for (var j = 0; j < rows.length; j++) {
+          var cell = rows[j].querySelector('td');
+          if (!cell) continue;
+          var match = !q || cell.textContent.toLowerCase().indexOf(q) !== -1;
+          rows[j].style.display = match ? '' : 'none';
+        }
+      });
+    }
+  });
+})();

--- a/internal/ui/static/styles.css
+++ b/internal/ui/static/styles.css
@@ -1,0 +1,312 @@
+:root {
+  --bg: #0f1115;
+  --bg-2: #161a22;
+  --bg-3: #1d222c;
+  --border: #2b313c;
+  --border-strong: #3a414e;
+  --text: #d7dae0;
+  --text-dim: #8b92a0;
+  --accent: #9c8fff;
+  --ok: #58c48b;
+  --bad: #e26a6a;
+  --warn: #d9b257;
+  --neutral: #8b92a0;
+  --ok-bg: rgba(88, 196, 139, 0.15);
+  --bad-bg: rgba(226, 106, 106, 0.15);
+  --warn-bg: rgba(217, 178, 87, 0.15);
+  --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+:root[data-theme="light"] {
+  --bg: #f5f2ea;
+  --bg-2: #fbf8f1;
+  --bg-3: #ece7da;
+  --border: #cfc7b2;
+  --border-strong: #b8ae94;
+  --text: #2c2a26;
+  --text-dim: #6e6a5f;
+  --accent: #6b4a9e;
+  --ok: #2f7a4d;
+  --bad: #a83c3c;
+  --warn: #8c6a14;
+  --neutral: #6e6a5f;
+  --ok-bg: rgba(47, 122, 77, 0.14);
+  --bad-bg: rgba(168, 60, 60, 0.16);
+  --warn-bg: rgba(140, 106, 20, 0.16);
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+nav.top {
+  background: var(--bg-2);
+  border-bottom: 1px solid var(--border);
+  padding: 10px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+nav.top .brand { color: var(--text); font-weight: bold; letter-spacing: -0.01em; }
+nav.top .crumbs { color: var(--text); font-size: 12px; }
+nav.top .crumbs a { color: var(--text-dim); }
+nav.top .crumbs a:hover { color: var(--text); text-decoration: none; }
+nav.top .crumbs .sep { margin: 0 8px; color: var(--text-dim); opacity: 0.5; }
+nav.top .spacer { flex: 1; }
+nav.top .theme-toggle {
+  background: transparent;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 3px 9px;
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  min-width: 28px;
+}
+nav.top .theme-toggle:hover { color: var(--text); border-color: var(--border-strong); }
+nav.top .theme-toggle [data-theme-icon-light] { display: none; }
+:root[data-theme="light"] nav.top .theme-toggle [data-theme-icon-dark] { display: none; }
+:root[data-theme="light"] nav.top .theme-toggle [data-theme-icon-light] { display: inline; }
+
+main { padding: 20px 24px; max-width: 1200px; margin: 0 auto; }
+
+h1 { font-size: 20px; font-weight: 600; letter-spacing: -0.01em; margin: 0 0 4px; }
+h2 { font-size: 11px; margin: 22px 0 8px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600; }
+h2:first-child { margin-top: 0; }
+
+.headline {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  padding-bottom: 12px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+.headline h1 { margin: 0; }
+
+.card {
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 12px 14px;
+  margin-bottom: 14px;
+}
+
+.row-list { display: flex; flex-direction: column; }
+.row-list > a,
+.row-list > .row {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+.row-list > a:last-child, .row-list > .row:last-child { border-bottom: 0; }
+.row-list > a:hover { background: var(--bg-3); }
+
+.card > .row {
+  padding: 8px 4px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+}
+.card > .row:last-of-type { border-bottom: 0; }
+.card > .row strong + .badge { margin-left: 8px; }
+.card > .row-body { padding: 0 4px 10px; color: var(--text-dim); white-space: pre-wrap; font-size: 12px; }
+
+table.grid { width: 100%; border-collapse: collapse; }
+table.grid th, table.grid td { text-align: left; padding: 7px 10px; }
+table.grid th {
+  color: var(--text-dim);
+  font-weight: 600;
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border-bottom: 1px solid var(--border-strong);
+  padding-bottom: 8px;
+}
+table.grid td { border-bottom: 1px dashed var(--border); }
+table.grid tbody tr:last-child td { border-bottom: 0; }
+table.grid tbody tr:hover { background: var(--bg-3); }
+table.grid td a { color: var(--text); }
+table.grid td a:hover { color: var(--accent); text-decoration: none; }
+
+.badge {
+  display: inline-block;
+  padding: 2px 7px;
+  border-radius: 3px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  background: var(--bg-3);
+  color: var(--text-dim);
+  vertical-align: baseline;
+}
+.badge.ok { background: var(--ok-bg); color: var(--ok); }
+.badge.bad { background: var(--bad-bg); color: var(--bad); }
+.badge.warn { background: var(--warn-bg); color: var(--warn); }
+.badge.neutral { background: var(--bg-3); color: var(--neutral); }
+
+/* Hero summary on branch detail — the load-bearing "mergeable?" line. */
+.summary-hero {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: 4px;
+  background: var(--bg-2);
+  margin-bottom: 18px;
+}
+.summary-hero.ok { border-left-color: var(--ok); }
+.summary-hero.bad { border-left-color: var(--bad); }
+.summary-hero .verdict { font-size: 15px; font-weight: 600; }
+.summary-hero.ok .verdict { color: var(--ok); }
+.summary-hero.bad .verdict { color: var(--bad); }
+.summary-hero .reasons { color: var(--text-dim); flex: 1; font-size: 12px; }
+.summary-hero .reasons .sep { margin: 0 6px; opacity: 0.5; }
+
+.diff-line {
+  display: flex;
+  gap: 10px;
+  padding: 4px 10px;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  position: relative;
+  align-items: baseline;
+}
+.diff-line:last-child { border-bottom: 0; }
+.diff-line::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+}
+.diff-line.add::before { background: var(--ok); }
+.diff-line.del::before { background: var(--bad); }
+.diff-line.mod::before { background: var(--warn); }
+.diff-line:hover { background: var(--bg-3); }
+.diff-line .path { flex: 1; }
+.diff-line .path a { color: var(--text); }
+.diff-line .path a:hover { color: var(--accent); text-decoration: none; }
+.diff-line.add .path::before { content: "+ "; color: var(--ok); font-weight: 600; }
+.diff-line.del .path::before { content: "− "; color: var(--bad); font-weight: 600; }
+.diff-line.mod .path::before { content: "~ "; color: var(--warn); font-weight: 600; }
+.diff-line .owners { color: var(--text-dim); font-size: 11px; }
+.diff-block-heading { font-size: 10.5px; color: var(--text-dim); margin: 4px 0 8px; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600; }
+.diff-block-heading .count { color: var(--text-dim); opacity: 0.8; font-weight: normal; margin-left: 6px; }
+
+.two-col { display: grid; grid-template-columns: 250px 1fr; gap: 14px; }
+
+.tree {
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px 0;
+  max-height: 70vh;
+  overflow-y: auto;
+  font-size: 12px;
+}
+.tree .item { display: flex; gap: 6px; padding: 3px 12px; color: var(--text-dim); align-items: baseline; }
+.tree .item:hover { background: var(--bg-3); color: var(--text); }
+.tree .item::before { width: 1ch; display: inline-block; color: var(--text-dim); }
+.tree .item.dir { color: var(--text); }
+.tree .item.dir::before { content: "▸"; }
+.tree .item.file::before { content: "·"; opacity: 0.5; }
+
+pre.code {
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 10px 0;
+  margin: 0;
+  overflow-x: auto;
+  font-size: 12px;
+  line-height: 1.55;
+}
+pre.code .ln { display: grid; grid-template-columns: 40px 1fr; }
+pre.code .ln:hover { background: var(--bg-3); }
+pre.code .num { color: var(--text-dim); user-select: none; text-align: right; padding-right: 10px; margin-right: 10px; font-size: 11px; border-right: 1px solid var(--border); }
+pre.code .text { white-space: pre; padding-right: 12px; }
+
+.policy-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border);
+}
+.policy-row:last-child { border-bottom: 0; }
+.policy-row .name { min-width: 200px; font-weight: 500; }
+.policy-row .reason { color: var(--text-dim); flex: 1; }
+
+.empty { color: var(--text-dim); padding: 10px; text-align: center; font-size: 12px; }
+
+.meta { color: var(--text-dim); font-size: 11px; }
+.meta .dot { margin: 0 6px; color: var(--border); }
+
+/* Branch list filter input. */
+.filter-bar { margin: 0 0 14px; }
+.filter-bar input {
+  width: 100%;
+  background: var(--bg-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px 10px;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.filter-bar input:focus { outline: none; border-color: var(--accent); }
+.filter-bar input::placeholder { color: var(--text-dim); }
+
+/* Check rows in branch-detail; clickable when a log URL is present. */
+.check-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 4px;
+  border-bottom: 1px solid var(--border);
+  color: inherit;
+}
+.check-row:last-child { border-bottom: 0; }
+.check-row.link { cursor: pointer; }
+.check-row.link:hover { background: var(--bg-3); text-decoration: none; }
+.check-row .open-log { color: var(--text-dim); font-size: 11px; }
+.check-row.link:hover .open-log { color: var(--accent); }
+
+.checks-collapsed {
+  padding: 6px 4px;
+  color: var(--text-dim);
+  font-size: 12px;
+  border-bottom: 1px solid var(--border);
+}
+.checks-collapsed:last-child { border-bottom: 0; }
+
+.err-box {
+  text-align: center;
+  padding: 60px 20px;
+}
+.err-box h1 { font-size: 24px; }
+.err-box p { color: var(--text-dim); }

--- a/internal/ui/templates/_diff.html
+++ b/internal/ui/templates/_diff.html
@@ -1,0 +1,12 @@
+{{define "diffBlock"}}
+<div class="diff-block-heading">{{.Title}} <span class="count">({{len .Entries}})</span></div>
+{{if not .Entries}}<div class="empty">no changes</div>{{end}}
+{{$own := .Ownership}}
+{{range .Entries}}
+<div class="diff-line {{diffClass .VersionID}}">
+  <span class="path"><a href="/ui/r/{{$.Repo}}/f/{{.Path}}?branch={{$.Branch}}">{{.Path}}</a></span>
+  {{if $own}}{{with index $own .Path}}{{if .}}<span class="owners">{{range $i, $o := .}}{{if $i}}, {{end}}{{$o}}{{end}}</span>{{end}}{{end}}{{end}}
+  <span class="meta">{{if .VersionID}}{{shortHash .VersionID}}{{else}}deleted{{end}}{{if .Binary}} · binary{{end}}</span>
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/branch_checks.html
+++ b/internal/ui/templates/branch_checks.html
@@ -1,0 +1,36 @@
+{{define "branch_checks.html"}}
+{{if not .CheckRuns}}<div class="empty">no checks yet</div>{{end}}
+{{$passed := 0}}
+{{range .CheckRuns}}{{if eq (printf "%s" .Status) "passed"}}{{$passed = add $passed 1}}{{end}}{{end}}
+{{range .CheckRuns}}
+{{if ne (printf "%s" .Status) "passed"}}
+{{if .LogURL}}
+<a class="check-row link" href="{{.LogURL}}" target="_blank" rel="noopener">
+  <div>
+    <strong>{{.CheckName}}</strong>
+    <span class="badge {{statusClass (printf "%s" .Status)}}">{{.Status}}</span>
+    <div class="meta">{{.Reporter}} @ seq {{.Sequence}} · {{relTime .CreatedAt}}</div>
+  </div>
+  <span class="open-log">logs →</span>
+</a>
+{{else}}
+<div class="check-row">
+  <div>
+    <strong>{{.CheckName}}</strong>
+    <span class="badge {{statusClass (printf "%s" .Status)}}">{{.Status}}</span>
+    <div class="meta">{{.Reporter}} @ seq {{.Sequence}} · {{relTime .CreatedAt}}</div>
+  </div>
+</div>
+{{end}}
+{{end}}
+{{end}}
+{{if gt $passed 0}}
+<div class="checks-collapsed">
+  <span class="badge ok">{{$passed}} passed</span>
+  <span style="margin-left:8px">
+    {{$first := true}}
+    {{range .CheckRuns}}{{if eq (printf "%s" .Status) "passed"}}{{if not $first}}, {{end}}{{.CheckName}}{{$first = false}}{{end}}{{end}}
+  </span>
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/branch_detail.html
+++ b/internal/ui/templates/branch_detail.html
@@ -1,0 +1,125 @@
+{{define "content"}}
+{{with .Body}}
+{{$ctx := .Ctx}}
+{{$page := .}}
+<div class="headline">
+  <h1>{{.Repo.Name}} / {{$ctx.Branch.Name}}</h1>
+  <span>
+    {{if $ctx.Branch.Draft}}<span class="badge warn">draft</span>{{end}}
+    {{if $ctx.Branch.AutoMerge}}<span class="badge neutral">auto-merge</span>{{end}}
+    <span class="badge neutral">{{$ctx.Branch.Status}}</span>
+  </span>
+</div>
+<div class="meta" style="margin-bottom:14px">head {{$ctx.Branch.HeadSequence}} · base {{$ctx.Branch.BaseSequence}}</div>
+
+{{if $ctx.Mergeable}}
+<div class="summary-hero ok">
+  <span class="verdict">✓ Mergeable</span>
+  <span class="reasons">all policies and checks pass</span>
+</div>
+{{else}}
+<div class="summary-hero bad">
+  <span class="verdict">✗ Blocked</span>
+  <span class="reasons">{{range $i, $r := $page.Blockers}}{{if $i}}<span class="sep">·</span>{{end}}{{$r}}{{end}}{{if not $page.Blockers}}branch is not mergeable{{end}}</span>
+</div>
+{{end}}
+
+<h2>Policies ({{len $ctx.Policies}})</h2>
+<div class="card">
+  {{if not $ctx.Policies}}<div class="empty">no policies configured for this repo</div>{{end}}
+  {{range $ctx.Policies}}
+  <div class="policy-row">
+    <span class="name">{{.Name}}</span>
+    <span class="badge {{if .Pass}}ok{{else}}bad{{end}}">{{if .Pass}}pass{{else}}fail{{end}}</span>
+    <span class="reason">{{.Reason}}</span>
+  </div>
+  {{end}}
+</div>
+
+<div class="two-col">
+  <div>
+    <h2>Checks ({{len $ctx.CheckRuns}})</h2>
+    <div class="card" data-poll-url="/ui/_/r/{{.Repo.Name}}/b/{{$ctx.Branch.Name}}/checks" data-poll-interval="10000">
+      {{template "branch_checks.html" $ctx}}
+    </div>
+  </div>
+  <div>
+    <h2>Reviews ({{len $ctx.Reviews}})</h2>
+    <div class="card">
+      {{if not $ctx.Reviews}}<div class="empty">no reviews yet</div>{{end}}
+      {{range $ctx.Reviews}}
+      <div class="row">
+        <div>
+          <strong>{{.Reviewer}}</strong>
+          <span class="badge {{statusClass (printf "%s" .Status)}}">{{.Status}}</span>
+          <div class="meta">@ seq {{.Sequence}} · {{relTime .CreatedAt}}</div>
+        </div>
+      </div>
+      {{if .Body}}<div class="row-body">{{.Body}}</div>{{end}}
+      {{end}}
+    </div>
+  </div>
+</div>
+
+<h2>Diff</h2>
+<div class="card">
+  {{template "diffBlock" (dict "Title" "branch changes" "Entries" $ctx.Diff.BranchChanges "Repo" .Repo.Name "Branch" $ctx.Branch.Name "Ownership" $ctx.FileOwnership)}}
+  {{if $ctx.Diff.MainChanges}}
+    {{template "diffBlock" (dict "Title" "main changes since branch" "Entries" $ctx.Diff.MainChanges "Repo" .Repo.Name "Branch" "main" "Ownership" $ctx.FileOwnership)}}
+  {{end}}
+  {{if $ctx.Diff.Conflicts}}
+    <div class="diff-block-heading">conflicts <span class="count">({{len $ctx.Diff.Conflicts}})</span></div>
+    {{range $ctx.Diff.Conflicts}}
+    <div class="diff-line mod"><span class="path">{{.Path}}</span><span class="meta">main {{shortHash .MainVersionID}} · branch {{shortHash .BranchVersionID}}</span></div>
+    {{end}}
+  {{end}}
+</div>
+
+<h2>Proposal</h2>
+<div class="card">
+  {{if not $ctx.Proposals}}<div class="empty">no proposal opened for this branch</div>{{end}}
+  {{range $ctx.Proposals}}
+  <div class="row">
+    <div>
+      <strong>{{.Title}}</strong>
+      <div class="meta">{{.Author}} · opened {{relTime .CreatedAt}} · into {{.BaseBranch}}</div>
+    </div>
+    <span class="badge {{statusClass (printf "%s" .State)}}">{{.State}}</span>
+  </div>
+  {{if .Description}}<div class="row-body">{{.Description}}</div>{{end}}
+  {{end}}
+</div>
+
+<h2>Linked issues ({{len $ctx.LinkedIssues}})</h2>
+<div class="card">
+  {{if not $ctx.LinkedIssues}}<div class="empty">no linked issues</div>{{end}}
+  <div class="row-list">
+    {{range $ctx.LinkedIssues}}
+    <div class="row">
+      <div>#{{.Number}} <strong>{{.Title}}</strong> <span class="meta">by {{.Author}} · {{relTime .CreatedAt}}</span></div>
+      <span class="badge {{statusClass (printf "%s" .State)}}">{{.State}}</span>
+    </div>
+    {{end}}
+  </div>
+</div>
+
+<h2>Recent commits ({{len $ctx.RecentCommits}})</h2>
+<div class="card">
+  {{if not $ctx.RecentCommits}}<div class="empty">no commits on this branch yet</div>{{else}}
+  <table class="grid">
+    <thead><tr><th>seq</th><th>message</th><th>author</th><th>when</th></tr></thead>
+    <tbody>
+    {{range $ctx.RecentCommits}}
+    <tr>
+      <td>{{.Sequence}}</td>
+      <td>{{.Message}}</td>
+      <td>{{.Author}}</td>
+      <td class="meta">{{relTime .CreatedAt}}</td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{end}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/branches.html
+++ b/internal/ui/templates/branches.html
@@ -1,0 +1,39 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline"><h1>{{.Repo.Name}}</h1><span class="meta">owner {{.Repo.Owner}} · {{relTime .Repo.CreatedAt}}</span></div>
+
+<div class="filter-bar"><input type="search" data-branch-filter placeholder="filter branches by name…" autocomplete="off"></div>
+
+{{template "branchSection" (dict "Title" "Active" "Rows" .Active "Repo" .Repo.Name)}}
+{{template "branchSection" (dict "Title" "Merged" "Rows" .Merged "Repo" .Repo.Name)}}
+{{template "branchSection" (dict "Title" "Abandoned" "Rows" .Abandoned "Repo" .Repo.Name)}}
+{{end}}
+{{end}}
+
+{{define "branchSection"}}
+<h2>{{.Title}} ({{len .Rows}})</h2>
+<div class="card">
+  {{if not .Rows}}
+    <div class="empty">none</div>
+  {{else}}
+  <table class="grid">
+    <thead><tr><th>branch</th><th>status</th><th>head</th><th>base</th><th>flags</th><th></th></tr></thead>
+    <tbody>
+    {{range .Rows}}
+    <tr>
+      <td><a href="/ui/r/{{$.Repo}}/b/{{.Name}}">{{.Name}}</a></td>
+      <td><span class="badge {{statusClass .Status}}">{{.Status}}</span></td>
+      <td>{{.HeadSequence}}</td>
+      <td>{{.BaseSequence}}</td>
+      <td>
+        {{if .Draft}}<span class="badge warn">draft</span>{{end}}
+        {{if .AutoMerge}}<span class="badge ok">auto-merge</span>{{end}}
+      </td>
+      <td><a href="/ui/r/{{$.Repo}}/f/?branch={{.Name}}">files →</a></td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{end}}
+</div>
+{{end}}

--- a/internal/ui/templates/error.html
+++ b/internal/ui/templates/error.html
@@ -1,0 +1,7 @@
+{{define "content"}}
+<div class="err-box">
+  <h1>{{.Title}}</h1>
+  <p>{{.Err.Message}}</p>
+  <p><a href="/ui/">back to repos</a></p>
+</div>
+{{end}}

--- a/internal/ui/templates/file.html
+++ b/internal/ui/templates/file.html
@@ -1,0 +1,38 @@
+{{define "content"}}
+{{with .Body}}
+{{$page := .}}
+<div class="headline">
+  <h1>{{$page.Repo.Name}} <span class="meta">{{$page.Branch}}:{{$page.Path}}</span></h1>
+  <span class="meta">
+    {{if $page.File}}{{shortHash $page.File.ContentHash}}{{if $page.File.ContentType}} · {{$page.File.ContentType}}{{end}}<span class="dot">·</span>{{end}}
+    <a href="/ui/r/{{$page.Repo.Name}}/b/{{$page.Branch}}">branch: {{$page.Branch}} →</a>
+  </span>
+</div>
+
+<div class="two-col">
+  <div class="tree">
+    {{if $page.ParentDir}}<a class="item dir" href="/ui/r/{{$page.Repo.Name}}/f/{{$page.ParentDir}}?branch={{$page.Branch}}">..</a>{{end}}
+    {{range $page.Tree}}
+      {{if .IsDir}}
+        <a class="item dir" href="/ui/r/{{$page.Repo.Name}}/f/{{.Path}}?branch={{$page.Branch}}">{{.Name}}/</a>
+      {{else}}
+        <a class="item file" href="/ui/r/{{$page.Repo.Name}}/f/{{.Path}}?branch={{$page.Branch}}">{{.Name}}</a>
+      {{end}}
+    {{end}}
+    {{if not $page.Tree}}<div class="empty">empty</div>{{end}}
+  </div>
+
+  <div>
+    {{if $page.File}}
+    <pre class="code">
+    {{- range lines $page.File.Content}}<div class="ln"><span class="num">{{.Num}}</span><span class="text">{{.Text}}</span></div>{{end -}}
+    </pre>
+    {{else if $page.Path}}
+    <div class="card empty">file not found at this branch</div>
+    {{else}}
+    <div class="card empty">select a file from the tree</div>
+    {{end}}
+  </div>
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/layout.html
+++ b/internal/ui/templates/layout.html
@@ -1,0 +1,24 @@
+{{define "layout.html"}}<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{.Title}} · docstore</title>
+<script>(function(){try{var t=localStorage.getItem("ds-theme");if(t==="light"||t==="dark")document.documentElement.setAttribute("data-theme",t);}catch(e){}})();</script>
+<link rel="stylesheet" href="/ui/static/styles.css">
+<script defer src="/ui/static/poll.js"></script>
+</head>
+<body>
+<nav class="top">
+  <a class="brand" href="/ui/">docstore</a>
+  <span class="crumbs">
+  {{range $i, $c := .Breadcrumbs}}{{if $i}}<span class="sep">›</span>{{end}}{{if $c.Href}}<a href="{{$c.Href}}">{{$c.Label}}</a>{{else}}{{$c.Label}}{{end}}{{end}}
+  </span>
+  <span class="spacer"></span>
+  <button class="theme-toggle" data-theme-toggle type="button" aria-label="Toggle theme" title="Toggle theme"><span data-theme-icon-dark>☾</span><span data-theme-icon-light>☀</span></button>
+</nav>
+<main>
+{{block "content" .}}{{end}}
+</main>
+</body>
+</html>{{end}}

--- a/internal/ui/templates/repos.html
+++ b/internal/ui/templates/repos.html
@@ -1,0 +1,22 @@
+{{define "content"}}
+<h1>Repos</h1>
+{{with .Body}}
+{{if not .Orgs}}
+  <div class="card empty">No repos yet. Use <code>ds repos create</code> to add one.</div>
+{{else}}
+  {{range .Orgs}}
+  <div class="card">
+    <h2>{{.Name}}</h2>
+    <div class="row-list">
+      {{range .Repos}}
+      <a href="/ui/r/{{.Name}}">
+        <span>{{.Name}}</span>
+        <span class="meta">by {{.CreatedBy}} · {{relTime .CreatedAt}}</span>
+      </a>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+{{end}}
+{{end}}
+{{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1,0 +1,82 @@
+// Package ui serves a minimal read-only web UI over the docstore HTTP API.
+//
+// The UI is server-rendered with html/template + HTMX. All assets are embedded
+// so the server still ships as a single binary. The package does not perform
+// any mutations; users who need to write data use the `ds` CLI.
+package ui
+
+import (
+	"context"
+	"embed"
+	"io/fs"
+	"net/http"
+
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/store"
+)
+
+// ReadStore is the subset of server.ReadStore that the UI needs.
+type ReadStore interface {
+	MaterializeTree(ctx context.Context, repo, branch string, atSeq *int64, limit int, afterPath string) ([]store.TreeEntry, error)
+	GetFile(ctx context.Context, repo, branch, path string, atSeq *int64) (*store.FileContent, error)
+	GetBranch(ctx context.Context, repo, branch string) (*store.BranchInfo, error)
+	ListBranches(ctx context.Context, repo, statusFilter string, includeDraft, onlyDraft bool) ([]store.BranchInfo, error)
+}
+
+// WriteStoreLite is the subset of server.WriteStore that the UI needs for
+// listing repos and orgs. The UI never calls mutating methods.
+type WriteStoreLite interface {
+	ListRepos(ctx context.Context) ([]model.Repo, error)
+	ListOrgs(ctx context.Context) ([]model.Org, error)
+	GetRepo(ctx context.Context, name string) (*model.Repo, error)
+}
+
+// AssembleFn builds the full branch context snapshot used by the branch detail
+// page. The server wraps *server.AssembleAgentContext with an identity lookup
+// and injects the result, so the UI never sees identity directly.
+type AssembleFn func(ctx context.Context, repo, branch string) (*model.AgentContextResponse, error)
+
+//go:embed templates/*.html
+var templatesFS embed.FS
+
+//go:embed static
+var staticFS embed.FS
+
+// Handler renders the web UI.
+type Handler struct {
+	read      ReadStore
+	write     WriteStoreLite
+	assemble  AssembleFn
+	tmpl      *templateSet
+	staticSub fs.FS
+}
+
+// NewHandler constructs a UI handler wired to the given data sources.
+func NewHandler(read ReadStore, write WriteStoreLite, assemble AssembleFn) (*Handler, error) {
+	t, err := parseTemplates(templatesFS)
+	if err != nil {
+		return nil, err
+	}
+	sub, err := fs.Sub(staticFS, "static")
+	if err != nil {
+		return nil, err
+	}
+	return &Handler{
+		read:      read,
+		write:     write,
+		assemble:  assemble,
+		tmpl:      t,
+		staticSub: sub,
+	}, nil
+}
+
+// Register wires UI routes onto the provided mux. Caller is responsible for
+// placing this mux behind the same middleware chain used by the JSON API.
+func (h *Handler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /ui/{$}", h.handleRepos)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}", h.handleBranches)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}", h.handleBranchDetail)
+	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/checks", h.handleChecksPartial)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/f/{path...}", h.handleFile)
+	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
+}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1,0 +1,247 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// fakes
+// ---------------------------------------------------------------------------
+
+type fakeRead struct {
+	branches map[string][]store.BranchInfo
+	tree     map[string][]store.TreeEntry
+	files    map[string]*store.FileContent
+}
+
+func (f *fakeRead) MaterializeTree(_ context.Context, repo, _ string, _ *int64, _ int, _ string) ([]store.TreeEntry, error) {
+	return f.tree[repo], nil
+}
+func (f *fakeRead) GetFile(_ context.Context, repo, _, path string, _ *int64) (*store.FileContent, error) {
+	return f.files[repo+":"+path], nil
+}
+func (f *fakeRead) GetBranch(_ context.Context, _, _ string) (*store.BranchInfo, error) {
+	return nil, nil
+}
+func (f *fakeRead) ListBranches(_ context.Context, repo, _ string, _, _ bool) ([]store.BranchInfo, error) {
+	return f.branches[repo], nil
+}
+
+type fakeWrite struct {
+	repos []model.Repo
+	miss  bool
+}
+
+func (f *fakeWrite) ListRepos(_ context.Context) ([]model.Repo, error) { return f.repos, nil }
+func (f *fakeWrite) ListOrgs(_ context.Context) ([]model.Org, error)   { return nil, nil }
+func (f *fakeWrite) GetRepo(_ context.Context, name string) (*model.Repo, error) {
+	if f.miss {
+		return nil, db.ErrRepoNotFound
+	}
+	for _, r := range f.repos {
+		if r.Name == name {
+			return &r, nil
+		}
+	}
+	return nil, db.ErrRepoNotFound
+}
+
+func newFakeAssembler(branchName string) AssembleFn {
+	return func(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
+		if branch != branchName {
+			return nil, fmt.Errorf("branch not found")
+		}
+		return &model.AgentContextResponse{
+			Branch: model.Branch{
+				Name:         branchName,
+				HeadSequence: 42,
+				BaseSequence: 10,
+				Status:       model.BranchStatusActive,
+			},
+			Diff: model.DiffResponse{
+				BranchChanges: []model.DiffEntry{{Path: "docs/hello.md", VersionID: strPtr("v-abc123abc123")}},
+			},
+			Reviews:   []model.Review{},
+			CheckRuns: []model.CheckRun{},
+			Policies:  []model.PolicyResult{{Name: "at-least-one-review", Pass: false, Reason: "needs 1 more approval"}},
+			Mergeable: false,
+		}, nil
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func newTestHandler(t *testing.T, r ReadStore, w WriteStoreLite, a AssembleFn) http.Handler {
+	t.Helper()
+	h, err := NewHandler(r, w, a)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	mux := http.NewServeMux()
+	h.Register(mux)
+	return mux
+}
+
+func getStatusAndBody(t *testing.T, h http.Handler, target string) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec.Code, rec.Body.String()
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
+func TestHandleRepos_RendersOrgsAndRepos(t *testing.T) {
+	w := &fakeWrite{repos: []model.Repo{
+		{Name: "acme/a", Owner: "acme", CreatedBy: "me", CreatedAt: time.Now().Add(-1 * time.Hour)},
+		{Name: "acme/b", Owner: "acme", CreatedBy: "me", CreatedAt: time.Now()},
+		{Name: "beta/x", Owner: "beta", CreatedBy: "you", CreatedAt: time.Now()},
+	}}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200. body=%s", code, body)
+	}
+	for _, want := range []string{"acme/a", "acme/b", "beta/x", "docstore"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleBranches_UnknownRepo_Returns404HTML(t *testing.T) {
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{miss: true}, nil)
+	code, body := getStatusAndBody(t, h, "/ui/r/unknown/unknown")
+	if code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", code)
+	}
+	if !strings.Contains(body, "<!doctype html>") {
+		t.Errorf("expected HTML error page, got: %s", body)
+	}
+	if !strings.Contains(body, "repo not found") {
+		t.Errorf("expected 'repo not found' message")
+	}
+}
+
+func TestHandleBranches_RendersSections(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	r := &fakeRead{branches: map[string][]store.BranchInfo{
+		"acme/a": {
+			{Name: "feature-1", HeadSequence: 5, BaseSequence: 1, Status: "active"},
+			{Name: "old", HeadSequence: 10, BaseSequence: 1, Status: "merged"},
+		},
+	}}
+	h := newTestHandler(t, r, &fakeWrite{repos: repos}, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if !strings.Contains(body, "feature-1") || !strings.Contains(body, "Active (1)") {
+		t.Errorf("active section missing: %s", body)
+	}
+	if !strings.Contains(body, "Merged (1)") {
+		t.Errorf("merged section missing")
+	}
+}
+
+func TestHandleBranchDetail_RendersContext(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, newFakeAssembler("feat-x"))
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/b/feat-x")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"feat-x", "docs/hello.md", "at-least-one-review", "Blocked"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleBranchDetail_BranchNotFound_Returns404(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, newFakeAssembler("only-feat"))
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/b/does-not-exist")
+	if code != http.StatusNotFound {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+}
+
+func TestHandleChecksPartial_ReturnsFragment(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme"}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, newFakeAssembler("feat-x"))
+	code, body := getStatusAndBody(t, h, "/ui/_/r/acme/a/b/feat-x/checks")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if strings.Contains(body, "<!doctype html>") {
+		t.Errorf("expected fragment, got full layout")
+	}
+	if !strings.Contains(body, "no checks yet") {
+		t.Errorf("expected empty-checks marker, got: %s", body)
+	}
+}
+
+func TestHandleFile_RendersTreeAndContent(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	tree := []store.TreeEntry{
+		{Path: "README.md", VersionID: "v-1"},
+		{Path: "docs/hello.md", VersionID: "v-2"},
+		{Path: "docs/nested/deep.md", VersionID: "v-3"},
+	}
+	fc := &store.FileContent{Path: "docs/hello.md", VersionID: "v-2", ContentHash: "abc", Content: []byte("line1\nline2\n")}
+	r := &fakeRead{
+		tree:  map[string][]store.TreeEntry{"acme/a": tree},
+		files: map[string]*store.FileContent{"acme/a:docs/hello.md": fc},
+	}
+	h := newTestHandler(t, r, &fakeWrite{repos: repos}, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/f/docs/hello.md?branch=main")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"hello.md", "line1", "line2", "nested"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q in body", want)
+		}
+	}
+}
+
+func TestSiblingTreeRows_DedupsDirs(t *testing.T) {
+	entries := []store.TreeEntry{
+		{Path: "a.md"},
+		{Path: "dir/b.md"},
+		{Path: "dir/c.md"},
+		{Path: "dir/sub/d.md"},
+	}
+	rows := siblingTreeRows(entries, "")
+	if len(rows) != 2 {
+		t.Fatalf("rows=%+v", rows)
+	}
+	if !rows[0].IsDir || rows[0].Name != "dir" {
+		t.Errorf("want dir row first, got %+v", rows[0])
+	}
+	if rows[1].IsDir || rows[1].Name != "a.md" {
+		t.Errorf("want file a.md second, got %+v", rows[1])
+	}
+}


### PR DESCRIPTION
## Summary

Adds a single-binary web UI for browsing repos, branches, and files — served from the existing `http.ServeMux` behind the same IAP + RBAC middleware as the JSON API. No new build toolchain, no JS framework: stdlib `html/template` + `embed.FS` + a ~15-line vanilla polling shim for live CI status.

Screens:

| Route | Page |
|---|---|
| `GET /ui/` | repo list grouped by org |
| `GET /ui/r/{org}/{name}` | branch list (active/merged/abandoned) with a client-side filter |
| `GET /ui/r/{org}/{name}/b/{branch}` | branch detail — the marquee page |
| `GET /ui/r/{org}/{name}/f/{path...}` | file viewer with sibling tree pane |
| `GET /ui/_/r/.../b/.../checks` | polled partial for live check status |

The branch-detail page leads with a **mergeable / blocked hero summary** that joins failing policy reasons and failing/pending check names, so "is this safe to merge?" is answerable without scrolling. Passed checks collapse into a single line; failed/pending checks remain full rows and the whole row is clickable to the log URL.

Dark theme (default) and a warm-paper light theme with a nav toggle. Theme preference persists via `localStorage` and is applied inline in `<head>` before CSS loads to avoid FOUC.

Also extracts `AssembleAgentContext` out of `handleAgentContext` so the UI branch-detail handler can call it directly — no internal HTTP hop.

`cmd/ui-preview` is a small binary that serves the UI against in-memory fake data (no database needed), so the UI can be iterated on locally.

## Non-goals

- No mutations. Mutations stay in the `ds` CLI. No forms, no CSRF, no role management in-UI.
- No JS framework, no icon library, no new third-party deps.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./internal/ui/...` — 7 unit tests (handler smoke tests + `siblingTreeRows` dedup)
- [ ] `go test ./...` against a live Postgres
- [ ] `golangci-lint run ./...`
- [x] Manual: `go run ./cmd/ui-preview` and walk: repo list → repo → branch detail → file viewer → toggle theme → filter branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)