### PR TITLE
feat: add dry-run mode to merge endpoint (closes #248)

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -404,6 +404,7 @@ type MergeRequest struct {
 	Repo   string `json:"repo,omitempty"`
 	Branch string `json:"branch"`
 	Author string `json:"author,omitempty"`
+	DryRun bool   `json:"dry_run,omitempty"`
 }
 
 // MergeResponse is the response for a successful POST /merge.

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -708,6 +708,10 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 	}
 
 	if len(branchChanges) == 0 {
+		// For dry_run, return without modifying state (defer will rollback).
+		if req.DryRun {
+			return &model.MergeResponse{Sequence: mainHead}, nil, nil
+		}
 		// Nothing to merge — mark branch as merged anyway.
 		_, err = tx.ExecContext(ctx,
 			"UPDATE branches SET status = 'merged' WHERE repo = $1 AND name = $2",
@@ -804,6 +808,12 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 	mergeHash := computeCommitHash(prevHash, newSeq, req.Repo, "main", req.Author, mergeMsg, mergeCreatedAt, hashFiles)
 	if err := updateCommitHash(ctx, tx, req.Repo, newSeq, mergeHash); err != nil {
 		return nil, nil, fmt.Errorf("store merge commit hash: %w", err)
+	}
+
+	// For dry_run, return computed sequence without committing (defer will rollback).
+	if req.DryRun {
+		slog.Info("merge dry-run complete", "repo", req.Repo, "branch", req.Branch, "sequence", newSeq, "files", len(branchChanges))
+		return &model.MergeResponse{Sequence: newSeq}, nil, nil
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2162,6 +2162,13 @@ func (s *server) handleMerge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Dry-run: skip all side effects and return the computed sequence.
+	if req.DryRun {
+		slog.Info("merge dry-run", "repo", repo, "branch", req.Branch, "by", req.Author, "sequence", resp.Sequence)
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
 	// Invalidate the policy cache: the merge may have updated policies on main.
 	if s.policyCache != nil {
 		s.policyCache.Invalidate(repo)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1482,6 +1482,118 @@ func TestHandleMerge_RepoNotFound(t *testing.T) {
 	}
 }
 
+func TestHandleMerge_DryRun_NoConflicts(t *testing.T) {
+	ms := &mockStore{
+		mergeFn: func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
+			if !req.DryRun {
+				t.Error("expected DryRun=true in store call")
+			}
+			return &model.MergeResponse{Sequence: 10}, nil, nil
+		},
+		listReviewsFn:   func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error) { return nil, nil },
+		listCheckRunsFn: func(ctx context.Context, repo, branch string, atSeq *int64, history bool) ([]model.CheckRun, error) { return nil, nil },
+	}
+	pc := &mockPolicyCache{}
+	srv := newTestHandler(ms, &mockReadStore{}, pc)
+
+	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/test", DryRun: true})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/merge", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp model.MergeResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Sequence != 10 {
+		t.Errorf("expected sequence 10, got %d", resp.Sequence)
+	}
+	// Policy cache must not be invalidated on dry-run.
+	if len(pc.invalidated) > 0 {
+		t.Errorf("policy cache should not be invalidated on dry-run, got: %v", pc.invalidated)
+	}
+}
+
+func TestHandleMerge_DryRun_Conflict(t *testing.T) {
+	ms := &mockStore{
+		mergeFn: func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
+			if !req.DryRun {
+				t.Error("expected DryRun=true in store call")
+			}
+			return nil, []db.MergeConflict{
+				{Path: "conflict.txt", MainVersionID: "v1", BranchVersionID: "v2"},
+			}, db.ErrMergeConflict
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+
+	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/conflict", DryRun: true})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/merge", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var errResp model.MergeConflictError
+	if err := json.NewDecoder(rec.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(errResp.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d", len(errResp.Conflicts))
+	}
+	if errResp.Conflicts[0].Path != "conflict.txt" {
+		t.Errorf("expected conflict.txt, got %q", errResp.Conflicts[0].Path)
+	}
+}
+
+func TestHandleMerge_DryRun_PolicyReject(t *testing.T) {
+	engine := mustBuildEngine(t, "require_review", `
+package docstore.require_review
+default allow = false
+default reason = "a review is required"
+`)
+
+	mergeCalled := false
+	ms := &mockStore{
+		mergeFn: func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
+			mergeCalled = true
+			return nil, nil, nil
+		},
+		listReviewsFn:   func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error) { return nil, nil },
+		listCheckRunsFn: func(ctx context.Context, repo, branch string, atSeq *int64, history bool) ([]model.CheckRun, error) { return nil, nil },
+	}
+	pc := &mockPolicyCache{
+		loadFn: func(ctx context.Context, repo string, _ policy.ReadStore) (*policy.Engine, map[string][]string, error) {
+			return engine, nil, nil
+		},
+	}
+
+	srv := newTestHandler(ms, &mockReadStore{}, pc)
+
+	body, _ := json.Marshal(model.MergeRequest{Branch: "feature/test", DryRun: true})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/merge", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	if mergeCalled {
+		t.Error("store.Merge should not be called when policy denies")
+	}
+	var resp model.MergePolicyError
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Policies) != 1 || resp.Policies[0].Pass {
+		t.Errorf("expected one failing policy result, got: %+v", resp.Policies)
+	}
+}
+
 func TestHandleRebase_RepoNotFound(t *testing.T) {
 	store := &mockStore{
 		getRepoFn: func(ctx context.Context, name string) (*model.Repo, error) {


### PR DESCRIPTION
## Summary

- Adds `dry_run: bool` to `MergeRequest` in `api/types.go`
- `Store.Merge()` skips `tx.Commit()` when `DryRun` is true (same rollback-on-return pattern as `Purge()`)
- `handleMerge()` skips policy cache invalidation, proposal state transition, and event emission when dry-run; policy evaluation still runs normally
- Adds three handler-level tests: dry-run no-conflicts (sequence returned, cache not invalidated), dry-run with conflicts (409 returned), dry-run with policy rejection (403 returned)

## Test plan

- [x] `TestHandleMerge_DryRun_NoConflicts` — 200 with sequence, DryRun=true passed to store, policy cache not invalidated
- [x] `TestHandleMerge_DryRun_Conflict` — 409 with conflict list, DryRun=true passed to store
- [x] `TestHandleMerge_DryRun_PolicyReject` — 403 returned, store.Merge not called
- [x] All existing tests pass; `TestDockerSmoke` pre-existing failure (gcloud credentials unavailable in dev environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)