### PR TITLE
fix(migration): deduplicate check_runs before adding unique constraint

### DIFF
--- a/internal/db/migrations/000015_add_check_attempt.up.sql
+++ b/internal/db/migrations/000015_add_check_attempt.up.sql
@@ -1,3 +1,13 @@
 ALTER TABLE check_runs ADD COLUMN attempt SMALLINT NOT NULL DEFAULT 1;
 DROP INDEX idx_check_runs_repo_branch_seq_name;
+-- Remove duplicate rows that would violate the upcoming unique constraint.
+-- Before this migration there was no unique index, so multiple status-update
+-- rows could exist for the same (repo, branch, sequence, check_name). Keep
+-- only the most-recently created row per tuple; all get attempt=1 above.
+DELETE FROM check_runs
+WHERE id NOT IN (
+    SELECT DISTINCT ON (repo, branch, sequence, check_name) id
+    FROM check_runs
+    ORDER BY repo, branch, sequence, check_name, created_at DESC
+);
 ALTER TABLE check_runs ADD CONSTRAINT check_runs_unique UNIQUE (repo, branch, sequence, check_name, attempt);


### PR DESCRIPTION
## Summary

- Migration 000015 has been failing on the production database since it was merged in #265, because existing `check_runs` rows have duplicate `(repo, branch, sequence, check_name)` tuples (the old code had no unique constraint and inserted a new row per status update)
- When the migration adds `attempt SMALLINT DEFAULT 1`, all existing duplicates collide on the new `UNIQUE` constraint, the migration fails, and `golang-migrate` sets `dirty=true` — blocking all subsequent startups with `ErrDirty`
- This is why every deploy since #265 fails with: *"container failed to start and listen on port 8080"*

This PR adds a `DELETE` step before the constraint to keep only the most-recently-created row per `(repo, branch, sequence, check_name)` tuple.

## Production DB fix required

**Before the next deploy lands**, the `schema_migrations` dirty state must be manually reset:

```sql
UPDATE schema_migrations SET dirty = false, version = 14;
```

This allows the fixed migration to re-run cleanly.

## Test plan

- [ ] Reset production `schema_migrations` as above before merging
- [ ] Verify deploy succeeds after merge
- [ ] Existing migration tests pass (fresh DB sees no duplicates to delete, constraint applies cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)