### PR TITLE
fix: support If-Match: * wildcard and add If-Match to handleDeleteBranch

### DIFF
--- a/internal/server/handlers_branches.go
+++ b/internal/server/handlers_branches.go
@@ -201,8 +201,16 @@ func (s *server) handleDisableAutoMerge(w http.ResponseWriter, r *http.Request) 
 func (s *server) handleDeleteBranch(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
 	bname := r.PathValue("bname")
+
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
 	if bname == "main" {
 		writeError(w, http.StatusBadRequest, "cannot delete branch 'main'")
+		return
+	}
+
+	if !s.checkBranchIfMatch(w, r, repo, bname) {
 		return
 	}
 
@@ -297,6 +305,10 @@ func (s *server) checkBranchIfMatch(w http.ResponseWriter, r *http.Request, repo
 	if bi == nil {
 		writeAPIError(w, ErrCodeBranchNotFound, http.StatusNotFound, "branch not found")
 		return false
+	}
+	if ifMatch == "*" {
+		// RFC 7232 §3.2: "If-Match: *" means proceed if the resource exists.
+		return true
 	}
 	etag := computeETag(repo, branch, fmt.Sprintf("%d", bi.HeadSequence))
 	if etag != ifMatch {

--- a/internal/server/handlers_etag_test.go
+++ b/internal/server/handlers_etag_test.go
@@ -394,3 +394,133 @@ func TestErrCodePreconditionFailed_MapsTo412(t *testing.T) {
 		t.Errorf("statusToCode(412) = %q; want %q", code, ErrCodePreconditionFailed)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// If-Match: * wildcard tests (RFC 7232 §3.2)
+// ---------------------------------------------------------------------------
+
+func TestUpdateBranch_WithWildcardIfMatch_Succeeds(t *testing.T) {
+	ms := &mockStore{
+		updateBranchDraftFn: func(_ context.Context, _, _ string, _ bool) error {
+			return nil
+		},
+	}
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
+			return &store.BranchInfo{Name: "feat", HeadSequence: 5}, nil
+		},
+	}
+	srv := NewWithReadStore(ms, rs, devID, devID)
+
+	body, _ := json.Marshal(model.UpdateBranchRequest{Draft: true})
+	req := httptest.NewRequest(http.MethodPatch, "/repos/default/default/-/branch/feat", bytes.NewReader(body))
+	req.Header.Set("If-Match", "*")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for If-Match: *, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdateProposal_WithWildcardIfMatch_Succeeds(t *testing.T) {
+	ts := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	p := makeTestProposal("prop-wc", ts)
+	newTitle := "Wildcard update"
+	ms := &mockStore{
+		getProposalFn: func(_ context.Context, _, _ string) (*model.Proposal, error) {
+			return p, nil
+		},
+		updateProposalFn: func(_ context.Context, _, _ string, _, _ *string) (*model.Proposal, error) {
+			updated := *p
+			updated.Title = newTitle
+			return &updated, nil
+		},
+	}
+	srv := NewWithReadStore(ms, &mockReadStore{}, devID, devID)
+
+	body, _ := json.Marshal(model.UpdateProposalRequest{Title: &newTitle})
+	req := httptest.NewRequest(http.MethodPatch, "/repos/default/default/-/proposals/prop-wc", bytes.NewReader(body))
+	req.Header.Set("If-Match", "*")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for If-Match: *, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleDeleteBranch If-Match tests
+// ---------------------------------------------------------------------------
+
+func TestDeleteBranch_WithNoIfMatch_Proceeds(t *testing.T) {
+	ms := &mockStore{
+		deleteBranchFn: func(_ context.Context, _, _ string) error {
+			return nil
+		},
+	}
+	srv := NewWithReadStore(ms, &mockReadStore{}, devID, devID)
+
+	req := httptest.NewRequest(http.MethodDelete, "/repos/default/default/-/branch/feat", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDeleteBranch_WithCorrectIfMatch_Succeeds(t *testing.T) {
+	const repo, branch = "default/default", "feat"
+	bi := &store.BranchInfo{Name: branch, HeadSequence: 4}
+	ms := &mockStore{
+		deleteBranchFn: func(_ context.Context, _, _ string) error {
+			return nil
+		},
+	}
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
+			return bi, nil
+		},
+	}
+	srv := NewWithReadStore(ms, rs, devID, devID)
+
+	etag := computeETag(repo, branch, "4")
+	req := httptest.NewRequest(http.MethodDelete, "/repos/"+repo+"/-/branch/"+branch, nil)
+	req.Header.Set("If-Match", etag)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDeleteBranch_WithStaleIfMatch_Returns412(t *testing.T) {
+	const repo, branch = "default/default", "feat"
+	bi := &store.BranchInfo{Name: branch, HeadSequence: 8}
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
+			return bi, nil
+		},
+	}
+	srv := NewWithReadStore(&mockStore{}, rs, devID, devID)
+
+	staleETag := computeETag(repo, branch, "2") // sequence 2 != actual 8
+	req := httptest.NewRequest(http.MethodDelete, "/repos/"+repo+"/-/branch/"+branch, nil)
+	req.Header.Set("If-Match", staleETag)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Fatalf("expected 412, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp APIError
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Code != ErrCodePreconditionFailed {
+		t.Errorf("code = %q; want %q", resp.Code, ErrCodePreconditionFailed)
+	}
+}

--- a/internal/server/handlers_proposals.go
+++ b/internal/server/handlers_proposals.go
@@ -709,6 +709,10 @@ func checkProposalIfMatch(w http.ResponseWriter, r *http.Request, p *model.Propo
 	if ifMatch == "" {
 		return true
 	}
+	if ifMatch == "*" {
+		// RFC 7232 §3.2: "If-Match: *" means proceed if the resource exists.
+		return true
+	}
 	etag := computeETag(p.ID, fmt.Sprintf("%d", p.UpdatedAt.UnixNano()))
 	if etag != ifMatch {
 		writeAPIError(w, ErrCodePreconditionFailed, http.StatusPreconditionFailed, "ETag mismatch")


### PR DESCRIPTION
## Summary

- **If-Match: \* wildcard** (`checkBranchIfMatch`, `checkProposalIfMatch`): RFC 7232 §3.2 requires `If-Match: *` to mean "proceed if the resource exists", not match a literal `*`. Added an early return when `ifMatch == "*"` so the ETag comparison is skipped.
- **handleDeleteBranch If-Match support**: This write endpoint was missing both `validateRepo` and `checkBranchIfMatch`. Added both following the same pattern as `handleUpdateBranch` (validateRepo → main guard → checkBranchIfMatch → store call).

## Test plan

- [x] `TestUpdateBranch_WithWildcardIfMatch_Succeeds` — branch PATCH with `If-Match: *` returns 200
- [x] `TestUpdateProposal_WithWildcardIfMatch_Succeeds` — proposal PATCH with `If-Match: *` returns 200
- [x] `TestDeleteBranch_WithNoIfMatch_Proceeds` — DELETE without If-Match returns 204
- [x] `TestDeleteBranch_WithCorrectIfMatch_Succeeds` — DELETE with matching ETag returns 204
- [x] `TestDeleteBranch_WithStaleIfMatch_Returns412` — DELETE with stale ETag returns 412 with `precondition_failed` error code
- [x] Full test suite passes: `go test ./... -count=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)