### PR TITLE
refactor: extract shared commit hash to internal/hash

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -22,6 +22,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/dlorenc/docstore/internal/hash"
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/tui"
 )
@@ -63,36 +64,7 @@ type chainEntry struct {
 	Message    string      `json:"message"`
 	CreatedAt  time.Time   `json:"created_at"`
 	CommitHash *string     `json:"commit_hash"`
-	Files      []chainFile `json:"files"`
-}
-
-// chainFile is one file in a chainEntry.
-type chainFile struct {
-	Path        string `json:"path"`
-	ContentHash string `json:"content_hash"`
-}
-
-// genesisHash is the all-zeros hash used as the previous-hash for the first chain entry.
-const genesisHash = "0000000000000000000000000000000000000000000000000000000000000000"
-
-// computeChainHash recomputes the SHA256 chain hash for a commit entry.
-// This must exactly match the server-side formula in internal/db/store.go.
-func computeChainHash(prevHash string, seq int64, repo, branch, author, message string, createdAt time.Time, files []chainFile) string {
-	h := sha256.New()
-	h.Write([]byte(prevHash + "\n"))
-	h.Write([]byte(fmt.Sprintf("%d\n", seq)))
-	h.Write([]byte(repo + "\n"))
-	h.Write([]byte(branch + "\n"))
-	h.Write([]byte(author + "\n"))
-	h.Write([]byte(message + "\n"))
-	h.Write([]byte(createdAt.UTC().Format(time.RFC3339Nano) + "\n"))
-	sorted := make([]chainFile, len(files))
-	copy(sorted, files)
-	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Path < sorted[j].Path })
-	for _, f := range sorted {
-		h.Write([]byte(f.Path + ":" + f.ContentHash + "\n"))
-	}
-	return hex.EncodeToString(h.Sum(nil))
+	Files      []hash.File `json:"files"`
 }
 
 // fetchChain calls GET /-/chain?from=N&to=M and returns the decoded entries.
@@ -764,7 +736,7 @@ func (a *App) Pull(skipVerify bool) error {
 	// Only process entries on the current branch (per-branch chain semantics).
 	prevHash := oldState.CommitHash
 	if anchor.CommitHash == nil {
-		prevHash = genesisHash
+		prevHash = hash.GenesisHash
 	}
 	skippedBoundary := false
 	for _, e := range entries[1:] {
@@ -777,10 +749,10 @@ func (a *App) Pull(skipVerify bool) error {
 				fmt.Fprintf(a.Out, "note: skipping pre-feature commit at sequence %d (no commit_hash)\n", e.Sequence)
 				skippedBoundary = true
 			}
-			prevHash = genesisHash
+			prevHash = hash.GenesisHash
 			continue
 		}
-		computed := computeChainHash(prevHash, e.Sequence, cfg.Repo, e.Branch, e.Author, e.Message, e.CreatedAt, e.Files)
+		computed := hash.CommitHash(prevHash, e.Sequence, cfg.Repo, e.Branch, e.Author, e.Message, e.CreatedAt, e.Files)
 		if computed != *e.CommitHash {
 			return fmt.Errorf("chain integrity error at sequence %d: expected %s got %s", e.Sequence, computed, *e.CommitHash)
 		}
@@ -821,7 +793,7 @@ func (a *App) Verify() error {
 		return nil
 	}
 
-	prevHash := genesisHash
+	prevHash := hash.GenesisHash
 	foundFirst := false
 	var verifyErr error
 	for _, e := range entries {
@@ -832,7 +804,7 @@ func (a *App) Verify() error {
 		if e.CommitHash == nil {
 			fmt.Fprintf(a.Out, "seq %-4d  SKIP  (no commit_hash)  %s\n", e.Sequence, e.Message)
 			// Reset prevHash so the next hashed commit starts a new chain segment.
-			prevHash = genesisHash
+			prevHash = hash.GenesisHash
 			continue
 		}
 		if !foundFirst {
@@ -842,7 +814,7 @@ func (a *App) Verify() error {
 			fmt.Fprintf(a.Out, "seq %-4d  OK    %.16s  %s\n", e.Sequence, *e.CommitHash, e.Message)
 			continue
 		}
-		computed := computeChainHash(prevHash, e.Sequence, cfg.Repo, e.Branch, e.Author, e.Message, e.CreatedAt, e.Files)
+		computed := hash.CommitHash(prevHash, e.Sequence, cfg.Repo, e.Branch, e.Author, e.Message, e.CreatedAt, e.Files)
 		if computed == *e.CommitHash {
 			prevHash = *e.CommitHash
 			fmt.Fprintf(a.Out, "seq %-4d  OK    %.16s  %s\n", e.Sequence, *e.CommitHash, e.Message)

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dlorenc/docstore/internal/hash"
 	"github.com/dlorenc/docstore/internal/model"
 )
 
@@ -2647,21 +2648,21 @@ func TestImportGitDefaultMode(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // buildChainHash replicates the server-side hash formula for tests.
-func buildChainHash(prevHash string, seq int64, repo, branch, author, message string, createdAt time.Time, files []chainFile) string {
-	return computeChainHash(prevHash, seq, repo, branch, author, message, createdAt, files)
+func buildChainHash(prevHash string, seq int64, repo, branch, author, message string, createdAt time.Time, files []hash.File) string {
+	return hash.CommitHash(prevHash, seq, repo, branch, author, message, createdAt, files)
 }
 
 // newChainEntry builds a minimal chainEntry with a correct commit_hash for testing.
 func newChainEntry(prevHash string, seq int64, repo, branch, author, msg string, ts time.Time) chainEntry {
-	hash := buildChainHash(prevHash, seq, repo, branch, author, msg, ts, nil)
+	commitHash := buildChainHash(prevHash, seq, repo, branch, author, msg, ts, nil)
 	return chainEntry{
 		Sequence:   seq,
 		Branch:     branch,
 		Author:     author,
 		Message:    msg,
 		CreatedAt:  ts,
-		CommitHash: &hash,
-		Files:      []chainFile{},
+		CommitHash: &commitHash,
+		Files:      []hash.File{},
 	}
 }
 
@@ -2687,7 +2688,7 @@ func newPullServer(t *testing.T, branch string, headSeq int64, chainEntries []ch
 // TestPull_TOFU verifies that the first pull (no stored CommitHash) stores the tip hash.
 func TestPull_TOFU(t *testing.T) {
 	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	e1 := newChainEntry(genesisHash, 1, "default/default", "main", "alice", "first", ts)
+	e1 := newChainEntry(hash.GenesisHash, 1, "default/default", "main", "alice", "first", ts)
 
 	srv := newPullServer(t, "main", 1, []chainEntry{e1})
 	defer srv.Close()
@@ -2714,7 +2715,7 @@ func TestPull_TOFU(t *testing.T) {
 // TestPull_VerificationSuccess verifies that a subsequent pull with a valid chain passes.
 func TestPull_VerificationSuccess(t *testing.T) {
 	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	e1 := newChainEntry(genesisHash, 1, "default/default", "main", "alice", "first", ts)
+	e1 := newChainEntry(hash.GenesisHash, 1, "default/default", "main", "alice", "first", ts)
 	ts2 := ts.Add(time.Second)
 	e2 := newChainEntry(*e1.CommitHash, 2, "default/default", "main", "alice", "second", ts2)
 
@@ -2743,7 +2744,7 @@ func TestPull_VerificationSuccess(t *testing.T) {
 // TestPull_VerificationFailure verifies that a wrong hash causes an error.
 func TestPull_VerificationFailure(t *testing.T) {
 	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	e1 := newChainEntry(genesisHash, 1, "default/default", "main", "alice", "first", ts)
+	e1 := newChainEntry(hash.GenesisHash, 1, "default/default", "main", "alice", "first", ts)
 	ts2 := ts.Add(time.Second)
 	// Build a second entry with a wrong hash.
 	badHash := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
@@ -2754,7 +2755,7 @@ func TestPull_VerificationFailure(t *testing.T) {
 		Message:    "second",
 		CreatedAt:  ts2,
 		CommitHash: &badHash,
-		Files:      []chainFile{},
+		Files:      []hash.File{},
 	}
 
 	srv := newPullServer(t, "main", 2, []chainEntry{e1, e2Wrong})
@@ -2780,7 +2781,7 @@ func TestPull_VerificationFailure(t *testing.T) {
 // TestVerify_HappyPath verifies ds verify prints OK for a valid chain.
 func TestVerify_HappyPath(t *testing.T) {
 	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	e1 := newChainEntry(genesisHash, 1, "default/default", "main", "alice", "first", ts)
+	e1 := newChainEntry(hash.GenesisHash, 1, "default/default", "main", "alice", "first", ts)
 	ts2 := ts.Add(time.Second)
 	e2 := newChainEntry(*e1.CommitHash, 2, "default/default", "main", "alice", "second", ts2)
 
@@ -2821,7 +2822,7 @@ func TestVerify_HappyPath(t *testing.T) {
 // what the client has stored in state (FIX-7).
 func TestPull_AnchorTampered(t *testing.T) {
 	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	e1 := newChainEntry(genesisHash, 1, "default/default", "main", "alice", "first", ts)
+	e1 := newChainEntry(hash.GenesisHash, 1, "default/default", "main", "alice", "first", ts)
 
 	// Server returns a tampered hash for the anchor sequence.
 	tamperedHash := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
@@ -2832,7 +2833,7 @@ func TestPull_AnchorTampered(t *testing.T) {
 		Message:    "first",
 		CreatedAt:  ts,
 		CommitHash: &tamperedHash,
-		Files:      []chainFile{},
+		Files:      []hash.File{},
 	}
 
 	srv := newPullServer(t, "main", 2, []chainEntry{e1Tampered})
@@ -2869,7 +2870,7 @@ func TestPull_TOFU_NullHash(t *testing.T) {
 		Message:    "legacy commit",
 		CreatedAt:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 		CommitHash: nil,
-		Files:      []chainFile{},
+		Files:      []hash.File{},
 	}
 
 	srv := newPullServer(t, "main", 1, []chainEntry{nullEntry})
@@ -3088,7 +3089,7 @@ func TestPurge_DryRun(t *testing.T) {
 // but skips chain verification even when the chain would fail.
 func TestPull_SkipVerify(t *testing.T) {
 	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	e1 := newChainEntry(genesisHash, 1, "default/default", "main", "alice", "first", ts)
+	e1 := newChainEntry(hash.GenesisHash, 1, "default/default", "main", "alice", "first", ts)
 
 	// Build a second entry with a deliberately wrong hash.
 	badHash := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
@@ -3099,7 +3100,7 @@ func TestPull_SkipVerify(t *testing.T) {
 		Message:    "second",
 		CreatedAt:  ts.Add(time.Second),
 		CommitHash: &badHash,
-		Files:      []chainFile{},
+		Files:      []hash.File{},
 	}
 
 	// The server has a bad chain that would normally cause a verification error.

--- a/internal/db/bench_test.go
+++ b/internal/db/bench_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/dlorenc/docstore/internal/hash"
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/store"
 	"github.com/dlorenc/docstore/internal/testutil"
@@ -40,17 +41,17 @@ func BenchmarkChainWalk_100Commits(b *testing.B) {
 			b.Fatalf("GetChain: %v", err)
 		}
 
-		prevHash := genesisHash
+		prevHash := hash.GenesisHash
 		for _, e := range entries {
 			if e.CommitHash == nil {
-				prevHash = genesisHash
+				prevHash = hash.GenesisHash
 				continue
 			}
-			files := make([]chainFile, len(e.Files))
+			files := make([]hash.File, len(e.Files))
 			for j, f := range e.Files {
-				files[j] = chainFile{path: f.Path, contentHash: f.ContentHash}
+				files[j] = hash.File{Path: f.Path, ContentHash: f.ContentHash}
 			}
-			got := computeCommitHash(prevHash, e.Sequence, "default/default", e.Branch, e.Author, e.Message, e.CreatedAt, files)
+			got := hash.CommitHash(prevHash, e.Sequence, "default/default", e.Branch, e.Author, e.Message, e.CreatedAt, files)
 			if got != *e.CommitHash {
 				b.Fatalf("chain integrity error at sequence %d: got %s want %s", e.Sequence, got, *e.CommitHash)
 			}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -10,50 +10,17 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"sort"
-	"strconv"
 	"time"
 
 	"github.com/dlorenc/docstore/internal/blob"
+	"github.com/dlorenc/docstore/internal/hash"
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 )
 
-// genesisHash is the all-zeros hash used as the previous hash for the first commit.
-const genesisHash = "0000000000000000000000000000000000000000000000000000000000000000"
-
-// chainFile holds a path and content_hash for commit hash computation.
-type chainFile struct {
-	path        string
-	contentHash string
-}
-
-// computeCommitHash computes the SHA256 chain hash for a commit.
-// prevHash is the hex-encoded hash of the previous commit (or genesisHash for the first commit).
-// files are sorted by path internally, so caller order does not matter.
-func computeCommitHash(prevHash string, seq int64, repo, branch, author, message string, createdAt time.Time, files []chainFile) string {
-	// Sort a copy so the hash is always canonical regardless of input order.
-	sorted := make([]chainFile, len(files))
-	copy(sorted, files)
-	sort.Slice(sorted, func(i, j int) bool { return sorted[i].path < sorted[j].path })
-
-	h := sha256.New()
-	h.Write([]byte(prevHash + "\n"))
-	h.Write([]byte(strconv.FormatInt(seq, 10) + "\n"))
-	h.Write([]byte(repo + "\n"))
-	h.Write([]byte(branch + "\n"))
-	h.Write([]byte(author + "\n"))
-	h.Write([]byte(message + "\n"))
-	h.Write([]byte(createdAt.UTC().Format(time.RFC3339Nano) + "\n"))
-	for _, f := range sorted {
-		h.Write([]byte(f.path + ":" + f.contentHash + "\n"))
-	}
-	return hex.EncodeToString(h.Sum(nil))
-}
-
 // fetchPrevCommitHash fetches the commit_hash of the most recent commit before seq
-// on the same branch. Returns genesisHash if no previous commit exists on this branch
+// on the same branch. Returns hash.GenesisHash if no previous commit exists on this branch
 // or if the previous commit has a NULL commit_hash (pre-feature commit).
 // Using per-branch lookup ensures same-branch commits form a coherent linear chain;
 // different branches have independent chains and are not subject to cross-branch races.
@@ -66,13 +33,13 @@ func fetchPrevCommitHash(ctx context.Context, tx *sql.Tx, repo, branch string, s
 		repo, branch, seq,
 	).Scan(&prevNull)
 	if errors.Is(err, sql.ErrNoRows) {
-		return genesisHash, nil
+		return hash.GenesisHash, nil
 	}
 	if err != nil {
 		return "", fmt.Errorf("fetch prev commit hash: %w", err)
 	}
 	if !prevNull.Valid || prevNull.String == "" {
-		return genesisHash, nil
+		return hash.GenesisHash, nil
 	}
 	return prevNull.String, nil
 }
@@ -447,7 +414,7 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 	}
 
 	results := make([]model.CommitFileResult, 0, len(req.Files))
-	hashFiles := make([]chainFile, 0, len(req.Files))
+	hashFiles := make([]hash.File, 0, len(req.Files))
 
 	for _, f := range req.Files {
 		var versionIDPtr *string
@@ -519,7 +486,7 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 			Path:      f.Path,
 			VersionID: versionIDPtr,
 		})
-		hashFiles = append(hashFiles, chainFile{path: f.Path, contentHash: fileContentHash})
+		hashFiles = append(hashFiles, hash.File{Path: f.Path, ContentHash: fileContentHash})
 	}
 
 	// Advance branch head.
@@ -536,8 +503,8 @@ func (s *Store) Commit(ctx context.Context, req model.CommitRequest) (*model.Com
 	if err != nil {
 		return nil, err
 	}
-	// computeCommitHash sorts files internally; no pre-sort needed.
-	commitHash := computeCommitHash(prevHash, newSeq, req.Repo, req.Branch, req.Author, req.Message, commitCreatedAt, hashFiles)
+	// hash.CommitHash sorts files internally; no pre-sort needed.
+	commitHash := hash.CommitHash(prevHash, newSeq, req.Repo, req.Branch, req.Author, req.Message, commitCreatedAt, hashFiles)
 	if err := updateCommitHash(ctx, tx, req.Repo, newSeq, commitHash); err != nil {
 		return nil, fmt.Errorf("store commit hash: %w", err)
 	}
@@ -796,16 +763,16 @@ func (s *Store) Merge(ctx context.Context, req model.MergeRequest) (*model.Merge
 	if err != nil {
 		return nil, nil, err
 	}
-	hashFiles := make([]chainFile, 0, len(branchChanges))
+	hashFiles := make([]hash.File, 0, len(branchChanges))
 	for path, versionID := range branchChanges {
 		contentHash, err := fetchVersionContentHash(ctx, tx, versionID)
 		if err != nil {
 			return nil, nil, err
 		}
-		hashFiles = append(hashFiles, chainFile{path: path, contentHash: contentHash})
+		hashFiles = append(hashFiles, hash.File{Path: path, ContentHash: contentHash})
 	}
-	// computeCommitHash sorts files internally; no pre-sort needed.
-	mergeHash := computeCommitHash(prevHash, newSeq, req.Repo, "main", req.Author, mergeMsg, mergeCreatedAt, hashFiles)
+	// hash.CommitHash sorts files internally; no pre-sort needed.
+	mergeHash := hash.CommitHash(prevHash, newSeq, req.Repo, "main", req.Author, mergeMsg, mergeCreatedAt, hashFiles)
 	if err := updateCommitHash(ctx, tx, req.Repo, newSeq, mergeHash); err != nil {
 		return nil, nil, fmt.Errorf("store merge commit hash: %w", err)
 	}
@@ -960,16 +927,16 @@ func (s *Store) Rebase(ctx context.Context, req model.RebaseRequest) (*model.Reb
 		if err != nil {
 			return nil, nil, err
 		}
-		hashFiles := make([]chainFile, 0, len(g.files))
+		hashFiles := make([]hash.File, 0, len(g.files))
 		for _, f := range g.files {
 			contentHash, err := fetchVersionContentHash(ctx, tx, f.versionID)
 			if err != nil {
 				return nil, nil, err
 			}
-			hashFiles = append(hashFiles, chainFile{path: f.path, contentHash: contentHash})
+			hashFiles = append(hashFiles, hash.File{Path: f.path, ContentHash: contentHash})
 		}
-		// computeCommitHash sorts files internally; no pre-sort needed.
-		rebaseHash := computeCommitHash(prevHash, newSeq, req.Repo, req.Branch, author, rebaseMsg, rebaseCreatedAt, hashFiles)
+		// hash.CommitHash sorts files internally; no pre-sort needed.
+		rebaseHash := hash.CommitHash(prevHash, newSeq, req.Repo, req.Branch, author, rebaseMsg, rebaseCreatedAt, hashFiles)
 		if err := updateCommitHash(ctx, tx, req.Repo, newSeq, rebaseHash); err != nil {
 			return nil, nil, fmt.Errorf("store rebase commit hash: %w", err)
 		}

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dlorenc/docstore/internal/hash"
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/testutil"
 )
@@ -3190,7 +3191,7 @@ func TestIsForeignKeyViolation_FromDB(t *testing.T) {
 // expectedCommitHash is a regression sentinel: the known SHA256 for the fixed
 // test inputs used in TestComputeCommitHash. If the hash formula changes, this
 // constant must be updated deliberately (it catches accidental formula drift).
-// Inputs: prevHash=genesisHash, seq=1, repo="myorg/repo", branch="main",
+// Inputs: prevHash=hash.GenesisHash, seq=1, repo="myorg/repo", branch="main",
 // author="alice", message="first commit", ts=2024-01-01T00:00:00Z,
 // files=[{a.txt:aaa},{b.txt:bbb}] (sorted alphabetically by path).
 const expectedCommitHash = "54662b84dcaca30b108d9b779bec9ad8727f35db9e6742401aaa5d09a5a5b987"
@@ -3199,12 +3200,12 @@ const expectedCommitHash = "54662b84dcaca30b108d9b779bec9ad8727f35db9e6742401aaa
 func TestComputeCommitHash(t *testing.T) {
 	t.Parallel()
 	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	files := []chainFile{
-		{path: "b.txt", contentHash: "bbb"},
-		{path: "a.txt", contentHash: "aaa"},
+	files := []hash.File{
+		{Path: "b.txt", ContentHash: "bbb"},
+		{Path: "a.txt", ContentHash: "aaa"},
 	}
 	// Files are sorted inside computeCommitHash, so order of input shouldn't matter.
-	got := computeCommitHash(genesisHash, 1, "myorg/repo", "main", "alice", "first commit", ts, files)
+	got := hash.CommitHash(hash.GenesisHash, 1, "myorg/repo", "main", "alice", "first commit", ts, files)
 	if len(got) != 64 {
 		t.Fatalf("expected 64-char hex string, got %q (len=%d)", got, len(got))
 	}
@@ -3215,7 +3216,7 @@ func TestComputeCommitHash(t *testing.T) {
 	}
 
 	// Recomputing with the same inputs must produce the same hash.
-	got2 := computeCommitHash(genesisHash, 1, "myorg/repo", "main", "alice", "first commit", ts, files)
+	got2 := hash.CommitHash(hash.GenesisHash, 1, "myorg/repo", "main", "alice", "first commit", ts, files)
 	if got != got2 {
 		t.Errorf("hash not deterministic: got %q vs %q", got, got2)
 	}
@@ -3226,19 +3227,19 @@ func TestComputeCommitHash(t *testing.T) {
 		fn   func() string
 	}{
 		{"author", func() string {
-			return computeCommitHash(genesisHash, 1, "myorg/repo", "main", "bob", "first commit", ts, files)
+			return hash.CommitHash(hash.GenesisHash, 1, "myorg/repo", "main", "bob", "first commit", ts, files)
 		}},
 		{"message", func() string {
-			return computeCommitHash(genesisHash, 1, "myorg/repo", "main", "alice", "other msg", ts, files)
+			return hash.CommitHash(hash.GenesisHash, 1, "myorg/repo", "main", "alice", "other msg", ts, files)
 		}},
 		{"sequence", func() string {
-			return computeCommitHash(genesisHash, 2, "myorg/repo", "main", "alice", "first commit", ts, files)
+			return hash.CommitHash(hash.GenesisHash, 2, "myorg/repo", "main", "alice", "first commit", ts, files)
 		}},
 		{"repo", func() string {
-			return computeCommitHash(genesisHash, 1, "other/repo", "main", "alice", "first commit", ts, files)
+			return hash.CommitHash(hash.GenesisHash, 1, "other/repo", "main", "alice", "first commit", ts, files)
 		}},
 		{"prevHash", func() string {
-			return computeCommitHash("aaaa"+genesisHash[4:], 1, "myorg/repo", "main", "alice", "first commit", ts, files)
+			return hash.CommitHash("aaaa"+hash.GenesisHash[4:], 1, "myorg/repo", "main", "alice", "first commit", ts, files)
 		}},
 	} {
 		if diff := tc.fn(); diff == got {
@@ -3249,7 +3250,7 @@ func TestComputeCommitHash(t *testing.T) {
 	// Verify expected value by building the same hash inline.
 	// computeCommitHash sorts files internally, so feed them sorted.
 	h := sha256.New()
-	h.Write([]byte(genesisHash + "\n"))
+	h.Write([]byte(hash.GenesisHash + "\n"))
 	h.Write([]byte("1\n"))
 	h.Write([]byte("myorg/repo\n"))
 	h.Write([]byte("main\n"))
@@ -3363,15 +3364,15 @@ func TestCommit_ChainLinks(t *testing.T) {
 	).Scan(&contentHash2); err != nil {
 		t.Fatalf("query content hash for b.txt: %v", err)
 	}
-	hashFiles2 := []chainFile{{path: "b.txt", contentHash: contentHash2.String}}
-	recomputed2 := computeCommitHash(hash1.String, resp2.Sequence, "default/default", "main", author2, message2, createdAt2, hashFiles2)
+	hashFiles2 := []hash.File{{Path: "b.txt", ContentHash: contentHash2.String}}
+	recomputed2 := hash.CommitHash(hash1.String, resp2.Sequence, "default/default", "main", author2, message2, createdAt2, hashFiles2)
 	if recomputed2 != hash2.String {
 		t.Errorf("chain linkage broken: recomputed hash2=%s, stored hash2=%s", recomputed2, hash2.String)
 	}
 }
 
 // TestCommit_PerBranchChain verifies that commits on different branches each
-// start their own chain from genesisHash, independently of each other.
+// start their own chain from hash.GenesisHash, independently of each other.
 func TestCommit_PerBranchChain(t *testing.T) {
 	t.Parallel()
 	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
@@ -3418,7 +3419,7 @@ func TestCommit_PerBranchChain(t *testing.T) {
 	}
 
 	// Both commits should be the first on their respective branches, so both
-	// prevHash values should be genesisHash. Retrieve metadata to recompute.
+	// prevHash values should be hash.GenesisHash. Retrieve metadata to recompute.
 	type commitMeta struct {
 		author, message string
 		createdAt       time.Time
@@ -3449,18 +3450,18 @@ func TestCommit_PerBranchChain(t *testing.T) {
 	mainMeta := getMeta(mainResp.Sequence)
 	featureMeta := getMeta(featureResp.Sequence)
 
-	// Main commit: prevHash must be genesisHash (first on main).
-	expectedMain := computeCommitHash(genesisHash, mainResp.Sequence, "default/default", "main",
+	// Main commit: prevHash must be hash.GenesisHash (first on main).
+	expectedMain := hash.CommitHash(hash.GenesisHash, mainResp.Sequence, "default/default", "main",
 		mainMeta.author, mainMeta.message, mainMeta.createdAt,
-		[]chainFile{{path: "base.txt", contentHash: getContentHash(mainResp.Sequence, "base.txt")}})
+		[]hash.File{{Path: "base.txt", ContentHash: getContentHash(mainResp.Sequence, "base.txt")}})
 	if expectedMain != mainHash.String {
 		t.Errorf("main chain: expected %s, got %s", expectedMain, mainHash.String)
 	}
 
-	// Feature commit: prevHash must be genesisHash (first on feature/x, independent of main).
-	expectedFeature := computeCommitHash(genesisHash, featureResp.Sequence, "default/default", "feature/x",
+	// Feature commit: prevHash must be hash.GenesisHash (first on feature/x, independent of main).
+	expectedFeature := hash.CommitHash(hash.GenesisHash, featureResp.Sequence, "default/default", "feature/x",
 		featureMeta.author, featureMeta.message, featureMeta.createdAt,
-		[]chainFile{{path: "feat.txt", contentHash: getContentHash(featureResp.Sequence, "feat.txt")}})
+		[]hash.File{{Path: "feat.txt", ContentHash: getContentHash(featureResp.Sequence, "feat.txt")}})
 	if expectedFeature != featureHash.String {
 		t.Errorf("feature chain: expected %s, got %s", expectedFeature, featureHash.String)
 	}

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -1,0 +1,43 @@
+// Package hash provides the canonical commit chain hash function for docstore.
+// Both the server (internal/db) and client (internal/cli) must use this function
+// to ensure identical hash computation.
+package hash
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strconv"
+	"time"
+)
+
+// GenesisHash is the all-zeros hash used as the previous-hash for the first chain entry.
+const GenesisHash = "0000000000000000000000000000000000000000000000000000000000000000"
+
+// File holds a path and content hash for commit hash computation.
+type File struct {
+	Path        string `json:"path"`
+	ContentHash string `json:"content_hash"`
+}
+
+// CommitHash computes the SHA256 chain hash for a commit.
+// prevHash is the hex-encoded hash of the previous commit (or GenesisHash for the first commit).
+// Files are sorted by path internally, so caller order does not matter.
+func CommitHash(prevHash string, seq int64, repo, branch, author, message string, createdAt time.Time, files []File) string {
+	sorted := make([]File, len(files))
+	copy(sorted, files)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Path < sorted[j].Path })
+
+	h := sha256.New()
+	h.Write([]byte(prevHash + "\n"))
+	h.Write([]byte(strconv.FormatInt(seq, 10) + "\n"))
+	h.Write([]byte(repo + "\n"))
+	h.Write([]byte(branch + "\n"))
+	h.Write([]byte(author + "\n"))
+	h.Write([]byte(message + "\n"))
+	h.Write([]byte(createdAt.UTC().Format(time.RFC3339Nano) + "\n"))
+	for _, f := range sorted {
+		h.Write([]byte(f.Path + ":" + f.ContentHash + "\n"))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/hash/hash_test.go
+++ b/internal/hash/hash_test.go
@@ -1,0 +1,116 @@
+package hash_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dlorenc/docstore/internal/hash"
+)
+
+// TestCommitHash_Deterministic verifies that CommitHash returns the same value
+// for identical inputs regardless of call order.
+func TestCommitHash_Deterministic(t *testing.T) {
+	t.Parallel()
+	ts := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+	files := []hash.File{
+		{Path: "b.txt", ContentHash: "bbbbbbbb"},
+		{Path: "a.txt", ContentHash: "aaaaaaaa"},
+	}
+	got1 := hash.CommitHash(hash.GenesisHash, 1, "org/repo", "main", "alice@example.com", "init", ts, files)
+	got2 := hash.CommitHash(hash.GenesisHash, 1, "org/repo", "main", "alice@example.com", "init", ts, files)
+	if got1 != got2 {
+		t.Errorf("non-deterministic: %q != %q", got1, got2)
+	}
+}
+
+// TestCommitHash_FileOrderIndependent verifies that file order does not affect the hash.
+func TestCommitHash_FileOrderIndependent(t *testing.T) {
+	t.Parallel()
+	ts := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+	filesAB := []hash.File{
+		{Path: "a.txt", ContentHash: "aaa"},
+		{Path: "b.txt", ContentHash: "bbb"},
+	}
+	filesBA := []hash.File{
+		{Path: "b.txt", ContentHash: "bbb"},
+		{Path: "a.txt", ContentHash: "aaa"},
+	}
+	h1 := hash.CommitHash(hash.GenesisHash, 1, "org/repo", "main", "alice", "msg", ts, filesAB)
+	h2 := hash.CommitHash(hash.GenesisHash, 1, "org/repo", "main", "alice", "msg", ts, filesBA)
+	if h1 != h2 {
+		t.Errorf("file order affected hash: %q vs %q", h1, h2)
+	}
+}
+
+// TestCommitHash_ChainLinks verifies that prevHash is incorporated so consecutive
+// commits form a linked chain (changing prevHash changes the output).
+func TestCommitHash_ChainLinks(t *testing.T) {
+	t.Parallel()
+	ts := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+	files := []hash.File{{Path: "f.txt", ContentHash: "cccc"}}
+
+	h1 := hash.CommitHash(hash.GenesisHash, 1, "org/repo", "main", "alice", "first", ts, files)
+	h2 := hash.CommitHash(h1, 2, "org/repo", "main", "alice", "second", ts, files)
+	h3WithWrongPrev := hash.CommitHash(hash.GenesisHash, 2, "org/repo", "main", "alice", "second", ts, files)
+
+	if h2 == h3WithWrongPrev {
+		t.Error("prevHash not incorporated: different prevHash produced the same hash")
+	}
+}
+
+// TestCommitHash_KnownValue is a golden-value test ensuring the algorithm does not
+// silently change. If this test breaks, all stored hashes must be recomputed.
+func TestCommitHash_KnownValue(t *testing.T) {
+	t.Parallel()
+	ts := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+	files := []hash.File{
+		{Path: "README.md", ContentHash: "deadbeef"},
+	}
+	got := hash.CommitHash(hash.GenesisHash, 1, "org/repo", "main", "alice@example.com", "initial commit", ts, files)
+	// The want value is computed from the canonical algorithm; update it here if the
+	// algorithm is intentionally changed (requires recomputing all stored hashes).
+	const want = "e245acb0715bd67a76e1395fc4b27229835c93e133b51b9e96364f4507e0c06b"
+	if got != want {
+		t.Errorf("hash formula changed: got %s, want %s — update this constant only if the algorithm change is intentional (all stored hashes must be recomputed)", got, want)
+	}
+}
+
+// TestGenesisHash verifies the GenesisHash constant has the expected format.
+func TestGenesisHash(t *testing.T) {
+	t.Parallel()
+	if len(hash.GenesisHash) != 64 {
+		t.Errorf("GenesisHash len=%d, want 64", len(hash.GenesisHash))
+	}
+	for _, c := range hash.GenesisHash {
+		if c != '0' {
+			t.Errorf("GenesisHash contains non-zero char %q", c)
+			break
+		}
+	}
+}
+
+// TestCommitHash_ServerClientConsistency explicitly documents that the function
+// is the single shared implementation for both server (internal/db) and client
+// (internal/cli) and verifies it produces results matching the documented formula.
+func TestCommitHash_ServerClientConsistency(t *testing.T) {
+	t.Parallel()
+	// Simulate the server computing a hash during a Commit call.
+	ts := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	serverFiles := []hash.File{
+		{Path: "doc.txt", ContentHash: "abc123"},
+		{Path: "README.md", ContentHash: "def456"},
+	}
+	serverHash := hash.CommitHash(hash.GenesisHash, 3, "myorg/myrepo", "feature", "bob@example.com", "add docs", ts, serverFiles)
+
+	// Simulate the client recomputing the same hash during a Verify call.
+	// The client receives files from the server's JSON response (same values, possibly different order).
+	clientFiles := []hash.File{
+		{Path: "README.md", ContentHash: "def456"},
+		{Path: "doc.txt", ContentHash: "abc123"},
+	}
+	clientHash := hash.CommitHash(hash.GenesisHash, 3, "myorg/myrepo", "feature", "bob@example.com", "add docs", ts, clientFiles)
+
+	if serverHash != clientHash {
+		t.Errorf("server hash %q != client hash %q — implementations diverged", serverHash, clientHash)
+	}
+}


### PR DESCRIPTION
## Summary

- Extracts the duplicate SHA256 chain hash implementations from `internal/db/store.go` (`computeCommitHash`) and `internal/cli/app.go` (`computeChainHash`) into a single canonical package `internal/hash`
- Both callers now import and use `hash.CommitHash` — eliminating the risk of the two implementations drifting apart
- `chainEntry.Files` in the CLI is now typed as `[]hash.File` (same exported fields, same JSON tags)
- All test files updated to use the new package (`bench_test.go`, `store_test.go`, `app_test.go`)

## New package: `internal/hash`

- `GenesisHash` — the all-zeros sentinel for the first chain entry
- `File{Path, ContentHash}` — exported struct with JSON tags matching the wire format
- `CommitHash(prevHash, seq, repo, branch, author, message, createdAt, files)` — canonical implementation

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/hash/... -v` — 6 new tests all pass:
  - `TestCommitHash_Deterministic`
  - `TestCommitHash_FileOrderIndependent`
  - `TestCommitHash_ChainLinks`
  - `TestCommitHash_KnownValue` (golden value `e245acb0...`)
  - `TestGenesisHash`
  - `TestCommitHash_ServerClientConsistency`
- [x] `go test` on non-DB packages — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)