### PR TITLE
chore: move Playwright MCP config to .mcp.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,1 @@
-{
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
-    }
-  }
-}
+{}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Moves the Playwright MCP server configuration from `.claude/settings.json` to the standard `.mcp.json` location
- Clears `.claude/settings.json` back to an empty object

## Test plan

- [ ] Verify Playwright MCP tools are available in Claude Code after pulling this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)