### PR TITLE
feat: embed BranchStatusResponse snapshot in events (closes #247)

### DIFF
--- a/internal/events/types/branch.go
+++ b/internal/events/types/branch.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/dlorenc/docstore/api"
+
 // BranchCreated is emitted when a new branch is created.
 type BranchCreated struct {
 	Repo         string `json:"repo"`
@@ -14,10 +16,11 @@ func (e BranchCreated) Data() any      { return e }
 
 // BranchMerged is emitted when a branch is merged into main.
 type BranchMerged struct {
-	Repo     string `json:"repo"`
-	Branch   string `json:"branch"`
-	Sequence int64  `json:"sequence"`
-	MergedBy string `json:"merged_by"`
+	Repo         string                    `json:"repo"`
+	Branch       string                    `json:"branch"`
+	Sequence     int64                     `json:"sequence"`
+	MergedBy     string                    `json:"merged_by"`
+	BranchStatus *api.BranchStatusResponse `json:"branch_status,omitempty"`
 }
 
 func (e BranchMerged) Type() string   { return "com.docstore.branch.merged" }
@@ -26,12 +29,13 @@ func (e BranchMerged) Data() any      { return e }
 
 // BranchRebased is emitted when a branch is rebased onto main.
 type BranchRebased struct {
-	Repo            string `json:"repo"`
-	Branch          string `json:"branch"`
-	NewBaseSequence int64  `json:"new_base_sequence"`
-	NewHeadSequence int64  `json:"new_head_sequence"`
-	CommitsReplayed int64  `json:"commits_replayed"`
-	RebasedBy       string `json:"rebased_by"`
+	Repo            string                    `json:"repo"`
+	Branch          string                    `json:"branch"`
+	NewBaseSequence int64                     `json:"new_base_sequence"`
+	NewHeadSequence int64                     `json:"new_head_sequence"`
+	CommitsReplayed int64                     `json:"commits_replayed"`
+	RebasedBy       string                    `json:"rebased_by"`
+	BranchStatus    *api.BranchStatusResponse `json:"branch_status,omitempty"`
 }
 
 func (e BranchRebased) Type() string   { return "com.docstore.branch.rebased" }

--- a/internal/events/types/check.go
+++ b/internal/events/types/check.go
@@ -1,13 +1,16 @@
 package types
 
+import "github.com/dlorenc/docstore/api"
+
 // CheckReported is emitted when a CI check run is reported.
 type CheckReported struct {
-	Repo      string `json:"repo"`
-	Branch    string `json:"branch"`
-	Sequence  int64  `json:"sequence"`
-	CheckName string `json:"check_name"`
-	Status    string `json:"status"`
-	Reporter  string `json:"reporter"`
+	Repo         string                    `json:"repo"`
+	Branch       string                    `json:"branch"`
+	Sequence     int64                     `json:"sequence"`
+	CheckName    string                    `json:"check_name"`
+	Status       string                    `json:"status"`
+	Reporter     string                    `json:"reporter"`
+	BranchStatus *api.BranchStatusResponse `json:"branch_status,omitempty"`
 }
 
 func (e CheckReported) Type() string   { return "com.docstore.check.reported" }

--- a/internal/events/types/review.go
+++ b/internal/events/types/review.go
@@ -1,12 +1,15 @@
 package types
 
+import "github.com/dlorenc/docstore/api"
+
 // ReviewSubmitted is emitted when a review is submitted.
 type ReviewSubmitted struct {
-	Repo     string `json:"repo"`
-	Branch   string `json:"branch"`
-	Sequence int64  `json:"sequence"`
-	Reviewer string `json:"reviewer"`
-	Status   string `json:"status"`
+	Repo         string                    `json:"repo"`
+	Branch       string                    `json:"branch"`
+	Sequence     int64                     `json:"sequence"`
+	Reviewer     string                    `json:"reviewer"`
+	Status       string                    `json:"status"`
+	BranchStatus *api.BranchStatusResponse `json:"branch_status,omitempty"`
 }
 
 func (e ReviewSubmitted) Type() string   { return "com.docstore.review.submitted" }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -855,12 +855,17 @@ func (s *server) handleReview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	bs, bsErr := s.computeBranchStatus(r.Context(), repo, req.Branch, reviewer)
+	if bsErr != nil {
+		slog.Warn("branch status computation failed", "op", "review", "repo", repo, "branch", req.Branch, "error", bsErr)
+	}
 	s.emit(r.Context(), evtypes.ReviewSubmitted{
-		Repo:     repo,
-		Branch:   req.Branch,
-		Sequence: review.Sequence,
-		Reviewer: reviewer,
-		Status:   string(req.Status),
+		Repo:         repo,
+		Branch:       req.Branch,
+		Sequence:     review.Sequence,
+		Reviewer:     reviewer,
+		Status:       string(req.Status),
+		BranchStatus: bs,
 	})
 	slog.Info("review submitted", "repo", repo, "branch", req.Branch, "reviewer", reviewer, "status", req.Status)
 	writeJSON(w, http.StatusCreated, model.CreateReviewResponse{
@@ -908,13 +913,18 @@ func (s *server) handleCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	bs, bsErr := s.computeBranchStatus(r.Context(), repo, req.Branch, reporter)
+	if bsErr != nil {
+		slog.Warn("branch status computation failed", "op", "check", "repo", repo, "branch", req.Branch, "error", bsErr)
+	}
 	s.emit(r.Context(), evtypes.CheckReported{
-		Repo:      repo,
-		Branch:    req.Branch,
-		Sequence:  cr.Sequence,
-		CheckName: req.CheckName,
-		Status:    string(req.Status),
-		Reporter:  reporter,
+		Repo:         repo,
+		Branch:       req.Branch,
+		Sequence:     cr.Sequence,
+		CheckName:    req.CheckName,
+		Status:       string(req.Status),
+		Reporter:     reporter,
+		BranchStatus: bs,
 	})
 	writeJSON(w, http.StatusCreated, model.CreateCheckRunResponse{
 		ID:       cr.ID,
@@ -1855,6 +1865,10 @@ func (s *server) handleRebase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	bs, bsErr := s.computeBranchStatus(r.Context(), repo, req.Branch, req.Author)
+	if bsErr != nil {
+		slog.Warn("branch status computation failed", "op", "rebase", "repo", repo, "branch", req.Branch, "error", bsErr)
+	}
 	s.emit(r.Context(), evtypes.BranchRebased{
 		Repo:            repo,
 		Branch:          req.Branch,
@@ -1862,6 +1876,7 @@ func (s *server) handleRebase(w http.ResponseWriter, r *http.Request) {
 		NewHeadSequence: resp.NewHeadSequence,
 		CommitsReplayed: resp.CommitsReplayed,
 		RebasedBy:       req.Author,
+		BranchStatus:    bs,
 	})
 	slog.Info("branch rebased", "repo", repo, "branch", req.Branch, "by", req.Author, "commits_replayed", resp.CommitsReplayed)
 	writeJSON(w, http.StatusOK, resp)
@@ -2185,11 +2200,16 @@ func (s *server) handleMerge(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	bsMerge, bsMergeErr := s.computeBranchStatus(r.Context(), repo, req.Branch, req.Author)
+	if bsMergeErr != nil {
+		slog.Warn("branch status computation failed", "op", "merge", "repo", repo, "branch", req.Branch, "error", bsMergeErr)
+	}
 	s.emit(r.Context(), evtypes.BranchMerged{
-		Repo:     repo,
-		Branch:   req.Branch,
-		Sequence: resp.Sequence,
-		MergedBy: req.Author,
+		Repo:         repo,
+		Branch:       req.Branch,
+		Sequence:     resp.Sequence,
+		MergedBy:     req.Author,
+		BranchStatus: bsMerge,
 	})
 	slog.Info("branch merged", "repo", repo, "branch", req.Branch, "by", req.Author, "sequence", resp.Sequence)
 	writeJSON(w, http.StatusOK, resp)
@@ -2220,6 +2240,76 @@ func (s *server) evaluateMergePolicy(ctx context.Context, repo, branch, actor st
 // Branch status handler
 // ---------------------------------------------------------------------------
 
+// computeBranchStatus evaluates merge-eligibility for the given branch and
+// returns the result as a BranchStatusResponse. It is best-effort: if the
+// read store is unavailable or the branch cannot be found, it returns
+// (nil, nil) so callers can omit the field without blocking the primary
+// operation. Infrastructure errors are returned for the caller to log.
+func (s *server) computeBranchStatus(ctx context.Context, repo, branch, actor string) (*model.BranchStatusResponse, error) {
+	if s.readStore == nil {
+		return nil, nil
+	}
+
+	// Load policies (nil engine → bootstrap mode → mergeable=true).
+	var engine *policy.Engine
+	var owners map[string][]string
+	if s.policyCache != nil {
+		var err error
+		engine, owners, err = s.policyCache.Load(ctx, repo, s.readStore)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Fetch branch info to populate auto_merge in the response.
+	branchInfo, err := s.readStore.GetBranch(ctx, repo, branch)
+	if err != nil {
+		return nil, err
+	}
+	if branchInfo == nil {
+		return nil, nil
+	}
+
+	if engine == nil {
+		// Bootstrap mode: no policies defined.
+		return &model.BranchStatusResponse{
+			Mergeable: true,
+			Policies:  []model.PolicyResult{},
+			AutoMerge: branchInfo.AutoMerge,
+		}, nil
+	}
+
+	input, err := s.assembleMergeInput(ctx, repo, branch, actor, owners)
+	if err != nil {
+		return nil, err
+	}
+	if input == nil {
+		return nil, nil
+	}
+
+	results, err := engine.Evaluate(ctx, *input)
+	if err != nil {
+		return nil, err
+	}
+	if results == nil {
+		results = []model.PolicyResult{}
+	}
+
+	mergeable := true
+	for _, res := range results {
+		if !res.Pass {
+			mergeable = false
+			break
+		}
+	}
+
+	return &model.BranchStatusResponse{
+		Mergeable: mergeable,
+		Policies:  results,
+		AutoMerge: branchInfo.AutoMerge,
+	}, nil
+}
+
 // handleBranchStatus implements GET /repos/:name/branch/:branch/status.
 // It evaluates merge policies without performing any write operations.
 func (s *server) handleBranchStatus(w http.ResponseWriter, r *http.Request, repo, branch string) {
@@ -2235,75 +2325,18 @@ func (s *server) handleBranchStatus(w http.ResponseWriter, r *http.Request, repo
 		return
 	}
 
-	// Load policies (nil engine → bootstrap mode → mergeable=true).
-	var engine *policy.Engine
-	var owners map[string][]string
-	if s.policyCache != nil {
-		var err error
-		engine, owners, err = s.policyCache.Load(r.Context(), repo, s.readStore)
-		if err != nil {
-			slog.Error("policy cache load error", "op", "branch_status", "repo", repo, "error", err)
-			writeError(w, http.StatusInternalServerError, "policy evaluation error")
-			return
-		}
-	}
-
-	// Fetch branch info to populate auto_merge in the response.
-	branchInfo, err := s.readStore.GetBranch(r.Context(), repo, branch)
+	resp, err := s.computeBranchStatus(r.Context(), repo, branch, actor)
 	if err != nil {
-		slog.Error("get branch error", "op", "branch_status", "repo", repo, "branch", branch, "error", err)
-		writeError(w, http.StatusInternalServerError, "query failed")
-		return
-	}
-	if branchInfo == nil {
-		writeError(w, http.StatusNotFound, "branch not found")
-		return
-	}
-
-	if engine == nil {
-		// Bootstrap mode: no policies defined.
-		writeJSON(w, http.StatusOK, model.BranchStatusResponse{
-			Mergeable: true,
-			Policies:  []model.PolicyResult{},
-			AutoMerge: branchInfo.AutoMerge,
-		})
-		return
-	}
-
-	input, err := s.assembleMergeInput(r.Context(), repo, branch, actor, owners)
-	if err != nil {
-		slog.Error("assemble merge input error", "op", "branch_status", "repo", repo, "branch", branch, "error", err)
-		writeError(w, http.StatusInternalServerError, "query failed")
-		return
-	}
-	if input == nil {
-		writeError(w, http.StatusNotFound, "branch not found")
-		return
-	}
-
-	results, err := engine.Evaluate(r.Context(), *input)
-	if err != nil {
-		slog.Error("policy evaluation error", "op", "branch_status", "repo", repo, "branch", branch, "error", err)
+		slog.Error("branch status error", "op", "branch_status", "repo", repo, "branch", branch, "error", err)
 		writeError(w, http.StatusInternalServerError, "policy evaluation error")
 		return
 	}
-	if results == nil {
-		results = []model.PolicyResult{}
+	if resp == nil {
+		writeError(w, http.StatusNotFound, "branch not found")
+		return
 	}
 
-	mergeable := true
-	for _, res := range results {
-		if !res.Pass {
-			mergeable = false
-			break
-		}
-	}
-
-	writeJSON(w, http.StatusOK, model.BranchStatusResponse{
-		Mergeable: mergeable,
-		Policies:  results,
-		AutoMerge: branchInfo.AutoMerge,
-	})
+	writeJSON(w, http.StatusOK, *resp)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3969,3 +3969,102 @@ func TestAgentContext_LinkedIssues(t *testing.T) {
 		t.Errorf("expected 1 linked issue with number 42, got: %+v", resp.LinkedIssues)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// computeBranchStatus tests
+// ---------------------------------------------------------------------------
+
+func TestComputeBranchStatus_NilReadStore(t *testing.T) {
+	s := &server{} // readStore is nil
+	resp, err := s.computeBranchStatus(context.Background(), "acme/repo", "feature/x", "actor")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("expected nil when readStore is nil, got %+v", resp)
+	}
+}
+
+func TestComputeBranchStatus_Bootstrap(t *testing.T) {
+	// No policyCache → bootstrap mode → always mergeable.
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
+			return &store.BranchInfo{Name: "feature/x", Status: "active", AutoMerge: true}, nil
+		},
+	}
+	s := &server{readStore: rs}
+
+	resp, err := s.computeBranchStatus(context.Background(), "acme/repo", "feature/x", "actor")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if !resp.Mergeable {
+		t.Error("expected mergeable=true in bootstrap mode")
+	}
+	if !resp.AutoMerge {
+		t.Error("expected auto_merge=true")
+	}
+	if len(resp.Policies) != 0 {
+		t.Errorf("expected empty policies in bootstrap mode, got %v", resp.Policies)
+	}
+}
+
+func TestComputeBranchStatus_BranchNotFound(t *testing.T) {
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
+			return nil, nil // branch does not exist
+		},
+	}
+	s := &server{readStore: rs}
+
+	resp, err := s.computeBranchStatus(context.Background(), "acme/repo", "missing", "actor")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("expected nil when branch not found, got %+v", resp)
+	}
+}
+
+func TestComputeBranchStatus_WithPolicy(t *testing.T) {
+	engine := mustBuildEngine(t, "always_pass", `
+package docstore.always_pass
+default allow = true
+default reason = "all good"
+`)
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
+			return &store.BranchInfo{Name: "feature/x", Status: "active", AutoMerge: false}, nil
+		},
+	}
+	pc := &mockPolicyCache{
+		loadFn: func(_ context.Context, _ string, _ policy.ReadStore) (*policy.Engine, map[string][]string, error) {
+			return engine, nil, nil
+		},
+	}
+	ms := &mockStore{
+		listReviewsFn:   func(_ context.Context, _, _ string, _ *int64) ([]model.Review, error) { return nil, nil },
+		listCheckRunsFn: func(_ context.Context, _, _ string, _ *int64, _ bool) ([]model.CheckRun, error) { return nil, nil },
+	}
+	s := &server{readStore: rs, policyCache: pc, commitStore: ms}
+
+	resp, err := s.computeBranchStatus(context.Background(), "acme/repo", "feature/x", "actor")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if !resp.Mergeable {
+		t.Error("expected mergeable=true when all policies pass")
+	}
+	if resp.AutoMerge {
+		t.Error("expected auto_merge=false")
+	}
+	if len(resp.Policies) == 0 {
+		t.Error("expected at least one policy result")
+	}
+}


### PR DESCRIPTION
## Summary

- Extract `computeBranchStatus(ctx, repo, branch, actor)` helper from `handleBranchStatus()` in `internal/server/handlers.go`, eliminating duplicated policy evaluation logic
- Add optional `BranchStatus *api.BranchStatusResponse` field (`branch_status,omitempty`) to `CheckReported`, `ReviewSubmitted`, `BranchMerged`, and `BranchRebased` event types in `internal/events/types/`
- Populate the field at each emit site via the new helper; errors are logged as warnings and the field is omitted rather than blocking the primary operation

## Test plan

- [ ] `TestComputeBranchStatus_NilReadStore` — returns `(nil, nil)` when read store is unavailable
- [ ] `TestComputeBranchStatus_Bootstrap` — returns `{Mergeable: true, AutoMerge: true, Policies: []}` when no policy cache is configured
- [ ] `TestComputeBranchStatus_BranchNotFound` — returns `(nil, nil)` when branch does not exist
- [ ] `TestComputeBranchStatus_WithPolicy` — returns correct policy evaluation result
- [ ] Full test suite: `go test ./... -count=1` — all pass

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)