### PR TITLE
chore: add project-level Playwright MCP config for UI iteration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with Playwright MCP server config
- Claude Code will automatically load Playwright when working in this repo
- Enables screenshot + browser interaction for web UI development iteration (see #97 and #285)

## Test plan

- Restart Claude Code in this repo
- Confirm `mcp__playwright__*` tools are available