### PR TITLE
test: add coverage for since_seq replay and pg_notify broker wake-up

### DIFF
--- a/internal/events/outbox_test.go
+++ b/internal/events/outbox_test.go
@@ -171,5 +171,44 @@ func TestOutbox_Cleanup(t *testing.T) {
 	}
 }
 
+func TestPGListener_NotifyWakesBroker(t *testing.T) {
+	t.Parallel()
+	// Get both the *sql.DB and its DSN so we can wire up pq.Listener via StartDispatcher.
+	d, dsn := testutil.TestDBAndDSNFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+
+	b := events.NewBroker(nil) // WaitForEvent/Notify need no DB
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// StartDispatcher launches startPGListener in a goroutine. Give it a moment
+	// to open the pq.Listener connection and call LISTEN before we notify.
+	events.StartDispatcher(ctx, d, dsn, b)
+	time.Sleep(300 * time.Millisecond)
+
+	// WaitForEvent should unblock when broker.Notify() is called by the listener.
+	done := make(chan error, 1)
+	go func() {
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer waitCancel()
+		done <- b.WaitForEvent(waitCtx)
+	}()
+
+	// Send a pg_notify on the "event_log" channel — simulates another instance
+	// writing an event and waking SSE clients on this instance.
+	if _, err := d.ExecContext(context.Background(), "SELECT pg_notify('event_log', '')"); err != nil {
+		t.Fatalf("pg_notify: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("WaitForEvent returned error after pg_notify: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForEvent did not unblock after pg_notify('event_log', '')")
+	}
+}
+
 // ensure pq is used
 var _ = pq.Array

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -161,6 +162,60 @@ func TestSSE_FilterByType(t *testing.T) {
 		}
 	}
 	t.Fatal("did not receive branch.created event")
+}
+
+func TestSSE_SinceSeqReplay(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seedForEvents(t, db)
+	db.Exec(`INSERT INTO roles (repo, identity, role) VALUES ('default/default', 'test@example.com', 'admin') ON CONFLICT DO NOTHING`)
+
+	srv, broker := newEventTestServer(t, db)
+
+	// Record the current tail so we know where to start replaying from.
+	seq0, err := broker.CurrentSeq(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentSeq: %v", err)
+	}
+
+	// Emit three events before the client connects.
+	broker.Emit(context.Background(), &branchCreatedStub{repo: "default/default"})
+	broker.Emit(context.Background(), &commitCreatedStub{repo: "default/default"})
+	broker.Emit(context.Background(), &branchCreatedStub{repo: "default/default"})
+
+	// Connect with ?since_seq pointing to the position before the emits.
+	// The handler must replay all three events immediately.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
+		fmt.Sprintf("%s/repos/default/default/-/events?since_seq=%d", srv.URL, seq0), nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("SSE connect: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	// Count data lines; expect at least 3 replayed events.
+	received := 0
+	scanner := bufio.NewScanner(resp.Body)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !scanner.Scan() {
+			break
+		}
+		if strings.HasPrefix(scanner.Text(), "data: ") {
+			received++
+			if received >= 3 {
+				return // success
+			}
+		}
+	}
+	t.Fatalf("expected at least 3 replayed events via since_seq, got %d", received)
 }
 
 // Stub event types for testing.

--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -73,9 +73,25 @@ func TestDBFromShared(t testing.TB, adminDSN string, migrate func(*sql.DB) error
 	return testDBFromDSN(t, adminDSN, migrate)
 }
 
+// TestDBAndDSNFromShared is like TestDBFromShared but also returns the DSN
+// for the isolated test database. Use when you need the DSN directly (e.g.
+// for pq.Listener or other low-level PostgreSQL drivers).
+func TestDBAndDSNFromShared(t testing.TB, adminDSN string, migrate func(*sql.DB) error) (*sql.DB, string) {
+	t.Helper()
+	return testDBAndDSN(t, adminDSN, migrate)
+}
+
 // testDBFromDSN is the legacy path: use a pre-existing PostgreSQL server via DSN.
 // It creates a unique database per test so parallel tests don't interfere.
 func testDBFromDSN(t testing.TB, dsn string, migrate func(*sql.DB) error) *sql.DB {
+	t.Helper()
+	d, _ := testDBAndDSN(t, dsn, migrate)
+	return d
+}
+
+// testDBAndDSN creates an isolated test database and returns both the *sql.DB
+// and the DSN string for that database.
+func testDBAndDSN(t testing.TB, dsn string, migrate func(*sql.DB) error) (*sql.DB, string) {
 	t.Helper()
 
 	// Connect to the server using the provided DSN (admin connection).
@@ -138,7 +154,7 @@ func testDBFromDSN(t testing.TB, dsn string, migrate func(*sql.DB) error) *sql.D
 		t.Fatalf("run migrations: %v", err)
 	}
 
-	return d
+	return d, testDSN
 }
 
 // replaceDBName replaces the database name in a PostgreSQL DSN. It handles


### PR DESCRIPTION
## Summary

- **`TestSSE_SinceSeqReplay`** (`internal/server/events_test.go`): Emits 3 events before connecting, then opens the SSE endpoint with `?since_seq=N` pointing to the pre-emit position and verifies all 3 events are replayed. Covers the reconnect path in `streamSSE`.
- **`TestPGListener_NotifyWakesBroker`** (`internal/events/outbox_test.go`): Starts `StartDispatcher` with a real DSN, then calls `SELECT pg_notify('event_log', '')` directly on the test DB and asserts `WaitForEvent()` unblocks. Confirms the LISTEN/NOTIFY → `broker.Notify()` cross-instance wake-up path in `startPGListener`.
- **`testutil.TestDBAndDSNFromShared`** (`internal/testutil/testdb.go`): New helper that returns both `*sql.DB` and the isolated test DB's DSN string. Required by the pg_notify test to wire up `pq.Listener`.

Closes the two untested paths identified in the PR #271 review.

## Test plan
- [x] `go test ./internal/events/... ./internal/server/... -run TestSSE_SinceSeqReplay|TestPGListener_NotifyWakesBroker` — both pass
- [x] `go test ./... -count=1` — full suite passes
- [x] `go build ./...` and `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)