### PR TITLE
fix: prevent full event replay when CurrentSeq fails; guard empty branch in automerge

### DIFF
--- a/internal/automerge/worker.go
+++ b/internal/automerge/worker.go
@@ -66,9 +66,22 @@ func (w *Worker) Run(ctx context.Context) {
 	}
 
 	// Start from the current tail so we don't replay historical events.
-	sinceSeq, err := w.broker.CurrentSeq(ctx)
-	if err != nil {
-		slog.Error("auto-merge: CurrentSeq failed", "error", err)
+	// Retry with backoff until CurrentSeq succeeds — proceeding with 0 would
+	// replay all historical events and trigger spurious auto-merges.
+	var sinceSeq int64
+	for {
+		seq, err := w.broker.CurrentSeq(ctx)
+		if err != nil {
+			slog.Error("auto-merge: CurrentSeq failed, retrying in 5s", "error", err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(5 * time.Second):
+			}
+			continue
+		}
+		sinceSeq = seq
+		break
 	}
 
 	for {
@@ -90,6 +103,11 @@ func (w *Worker) Run(ctx context.Context) {
 			if err := json.Unmarshal(ev.Payload, &envelope); err != nil {
 				slog.Warn("auto-merge: unmarshal event payload failed",
 					"type", ev.Type, "seq", ev.Seq, "error", err)
+				continue
+			}
+			if envelope.Data.Branch == "" {
+				slog.Warn("auto-merge: event missing branch field, skipping",
+					"type", ev.Type, "seq", ev.Seq, "repo", ev.Repo)
 				continue
 			}
 			w.tryAutoMerge(ctx, ev.Repo, envelope.Data.Branch)

--- a/internal/automerge/worker_test.go
+++ b/internal/automerge/worker_test.go
@@ -2,9 +2,11 @@ package automerge
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	dbpkg "github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/events"
@@ -312,5 +314,74 @@ func TestTryAutoMerge_HandlesNilBranch(t *testing.T) {
 
 	if ms.mergeCalled {
 		t.Error("expected Merge not to be called when branch is nil")
+	}
+}
+
+func TestRun_CurrentSeqFailRetryExitsOnContextCancel(t *testing.T) {
+	// Use a closed *sql.DB for the broker so CurrentSeq always fails, forcing
+	// the retry loop in Run().  The context cancels quickly so the worker must
+	// exit cleanly without ever calling Merge.
+	brokenDB, err := sql.Open("postgres", sharedAdminDSN)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	brokenDB.Close() // closed pool → every query returns sql.ErrConnDone
+
+	broker := events.NewBroker(brokenDB)
+	ms := &mockStore{}
+	rs := &mockReadStore{}
+	w := New(broker, ms, rs, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	w.Run(ctx) // must return, not hang; must not proceed with sinceSeq=0
+
+	if ms.mergeCalled {
+		t.Error("Merge should not be called when CurrentSeq fails at startup")
+	}
+}
+
+func TestRun_EmptyBranchEventSkipped(t *testing.T) {
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+
+	var getBranchCalledWithEmpty bool
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, branch string) (*store.BranchInfo, error) {
+			if branch == "" {
+				getBranchCalledWithEmpty = true
+			}
+			return nil, nil
+		},
+	}
+	ms := &mockStore{}
+	broker := events.NewBroker(d)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// After the worker starts and enters its first WaitForEvent (a few ms),
+	// inject an event whose "data" payload has no branch field, then Notify
+	// so the worker wakes and processes it.  After processing we cancel the
+	// context so Run() returns.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		d.ExecContext(ctx, //nolint:errcheck
+			`INSERT INTO event_log (repo, type, payload) VALUES
+			 ('myrepo', 'com.docstore.check.reported',
+			  '{"type":"com.docstore.check.reported","source":"/repos/myrepo","data":{}}')`)
+		broker.Notify()
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+
+	w := New(broker, ms, rs, nil)
+	w.Run(ctx)
+
+	if getBranchCalledWithEmpty {
+		t.Error("GetBranch should not be called with empty branch name")
+	}
+	if ms.mergeCalled {
+		t.Error("Merge should not be called when event has empty branch field")
 	}
 }

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -361,6 +361,38 @@ func TestWebhook_RetriedOnFailure(t *testing.T) {
 	t.Fatalf("webhook was never delivered after retry; call count = %d", atomic.LoadInt64(&callCount))
 }
 
+func TestSSE_CurrentSeqFailure_Returns503(t *testing.T) {
+	t.Parallel()
+	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)
+	seedForEvents(t, db)
+	db.Exec(`INSERT INTO roles (repo, identity, role) VALUES ('default/default', 'test@example.com', 'admin') ON CONFLICT DO NOTHING`)
+
+	// Give the broker a closed *sql.DB so CurrentSeq always fails.  The
+	// server's write/read store still uses the working db, so validateRepo
+	// passes, but streamSSE must return 503 instead of silently using seq=0.
+	brokenDB, err := sql.Open("postgres", sharedAdminDSN)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	brokenDB.Close()
+
+	st := dbpkg.NewStore(db)
+	broker := events.NewBroker(brokenDB)
+	handler := server.NewWithBroker(st, db, nil, broker, "test@example.com", "test@example.com")
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/repos/default/default/-/events")
+	if err != nil {
+		t.Fatalf("GET /events: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", resp.StatusCode)
+	}
+}
+
 func TestSubscription_AdminOnly(t *testing.T) {
 	t.Parallel()
 	db := testutil.TestDBFromShared(t, sharedAdminDSN, dbpkg.RunMigrations)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -3069,9 +3069,10 @@ func (s *server) streamSSE(w http.ResponseWriter, r *http.Request, repo string) 
 		seq, err := s.broker.CurrentSeq(ctx)
 		if err != nil {
 			slog.Error("SSE: CurrentSeq failed", "error", err)
-		} else {
-			sinceSeq = seq
+			writeError(w, http.StatusServiceUnavailable, "event streaming temporarily unavailable")
+			return
 		}
+		sinceSeq = seq
 	}
 
 	w.Header().Set("Content-Type", "text/event-stream")


### PR DESCRIPTION
## Summary

Fixes three high-severity bugs identified in the PR #271 review:

- **SSE 503 on CurrentSeq failure**: `streamSSE` now returns HTTP 503 (via `writeError + return`) when `broker.CurrentSeq()` fails and no explicit `?since_seq` was given, instead of silently proceeding with `sinceSeq=0` which would replay the entire event log to the client.

- **Automerge CurrentSeq retry with backoff**: `automerge.Worker.Run()` now retries `CurrentSeq` with a 5s sleep when it fails at startup, rather than proceeding with `sinceSeq=0` and calling `tryAutoMerge` against every historical `check.reported`/`review.submitted` event. Context cancellation is honoured during the retry loop.

- **Empty branch guard in automerge poll loop**: After a successful JSON unmarshal, if `envelope.Data.Branch` is empty, the worker logs a warning and continues rather than calling `tryAutoMerge(ctx, repo, "")`.

## Test plan

- [x] `TestSSE_CurrentSeqFailure_Returns503` — verifies 503 when broker DB is broken and no `since_seq` param
- [x] `TestRun_CurrentSeqFailRetryExitsOnContextCancel` — verifies context cancellation exits the retry cleanly without calling Merge
- [x] `TestRun_EmptyBranchEventSkipped` — injects an event with no branch field, verifies `GetBranch` is never called with `""` and `Merge` is never called
- [x] Full suite: `go test ./... -count=1` — all pass
- [x] `go build ./...` and `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)