### PR TITLE
feat: add inline review comments and file history to web UI (issue #97)

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -52,6 +52,14 @@ func (fakeRead) GetFile(_ context.Context, _, _, path string, _ *int64) (*store.
 
 func (fakeRead) GetBranch(_ context.Context, _, _ string) (*store.BranchInfo, error) { return nil, nil }
 
+func (fakeRead) GetFileHistory(_ context.Context, _, _, _ string, _ int, _ *int64) ([]store.FileHistoryEntry, error) {
+	t := time.Now()
+	return []store.FileHistoryEntry{
+		{Sequence: 47, Message: "add onboarding guide", Author: "ajay@acme", CreatedAt: t.Add(-2 * time.Hour)},
+		{Sequence: 42, Message: "initial commit", Author: "sam@acme", CreatedAt: t.Add(-30 * 24 * time.Hour)},
+	}, nil
+}
+
 func (fakeRead) ListBranches(_ context.Context, repo, _ string, _, _ bool) ([]store.BranchInfo, error) {
 	if repo != "acme/platform" {
 		return []store.BranchInfo{{Name: "main", HeadSequence: 3, BaseSequence: 0, Status: "active"}}, nil
@@ -79,6 +87,29 @@ func (fakeWrite) ListRepos(_ context.Context) ([]model.Repo, error) {
 }
 
 func (fakeWrite) ListOrgs(_ context.Context) ([]model.Org, error) { return nil, nil }
+
+func (fakeWrite) ListReviewComments(_ context.Context, _, _ string, _ *string) ([]model.ReviewComment, error) {
+	t := time.Now()
+	return []model.ReviewComment{
+		{ID: "rc1", Branch: "add-onboarding-guide", Path: "docs/guides/onboarding.md", Body: "Step 3 should mention the role types.", Author: "sam@acme", Sequence: 47, CreatedAt: t.Add(-1 * time.Hour)},
+	}, nil
+}
+
+func (fakeWrite) ListOrgMembers(_ context.Context, _ string) ([]model.OrgMember, error) {
+	t := time.Now()
+	return []model.OrgMember{
+		{Org: "acme", Identity: "ajay@acme", Role: api.OrgRoleOwner, InvitedBy: "system", CreatedAt: t.Add(-30 * 24 * time.Hour)},
+		{Org: "acme", Identity: "sam@acme", Role: api.OrgRoleMember, InvitedBy: "ajay@acme", CreatedAt: t.Add(-14 * 24 * time.Hour)},
+	}, nil
+}
+
+func (fakeWrite) ListRoles(_ context.Context, _ string) ([]model.Role, error) {
+	return []model.Role{
+		{Identity: "ajay@acme", Role: model.RoleAdmin},
+		{Identity: "sam@acme", Role: model.RoleWriter},
+		{Identity: "lee@beta", Role: model.RoleReader},
+	}, nil
+}
 
 func (fakeWrite) GetRepo(_ context.Context, name string) (*model.Repo, error) {
 	all, _ := (fakeWrite{}).ListRepos(context.Background())

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -31,6 +31,8 @@ type branchesPage struct {
 	Active    []branchRow
 	Merged    []branchRow
 	Abandoned []branchRow
+	Members   []model.OrgMember
+	Roles     []model.Role
 }
 
 type branchRow struct {
@@ -40,6 +42,11 @@ type branchRow struct {
 	Draft        bool
 	AutoMerge    bool
 	Status       string
+}
+
+type reviewCommentGroup struct {
+	Path     string
+	Comments []model.ReviewComment
 }
 
 type branchDetailPage struct {
@@ -52,13 +59,14 @@ type branchDetailPage struct {
 }
 
 type filePage struct {
-	Repo      model.Repo
-	Branch    string
-	AtSeq     *int64
-	Path      string
-	File      *fileView
-	Tree      []treeRow
-	ParentDir string
+	Repo        model.Repo
+	Branch      string
+	AtSeq       *int64
+	Path        string
+	File        *fileView
+	Tree        []treeRow
+	ParentDir   string
+	FileHistory []store.FileHistoryEntry
 }
 
 type fileView struct {
@@ -131,7 +139,20 @@ func (h *Handler) handleBranches(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	page := branchesPage{Repo: *repo}
+	members, err := h.write.ListOrgMembers(ctx, repo.Owner)
+	if err != nil {
+		slog.Error("ui list org members", "org", repo.Owner, "error", err)
+		// Non-fatal: render page without members.
+		members = nil
+	}
+	roles, err := h.write.ListRoles(ctx, repoName)
+	if err != nil {
+		slog.Error("ui list roles", "repo", repoName, "error", err)
+		// Non-fatal: render page without roles.
+		roles = nil
+	}
+
+	page := branchesPage{Repo: *repo, Members: members, Roles: roles}
 	for _, b := range branches {
 		row := branchRow{
 			Name:         b.Name,
@@ -320,6 +341,14 @@ func (h *Handler) handleFile(w http.ResponseWriter, r *http.Request) {
 				ContentType: fc.ContentType,
 			}
 		}
+
+		hist, err := h.read.GetFileHistory(r.Context(), repoName, branch, path, 20, nil)
+		if err != nil {
+			slog.Error("ui get file history", "repo", repoName, "path", path, "error", err)
+			// Non-fatal: render without history.
+		} else {
+			page.FileHistory = hist
+		}
 	}
 
 	h.render(w, h.tmpl.fileView, "layout.html", pageData{
@@ -331,6 +360,38 @@ func (h *Handler) handleFile(w http.ResponseWriter, r *http.Request) {
 		},
 		Body: page,
 	})
+}
+
+// handleReviewCommentsPartial returns the inline review comments for a branch,
+// grouped by file path, as an HTMX partial.
+func (h *Handler) handleReviewCommentsPartial(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	branch := r.PathValue("branch")
+	repoName := owner + "/" + name
+
+	comments, err := h.write.ListReviewComments(r.Context(), repoName, branch, nil)
+	if err != nil {
+		slog.Error("ui list review comments", "repo", repoName, "branch", branch, "error", err)
+		http.Error(w, "query failed", http.StatusInternalServerError)
+		return
+	}
+
+	// Group by file path.
+	order := []string{}
+	byPath := map[string][]model.ReviewComment{}
+	for _, c := range comments {
+		if _, seen := byPath[c.Path]; !seen {
+			order = append(order, c.Path)
+		}
+		byPath[c.Path] = append(byPath[c.Path], c)
+	}
+	groups := make([]reviewCommentGroup, 0, len(order))
+	for _, p := range order {
+		groups = append(groups, reviewCommentGroup{Path: p, Comments: byPath[p]})
+	}
+
+	h.render(w, h.tmpl.reviewComments, "review_comments.html", groups)
 }
 
 // siblingTreeRows returns the immediate children of dir within entries, with

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -14,12 +14,13 @@ import (
 // templateSet holds the parsed template tree. Each page has its own *Template
 // so it can define its own "content" block against the shared layout.
 type templateSet struct {
-	repos         *template.Template
-	branches      *template.Template
-	branchDetail  *template.Template
-	branchChecks  *template.Template
-	fileView      *template.Template
-	errorPage     *template.Template
+	repos          *template.Template
+	branches       *template.Template
+	branchDetail   *template.Template
+	branchChecks   *template.Template
+	reviewComments *template.Template
+	fileView       *template.Template
+	errorPage      *template.Template
 }
 
 func parseTemplates(root fs.FS) (*templateSet, error) {
@@ -58,6 +59,10 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse branch_checks: %w", err)
 	}
+	reviewComments, err := loadFragment("review_comments.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse review_comments: %w", err)
+	}
 	fileView, err := load("file.html")
 	if err != nil {
 		return nil, fmt.Errorf("parse file: %w", err)
@@ -67,12 +72,13 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		return nil, fmt.Errorf("parse error: %w", err)
 	}
 	return &templateSet{
-		repos:        repos,
-		branches:     branches,
-		branchDetail: branchDetail,
-		branchChecks: branchChecks,
-		fileView:     fileView,
-		errorPage:    errorPage,
+		repos:          repos,
+		branches:       branches,
+		branchDetail:   branchDetail,
+		branchChecks:   branchChecks,
+		reviewComments: reviewComments,
+		fileView:       fileView,
+		errorPage:      errorPage,
 	}, nil
 }
 

--- a/internal/ui/templates/branch_detail.html
+++ b/internal/ui/templates/branch_detail.html
@@ -54,9 +54,14 @@
           <span class="badge {{statusClass (printf "%s" .Status)}}">{{.Status}}</span>
           <div class="meta">@ seq {{.Sequence}} · {{relTime .CreatedAt}}</div>
         </div>
+        <button class="btn-link"
+          hx-get="/ui/_/r/{{$page.Repo.Name}}/b/{{$ctx.Branch.Name}}/comments"
+          hx-target="#review-comments-{{$ctx.Branch.Name}}"
+          hx-swap="innerHTML">inline comments ▾</button>
       </div>
       {{if .Body}}<div class="row-body">{{.Body}}</div>{{end}}
       {{end}}
+      <div id="review-comments-{{$ctx.Branch.Name}}"></div>
     </div>
   </div>
 </div>

--- a/internal/ui/templates/branches.html
+++ b/internal/ui/templates/branches.html
@@ -7,6 +7,42 @@
 {{template "branchSection" (dict "Title" "Active" "Rows" .Active "Repo" .Repo.Name)}}
 {{template "branchSection" (dict "Title" "Merged" "Rows" .Merged "Repo" .Repo.Name)}}
 {{template "branchSection" (dict "Title" "Abandoned" "Rows" .Abandoned "Repo" .Repo.Name)}}
+
+<h2>Members ({{len .Members}})</h2>
+<div class="card">
+  {{if not .Members}}<div class="empty">no members</div>{{else}}
+  <table class="grid">
+    <thead><tr><th>identity</th><th>role</th><th>invited by</th><th>joined</th></tr></thead>
+    <tbody>
+    {{range .Members}}
+    <tr>
+      <td>{{.Identity}}</td>
+      <td><span class="badge neutral">{{.Role}}</span></td>
+      <td>{{.InvitedBy}}</td>
+      <td class="meta">{{relTime .CreatedAt}}</td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{end}}
+</div>
+
+<h2>Roles ({{len .Roles}})</h2>
+<div class="card">
+  {{if not .Roles}}<div class="empty">no roles configured</div>{{else}}
+  <table class="grid">
+    <thead><tr><th>identity</th><th>role</th></tr></thead>
+    <tbody>
+    {{range .Roles}}
+    <tr>
+      <td>{{.Identity}}</td>
+      <td><span class="badge neutral">{{.Role}}</span></td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{end}}
+</div>
 {{end}}
 {{end}}
 

--- a/internal/ui/templates/file.html
+++ b/internal/ui/templates/file.html
@@ -32,6 +32,25 @@
     {{else}}
     <div class="card empty">select a file from the tree</div>
     {{end}}
+
+    {{if and $page.Path $page.FileHistory}}
+    <h2>File history</h2>
+    <div class="card">
+      <table class="grid">
+        <thead><tr><th>seq</th><th>message</th><th>author</th><th>when</th></tr></thead>
+        <tbody>
+        {{range $page.FileHistory}}
+        <tr>
+          <td><a href="/ui/r/{{$page.Repo.Name}}/b/{{$page.Branch}}/c/{{.Sequence}}">{{.Sequence}}</a></td>
+          <td>{{.Message}}</td>
+          <td>{{.Author}}</td>
+          <td class="meta">{{relTime .CreatedAt}}</td>
+        </tr>
+        {{end}}
+        </tbody>
+      </table>
+    </div>
+    {{end}}
   </div>
 </div>
 {{end}}

--- a/internal/ui/templates/review_comments.html
+++ b/internal/ui/templates/review_comments.html
@@ -1,0 +1,20 @@
+{{define "review_comments.html"}}
+{{if not .}}
+<div class="empty">no inline comments on this branch</div>
+{{else}}
+{{range .}}
+<div class="comment-file-group">
+  <div class="comment-file-path">{{.Path}}</div>
+  {{range .Comments}}
+  <div class="row">
+    <div>
+      <strong>{{.Author}}</strong>
+      <span class="meta">@ seq {{.Sequence}} · {{relTime .CreatedAt}}</span>
+    </div>
+    <div class="row-body">{{.Body}}</div>
+  </div>
+  {{end}}
+</div>
+{{end}}
+{{end}}
+{{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -22,6 +22,7 @@ type ReadStore interface {
 	GetFile(ctx context.Context, repo, branch, path string, atSeq *int64) (*store.FileContent, error)
 	GetBranch(ctx context.Context, repo, branch string) (*store.BranchInfo, error)
 	ListBranches(ctx context.Context, repo, statusFilter string, includeDraft, onlyDraft bool) ([]store.BranchInfo, error)
+	GetFileHistory(ctx context.Context, repo, branch, path string, limit int, afterSeq *int64) ([]store.FileHistoryEntry, error)
 }
 
 // WriteStoreLite is the subset of server.WriteStore that the UI needs for
@@ -30,6 +31,9 @@ type WriteStoreLite interface {
 	ListRepos(ctx context.Context) ([]model.Repo, error)
 	ListOrgs(ctx context.Context) ([]model.Org, error)
 	GetRepo(ctx context.Context, name string) (*model.Repo, error)
+	ListReviewComments(ctx context.Context, repo, branch string, path *string) ([]model.ReviewComment, error)
+	ListOrgMembers(ctx context.Context, org string) ([]model.OrgMember, error)
+	ListRoles(ctx context.Context, repo string) ([]model.Role, error)
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -102,6 +106,7 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/r/{owner}/{name}", h.handleBranches)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}", h.handleBranchDetail)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/checks", h.handleChecksPartial)
+	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/comments", h.handleReviewCommentsPartial)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/f/{path...}", h.handleFile)
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -36,6 +36,9 @@ func (f *fakeRead) GetBranch(_ context.Context, _, _ string) (*store.BranchInfo,
 func (f *fakeRead) ListBranches(_ context.Context, repo, _ string, _, _ bool) ([]store.BranchInfo, error) {
 	return f.branches[repo], nil
 }
+func (f *fakeRead) GetFileHistory(_ context.Context, _, _, _ string, _ int, _ *int64) ([]store.FileHistoryEntry, error) {
+	return nil, nil
+}
 
 type fakeWrite struct {
 	repos []model.Repo
@@ -54,6 +57,15 @@ func (f *fakeWrite) GetRepo(_ context.Context, name string) (*model.Repo, error)
 		}
 	}
 	return nil, db.ErrRepoNotFound
+}
+func (f *fakeWrite) ListReviewComments(_ context.Context, _, _ string, _ *string) ([]model.ReviewComment, error) {
+	return nil, nil
+}
+func (f *fakeWrite) ListOrgMembers(_ context.Context, _ string) ([]model.OrgMember, error) {
+	return nil, nil
+}
+func (f *fakeWrite) ListRoles(_ context.Context, _ string) ([]model.Role, error) {
+	return nil, nil
 }
 
 func newFakeAssembler(branchName string) AssembleFn {


### PR DESCRIPTION
## Summary

- Inline review comments on branch detail page via HTMX expand toggle (`GET /ui/_/r/{owner}/{name}/b/{branch}/comments` returns `review_comments.html` partial grouped by file path)
- File history section on file viewer showing last 20 commits that touched the file, each linking to `/ui/r/{owner}/{name}/b/{branch}/c/{seq}`
- Members and Roles tables on the repo/branches page using `ListOrgMembers` and `ListRoles`

## Changes

- `internal/ui/ui.go`: Extended `ReadStore` with `GetFileHistory`; extended `WriteStoreLite` with `ListReviewComments`, `ListOrgMembers`, `ListRoles`; registered new partial route
- `internal/ui/handlers.go`: Added `reviewCommentGroup` struct, `handleReviewCommentsPartial`, file history loading in `handleFile`, members/roles loading in `handleBranches`
- `internal/ui/render.go`: Added `reviewComments` template to templateSet
- `internal/ui/templates/review_comments.html`: New HTMX partial
- `internal/ui/templates/branch_detail.html`: Added HTMX expand button on review rows
- `internal/ui/templates/file.html`: Added file history table
- `internal/ui/templates/branches.html`: Added Members and Roles sections
- `internal/ui/ui_test.go`: Added stub implementations for new interface methods
- `cmd/ui-preview/main.go`: Added fake implementations with sample data

## Test plan

- [x] `go test ./... -count=1` — all pass
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean

## Notes / Opportunities

- The file history table links to `/ui/r/{owner}/{name}/b/{branch}/c/{seq}` — that route (`handleCommit`) does not exist yet in the UI; could be added in a follow-up
- Review comments expand button loads all branch comments (not per-review); if a branch has many reviews this is fine since comments are already scoped to the branch
- Members errors are treated as non-fatal (page renders without members); same for roles — supervisor may want stricter error handling

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)