### PR TITLE
fix: 409 for BranchNotActive in rebase, rollback error logging, Poll doc comment, dry-run merge tests

### DIFF
--- a/internal/db/tx.go
+++ b/internal/db/tx.go
@@ -26,7 +26,9 @@ func WithTx(ctx context.Context, db *sql.DB, fn func(*sql.Tx) error) (retErr err
 	}
 	defer func() {
 		if p := recover(); p != nil {
-			_ = tx.Rollback()
+			if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+				slog.Error("tx rollback failed during panic recovery", "error", rollbackErr)
+			}
 			panic(p)
 		}
 		if retErr != nil {

--- a/internal/events/broker.go
+++ b/internal/events/broker.go
@@ -83,6 +83,10 @@ func (b *Broker) CurrentSeq(ctx context.Context) (int64, error) {
 // If repo is "*", events from all repos are returned.
 // If types is empty, all event types are returned.
 // Results are ordered by seq ASC, capped at 200 rows per call.
+//
+// Poll does not apply any internal back-off. Callers are responsible for
+// sleeping between calls (e.g. after an error or when the result is empty)
+// to avoid tight polling loops.
 func (b *Broker) Poll(ctx context.Context, repo string, sinceSeq int64, types []string) ([]LoggedEvent, error) {
 	if b.db == nil {
 		return nil, nil

--- a/internal/server/handlers_branches.go
+++ b/internal/server/handlers_branches.go
@@ -281,7 +281,7 @@ func (s *server) handleRebase(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, db.ErrBranchNotFound):
 			writeAPIError(w, ErrCodeBranchNotFound, http.StatusNotFound, "branch not found")
 		case errors.Is(err, db.ErrBranchNotActive):
-			writeAPIError(w, ErrCodeBranchNotActive, http.StatusBadRequest, "branch is not active")
+			writeAPIError(w, ErrCodeBranchNotActive, http.StatusConflict, "branch is not active")
 		default:
 			slog.Error("internal error", "op", "rebase", "repo", repo, "branch", req.Branch, "error", err)
 			writeAPIError(w, ErrCodeInternalError, http.StatusInternalServerError, "internal server error")

--- a/internal/server/handlers_gap_test.go
+++ b/internal/server/handlers_gap_test.go
@@ -939,6 +939,75 @@ func TestHandleDisableAutoMerge_StoreError(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// handleMerge dry-run tests
+// ---------------------------------------------------------------------------
+
+// TestHandleMerge_DryRun verifies that a merge with dry_run=true returns the
+// computed sequence without persisting the merge (policyCache is nil so
+// policy evaluation is skipped, and the mock Merge fn signals dry-run by
+// returning the expected sequence).
+func TestHandleMerge_DryRun(t *testing.T) {
+	const wantSeq = int64(42)
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return &model.Repo{Name: name}, nil
+		},
+		mergeFn: func(_ context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
+			if !req.DryRun {
+				t.Error("expected DryRun=true inside Merge call")
+			}
+			return &model.MergeResponse{Sequence: wantSeq}, nil, nil
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	body, _ := json.Marshal(model.MergeRequest{Branch: "feature", DryRun: true})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/merge", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp model.MergeResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Sequence != wantSeq {
+		t.Errorf("expected sequence %d, got %d", wantSeq, resp.Sequence)
+	}
+}
+
+// TestHandleMerge_DryRun_DoesNotPersist verifies that dry_run=true does not
+// cause a second Merge call or any proposal side-effects: the merge function
+// is called exactly once and the server returns 200 without emitting events.
+func TestHandleMerge_DryRun_DoesNotPersist(t *testing.T) {
+	calls := 0
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return &model.Repo{Name: name}, nil
+		},
+		mergeFn: func(_ context.Context, req model.MergeRequest) (*model.MergeResponse, []db.MergeConflict, error) {
+			calls++
+			return &model.MergeResponse{Sequence: 7}, nil, nil
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	body, _ := json.Marshal(model.MergeRequest{Branch: "feature", DryRun: true})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/merge", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	if calls != 1 {
+		t.Errorf("expected Merge to be called exactly once, got %d", calls)
+	}
+}
+
 // 14. Config sent as a JSON array → 400.
 func TestHandleCreateSubscription_InvalidConfigType(t *testing.T) {
 	srv := New(&mockStore{}, nil, devID, devID)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1429,8 +1429,8 @@ func TestHandleRebase_BranchNotActive(t *testing.T) {
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", rec.Code)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", rec.Code)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **handlers_branches.go**: rebase handler returns 409 (Conflict) for `ErrCodeBranchNotActive`, consistent with delete and merge handlers (was incorrectly returning 400)
- **db/tx.go**: log `slog.Error` when rollback fails during panic recovery instead of silently swallowing with `_ = tx.Rollback()`
- **events/broker.go**: add doc comment to `Poll()` explicitly stating callers are responsible for applying back-off between calls
- **handlers_gap_test.go**: two new unit tests for the merge dry-run path verifying 200 response with computed sequence and that `Merge` is called exactly once
- **server_test.go**: update `TestHandleRebase_BranchNotActive` to expect 409 (matching the bug fix)

## Test plan
- [x] `go test ./internal/server/... ./internal/db/... ./internal/events/... -count=1` — all pass
- [x] `go build ./... && go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)