### PR TITLE
feat: ETag/If-Match conditional writes for branches and proposals (#250)

### DIFF
--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -1,6 +1,10 @@
 package server
 
-import "net/http"
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+)
 
 // ErrorCode is a machine-readable code included in every API error response.
 // Clients can switch on Code to handle specific error types programmatically
@@ -33,6 +37,9 @@ const (
 	// Auth errors
 	ErrCodeUnauthorized ErrorCode = "UNAUTHORIZED"
 	ErrCodeForbidden    ErrorCode = "FORBIDDEN"
+
+	// Precondition errors (HTTP 412)
+	ErrCodePreconditionFailed ErrorCode = "PRECONDITION_FAILED"
 
 	// Client errors
 	ErrCodeBadRequest       ErrorCode = "BAD_REQUEST"
@@ -86,9 +93,25 @@ func statusToCode(status int) ErrorCode {
 		return ErrCodeGone
 	case http.StatusNotImplemented:
 		return ErrCodeNotImplemented
+	case http.StatusPreconditionFailed:
+		return ErrCodePreconditionFailed
 	case http.StatusServiceUnavailable:
 		return ErrCodeServiceUnavailable
 	default:
 		return ErrCodeInternalError
 	}
+}
+
+// computeETag returns a quoted ETag string by SHA-256-hashing the given parts
+// joined with colons. The result is hex-encoded and wrapped in double quotes
+// per the HTTP ETag format (RFC 9110).
+func computeETag(parts ...string) string {
+	h := sha256.New()
+	for i, p := range parts {
+		if i > 0 {
+			h.Write([]byte(":"))
+		}
+		h.Write([]byte(p))
+	}
+	return fmt.Sprintf(`"%x"`, h.Sum(nil))
 }

--- a/internal/server/handlers_branches.go
+++ b/internal/server/handlers_branches.go
@@ -101,6 +101,10 @@ func (s *server) handleUpdateBranch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !s.checkBranchIfMatch(w, r, repo, bname) {
+		return
+	}
+
 	var req model.UpdateBranchRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
@@ -137,6 +141,10 @@ func (s *server) handleEnableAutoMerge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !s.checkBranchIfMatch(w, r, repo, bname) {
+		return
+	}
+
 	if err := s.commitStore.SetBranchAutoMerge(r.Context(), repo, bname, true); err != nil {
 		switch {
 		case errors.Is(err, db.ErrBranchNotFound):
@@ -165,6 +173,10 @@ func (s *server) handleDisableAutoMerge(w http.ResponseWriter, r *http.Request) 
 	}
 	if bname == "main" {
 		writeError(w, http.StatusBadRequest, "cannot disable auto-merge on branch 'main'")
+		return
+	}
+
+	if !s.checkBranchIfMatch(w, r, repo, bname) {
 		return
 	}
 
@@ -234,8 +246,64 @@ func (s *server) handleBranchGet(w http.ResponseWriter, r *http.Request) {
 		branch := strings.TrimSuffix(branchPath, "/comments")
 		s.handleListReviewComments(w, r, repo, branch)
 	default:
-		writeError(w, http.StatusNotFound, "not found")
+		s.handleGetBranch(w, r, repo, branchPath)
 	}
+}
+
+// handleGetBranch implements GET /repos/:name/branch/:branch (bare branch fetch).
+// It returns the branch metadata and sets an ETag header derived from the branch's
+// head_sequence so clients can use conditional writes (If-Match).
+func (s *server) handleGetBranch(w http.ResponseWriter, r *http.Request, repo, branch string) {
+	if s.readStore == nil {
+		writeAPIError(w, ErrCodeServiceUnavailable, http.StatusServiceUnavailable, "read store not available")
+		return
+	}
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+	bi, err := s.readStore.GetBranch(r.Context(), repo, branch)
+	if err != nil {
+		slog.Error("internal error", "op", "get_branch", "repo", repo, "branch", branch, "error", err)
+		writeAPIError(w, ErrCodeInternalError, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if bi == nil {
+		writeAPIError(w, ErrCodeBranchNotFound, http.StatusNotFound, "branch not found")
+		return
+	}
+	etag := computeETag(repo, branch, fmt.Sprintf("%d", bi.HeadSequence))
+	w.Header().Set("ETag", etag)
+	writeJSON(w, http.StatusOK, bi)
+}
+
+// checkBranchIfMatch validates the If-Match header for a branch conditional write.
+// Returns true if the check passes (header absent or ETag matches); writes the
+// appropriate error and returns false otherwise.
+func (s *server) checkBranchIfMatch(w http.ResponseWriter, r *http.Request, repo, branch string) bool {
+	ifMatch := r.Header.Get("If-Match")
+	if ifMatch == "" {
+		return true
+	}
+	if s.readStore == nil {
+		writeAPIError(w, ErrCodeServiceUnavailable, http.StatusServiceUnavailable, "read store not available")
+		return false
+	}
+	bi, err := s.readStore.GetBranch(r.Context(), repo, branch)
+	if err != nil {
+		slog.Error("internal error", "op", "if_match_branch", "repo", repo, "branch", branch, "error", err)
+		writeAPIError(w, ErrCodeInternalError, http.StatusInternalServerError, "query failed")
+		return false
+	}
+	if bi == nil {
+		writeAPIError(w, ErrCodeBranchNotFound, http.StatusNotFound, "branch not found")
+		return false
+	}
+	etag := computeETag(repo, branch, fmt.Sprintf("%d", bi.HeadSequence))
+	if etag != ifMatch {
+		writeAPIError(w, ErrCodePreconditionFailed, http.StatusPreconditionFailed, "ETag mismatch")
+		return false
+	}
+	return true
 }
 
 // handleRebase implements POST /repos/:name/rebase

--- a/internal/server/handlers_etag_test.go
+++ b/internal/server/handlers_etag_test.go
@@ -1,0 +1,396 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// Branch ETag tests
+// ---------------------------------------------------------------------------
+
+func TestGetBranch_ReturnsETag(t *testing.T) {
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, branch string) (*store.BranchInfo, error) {
+			return &store.BranchInfo{Name: branch, HeadSequence: 7}, nil
+		},
+	}
+	srv := NewWithReadStore(&mockStore{}, rs, devID, devID)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/feat", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	etag := rec.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("expected ETag header, got none")
+	}
+	want := computeETag("default/default", "feat", "7")
+	if etag != want {
+		t.Errorf("ETag = %q; want %q", etag, want)
+	}
+}
+
+func TestGetBranch_NoReadStore_Returns503(t *testing.T) {
+	// New with nil database → no readStore
+	srv := New(&mockStore{}, nil, devID, devID)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/feat", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+}
+
+func TestGetBranch_NotFound_Returns404(t *testing.T) {
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
+			return nil, nil // branch not found
+		},
+	}
+	srv := NewWithReadStore(&mockStore{}, rs, devID, devID)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/branch/nonexistent", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestUpdateBranch_WithNoIfMatch_Proceeds(t *testing.T) {
+	ms := &mockStore{
+		updateBranchDraftFn: func(_ context.Context, _, _ string, _ bool) error {
+			return nil
+		},
+	}
+	// readStore's GetBranch won't be called (no If-Match header)
+	srv := NewWithReadStore(ms, &mockReadStore{}, devID, devID)
+
+	body, _ := json.Marshal(model.UpdateBranchRequest{Draft: true})
+	req := httptest.NewRequest(http.MethodPatch, "/repos/default/default/-/branch/feat", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdateBranch_WithCorrectIfMatch_Succeeds(t *testing.T) {
+	const repo, branch = "default/default", "feat"
+	bi := &store.BranchInfo{Name: branch, HeadSequence: 3}
+	ms := &mockStore{
+		updateBranchDraftFn: func(_ context.Context, _, _ string, _ bool) error {
+			return nil
+		},
+	}
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
+			return bi, nil
+		},
+	}
+	srv := NewWithReadStore(ms, rs, devID, devID)
+
+	etag := computeETag(repo, branch, "3")
+	body, _ := json.Marshal(model.UpdateBranchRequest{Draft: true})
+	req := httptest.NewRequest(http.MethodPatch, "/repos/"+repo+"/-/branch/"+branch, bytes.NewReader(body))
+	req.Header.Set("If-Match", etag)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdateBranch_WithStaleIfMatch_Returns412(t *testing.T) {
+	const repo, branch = "default/default", "feat"
+	bi := &store.BranchInfo{Name: branch, HeadSequence: 5}
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
+			return bi, nil
+		},
+	}
+	srv := NewWithReadStore(&mockStore{}, rs, devID, devID)
+
+	staleETag := computeETag(repo, branch, "3") // sequence 3 != actual 5
+	body, _ := json.Marshal(model.UpdateBranchRequest{Draft: true})
+	req := httptest.NewRequest(http.MethodPatch, "/repos/"+repo+"/-/branch/"+branch, bytes.NewReader(body))
+	req.Header.Set("If-Match", staleETag)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Fatalf("expected 412, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp APIError
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Code != ErrCodePreconditionFailed {
+		t.Errorf("code = %q; want %q", resp.Code, ErrCodePreconditionFailed)
+	}
+}
+
+func TestEnableAutoMerge_WithStaleIfMatch_Returns412(t *testing.T) {
+	const repo, branch = "default/default", "feat"
+	bi := &store.BranchInfo{Name: branch, HeadSequence: 9}
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
+			return bi, nil
+		},
+	}
+	srv := NewWithReadStore(&mockStore{}, rs, devID, devID)
+
+	staleETag := computeETag(repo, branch, "1")
+	req := httptest.NewRequest(http.MethodPost, "/repos/"+repo+"/-/branch/"+branch+"/auto-merge", nil)
+	req.Header.Set("If-Match", staleETag)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Fatalf("expected 412, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDisableAutoMerge_WithStaleIfMatch_Returns412(t *testing.T) {
+	const repo, branch = "default/default", "feat"
+	bi := &store.BranchInfo{Name: branch, HeadSequence: 9}
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
+			return bi, nil
+		},
+	}
+	srv := NewWithReadStore(&mockStore{}, rs, devID, devID)
+
+	staleETag := computeETag(repo, branch, "1")
+	req := httptest.NewRequest(http.MethodDelete, "/repos/"+repo+"/-/branch/"+branch+"/auto-merge", nil)
+	req.Header.Set("If-Match", staleETag)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Fatalf("expected 412, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Proposal ETag tests
+// ---------------------------------------------------------------------------
+
+func makeTestProposal(id string, updatedAt time.Time) *model.Proposal {
+	return &model.Proposal{
+		ID:        id,
+		Repo:      "default/default",
+		Branch:    "feat",
+		Title:     "Test proposal",
+		Author:    devID,
+		State:     model.ProposalOpen,
+		UpdatedAt: updatedAt,
+		CreatedAt: updatedAt,
+	}
+}
+
+func TestGetProposal_ReturnsETag(t *testing.T) {
+	ts := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	p := makeTestProposal("prop-1", ts)
+	ms := &mockStore{
+		getProposalFn: func(_ context.Context, _, _ string) (*model.Proposal, error) {
+			return p, nil
+		},
+	}
+	srv := NewWithReadStore(ms, &mockReadStore{}, devID, devID)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/default/default/-/proposals/prop-1", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	etag := rec.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("expected ETag header, got none")
+	}
+	want := computeETag(p.ID, fmt.Sprintf("%d", ts.UnixNano()))
+	if etag != want {
+		t.Errorf("ETag = %q; want %q", etag, want)
+	}
+}
+
+func TestUpdateProposal_WithCorrectIfMatch_Succeeds(t *testing.T) {
+	ts := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	p := makeTestProposal("prop-2", ts)
+	newTitle := "Updated"
+	ms := &mockStore{
+		getProposalFn: func(_ context.Context, _, _ string) (*model.Proposal, error) {
+			return p, nil
+		},
+		updateProposalFn: func(_ context.Context, _, _ string, _, _ *string) (*model.Proposal, error) {
+			updated := *p
+			updated.Title = newTitle
+			return &updated, nil
+		},
+	}
+	srv := NewWithReadStore(ms, &mockReadStore{}, devID, devID)
+
+	etag := computeETag(p.ID, fmt.Sprintf("%d", ts.UnixNano()))
+	body, _ := json.Marshal(model.UpdateProposalRequest{Title: &newTitle})
+	req := httptest.NewRequest(http.MethodPatch, "/repos/default/default/-/proposals/prop-2", bytes.NewReader(body))
+	req.Header.Set("If-Match", etag)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdateProposal_WithStaleIfMatch_Returns412(t *testing.T) {
+	ts := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	p := makeTestProposal("prop-3", ts)
+	ms := &mockStore{
+		getProposalFn: func(_ context.Context, _, _ string) (*model.Proposal, error) {
+			return p, nil
+		},
+	}
+	srv := NewWithReadStore(ms, &mockReadStore{}, devID, devID)
+
+	staleETag := computeETag(p.ID, "0") // wrong timestamp
+	newTitle := "Updated"
+	body, _ := json.Marshal(model.UpdateProposalRequest{Title: &newTitle})
+	req := httptest.NewRequest(http.MethodPatch, "/repos/default/default/-/proposals/prop-3", bytes.NewReader(body))
+	req.Header.Set("If-Match", staleETag)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Fatalf("expected 412, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp APIError
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Code != ErrCodePreconditionFailed {
+		t.Errorf("code = %q; want %q", resp.Code, ErrCodePreconditionFailed)
+	}
+}
+
+func TestUpdateProposal_WithNoIfMatch_Proceeds(t *testing.T) {
+	ts := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	p := makeTestProposal("prop-4", ts)
+	newTitle := "Updated"
+	ms := &mockStore{
+		getProposalFn: func(_ context.Context, _, _ string) (*model.Proposal, error) {
+			return p, nil
+		},
+		updateProposalFn: func(_ context.Context, _, _ string, _, _ *string) (*model.Proposal, error) {
+			updated := *p
+			updated.Title = newTitle
+			return &updated, nil
+		},
+	}
+	srv := NewWithReadStore(ms, &mockReadStore{}, devID, devID)
+
+	body, _ := json.Marshal(model.UpdateProposalRequest{Title: &newTitle})
+	req := httptest.NewRequest(http.MethodPatch, "/repos/default/default/-/proposals/prop-4", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCloseProposal_WithStaleIfMatch_Returns412(t *testing.T) {
+	ts := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	p := makeTestProposal("prop-5", ts)
+	ms := &mockStore{
+		getProposalFn: func(_ context.Context, _, _ string) (*model.Proposal, error) {
+			return p, nil
+		},
+	}
+	srv := NewWithReadStore(ms, &mockReadStore{}, devID, devID)
+
+	staleETag := computeETag(p.ID, "0")
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/proposals/prop-5/close", nil)
+	req.Header.Set("If-Match", staleETag)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Fatalf("expected 412, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCloseProposal_WithNoIfMatch_Proceeds(t *testing.T) {
+	ts := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	p := makeTestProposal("prop-6", ts)
+	ms := &mockStore{
+		getProposalFn: func(_ context.Context, _, _ string) (*model.Proposal, error) {
+			return p, nil
+		},
+		closeProposalFn: func(_ context.Context, _, _ string) error {
+			return nil
+		},
+	}
+	srv := NewWithReadStore(ms, &mockReadStore{}, devID, devID)
+
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/proposals/prop-6/close", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// computeETag unit tests
+// ---------------------------------------------------------------------------
+
+func TestComputeETag_Deterministic(t *testing.T) {
+	e1 := computeETag("repo", "branch", "42")
+	e2 := computeETag("repo", "branch", "42")
+	if e1 != e2 {
+		t.Errorf("computeETag not deterministic: %q != %q", e1, e2)
+	}
+}
+
+func TestComputeETag_DifferentInputsDifferentOutput(t *testing.T) {
+	e1 := computeETag("repo", "branch", "42")
+	e2 := computeETag("repo", "branch", "43")
+	if e1 == e2 {
+		t.Errorf("expected different ETags for different sequences, got %q", e1)
+	}
+}
+
+func TestComputeETag_IsQuoted(t *testing.T) {
+	e := computeETag("x")
+	if len(e) < 2 || e[0] != '"' || e[len(e)-1] != '"' {
+		t.Errorf("expected quoted ETag, got %q", e)
+	}
+}
+
+func TestErrCodePreconditionFailed_MapsTo412(t *testing.T) {
+	code := statusToCode(http.StatusPreconditionFailed)
+	if code != ErrCodePreconditionFailed {
+		t.Errorf("statusToCode(412) = %q; want %q", code, ErrCodePreconditionFailed)
+	}
+}

--- a/internal/server/handlers_proposals.go
+++ b/internal/server/handlers_proposals.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -445,6 +446,8 @@ func (s *server) handleGetProposal(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	etag := computeETag(p.ID, fmt.Sprintf("%d", p.UpdatedAt.UnixNano()))
+	w.Header().Set("ETag", etag)
 	writeJSON(w, http.StatusOK, p)
 }
 
@@ -473,6 +476,10 @@ func (s *server) handleUpdateProposal(w http.ResponseWriter, r *http.Request) {
 
 	if existing.Author != identity && role != model.RoleMaintainer && role != model.RoleAdmin {
 		writeAPIError(w, ErrCodeForbidden, http.StatusForbidden, "forbidden: must be proposal author or maintainer")
+		return
+	}
+
+	if !checkProposalIfMatch(w, r, existing) {
 		return
 	}
 
@@ -523,6 +530,10 @@ func (s *server) handleCloseProposal(w http.ResponseWriter, r *http.Request) {
 
 	if existing.Author != identity && role != model.RoleMaintainer && role != model.RoleAdmin {
 		writeAPIError(w, ErrCodeForbidden, http.StatusForbidden, "forbidden: must be proposal author or maintainer")
+		return
+	}
+
+	if !checkProposalIfMatch(w, r, existing) {
 		return
 	}
 
@@ -687,4 +698,21 @@ func (s *server) upsertProposalMentionRefs(ctx context.Context, repo, proposalID
 			slog.Warn("upsert proposal mention ref", "repo", repo, "issue", num, "proposal", proposalID, "error", err)
 		}
 	}
+}
+
+// checkProposalIfMatch validates the If-Match header against the proposal's ETag.
+// Returns true if the check passes (header absent or ETag matches); writes the
+// appropriate error and returns false otherwise. The proposal must already be
+// fetched by the caller.
+func checkProposalIfMatch(w http.ResponseWriter, r *http.Request, p *model.Proposal) bool {
+	ifMatch := r.Header.Get("If-Match")
+	if ifMatch == "" {
+		return true
+	}
+	etag := computeETag(p.ID, fmt.Sprintf("%d", p.UpdatedAt.UnixNano()))
+	if etag != ifMatch {
+		writeAPIError(w, ErrCodePreconditionFailed, http.StatusPreconditionFailed, "ETag mismatch")
+		return false
+	}
+	return true
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -76,6 +76,9 @@ type mockStore struct {
 	resumeSubscriptionFn             func(ctx context.Context, id string) error
 
 	listProposalsFn   func(ctx context.Context, repo string, state *model.ProposalState, branch *string) ([]*model.Proposal, error)
+	getProposalFn     func(ctx context.Context, repo, proposalID string) (*model.Proposal, error)
+	updateProposalFn  func(ctx context.Context, repo, proposalID string, title, description *string) (*model.Proposal, error)
+	closeProposalFn   func(ctx context.Context, repo, proposalID string) error
 	listIssuesByRefFn func(ctx context.Context, repo string, refType model.IssueRefType, refID string) ([]model.Issue, error)
 }
 
@@ -405,7 +408,10 @@ func (m *mockStore) CreateProposal(_ context.Context, _, _, _, _, _, _ string) (
 	return nil, errors.New("not implemented")
 }
 
-func (m *mockStore) GetProposal(_ context.Context, _, _ string) (*model.Proposal, error) {
+func (m *mockStore) GetProposal(ctx context.Context, repo, proposalID string) (*model.Proposal, error) {
+	if m.getProposalFn != nil {
+		return m.getProposalFn(ctx, repo, proposalID)
+	}
 	return nil, db.ErrProposalNotFound
 }
 
@@ -416,11 +422,17 @@ func (m *mockStore) ListProposals(ctx context.Context, repo string, state *model
 	return []*model.Proposal{}, nil
 }
 
-func (m *mockStore) UpdateProposal(_ context.Context, _, _ string, _, _ *string) (*model.Proposal, error) {
+func (m *mockStore) UpdateProposal(ctx context.Context, repo, proposalID string, title, description *string) (*model.Proposal, error) {
+	if m.updateProposalFn != nil {
+		return m.updateProposalFn(ctx, repo, proposalID, title, description)
+	}
 	return nil, db.ErrProposalNotFound
 }
 
-func (m *mockStore) CloseProposal(_ context.Context, _, _ string) error {
+func (m *mockStore) CloseProposal(ctx context.Context, repo, proposalID string) error {
+	if m.closeProposalFn != nil {
+		return m.closeProposalFn(ctx, repo, proposalID)
+	}
 	return db.ErrProposalNotFound
 }
 


### PR DESCRIPTION
## Summary

- Adds `ErrCodePreconditionFailed` (`PRECONDITION_FAILED`) error code and HTTP 412 support
- Adds `computeETag(parts ...string) string` helper (SHA-256, hex, RFC 9110 quoted format)
- **GET branch** (bare path e.g. `GET /repos/:r/-/branch/:b`) now returns branch info + `ETag` header derived from `repo:name:head_sequence`
- **GET proposal** now sets `ETag` header derived from `id:updated_at.UnixNano()`
- **Write endpoints with If-Match checking:**
  - `handleUpdateBranch` (PATCH `…/branch/:b`)
  - `handleEnableAutoMerge` (POST `…/branch/:b/auto-merge`)
  - `handleDisableAutoMerge` (DELETE `…/branch/:b/auto-merge`)
  - `handleUpdateProposal` (PATCH `…/proposals/:id`)
  - `handleCloseProposal` (POST `…/proposals/:id/close`)
- Absent `If-Match` → proceed normally (standard HTTP behavior)
- Present but mismatched `If-Match` → 412 with `PRECONDITION_FAILED` code

## Design decisions followed

- Branch ETag source: `head_sequence` (no migration needed)
- Proposal ETag source: `updated_at` (already available on fetched proposal — no extra DB call)
- `checkBranchIfMatch` only hits `readStore.GetBranch` when the header is present
- `checkProposalIfMatch` reuses the already-fetched proposal (zero extra DB calls)

## Test plan

- [x] `TestGetBranch_ReturnsETag` — GET returns correct ETag
- [x] `TestGetBranch_NoReadStore_Returns503` — 503 when no read store
- [x] `TestGetBranch_NotFound_Returns404`
- [x] `TestUpdateBranch_WithNoIfMatch_Proceeds`
- [x] `TestUpdateBranch_WithCorrectIfMatch_Succeeds`
- [x] `TestUpdateBranch_WithStaleIfMatch_Returns412`
- [x] `TestEnableAutoMerge_WithStaleIfMatch_Returns412`
- [x] `TestDisableAutoMerge_WithStaleIfMatch_Returns412`
- [x] `TestGetProposal_ReturnsETag`
- [x] `TestUpdateProposal_WithCorrectIfMatch_Succeeds`
- [x] `TestUpdateProposal_WithStaleIfMatch_Returns412`
- [x] `TestUpdateProposal_WithNoIfMatch_Proceeds`
- [x] `TestCloseProposal_WithStaleIfMatch_Returns412`
- [x] `TestCloseProposal_WithNoIfMatch_Proceeds`
- [x] `TestComputeETag_*` (deterministic, distinct outputs, quoted format)
- [x] `TestErrCodePreconditionFailed_MapsTo412`
- [x] Full `go test ./... -count=1 -short` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)