### PR TITLE
feat: add Repo field to Branch, CheckRun, Review for canonical URI construction (#249)

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -117,6 +117,7 @@ type Repo struct {
 
 // Branch is a named pointer to a sequence.
 type Branch struct {
+	Repo         string       `json:"repo"`
 	Name         string       `json:"name"`
 	HeadSequence int64        `json:"head_sequence"`
 	BaseSequence int64        `json:"base_sequence"`
@@ -135,6 +136,7 @@ type Role struct {
 // head sequence.
 type Review struct {
 	ID        string       `json:"id"`
+	Repo      string       `json:"repo"`
 	Branch    string       `json:"branch"`
 	Reviewer  string       `json:"reviewer"`
 	Sequence  int64        `json:"sequence"`
@@ -147,6 +149,7 @@ type Review struct {
 // head sequence.
 type CheckRun struct {
 	ID        string         `json:"id"`
+	Repo      string         `json:"repo"`
 	Branch    string         `json:"branch"`
 	Sequence  int64          `json:"sequence"`
 	CheckName string         `json:"check_name"`

--- a/docs/canonical-resource-uris.md
+++ b/docs/canonical-resource-uris.md
@@ -1,0 +1,58 @@
+# Canonical Resource URIs
+
+Every resource in docstore has a canonical URI that uniquely identifies it across repos. These URIs are used by agents and external tools to reference resources without ambiguity.
+
+## URI Scheme
+
+The `repo` path segment is the full repo identifier (e.g. `acme/myrepo`).
+
+| Resource | Canonical URI pattern | Example |
+|---|---|---|
+| Branch (current head) | `{repo}/branches/{name}` | `acme/myrepo/branches/feature/x` |
+| Branch at sequence | `{repo}/branches/{name}@{seq}` | `acme/myrepo/branches/feature/x@42` |
+| CheckRun | `{repo}/checks/{id}` | `acme/myrepo/checks/550e8400-e29b-41d4-a716-446655440000` |
+| Review | `{repo}/reviews/{id}` | `acme/myrepo/reviews/6ba7b810-9dad-11d1-80b4-00c04fd430c8` |
+| Proposal | `{repo}/proposals/{id}` | `acme/myrepo/proposals/7c9e6679-7425-40de-944b-e07fc1f90ae7` |
+| File (on branch) | `{repo}/branches/{branch}/{path}` | `acme/myrepo/branches/feature/x/src/main.go` |
+| Issue | `{repo}/issues/{number}` | `acme/myrepo/issues/42` |
+
+## Repo field in API types
+
+The `Branch`, `CheckRun`, and `Review` types each carry a `repo` field so that agents holding a reference to one of these objects can construct the canonical URI without needing additional context.
+
+```json
+{
+  "repo": "acme/myrepo",
+  "name": "feature/x",
+  "head_sequence": 42,
+  ...
+}
+```
+
+This field is always populated by the server from the URL path; clients do not need to set it.
+
+## Constructing a URI
+
+Given a `Branch` object:
+
+```
+{branch.repo}/branches/{branch.name}
+```
+
+Given a `Branch` object at a specific sequence:
+
+```
+{branch.repo}/branches/{branch.name}@{branch.head_sequence}
+```
+
+Given a `CheckRun` object:
+
+```
+{check_run.repo}/checks/{check_run.id}
+```
+
+Given a `Review` object:
+
+```
+{review.repo}/reviews/{review.id}
+```

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1179,6 +1179,7 @@ func (s *Store) CreateReview(ctx context.Context, repo, branch, reviewer string,
 
 	return &model.Review{
 		ID:        id,
+		Repo:      repo,
 		Branch:    branch,
 		Reviewer:  reviewer,
 		Sequence:  headSeq,
@@ -1211,6 +1212,7 @@ func (s *Store) ListReviews(ctx context.Context, repo, branch string, atSeq *int
 	var reviews []model.Review
 	for rows.Next() {
 		var rev model.Review
+		rev.Repo = repo
 		rev.Branch = branch
 		var statusStr string
 		if err := rows.Scan(&rev.ID, &rev.Reviewer, &rev.Sequence, &statusStr, &rev.Body, &rev.CreatedAt); err != nil {
@@ -1430,6 +1432,7 @@ func (s *Store) CreateCheckRun(ctx context.Context, repo, branch, checkName stri
 
 	return &model.CheckRun{
 		ID:        id,
+		Repo:      repo,
 		Branch:    branch,
 		Sequence:  headSeq,
 		CheckName: checkName,
@@ -1572,6 +1575,7 @@ func (s *Store) ListCheckRuns(ctx context.Context, repo, branch string, atSeq *i
 	var checkRuns []model.CheckRun
 	for rows.Next() {
 		var cr model.CheckRun
+		cr.Repo = repo
 		cr.Branch = branch
 		var statusStr string
 		var nullLogURL sql.NullString

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2502,6 +2502,7 @@ func (s *server) AssembleAgentContext(ctx context.Context, repo, branch, actor s
 
 	return &model.AgentContextResponse{
 		Branch: model.Branch{
+			Repo:         repo,
 			Name:         branchInfo.Name,
 			HeadSequence: branchInfo.HeadSequence,
 			BaseSequence: branchInfo.BaseSequence,

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -958,6 +958,7 @@ func TestIntegrationReviewFlow(t *testing.T) {
 
 	var reviews []struct {
 		ID       string `json:"id"`
+		Repo     string `json:"repo"`
 		Reviewer string `json:"reviewer"`
 		Status   string `json:"status"`
 	}
@@ -969,6 +970,9 @@ func TestIntegrationReviewFlow(t *testing.T) {
 	}
 	if reviews[0].Status != "approved" {
 		t.Errorf("expected status approved, got %q", reviews[0].Status)
+	}
+	if reviews[0].Repo != "default/default" {
+		t.Errorf("expected repo default/default, got %q", reviews[0].Repo)
 	}
 
 	// Step 6: alice makes another commit — the prior review becomes stale.
@@ -1037,6 +1041,7 @@ func TestIntegrationCheckRunFlow(t *testing.T) {
 
 	var checks []struct {
 		ID        string `json:"id"`
+		Repo      string `json:"repo"`
 		CheckName string `json:"check_name"`
 		Status    string `json:"status"`
 	}
@@ -1048,6 +1053,9 @@ func TestIntegrationCheckRunFlow(t *testing.T) {
 	}
 	if checks[0].Status != "passed" {
 		t.Errorf("expected status passed, got %q", checks[0].Status)
+	}
+	if checks[0].Repo != "default/default" {
+		t.Errorf("expected repo default/default, got %q", checks[0].Repo)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1731,7 +1731,7 @@ func TestHandleGetReviews(t *testing.T) {
 				t.Errorf("expected branch feature/x, got %q", branch)
 			}
 			return []model.Review{
-				{ID: "r1", Branch: "feature/x", Reviewer: "alice", Sequence: 2, Status: model.ReviewApproved},
+				{ID: "r1", Repo: "default/default", Branch: "feature/x", Reviewer: "alice", Sequence: 2, Status: model.ReviewApproved},
 			}, nil
 		},
 	}
@@ -1754,6 +1754,9 @@ func TestHandleGetReviews(t *testing.T) {
 	if reviews[0].ID != "r1" {
 		t.Errorf("expected id r1, got %q", reviews[0].ID)
 	}
+	if reviews[0].Repo != "default/default" {
+		t.Errorf("expected repo default/default, got %q", reviews[0].Repo)
+	}
 }
 
 func TestHandleGetChecks(t *testing.T) {
@@ -1766,7 +1769,7 @@ func TestHandleGetChecks(t *testing.T) {
 				t.Errorf("expected branch feature/x, got %q", branch)
 			}
 			return []model.CheckRun{
-				{ID: "cr1", Branch: "feature/x", CheckName: "ci/build", Sequence: 2, Status: model.CheckRunPassed, Reporter: "ci-bot"},
+				{ID: "cr1", Repo: "default/default", Branch: "feature/x", CheckName: "ci/build", Sequence: 2, Status: model.CheckRunPassed, Reporter: "ci-bot"},
 			}, nil
 		},
 	}
@@ -1788,6 +1791,9 @@ func TestHandleGetChecks(t *testing.T) {
 	}
 	if checkRuns[0].ID != "cr1" {
 		t.Errorf("expected id cr1, got %q", checkRuns[0].ID)
+	}
+	if checkRuns[0].Repo != "default/default" {
+		t.Errorf("expected repo default/default, got %q", checkRuns[0].Repo)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -255,6 +255,7 @@ LIMIT $5`
 
 // BranchInfo describes a branch for listing.
 type BranchInfo struct {
+	Repo         string `json:"repo"`
 	Name         string `json:"name"`
 	HeadSequence int64  `json:"head_sequence"`
 	BaseSequence int64  `json:"base_sequence"`
@@ -298,6 +299,7 @@ func (s *Store) GetBranch(ctx context.Context, repo, branch string) (*BranchInfo
 		}
 		return nil, err
 	}
+	b.Repo = repo
 	return &b, nil
 }
 
@@ -332,6 +334,7 @@ func (s *Store) ListBranches(ctx context.Context, repo, statusFilter string, inc
 		if err := rows.Scan(&b.Name, &b.HeadSequence, &b.BaseSequence, &b.Status, &b.Draft, &b.AutoMerge); err != nil {
 			return nil, err
 		}
+		b.Repo = repo
 		branches = append(branches, b)
 	}
 	return branches, rows.Err()


### PR DESCRIPTION
## Summary

- Adds `Repo string json:"repo"` to `api.Branch`, `api.Review`, and `api.CheckRun` so agents can construct canonical URIs without additional context
- Adds `Repo` to `store.BranchInfo` (the `GET /branches` response type) for consistency
- Populates `Repo` in all relevant DB/store functions (`ListReviews`, `CreateReview`, `ListCheckRuns`, `CreateCheckRun`, `GetBranch`, `ListBranches`) and in `AssembleAgentContext`
- Adds assertions in `server_test.go` and `integration_test.go` verifying the `Repo` field is populated
- Adds `docs/canonical-resource-uris.md` documenting the canonical URI scheme table

All changes are additive and backward-compatible. Event types in `internal/events/types/` already carry `Repo` fields and required no changes.

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go vet ./...` — clean
- [ ] `go test ./... -count=1 -skip TestDockerSmoke` — all pass (`TestDockerSmoke` is a pre-existing failure due to expired GCP credentials in this environment, unrelated to this change)
- [ ] New assertions in `TestHandleGetReviews` and `TestHandleGetChecks` verify `Repo == "default/default"`
- [ ] New assertions in `TestIntegrationReviewFlow` and `TestIntegrationCheckRunFlow` verify `Repo == "default/default"` on listed objects

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)