### PR TITLE
feat: DB-backed SSE event log for horizontal scaling (closes #246)

### DIFF
--- a/cmd/docstore/main.go
+++ b/cmd/docstore/main.go
@@ -138,7 +138,7 @@ func main() {
 	// The dispatcher runs until dispatchCancel is called on shutdown.
 	broker := events.NewBroker(database)
 	dispatchCtx, dispatchCancel := context.WithCancel(context.Background())
-	events.StartDispatcher(dispatchCtx, database)
+	events.StartDispatcher(dispatchCtx, database, dsn, broker)
 
 	srv := server.NewWithBroker(commitStore, database, bs, broker, *devIdentity, *bootstrapAdmin)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -70,7 +70,7 @@ Deployment is automated via GitHub Actions (`.github/workflows/deploy.yml`) on e
 2. Deploys to Cloud Run with:
    - Cloud SQL instance: `dlorenc-chainguard:us-central1:docstore-mvp`
    - Secret: `DATABASE_URL` from `docstore-db-url` in Secret Manager
-   - 1 min instance, 1 max instance (no horizontal scaling; SSE broker is in-process)
+   - 1 min instance, auto-scaling enabled (SSE events are DB-backed via event_log)
    - `--no-cpu-throttling` — keeps the CPU active for background goroutines
    - VPC egress via `--network=default --subnet=default --vpc-egress=private-ranges-only` so Cloud Run can reach the internal GKE load balancer
 
@@ -90,7 +90,7 @@ gcloud run deploy docstore \
   --add-cloudsql-instances=dlorenc-chainguard:us-central1:docstore-mvp \
   --update-secrets=DATABASE_URL=docstore-db-url:latest \
   --allow-unauthenticated \
-  --min-instances=1 --max-instances=1 \
+  --min-instances=1 \
   --no-cpu-throttling \
   --port=8080
 ```
@@ -173,6 +173,6 @@ The deploy workflow (`deploy.yml`) also builds and deploys both CI binaries afte
    ds roles set alice@example.com admin
    ```
 
-## Horizontal scaling note
+## Horizontal scaling
 
-The event broker (`internal/events.Broker`) is in-process. With multiple Cloud Run instances, SSE streams (`GET /events`, `GET /repos/{name}/-/events`) only receive events from the instance that processed the mutation. Keep `--max-instances=1` unless you drop the SSE feature.
+The event broker persists all events to the `event_log` PostgreSQL table and uses `pg_notify` for real-time wake-ups. SSE streams (`GET /events`, `GET /repos/{name}/-/events`) poll `event_log` directly, so every instance sees every event regardless of which instance processed the original mutation. Multiple Cloud Run instances are fully supported.

--- a/internal/automerge/worker.go
+++ b/internal/automerge/worker.go
@@ -5,8 +5,10 @@ package automerge
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
+	"time"
 
 	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/events"
@@ -50,36 +52,56 @@ func New(broker *events.Broker, st Store, rs mergeutil.ReadStore, pc mergeutil.P
 	}
 }
 
-// Run starts the event loop. It blocks until ctx is cancelled.
+// Run starts the event loop. It polls event_log for check.reported and
+// review.submitted events and attempts auto-merge when a branch qualifies.
+// Blocks until ctx is cancelled.
 func (w *Worker) Run(ctx context.Context) {
 	if w.broker == nil || w.store == nil || w.readStore == nil {
 		return
 	}
 
-	ch, unsub := w.broker.Subscribe("*", []string{
+	targetTypes := []string{
 		"com.docstore.check.reported",
 		"com.docstore.review.submitted",
-	})
-	defer unsub()
+	}
+
+	// Start from the current tail so we don't replay historical events.
+	sinceSeq, err := w.broker.CurrentSeq(ctx)
+	if err != nil {
+		slog.Error("auto-merge: CurrentSeq failed", "error", err)
+	}
 
 	for {
-		select {
-		case <-ctx.Done():
-			return
-		case ev, ok := <-ch:
-			if !ok {
+		evs, pollErr := w.broker.Poll(ctx, "*", sinceSeq, targetTypes)
+		if pollErr != nil {
+			if ctx.Err() != nil {
 				return
 			}
-			var repo, branch string
-			switch e := ev.(type) {
-			case evtypes.CheckReported:
-				repo, branch = e.Repo, e.Branch
-			case evtypes.ReviewSubmitted:
-				repo, branch = e.Repo, e.Branch
-			default:
+			slog.Error("auto-merge: poll failed", "error", pollErr)
+		}
+
+		for _, ev := range evs {
+			sinceSeq = ev.Seq
+			var envelope struct {
+				Data struct {
+					Branch string `json:"branch"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(ev.Payload, &envelope); err != nil {
+				slog.Warn("auto-merge: unmarshal event payload failed",
+					"type", ev.Type, "seq", ev.Seq, "error", err)
 				continue
 			}
-			w.tryAutoMerge(ctx, repo, branch)
+			w.tryAutoMerge(ctx, ev.Repo, envelope.Data.Branch)
+		}
+
+		// Wait for a new event notification (or give up after 30 s and re-poll).
+		waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		w.broker.WaitForEvent(waitCtx) //nolint:errcheck
+		cancel()
+
+		if ctx.Err() != nil {
+			return
 		}
 	}
 }

--- a/internal/automerge/worker_test.go
+++ b/internal/automerge/worker_test.go
@@ -2,15 +2,35 @@ package automerge
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"testing"
 
-	"github.com/dlorenc/docstore/internal/db"
+	dbpkg "github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/events"
-	evtypes "github.com/dlorenc/docstore/internal/events/types"
 	mergeutil "github.com/dlorenc/docstore/internal/merge"
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/store"
+	"github.com/dlorenc/docstore/internal/testutil"
 )
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+
+var sharedAdminDSN string
+
+func TestMain(m *testing.M) {
+	dsn, cleanup, err := testutil.StartSharedPostgres()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "start shared postgres: %v\n", err)
+		os.Exit(1)
+	}
+	sharedAdminDSN = dsn
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}
 
 // ---------------------------------------------------------------------------
 // Mock Store (implements automerge.Store)
@@ -18,7 +38,7 @@ import (
 
 type mockStore struct {
 	setBranchAutoMergeFn func(ctx context.Context, repo, name string, autoMerge bool) error
-	mergeFn              func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error)
+	mergeFn              func(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []dbpkg.MergeConflict, error)
 	mergeProposalFn      func(ctx context.Context, repo, branch string) (*model.Proposal, error)
 	listReviewsFn        func(ctx context.Context, repo, branch string, atSeq *int64) ([]model.Review, error)
 	listCheckRunsFn      func(ctx context.Context, repo, branch string, atSeq *int64, history bool) ([]model.CheckRun, error)
@@ -40,7 +60,7 @@ func (m *mockStore) SetBranchAutoMerge(ctx context.Context, repo, name string, a
 	return nil
 }
 
-func (m *mockStore) Merge(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
+func (m *mockStore) Merge(ctx context.Context, req model.MergeRequest) (*model.MergeResponse, []dbpkg.MergeConflict, error) {
 	m.mergeCalled = true
 	if m.mergeFn != nil {
 		return m.mergeFn(ctx, req)
@@ -110,8 +130,6 @@ func (m *mockReadStore) GetFile(ctx context.Context, repo, branch, path string, 
 	return nil, nil
 }
 
-// Ensure mockReadStore also satisfies mergeutil.QueryStore (via mockStore) —
-// the worker passes w.store as the QueryStore argument to EvaluatePolicy.
 var _ mergeutil.ReadStore = (*mockReadStore)(nil)
 
 // ---------------------------------------------------------------------------
@@ -126,16 +144,6 @@ func activeBranch() *store.BranchInfo {
 		Draft:     false,
 		AutoMerge: true,
 	}
-}
-
-// subscribeAll subscribes to all event types and returns a buffered channel.
-func subscribeAll(broker *events.Broker) <-chan events.Event {
-	ch, _ := broker.Subscribe("*", []string{
-		"com.docstore.branch.merged",
-		"com.docstore.branch.automerge.failed",
-		"com.docstore.proposal.merged",
-	})
-	return ch
 }
 
 // ---------------------------------------------------------------------------
@@ -194,48 +202,51 @@ func TestTryAutoMerge_SkipsWhenNotActive(t *testing.T) {
 }
 
 func TestTryAutoMerge_MergesWhenAllowed(t *testing.T) {
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	rs := &mockReadStore{
 		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
 			return activeBranch(), nil
 		},
 	}
 	ms := &mockStore{}
-	broker := events.NewBroker(nil)
-	evCh := subscribeAll(broker)
+	broker := events.NewBroker(d)
 	w := New(broker, ms, rs, nil) // nil policyCache → all merges allowed
 
+	seq, _ := broker.CurrentSeq(context.Background())
 	w.tryAutoMerge(context.Background(), "myrepo", "my-feature")
 
 	if !ms.mergeCalled {
 		t.Fatal("expected Merge to be called")
 	}
 
-	// Expect a BranchMerged event.
-	select {
-	case ev := <-evCh:
-		if _, ok := ev.(evtypes.BranchMerged); !ok {
-			t.Errorf("expected BranchMerged event, got %T", ev)
-		}
-	default:
-		t.Error("expected BranchMerged event but channel was empty")
+	evs, err := broker.Poll(context.Background(), "*", seq, []string{"com.docstore.branch.merged"})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(evs) == 0 {
+		t.Error("expected BranchMerged event in event_log")
+	}
+	if len(evs) > 0 && evs[0].Type != "com.docstore.branch.merged" {
+		t.Errorf("expected branch.merged event, got %q", evs[0].Type)
 	}
 }
 
 func TestTryAutoMerge_DisablesOnConflict(t *testing.T) {
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	rs := &mockReadStore{
 		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
 			return activeBranch(), nil
 		},
 	}
 	ms := &mockStore{
-		mergeFn: func(_ context.Context, _ model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
-			return nil, []db.MergeConflict{{Path: "README.md"}}, db.ErrMergeConflict
+		mergeFn: func(_ context.Context, _ model.MergeRequest) (*model.MergeResponse, []dbpkg.MergeConflict, error) {
+			return nil, []dbpkg.MergeConflict{{Path: "README.md"}}, dbpkg.ErrMergeConflict
 		},
 	}
-	broker := events.NewBroker(nil)
-	evCh := subscribeAll(broker)
+	broker := events.NewBroker(d)
 	w := New(broker, ms, rs, nil)
 
+	seq, _ := broker.CurrentSeq(context.Background())
 	w.tryAutoMerge(context.Background(), "myrepo", "my-feature")
 
 	if !ms.setBranchAutoMergeCalled {
@@ -245,18 +256,17 @@ func TestTryAutoMerge_DisablesOnConflict(t *testing.T) {
 		t.Error("expected SetBranchAutoMerge(false) on conflict")
 	}
 
-	// Expect a BranchAutoMergeFailed event.
-	select {
-	case ev := <-evCh:
-		if _, ok := ev.(evtypes.BranchAutoMergeFailed); !ok {
-			t.Errorf("expected BranchAutoMergeFailed event, got %T", ev)
-		}
-	default:
-		t.Error("expected BranchAutoMergeFailed event but channel was empty")
+	evs, err := broker.Poll(context.Background(), "*", seq, []string{"com.docstore.branch.automerge.failed"})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(evs) == 0 {
+		t.Error("expected BranchAutoMergeFailed event in event_log")
 	}
 }
 
 func TestTryAutoMerge_EmitsProposalMerged(t *testing.T) {
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
 	rs := &mockReadStore{
 		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
 			return activeBranch(), nil
@@ -268,35 +278,22 @@ func TestTryAutoMerge_EmitsProposalMerged(t *testing.T) {
 			return &model.Proposal{ID: proposalID, Branch: "my-feature", BaseBranch: "main"}, nil
 		},
 	}
-	broker := events.NewBroker(nil)
-	evCh := subscribeAll(broker)
-	// Also subscribe to proposal.merged
-	propCh, _ := broker.Subscribe("*", []string{"com.docstore.proposal.merged"})
+	broker := events.NewBroker(d)
 	w := New(broker, ms, rs, nil)
 
+	seq, _ := broker.CurrentSeq(context.Background())
 	w.tryAutoMerge(context.Background(), "myrepo", "my-feature")
 
 	if !ms.mergeCalled {
 		t.Fatal("expected Merge to be called")
 	}
 
-	// Drain evCh looking for ProposalMerged; also check propCh.
-	var gotProposalMerged bool
-	for i := 0; i < 2; i++ {
-		select {
-		case ev := <-evCh:
-			if _, ok := ev.(evtypes.ProposalMerged); ok {
-				gotProposalMerged = true
-			}
-		case ev := <-propCh:
-			if _, ok := ev.(evtypes.ProposalMerged); ok {
-				gotProposalMerged = true
-			}
-		default:
-		}
+	evs, err := broker.Poll(context.Background(), "*", seq, []string{"com.docstore.proposal.merged"})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
 	}
-	if !gotProposalMerged {
-		t.Error("expected ProposalMerged event to be emitted")
+	if len(evs) == 0 {
+		t.Error("expected ProposalMerged event in event_log")
 	}
 }
 

--- a/internal/db/migrations/000017_add_event_log.down.sql
+++ b/internal/db/migrations/000017_add_event_log.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE event_log;

--- a/internal/db/migrations/000017_add_event_log.up.sql
+++ b/internal/db/migrations/000017_add_event_log.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE event_log (
+    seq        BIGSERIAL PRIMARY KEY,
+    repo       TEXT NOT NULL,
+    type       TEXT NOT NULL,
+    payload    BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Index for repo-scoped SSE polling (WHERE repo = $1 AND seq > $2).
+CREATE INDEX event_log_repo_seq ON event_log (repo, seq);

--- a/internal/events/broker.go
+++ b/internal/events/broker.go
@@ -3,129 +3,171 @@ package events
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
+
+	"github.com/lib/pq"
 )
 
-// Broker is the in-process event fan-out hub.
-// It fans out emitted events to SSE subscribers and writes outbox rows for
-// webhook subscriptions. SSE delivery is in-memory and best-effort; clients
-// that disconnect miss events. Webhook delivery is durable via the outbox.
-//
-// Horizontal scaling note: SSE fan-out is in-memory. Works correctly at
-// --max-instances=1 only. See OPERATIONS.md for details.
-type Broker struct {
-	db  *sql.DB
-	mu  sync.RWMutex
-	// subs maps "repo/*" or "repo/<full-type>" to subscriber channels.
-	subs map[string][]chan Event
+// LoggedEvent is a single row from the event_log table.
+type LoggedEvent struct {
+	Seq     int64
+	Repo    string
+	Type    string
+	Payload json.RawMessage
 }
 
-// NewBroker creates a new Broker. db is used for outbox writes on Emit.
-// Pass nil to disable webhook outbox writes (e.g. in tests that only need SSE).
+// Broker is the event hub. It persists events to the event_log table,
+// sends pg_notify for real-time wake-up, and exposes Poll/WaitForEvent
+// for SSE clients and background workers.
+// Because delivery is DB-backed, multiple server instances all see
+// every event — no --max-instances=1 constraint.
+type Broker struct {
+	db *sql.DB
+	mu sync.Mutex
+	// waitCh is closed whenever Notify is called, waking all WaitForEvent
+	// callers. A new channel is created after each close.
+	waitCh chan struct{}
+}
+
+// NewBroker creates a new Broker. db is used for event_log and outbox writes.
+// Pass nil to disable DB writes (e.g. unit tests that do not need persistence).
 func NewBroker(db *sql.DB) *Broker {
 	return &Broker{
-		db:   db,
-		subs: make(map[string][]chan Event),
+		db:     db,
+		waitCh: make(chan struct{}),
 	}
 }
 
-// Subscribe registers a channel to receive events for the given repo.
-// If types is empty, all events for the repo are received.
-// Otherwise, only events whose Type() matches one of the provided types
-// are received. Types must be the full CloudEvents type, e.g.
-// "com.docstore.commit.created".
-// Returns the channel and an unsubscribe function that must be called
-// when the subscriber is done (e.g. on client disconnect).
-func (b *Broker) Subscribe(repo string, types []string) (<-chan Event, func()) {
-	ch := make(chan Event, 64)
-	keys := subscriberKeys(repo, types)
-
+// Notify wakes all WaitForEvent callers. It is called by the pg_notify
+// listener goroutine in StartDispatcher whenever a new event_log row appears.
+func (b *Broker) Notify() {
 	b.mu.Lock()
-	for _, k := range keys {
-		b.subs[k] = append(b.subs[k], ch)
-	}
+	old := b.waitCh
+	b.waitCh = make(chan struct{})
 	b.mu.Unlock()
-
-	unsub := func() {
-		b.mu.Lock()
-		for _, k := range keys {
-			b.subs[k] = removeChannel(b.subs[k], ch)
-		}
-		b.mu.Unlock()
-		// Drain and close so SSE goroutine can exit cleanly.
-		for len(ch) > 0 {
-			<-ch
-		}
-		close(ch)
-	}
-	return ch, unsub
+	close(old)
 }
 
-// Emit publishes an event to all matching SSE subscribers and writes outbox
-// rows for each matching webhook subscription. Outbox writes are best-effort;
-// errors are logged but not returned.
-func (b *Broker) Emit(ctx context.Context, e Event) {
-	b.fanOutSSE(e)
+// WaitForEvent blocks until Notify is called or ctx is cancelled.
+// Returns nil when woken by a notification, or ctx.Err() on cancellation.
+func (b *Broker) WaitForEvent(ctx context.Context) error {
+	b.mu.Lock()
+	ch := b.waitCh
+	b.mu.Unlock()
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
 
+// CurrentSeq returns the current maximum sequence number in event_log.
+// Returns 0 if the table is empty or db is nil.
+func (b *Broker) CurrentSeq(ctx context.Context) (int64, error) {
+	if b.db == nil {
+		return 0, nil
+	}
+	var seq int64
+	err := b.db.QueryRowContext(ctx,
+		`SELECT COALESCE(MAX(seq), 0) FROM event_log`,
+	).Scan(&seq)
+	return seq, err
+}
+
+// Poll returns logged events with seq > sinceSeq.
+// If repo is "*", events from all repos are returned.
+// If types is empty, all event types are returned.
+// Results are ordered by seq ASC, capped at 200 rows per call.
+func (b *Broker) Poll(ctx context.Context, repo string, sinceSeq int64, types []string) ([]LoggedEvent, error) {
+	if b.db == nil {
+		return nil, nil
+	}
+
+	var (
+		sqlRows *sql.Rows
+		err     error
+	)
+
+	switch {
+	case repo == "*" && len(types) == 0:
+		sqlRows, err = b.db.QueryContext(ctx,
+			`SELECT seq, repo, type, payload FROM event_log
+			 WHERE seq > $1 ORDER BY seq LIMIT 200`,
+			sinceSeq)
+	case repo == "*":
+		sqlRows, err = b.db.QueryContext(ctx,
+			`SELECT seq, repo, type, payload FROM event_log
+			 WHERE seq > $1 AND type = ANY($2) ORDER BY seq LIMIT 200`,
+			sinceSeq, pq.Array(types))
+	case len(types) == 0:
+		sqlRows, err = b.db.QueryContext(ctx,
+			`SELECT seq, repo, type, payload FROM event_log
+			 WHERE seq > $1 AND repo = $2 ORDER BY seq LIMIT 200`,
+			sinceSeq, repo)
+	default:
+		sqlRows, err = b.db.QueryContext(ctx,
+			`SELECT seq, repo, type, payload FROM event_log
+			 WHERE seq > $1 AND repo = $2 AND type = ANY($3) ORDER BY seq LIMIT 200`,
+			sinceSeq, repo, pq.Array(types))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("poll event_log: %w", err)
+	}
+	defer sqlRows.Close()
+
+	var evs []LoggedEvent
+	for sqlRows.Next() {
+		var ev LoggedEvent
+		if err := sqlRows.Scan(&ev.Seq, &ev.Repo, &ev.Type, &ev.Payload); err != nil {
+			return nil, fmt.Errorf("scan event_log row: %w", err)
+		}
+		evs = append(evs, ev)
+	}
+	return evs, sqlRows.Err()
+}
+
+// Emit persists an event to event_log, sends a pg_notify wake-up, and writes
+// outbox rows for matching webhook subscriptions.
+// All DB operations are best-effort; errors are logged but not returned.
+func (b *Broker) Emit(ctx context.Context, e Event) {
 	if b.db == nil {
 		return
 	}
+
+	payload, err := ToCloudEvent(e)
+	if err != nil {
+		slog.Error("events: serialize event failed", "type", e.Type(), "error", err)
+		return
+	}
+
+	repo := repoFromSource(e.Source())
+
+	if _, err := b.db.ExecContext(ctx,
+		`INSERT INTO event_log (repo, type, payload) VALUES ($1, $2, $3)`,
+		repo, e.Type(), payload,
+	); err != nil {
+		slog.Error("events: event_log insert failed", "type", e.Type(), "error", err)
+	}
+
+	// Wake any pq.Listener goroutines on all instances.
+	if _, err := b.db.ExecContext(ctx,
+		`SELECT pg_notify('event_log', $1)`, repo,
+	); err != nil {
+		slog.Warn("events: pg_notify failed", "type", e.Type(), "error", err)
+	}
+
 	if err := insertOutboxForEvent(ctx, b.db, e); err != nil {
 		slog.Error("events: outbox insert failed", "type", e.Type(), "source", e.Source(), "error", err)
 	}
-}
 
-// fanOutSSE sends an event to all SSE subscribers whose keys match the event.
-func (b *Broker) fanOutSSE(e Event) {
-	// Derive the repo name from the source URI.
-	repo := repoFromSource(e.Source())
-
-	// Collect the set of matching subscriber keys.
-	// Also check global wildcard keys ("*/*" and "*/<type>") so that
-	// subscribers using repo="*" receive events from all repos.
-	wildcardKey := repo + "/*"
-	typeKey := repo + "/" + e.Type()
-	globalWildcardKey := "*/*"
-	globalTypeKey := "*/" + e.Type()
-
-	b.mu.RLock()
-	// Collect unique channels (a subscriber might appear under both keys theoretically,
-	// but our Subscribe logic ensures each channel is under exactly one set of keys).
-	seen := make(map[chan Event]struct{})
-	var targets []chan Event
-	for _, k := range []string{wildcardKey, typeKey, globalWildcardKey, globalTypeKey} {
-		for _, ch := range b.subs[k] {
-			if _, ok := seen[ch]; !ok {
-				seen[ch] = struct{}{}
-				targets = append(targets, ch)
-			}
-		}
-	}
-	b.mu.RUnlock()
-
-	for _, ch := range targets {
-		select {
-		case ch <- e:
-		default:
-			// Slow consumer; drop event rather than block.
-			slog.Warn("events: SSE subscriber too slow, dropping event",
-				"type", e.Type(), "repo", repo)
-		}
-	}
-}
-
-// subscriberKeys returns the broker map keys for the given repo and type filter.
-func subscriberKeys(repo string, types []string) []string {
-	if len(types) == 0 {
-		return []string{repo + "/*"}
-	}
-	keys := make([]string, len(types))
-	for i, t := range types {
-		keys[i] = repo + "/" + t
-	}
-	return keys
+	// Wake local waiters immediately. Cross-instance waiters are woken via
+	// the pg_notify → pq.Listener → Notify() path in StartDispatcher.
+	b.Notify()
 }
 
 // repoFromSource extracts the repo name from a CloudEvents source URI.
@@ -136,15 +178,4 @@ func repoFromSource(source string) string {
 		return source[len("/repos/"):]
 	}
 	return source
-}
-
-// removeChannel removes ch from slice without preserving order.
-func removeChannel(slice []chan Event, ch chan Event) []chan Event {
-	for i, c := range slice {
-		if c == ch {
-			slice[i] = slice[len(slice)-1]
-			return slice[:len(slice)-1]
-		}
-	}
-	return slice
 }

--- a/internal/events/broker_test.go
+++ b/internal/events/broker_test.go
@@ -5,16 +5,16 @@ import (
 	"testing"
 	"time"
 
+	dbpkg "github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/events"
 	evtypes "github.com/dlorenc/docstore/internal/events/types"
+	"github.com/dlorenc/docstore/internal/testutil"
 )
 
-func TestBroker_PublishAndReceive(t *testing.T) {
+func TestBroker_EmitAndPoll(t *testing.T) {
 	t.Parallel()
-	b := events.NewBroker(nil)
-
-	ch, unsub := b.Subscribe("acme/myrepo", nil)
-	defer unsub()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	b := events.NewBroker(d)
 
 	e := evtypes.CommitCreated{
 		Repo:     "acme/myrepo",
@@ -22,104 +22,153 @@ func TestBroker_PublishAndReceive(t *testing.T) {
 		Sequence: 1,
 		Author:   "alice@example.com",
 	}
+
+	seq, err := b.CurrentSeq(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentSeq: %v", err)
+	}
+
 	b.Emit(context.Background(), e)
 
-	select {
-	case got := <-ch:
-		if got.Type() != e.Type() {
-			t.Errorf("expected type %q, got %q", e.Type(), got.Type())
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for event")
+	evs, err := b.Poll(context.Background(), "acme/myrepo", seq, nil)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(evs) == 0 {
+		t.Fatal("expected at least one event after Emit")
+	}
+	if evs[0].Type != e.Type() {
+		t.Errorf("expected type %q, got %q", e.Type(), evs[0].Type)
+	}
+	if evs[0].Repo != "acme/myrepo" {
+		t.Errorf("expected repo %q, got %q", "acme/myrepo", evs[0].Repo)
 	}
 }
 
-func TestBroker_ClientDisconnect(t *testing.T) {
+func TestBroker_PollFilterByRepo(t *testing.T) {
 	t.Parallel()
-	b := events.NewBroker(nil)
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	b := events.NewBroker(d)
 
-	ch, unsub := b.Subscribe("acme/myrepo", nil)
+	seq, _ := b.CurrentSeq(context.Background())
 
-	// Unsubscribe before any events.
-	unsub()
+	b.Emit(context.Background(), evtypes.CommitCreated{Repo: "acme/repo-a", Branch: "main"})
+	b.Emit(context.Background(), evtypes.CommitCreated{Repo: "acme/repo-b", Branch: "main"})
 
-	// Emitting after unsubscribe should not panic or block.
-	b.Emit(context.Background(), evtypes.CommitCreated{
-		Repo:   "acme/myrepo",
-		Branch: "main",
-	})
-
-	// Channel should be closed.
-	select {
-	case _, ok := <-ch:
-		if ok {
-			t.Error("expected channel to be closed")
+	evs, err := b.Poll(context.Background(), "acme/repo-a", seq, nil)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	for _, ev := range evs {
+		if ev.Repo != "acme/repo-a" {
+			t.Errorf("expected repo acme/repo-a, got %q", ev.Repo)
 		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out: channel not closed after unsub")
+	}
+	if len(evs) == 0 {
+		t.Fatal("expected at least one event for acme/repo-a")
 	}
 }
 
-func TestBroker_FilterByType(t *testing.T) {
+func TestBroker_PollWildcardRepo(t *testing.T) {
 	t.Parallel()
-	b := events.NewBroker(nil)
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	b := events.NewBroker(d)
 
-	// Subscribe to only commit.created events.
-	ch, unsub := b.Subscribe("acme/myrepo", []string{"com.docstore.commit.created"})
-	defer unsub()
+	seq, _ := b.CurrentSeq(context.Background())
+
+	b.Emit(context.Background(), evtypes.CommitCreated{Repo: "acme/repo-x", Branch: "main"})
+	b.Emit(context.Background(), evtypes.CommitCreated{Repo: "acme/repo-y", Branch: "main"})
+
+	evs, err := b.Poll(context.Background(), "*", seq, nil)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(evs) < 2 {
+		t.Errorf("expected at least 2 events for wildcard poll, got %d", len(evs))
+	}
+}
+
+func TestBroker_PollFilterByType(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	b := events.NewBroker(d)
+
+	seq, _ := b.CurrentSeq(context.Background())
 
 	// Emit a non-matching event first.
-	b.Emit(context.Background(), evtypes.BranchCreated{
-		Repo:   "acme/myrepo",
-		Branch: "feature",
-	})
-
+	b.Emit(context.Background(), evtypes.BranchCreated{Repo: "acme/myrepo", Branch: "feature"})
 	// Emit a matching event.
-	b.Emit(context.Background(), evtypes.CommitCreated{
-		Repo:     "acme/myrepo",
-		Branch:   "main",
-		Sequence: 42,
-	})
+	b.Emit(context.Background(), evtypes.CommitCreated{Repo: "acme/myrepo", Branch: "main", Sequence: 42})
 
-	select {
-	case got := <-ch:
-		if got.Type() != "com.docstore.commit.created" {
-			t.Errorf("expected commit.created, got %q", got.Type())
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for filtered event")
+	evs, err := b.Poll(context.Background(), "acme/myrepo", seq, []string{"com.docstore.commit.created"})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
 	}
-
-	// Channel should have no more events.
-	select {
-	case unexpected := <-ch:
-		t.Errorf("received unexpected event: %s", unexpected.Type())
-	default:
-		// Good: no extra events.
+	for _, ev := range evs {
+		if ev.Type != "com.docstore.commit.created" {
+			t.Errorf("expected only commit.created events, got %q", ev.Type)
+		}
+	}
+	if len(evs) == 0 {
+		t.Fatal("expected at least one commit.created event")
 	}
 }
 
-func TestBroker_MultipleSubscribers(t *testing.T) {
+func TestBroker_WaitForEvent(t *testing.T) {
+	t.Parallel()
+	b := events.NewBroker(nil) // no DB needed for in-memory signalling
+
+	done := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		done <- b.WaitForEvent(ctx)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	b.Notify()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("expected nil error after Notify, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WaitForEvent did not return after Notify")
+	}
+}
+
+func TestBroker_WaitForEventTimeout(t *testing.T) {
 	t.Parallel()
 	b := events.NewBroker(nil)
 
-	ch1, unsub1 := b.Subscribe("acme/myrepo", nil)
-	defer unsub1()
-	ch2, unsub2 := b.Subscribe("acme/myrepo", nil)
-	defer unsub2()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
 
-	e := evtypes.CommitCreated{Repo: "acme/myrepo", Branch: "main"}
-	b.Emit(context.Background(), e)
+	err := b.WaitForEvent(ctx)
+	if err == nil {
+		t.Error("expected timeout error, got nil")
+	}
+}
 
-	for _, ch := range []<-chan events.Event{ch1, ch2} {
-		select {
-		case got := <-ch:
-			if got.Type() != e.Type() {
-				t.Errorf("expected %q, got %q", e.Type(), got.Type())
-			}
-		case <-time.After(time.Second):
-			t.Fatal("timed out waiting for event on subscriber")
-		}
+func TestBroker_CurrentSeq(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	b := events.NewBroker(d)
+
+	seq0, err := b.CurrentSeq(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentSeq: %v", err)
+	}
+
+	b.Emit(context.Background(), evtypes.CommitCreated{Repo: "acme/myrepo", Branch: "main"})
+
+	seq1, err := b.CurrentSeq(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentSeq after Emit: %v", err)
+	}
+	if seq1 <= seq0 {
+		t.Errorf("expected seq to increase after Emit: before=%d after=%d", seq0, seq1)
 	}
 }
 

--- a/internal/events/outbox.go
+++ b/internal/events/outbox.go
@@ -26,11 +26,17 @@ type outboxRow struct {
 	WebhookSecret  string
 }
 
-// StartDispatcher starts the outbox dispatcher goroutine. It polls for pending
-// outbox rows every 5 seconds, delivers webhooks with exponential backoff, and
-// cleans up delivered rows older than 7 days every hour.
-// The goroutine stops when ctx is cancelled (e.g. on SIGTERM).
-func StartDispatcher(ctx context.Context, db *sql.DB) {
+// StartDispatcher starts the outbox dispatcher and event_log cleanup goroutines.
+// It polls for pending outbox rows every 5 seconds, delivers webhooks with
+// exponential backoff, cleans up delivered outbox rows older than 7 days every
+// hour, and cleans up event_log rows older than 30 days every hour.
+//
+// dsn is the PostgreSQL DSN used to open a pq.Listener for pg_notify wake-ups.
+// broker.Notify() is called each time a new event_log notification arrives,
+// waking SSE clients and background workers via WaitForEvent.
+//
+// The goroutines stop when ctx is cancelled (e.g. on SIGTERM).
+func StartDispatcher(ctx context.Context, db *sql.DB, dsn string, broker *Broker) {
 	go func() {
 		pollTicker := time.NewTicker(5 * time.Second)
 		cleanupTicker := time.NewTicker(time.Hour)
@@ -47,9 +53,57 @@ func StartDispatcher(ctx context.Context, db *sql.DB) {
 				if err := cleanupOutbox(ctx, db); err != nil {
 					slog.Error("outbox: cleanup failed", "error", err)
 				}
+				if err := cleanupEventLog(ctx, db); err != nil {
+					slog.Error("event_log: cleanup failed", "error", err)
+				}
 			}
 		}
 	}()
+
+	go startPGListener(ctx, dsn, broker)
+}
+
+// startPGListener opens a pq.Listener on the "event_log" channel and calls
+// broker.Notify() each time a pg_notify arrives. This wakes WaitForEvent
+// callers on this instance without polling.
+func startPGListener(ctx context.Context, dsn string, broker *Broker) {
+	if dsn == "" || broker == nil {
+		return
+	}
+	listener := pq.NewListener(dsn,
+		10*time.Second, time.Minute,
+		func(ev pq.ListenerEventType, err error) {
+			if err != nil {
+				slog.Warn("pg_listen: connection event", "error", err)
+			}
+		},
+	)
+	if err := listener.Listen("event_log"); err != nil {
+		slog.Error("pg_listen: listen failed", "error", err)
+		listener.Close()
+		return
+	}
+	defer listener.Close()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-listener.Notify:
+			if !ok {
+				// Channel closed — listener reconnecting; keep waiting.
+				continue
+			}
+			broker.Notify()
+		}
+	}
+}
+
+// cleanupEventLog deletes event_log rows older than 30 days.
+func cleanupEventLog(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx,
+		`DELETE FROM event_log WHERE created_at < now() - interval '30 days'`)
+	return err
 }
 
 // processOutboxBatch claims and delivers one batch of pending outbox rows.

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -199,10 +199,10 @@ func TestWebhook_DeliveredAfterMutation(t *testing.T) {
 
 	srv, _ := newEventTestServer(t, db)
 
-	// Start the outbox dispatcher.
+	// Start the outbox dispatcher (no DSN/broker needed for webhook-only test).
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	events.StartDispatcher(ctx, db)
+	events.StartDispatcher(ctx, db, "", nil)
 
 	// Post a commit.
 	commitBody, _ := json.Marshal(model.CommitRequest{
@@ -264,7 +264,7 @@ func TestWebhook_HMACSignatureValid(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	events.StartDispatcher(ctx, db)
+	events.StartDispatcher(ctx, db, "", nil)
 
 	commitBody, _ := json.Marshal(model.CommitRequest{
 		Branch:  "main",
@@ -322,7 +322,7 @@ func TestWebhook_RetriedOnFailure(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	events.StartDispatcher(ctx, db)
+	events.StartDispatcher(ctx, db, "", nil)
 
 	commitBody, _ := json.Marshal(model.CommitRequest{
 		Branch:  "main",

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/dlorenc/docstore/internal/db"
-	"github.com/dlorenc/docstore/internal/events"
 	evtypes "github.com/dlorenc/docstore/internal/events/types"
 	mergeutil "github.com/dlorenc/docstore/internal/merge"
 	"github.com/dlorenc/docstore/internal/model"
@@ -3032,7 +3031,9 @@ func (s *server) handleSSEGlobalEvents(w http.ResponseWriter, r *http.Request) {
 }
 
 // streamSSE is the shared SSE streaming implementation.
-// repo is the repo to subscribe to (or "*" for global admin stream).
+// repo is the repo to stream events for (or "*" for global admin stream).
+// Clients may pass ?since_seq=N to replay events from a known position,
+// enabling reconnect without missing events.
 func (s *server) streamSSE(w http.ResponseWriter, r *http.Request, repo string) {
 	if s.broker == nil {
 		writeError(w, http.StatusServiceUnavailable, "event streaming not available")
@@ -3056,8 +3057,22 @@ func (s *server) streamSSE(w http.ResponseWriter, r *http.Request, repo string) 
 		}
 	}
 
-	ch, unsub := s.broker.Subscribe(repo, types)
-	defer unsub()
+	ctx := r.Context()
+
+	// Determine starting sequence. If the client supplies ?since_seq, replay
+	// from that position. Otherwise start from the current tail so the client
+	// only sees new events going forward.
+	var sinceSeq int64
+	if raw := r.URL.Query().Get("since_seq"); raw != "" {
+		sinceSeq, _ = strconv.ParseInt(raw, 10, 64)
+	} else {
+		seq, err := s.broker.CurrentSeq(ctx)
+		if err != nil {
+			slog.Error("SSE: CurrentSeq failed", "error", err)
+		} else {
+			sinceSeq = seq
+		}
+	}
 
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -3066,27 +3081,30 @@ func (s *server) streamSSE(w http.ResponseWriter, r *http.Request, repo string) 
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
-	keepAlive := time.NewTicker(15 * time.Second)
-	defer keepAlive.Stop()
-
-	ctx := r.Context()
 	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-keepAlive.C:
-			fmt.Fprint(w, ": keepalive\n\n")
-			flusher.Flush()
-		case e, ok := <-ch:
-			if !ok {
+		evs, err := s.broker.Poll(ctx, repo, sinceSeq, types)
+		if err != nil {
+			if ctx.Err() != nil {
 				return
 			}
-			data, err := events.ToCloudEvent(e)
-			if err != nil {
-				slog.Error("SSE: serialize event failed", "error", err)
-				continue
-			}
-			fmt.Fprintf(w, "data: %s\n\n", data)
+			slog.Error("SSE: poll failed", "error", err)
+		}
+		for _, ev := range evs {
+			fmt.Fprintf(w, "id: %d\ndata: %s\n\n", ev.Seq, ev.Payload)
+			flusher.Flush()
+			sinceSeq = ev.Seq
+		}
+
+		// Wait for the next notification (or keepalive timeout).
+		waitCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		waitErr := s.broker.WaitForEvent(waitCtx)
+		cancel()
+
+		if ctx.Err() != nil {
+			return
+		}
+		if errors.Is(waitErr, context.DeadlineExceeded) {
+			fmt.Fprint(w, ": keepalive\n\n")
 			flusher.Flush()
 		}
 	}


### PR DESCRIPTION
## Summary

- **New migration** `000017_add_event_log`: `event_log(seq BIGSERIAL PK, repo TEXT, type TEXT, payload BYTEA, created_at TIMESTAMPTZ)` with index on `(repo, seq)` for polling.
- **Rewrote `internal/events/broker.go`**: removed in-memory `Subscribe`/`fanOutSSE`/subs map; added `Poll`, `WaitForEvent`, `CurrentSeq`, `Notify`, and `LoggedEvent`. `Emit` inserts into `event_log`, calls `pg_notify('event_log', repo)`, and calls `Notify()` to wake same-instance SSE clients immediately.
- **Updated `internal/events/outbox.go`**: `StartDispatcher` gains `dsn string, broker *Broker` params; new `startPGListener` goroutine uses `pq.NewListener` on `"event_log"` channel to call `broker.Notify()` for cross-instance wake-ups; new `cleanupEventLog` (30-day retention) runs hourly.
- **Rewrote `streamSSE` in `internal/server/handlers.go`**: poll-based loop with `?since_seq` support for client reconnect, 15-second keepalive via `WaitForEvent` timeout. Sends `id: N` on each event.
- **Rewrote `Run()` in `internal/automerge/worker.go`**: replaced `broker.Subscribe` with `Poll`+`WaitForEvent` loop; extracts `branch` from JSON payload; 30-second poll interval.
- **Updated `cmd/docstore/main.go`**: pass `dsn` to `StartDispatcher`.
- **Tests updated**: `broker_test.go` rewritten with DB-backed `Poll`/`WaitForEvent` tests; `automerge/worker_test.go` adds `TestMain`+testDB, replaces channel-based `subscribeAll` with `event_log` queries.
- **`docs/deployment.md`**: removed `--max-instances=1` constraint; updated horizontal scaling note.

## Test plan

- [ ] `go test ./... -count=1` passes locally (verified)
- [ ] `go build ./...` and `go vet ./...` clean (verified)
- [ ] SSE tests (`TestSSE_ReceivesEventsOnCommit`, `TestSSE_FilterByType`) pass with new poll-based implementation
- [ ] Automerge tests pass with DB-backed event verification
- [ ] New broker tests cover `Emit`+`Poll`, repo filtering, type filtering, wildcard polling, `WaitForEvent`/`Notify`, and `CurrentSeq`

🤖 Generated with [Claude Code](https://claude.com/claude-code)