### PR TITLE
feat: add metadata JSONB field to check runs (#245)

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -155,6 +155,7 @@ type CheckRun struct {
 	LogURL    *string        `json:"log_url,omitempty"`
 	CreatedAt time.Time      `json:"created_at"`
 	Attempt   int16          `json:"attempt"`
+	Metadata  json.RawMessage `json:"metadata,omitempty"`
 }
 
 // Proposal is a request to merge a branch into a base branch.
@@ -501,8 +502,9 @@ type CreateCheckRunRequest struct {
 	CheckName string         `json:"check_name"`
 	Status    CheckRunStatus `json:"status"`
 	LogURL    *string        `json:"log_url,omitempty"`
-	Sequence  *int64         `json:"sequence,omitempty"`
-	Attempt   *int16         `json:"attempt,omitempty"`
+	Sequence  *int64          `json:"sequence,omitempty"`
+	Attempt   *int16          `json:"attempt,omitempty"`
+	Metadata  json.RawMessage `json:"metadata,omitempty"`
 }
 
 // CreateCheckRunResponse is the response for POST /check.

--- a/internal/db/migrations/000016_add_check_run_metadata.down.sql
+++ b/internal/db/migrations/000016_add_check_run_metadata.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE check_runs DROP COLUMN metadata;

--- a/internal/db/migrations/000016_add_check_run_metadata.up.sql
+++ b/internal/db/migrations/000016_add_check_run_metadata.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE check_runs ADD COLUMN metadata JSONB;

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1374,7 +1374,7 @@ func (s *Store) DeleteReviewComment(ctx context.Context, repo, id string) error 
 // attempt is the retry attempt number (1 = first run). If multiple rows exist
 // for the same (repo, branch, sequence, check_name, attempt), the status and
 // reporter are updated in place (upsert semantics).
-func (s *Store) CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16) (*model.CheckRun, error) {
+func (s *Store) CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16, metadata json.RawMessage) (*model.CheckRun, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		slog.Error("tx begin failed", "op", "create_check_run", "error", err)
@@ -1409,15 +1409,16 @@ func (s *Store) CreateCheckRun(ctx context.Context, repo, branch, checkName stri
 		nullLogURL = sql.NullString{String: *logURL, Valid: true}
 	}
 	err = tx.QueryRowContext(ctx,
-		`INSERT INTO check_runs (id, repo, branch, sequence, check_name, status, reporter, log_url, attempt)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		`INSERT INTO check_runs (id, repo, branch, sequence, check_name, status, reporter, log_url, attempt, metadata)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 		 ON CONFLICT (repo, branch, sequence, check_name, attempt)
 		 DO UPDATE SET
 		     status   = EXCLUDED.status,
 		     reporter = EXCLUDED.reporter,
-		     log_url  = COALESCE(EXCLUDED.log_url, check_runs.log_url)
+		     log_url  = COALESCE(EXCLUDED.log_url, check_runs.log_url),
+		     metadata = COALESCE(EXCLUDED.metadata, check_runs.metadata)
 		 RETURNING id, created_at`,
-		newID, repo, branch, headSeq, checkName, string(status), reporter, nullLogURL, attempt,
+		newID, repo, branch, headSeq, checkName, string(status), reporter, nullLogURL, attempt, []byte(metadata),
 	).Scan(&id, &createdAt)
 	if err != nil {
 		return nil, fmt.Errorf("insert check_run: %w", err)
@@ -1437,6 +1438,7 @@ func (s *Store) CreateCheckRun(ctx context.Context, repo, branch, checkName stri
 		LogURL:    logURL,
 		CreatedAt: createdAt,
 		Attempt:   attempt,
+		Metadata:  metadata,
 	}, nil
 }
 
@@ -1542,7 +1544,7 @@ func (s *Store) ListCheckRuns(ctx context.Context, repo, branch string, atSeq *i
 	args := []interface{}{repo, branch}
 
 	if history {
-		q = `SELECT id, sequence, check_name, status, reporter, log_url, created_at, attempt
+		q = `SELECT id, sequence, check_name, status, reporter, log_url, created_at, attempt, metadata
 		     FROM check_runs
 		     WHERE repo = $1 AND branch = $2`
 		if atSeq != nil {
@@ -1551,7 +1553,7 @@ func (s *Store) ListCheckRuns(ctx context.Context, repo, branch string, atSeq *i
 		}
 		q += " ORDER BY created_at DESC"
 	} else {
-		q = `SELECT DISTINCT ON (check_name) id, sequence, check_name, status, reporter, log_url, created_at, attempt
+		q = `SELECT DISTINCT ON (check_name) id, sequence, check_name, status, reporter, log_url, created_at, attempt, metadata
 		     FROM check_runs
 		     WHERE repo = $1 AND branch = $2`
 		if atSeq != nil {
@@ -1573,12 +1575,16 @@ func (s *Store) ListCheckRuns(ctx context.Context, repo, branch string, atSeq *i
 		cr.Branch = branch
 		var statusStr string
 		var nullLogURL sql.NullString
-		if err := rows.Scan(&cr.ID, &cr.Sequence, &cr.CheckName, &statusStr, &cr.Reporter, &nullLogURL, &cr.CreatedAt, &cr.Attempt); err != nil {
+		var nullMetadata []byte
+		if err := rows.Scan(&cr.ID, &cr.Sequence, &cr.CheckName, &statusStr, &cr.Reporter, &nullLogURL, &cr.CreatedAt, &cr.Attempt, &nullMetadata); err != nil {
 			return nil, err
 		}
 		cr.Status = model.CheckRunStatus(statusStr)
 		if nullLogURL.Valid {
 			cr.LogURL = &nullLogURL.String
+		}
+		if nullMetadata != nil {
+			cr.Metadata = json.RawMessage(nullMetadata)
 		}
 		checkRuns = append(checkRuns, cr)
 	}

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -1906,7 +1907,14 @@ func TestCreateCheckRun_WithMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateCheckRun: %v", err)
 	}
-	if string(cr.Metadata) != wantMeta {
+	var gotBuf, wantBuf bytes.Buffer
+	if err := json.Compact(&gotBuf, cr.Metadata); err != nil {
+		t.Fatalf("compact returned metadata: %v", err)
+	}
+	if err := json.Compact(&wantBuf, []byte(wantMeta)); err != nil {
+		t.Fatalf("compact wantMeta: %v", err)
+	}
+	if gotBuf.String() != wantBuf.String() {
 		t.Errorf("returned metadata: got %s, want %s", cr.Metadata, wantMeta)
 	}
 
@@ -1917,7 +1925,15 @@ func TestCreateCheckRun_WithMetadata(t *testing.T) {
 	if len(runs) == 0 {
 		t.Fatal("expected at least one check run")
 	}
-	if string(runs[0].Metadata) != wantMeta {
+	gotBuf.Reset()
+	wantBuf.Reset()
+	if err := json.Compact(&gotBuf, runs[0].Metadata); err != nil {
+		t.Fatalf("compact listed metadata: %v", err)
+	}
+	if err := json.Compact(&wantBuf, []byte(wantMeta)); err != nil {
+		t.Fatalf("compact wantMeta: %v", err)
+	}
+	if gotBuf.String() != wantBuf.String() {
 		t.Errorf("listed metadata: got %s, want %s", runs[0].Metadata, wantMeta)
 	}
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -1901,12 +1901,13 @@ func TestCreateCheckRun_WithMetadata(t *testing.T) {
 	ctx := context.Background()
 
 	meta := json.RawMessage(`{"key":"value"}`)
+	wantMeta := `{"key": "value"}`
 	cr, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil, 1, meta)
 	if err != nil {
 		t.Fatalf("CreateCheckRun: %v", err)
 	}
-	if string(cr.Metadata) != string(meta) {
-		t.Errorf("returned metadata: got %s, want %s", cr.Metadata, meta)
+	if string(cr.Metadata) != wantMeta {
+		t.Errorf("returned metadata: got %s, want %s", cr.Metadata, wantMeta)
 	}
 
 	runs, err := s.ListCheckRuns(ctx, "default/default", "main", nil, false)
@@ -1916,8 +1917,8 @@ func TestCreateCheckRun_WithMetadata(t *testing.T) {
 	if len(runs) == 0 {
 		t.Fatal("expected at least one check run")
 	}
-	if string(runs[0].Metadata) != string(meta) {
-		t.Errorf("listed metadata: got %s, want %s", runs[0].Metadata, meta)
+	if string(runs[0].Metadata) != wantMeta {
+		t.Errorf("listed metadata: got %s, want %s", runs[0].Metadata, wantMeta)
 	}
 }
 

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -1848,7 +1849,7 @@ func TestCreateCheckRun_Success(t *testing.T) {
 	s := NewStore(d)
 	ctx := context.Background()
 
-	cr, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil, 1)
+	cr, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil, 1, nil)
 	if err != nil {
 		t.Fatalf("CreateCheckRun: %v", err)
 	}
@@ -1884,12 +1885,39 @@ func TestCreateCheckRun_RecordedAtHeadSequence(t *testing.T) {
 		t.Fatalf("commit: %v", err)
 	}
 
-	cr, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil, 1)
+	cr, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil, 1, nil)
 	if err != nil {
 		t.Fatalf("CreateCheckRun: %v", err)
 	}
 	if cr.Sequence != 1 {
 		t.Errorf("expected sequence 1 (head), got %d", cr.Sequence)
+	}
+}
+
+func TestCreateCheckRun_WithMetadata(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	meta := json.RawMessage(`{"key":"value"}`)
+	cr, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil, 1, meta)
+	if err != nil {
+		t.Fatalf("CreateCheckRun: %v", err)
+	}
+	if string(cr.Metadata) != string(meta) {
+		t.Errorf("returned metadata: got %s, want %s", cr.Metadata, meta)
+	}
+
+	runs, err := s.ListCheckRuns(ctx, "default/default", "main", nil, false)
+	if err != nil {
+		t.Fatalf("ListCheckRuns: %v", err)
+	}
+	if len(runs) == 0 {
+		t.Fatal("expected at least one check run")
+	}
+	if string(runs[0].Metadata) != string(meta) {
+		t.Errorf("listed metadata: got %s, want %s", runs[0].Metadata, meta)
 	}
 }
 
@@ -1899,11 +1927,11 @@ func TestListCheckRuns_ByBranch(t *testing.T) {
 	s := NewStore(d)
 	ctx := context.Background()
 
-	_, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil, 1)
+	_, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil, 1, nil)
 	if err != nil {
 		t.Fatalf("check 1: %v", err)
 	}
-	_, err = s.CreateCheckRun(ctx, "default/default", "main", "ci/lint", model.CheckRunFailed, "ci-bot", nil, nil, 1)
+	_, err = s.CreateCheckRun(ctx, "default/default", "main", "ci/lint", model.CheckRunFailed, "ci-bot", nil, nil, 1, nil)
 	if err != nil {
 		t.Fatalf("check 2: %v", err)
 	}
@@ -1926,12 +1954,12 @@ func TestListCheckRuns_UpsertSameAttempt(t *testing.T) {
 	ctx := context.Background()
 
 	// Post pending at attempt 1.
-	_, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPending, "ci-bot", nil, nil, 1)
+	_, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPending, "ci-bot", nil, nil, 1, nil)
 	if err != nil {
 		t.Fatalf("check pending: %v", err)
 	}
 	// Post passed at same attempt — should upsert (update status).
-	_, err = s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil, 1)
+	_, err = s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil, 1, nil)
 	if err != nil {
 		t.Fatalf("check passed: %v", err)
 	}
@@ -1958,7 +1986,7 @@ func TestRetryChecks(t *testing.T) {
 	ctx := context.Background()
 
 	// First attempt: passed.
-	_, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil, 1)
+	_, err := s.CreateCheckRun(ctx, "default/default", "main", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil, 1, nil)
 	if err != nil {
 		t.Fatalf("CreateCheckRun: %v", err)
 	}
@@ -2474,7 +2502,7 @@ func TestPurge_DeletesReviewsAndChecks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create review: %v", err)
 	}
-	_, err = s.CreateCheckRun(ctx, "default/default", "feature/rev", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil, 1)
+	_, err = s.CreateCheckRun(ctx, "default/default", "feature/rev", "ci/build", model.CheckRunPassed, "ci-bot", nil, nil, 1, nil)
 	if err != nil {
 		t.Fatalf("create check_run: %v", err)
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -897,7 +897,7 @@ func (s *server) handleCheck(w http.ResponseWriter, r *http.Request) {
 	if req.Attempt != nil {
 		attempt = *req.Attempt
 	}
-	cr, err := s.commitStore.CreateCheckRun(r.Context(), repo, req.Branch, req.CheckName, req.Status, reporter, req.LogURL, req.Sequence, attempt)
+	cr, err := s.commitStore.CreateCheckRun(r.Context(), repo, req.Branch, req.CheckName, req.Status, reporter, req.LogURL, req.Sequence, attempt, req.Metadata)
 	if err != nil {
 		switch {
 		case errors.Is(err, db.ErrBranchNotFound):

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -78,7 +78,7 @@ type WriteStore interface {
 	// Review and check-run operations
 	CreateReview(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error)
 	ListReviews(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error)
-	CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16) (*model.CheckRun, error)
+	CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16, metadata json.RawMessage) (*model.CheckRun, error)
 	ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64, history bool) ([]model.CheckRun, error)
 	RetryChecks(ctx context.Context, repo, branch string, seq int64, checks []string) (int16, error)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -31,7 +31,7 @@ type mockStore struct {
 	getRepoFn       func(ctx context.Context, name string) (*model.Repo, error)
 	createReviewFn  func(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error)
 	listReviewsFn   func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error)
-	createCheckRunFn func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16) (*model.CheckRun, error)
+	createCheckRunFn func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16, metadata json.RawMessage) (*model.CheckRun, error)
 	listCheckRunsFn  func(ctx context.Context, repo, branch string, atSeq *int64, history bool) ([]model.CheckRun, error)
 	retryChecksFn    func(ctx context.Context, repo, branch string, seq int64, checks []string) (int16, error)
 	getRoleFn      func(ctx context.Context, repo, identity string) (*model.Role, error)
@@ -166,9 +166,9 @@ func (m *mockStore) ListReviews(ctx context.Context, repo, branch string, atSeq 
 	return nil, errors.New("not implemented")
 }
 
-func (m *mockStore) CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16) (*model.CheckRun, error) {
+func (m *mockStore) CreateCheckRun(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16, metadata json.RawMessage) (*model.CheckRun, error) {
 	if m.createCheckRunFn != nil {
-		return m.createCheckRunFn(ctx, repo, branch, checkName, status, reporter, logURL, atSequence, attempt)
+		return m.createCheckRunFn(ctx, repo, branch, checkName, status, reporter, logURL, atSequence, attempt, metadata)
 	}
 	return nil, errors.New("not implemented")
 }
@@ -1591,7 +1591,7 @@ func TestHandleReview_BranchNotFound(t *testing.T) {
 func TestHandleCheck_Success(t *testing.T) {
 	const identity = "ci-bot@example.com"
 	store := &mockStore{
-		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16) (*model.CheckRun, error) {
+		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16, metadata json.RawMessage) (*model.CheckRun, error) {
 			if repo != "default/default" {
 				t.Errorf("expected repo default, got %q", repo)
 			}
@@ -1632,12 +1632,42 @@ func TestHandleCheck_Success(t *testing.T) {
 	}
 }
 
+func TestHandleCheck_WithMetadata(t *testing.T) {
+	const identity = "ci-bot@example.com"
+	wantMeta := json.RawMessage(`{"agent":"v1","processed_seq":42}`)
+	var gotMeta json.RawMessage
+	store := &mockStore{
+		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16, metadata json.RawMessage) (*model.CheckRun, error) {
+			gotMeta = metadata
+			return &model.CheckRun{ID: "check-meta", Sequence: 1}, nil
+		},
+	}
+	srv := New(store, nil, identity, identity)
+
+	b, _ := json.Marshal(model.CreateCheckRunRequest{
+		Branch:    "feature/meta",
+		CheckName: "ci/build",
+		Status:    model.CheckRunPassed,
+		Metadata:  wantMeta,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/check", bytes.NewReader(b))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	if string(gotMeta) != string(wantMeta) {
+		t.Errorf("expected metadata %s, got %s", wantMeta, gotMeta)
+	}
+}
+
 func TestHandleCheck_ExplicitSequence(t *testing.T) {
 	const identity = "ci-bot@example.com"
 	const wantSeq int64 = 15
 	var gotSeq *int64
 	store := &mockStore{
-		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16) (*model.CheckRun, error) {
+		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16, metadata json.RawMessage) (*model.CheckRun, error) {
 			gotSeq = atSequence
 			seq := int64(0)
 			if atSequence != nil {
@@ -1667,7 +1697,7 @@ func TestHandleCheck_ExplicitSequence(t *testing.T) {
 
 func TestHandleCheck_BranchNotFound(t *testing.T) {
 	store := &mockStore{
-		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16) (*model.CheckRun, error) {
+		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16, metadata json.RawMessage) (*model.CheckRun, error) {
 			return nil, db.ErrBranchNotFound
 		},
 	}
@@ -2739,7 +2769,7 @@ default allow = true
 			writeDetector()
 			return nil, nil
 		},
-		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16) (*model.CheckRun, error) {
+		createCheckRunFn: func(ctx context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSequence *int64, attempt int16, metadata json.RawMessage) (*model.CheckRun, error) {
 			writeDetector()
 			return nil, nil
 		},


### PR DESCRIPTION
## Summary

- Adds migration 000016 to add a `metadata JSONB` column to `check_runs`
- Extends `CheckRun` and `CreateCheckRunRequest` API types with an optional `Metadata json.RawMessage` field
- Updates `CreateCheckRun` store method (and interface) to accept and persist metadata; UPSERT preserves existing metadata when new value is NULL
- Updates `ListCheckRuns` to read metadata back from DB
- Handler passes `req.Metadata` through to the store
- All existing call sites updated with `nil` for backward compatibility
- New tests: `TestHandleCheck_WithMetadata` (server) and `TestCreateCheckRun_WithMetadata` (store)

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/server/... -count=1` — all pass (TestDockerSmoke fails due to pre-existing missing GCloud credentials, unrelated to this change)

Note: `TestDockerSmoke` is a pre-existing failure caused by missing GCloud auth credentials in this environment, not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)