### PR TITLE
fix: address PR #271 review — dead code, poll back-off, seq index

### DIFF
--- a/internal/automerge/worker.go
+++ b/internal/automerge/worker.go
@@ -91,6 +91,7 @@ func (w *Worker) Run(ctx context.Context) {
 				return
 			}
 			slog.Error("auto-merge: poll failed", "error", pollErr)
+			time.Sleep(2 * time.Second)
 		}
 
 		for _, ev := range evs {

--- a/internal/db/migrations/000017_add_event_log.down.sql
+++ b/internal/db/migrations/000017_add_event_log.down.sql
@@ -1,1 +1,3 @@
+DROP INDEX event_log_seq;
+DROP INDEX event_log_repo_seq;
 DROP TABLE event_log;

--- a/internal/db/migrations/000017_add_event_log.up.sql
+++ b/internal/db/migrations/000017_add_event_log.up.sql
@@ -8,3 +8,6 @@ CREATE TABLE event_log (
 
 -- Index for repo-scoped SSE polling (WHERE repo = $1 AND seq > $2).
 CREATE INDEX event_log_repo_seq ON event_log (repo, seq);
+
+-- Index for wildcard-repo queries (WHERE seq > $1, no repo filter).
+CREATE INDEX event_log_seq ON event_log (seq);

--- a/internal/events/outbox.go
+++ b/internal/events/outbox.go
@@ -89,11 +89,7 @@ func startPGListener(ctx context.Context, dsn string, broker *Broker) {
 		select {
 		case <-ctx.Done():
 			return
-		case _, ok := <-listener.Notify:
-			if !ok {
-				// Channel closed — listener reconnecting; keep waiting.
-				continue
-			}
+		case <-listener.Notify:
 			broker.Notify()
 		}
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -3089,6 +3089,7 @@ func (s *server) streamSSE(w http.ResponseWriter, r *http.Request, repo string) 
 				return
 			}
 			slog.Error("SSE: poll failed", "error", err)
+			time.Sleep(2 * time.Second)
 		}
 		for _, ev := range evs {
 			fmt.Fprintf(w, "id: %d\ndata: %s\n\n", ev.Seq, ev.Payload)


### PR DESCRIPTION
## Summary

- **Dead code removal**: Remove unreachable `!ok` branch from `startPGListener` in `internal/events/outbox.go`. `pq.Listener` never closes its `Notify` channel, so the branch was dead. Nil notifications (reconnect spurious wakeups) now pass through unconditionally to `broker.Notify()` — harmless spurious wakeups just cause an empty `Poll`.
- **Poll error back-off**: Add `time.Sleep(2 * time.Second)` after poll error logging in both the SSE handler (`internal/server/handlers.go`) and the auto-merge worker (`internal/automerge/worker.go`) to prevent tight log spam / hot loop during DB outages.
- **Wildcard-repo seq index**: Add `CREATE INDEX event_log_seq ON event_log (seq)` to migration `000017` to support queries without a repo filter (e.g. `WHERE seq > $1`). Add corresponding `DROP INDEX` statements to the down migration.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)