### PR TITLE
feat(ui): add proposals and releases list/detail pages (issue #97)

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -127,6 +127,41 @@ func (fakeWrite) GetRepo(_ context.Context, name string) (*model.Repo, error) {
 	return nil, db.ErrRepoNotFound
 }
 
+func (fakeWrite) ListProposals(_ context.Context, _ string, _ *model.ProposalState, _ *string) ([]*model.Proposal, error) {
+	t := time.Now()
+	return []*model.Proposal{
+		{ID: "p-preview-1", Repo: "acme/platform", Branch: "add-onboarding-guide", BaseBranch: "main", Title: "docs: add onboarding guide", Author: "ajay@acme", State: model.ProposalOpen, CreatedAt: t.Add(-3 * time.Hour)},
+		{ID: "p-preview-2", Repo: "acme/platform", Branch: "bump-arch-doc", BaseBranch: "main", Title: "docs: update architecture notes", Author: "sam@acme", State: model.ProposalMerged, CreatedAt: t.Add(-24 * time.Hour)},
+	}, nil
+}
+
+func (fakeWrite) GetProposal(_ context.Context, _, id string) (*model.Proposal, error) {
+	t := time.Now()
+	proposals := map[string]*model.Proposal{
+		"p-preview-1": {ID: "p-preview-1", Repo: "acme/platform", Branch: "add-onboarding-guide", BaseBranch: "main", Title: "docs: add onboarding guide", Description: "Fills the gap new contributors keep asking about in slack.", Author: "ajay@acme", State: model.ProposalOpen, CreatedAt: t.Add(-3 * time.Hour), UpdatedAt: t.Add(-30 * time.Minute)},
+		"p-preview-2": {ID: "p-preview-2", Repo: "acme/platform", Branch: "bump-arch-doc", BaseBranch: "main", Title: "docs: update architecture notes", Author: "sam@acme", State: model.ProposalMerged, CreatedAt: t.Add(-24 * time.Hour), UpdatedAt: t.Add(-24 * time.Hour)},
+	}
+	return proposals[id], nil
+}
+
+func (fakeWrite) ListReleases(_ context.Context, _ string, _ int, _ string) ([]model.Release, error) {
+	t := time.Now()
+	return []model.Release{
+		{ID: "rel-1", Repo: "acme/platform", Name: "v1.0.0", Sequence: 42, Body: "Initial stable release.\n\n- Platform foundation\n- Reviewer policy v1\n- Onboarding guide", CreatedBy: "ajay@acme", CreatedAt: t.Add(-7 * 24 * time.Hour)},
+		{ID: "rel-2", Repo: "acme/platform", Name: "v1.1.0", Sequence: 48, Body: "Minor update.\n\n- Updated architecture doc\n- Tightened reviewer policy", CreatedBy: "sam@acme", CreatedAt: t.Add(-2 * 24 * time.Hour)},
+	}, nil
+}
+
+func (fakeWrite) GetRelease(_ context.Context, _, name string) (*model.Release, error) {
+	t := time.Now()
+	releases := map[string]*model.Release{
+		"v1.0.0": {ID: "rel-1", Repo: "acme/platform", Name: "v1.0.0", Sequence: 42, Body: "Initial stable release.\n\n- Platform foundation\n- Reviewer policy v1\n- Onboarding guide", CreatedBy: "ajay@acme", CreatedAt: t.Add(-7 * 24 * time.Hour)},
+		"v1.1.0": {ID: "rel-2", Repo: "acme/platform", Name: "v1.1.0", Sequence: 48, Body: "Minor update.\n\n- Updated architecture doc\n- Tightened reviewer policy", CreatedBy: "sam@acme", CreatedAt: t.Add(-2 * 24 * time.Hour)},
+	}
+	r := releases[name]
+	return r, nil
+}
+
 func fakeAssemble(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
 	t := time.Now()
 	vid := func(s string) *string { return &s }

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -118,6 +118,27 @@ type commitDetailPage struct {
 	Commit *store.CommitDetail
 }
 
+type proposalsPage struct {
+	Repo      model.Repo
+	Proposals []*model.Proposal
+	State     string
+}
+
+type proposalDetailPage struct {
+	Repo     model.Repo
+	Proposal *model.Proposal
+}
+
+type releasesPage struct {
+	Repo     model.Repo
+	Releases []model.Release
+}
+
+type releaseDetailPage struct {
+	Repo    model.Repo
+	Release *model.Release
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -439,6 +460,206 @@ func (h *Handler) handleReviewCommentsPartial(w http.ResponseWriter, r *http.Req
 	}
 
 	h.render(w, h.tmpl.reviewComments, "review_comments.html", groups)
+}
+
+// proposalStateFromQuery parses the "state" query param into a ProposalState
+// pointer. Unknown or empty values default to open.
+func proposalStateFromQuery(s string) (model.ProposalState, *model.ProposalState) {
+	switch s {
+	case "closed":
+		st := model.ProposalClosed
+		return st, &st
+	case "merged":
+		st := model.ProposalMerged
+		return st, &st
+	default:
+		st := model.ProposalOpen
+		return st, &st
+	}
+}
+
+// handleProposals renders the proposals list for a repo with state filter tabs.
+func (h *Handler) handleProposals(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	stateStr := r.URL.Query().Get("state")
+	if stateStr == "" {
+		stateStr = "open"
+	}
+	_, ps := proposalStateFromQuery(stateStr)
+
+	proposals, err := h.write.ListProposals(ctx, repoName, ps, nil)
+	if err != nil {
+		slog.Error("ui list proposals", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load proposals")
+		return
+	}
+
+	h.render(w, h.tmpl.proposals, "layout.html", pageData{
+		Title: repoName + " / proposals",
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: "proposals", Href: ""},
+		},
+		Body: proposalsPage{Repo: *repo, Proposals: proposals, State: stateStr},
+	})
+}
+
+// handleProposalsPartial returns just the proposals rows for HTMX tab swapping.
+func (h *Handler) handleProposalsPartial(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	stateStr := r.URL.Query().Get("state")
+	if stateStr == "" {
+		stateStr = "open"
+	}
+	_, ps := proposalStateFromQuery(stateStr)
+
+	proposals, err := h.write.ListProposals(ctx, repoName, ps, nil)
+	if err != nil {
+		slog.Error("ui list proposals partial", "repo", repoName, "error", err)
+		http.Error(w, "query failed", http.StatusInternalServerError)
+		return
+	}
+	h.render(w, h.tmpl.proposalsRows, "proposals_rows.html", proposals)
+}
+
+// handleProposalDetail renders the detail view for a single proposal.
+func (h *Handler) handleProposalDetail(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	id := r.PathValue("id")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	proposal, err := h.write.GetProposal(ctx, repoName, id)
+	if err != nil {
+		slog.Error("ui get proposal", "repo", repoName, "id", id, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load proposal")
+		return
+	}
+	if proposal == nil {
+		h.renderError(w, http.StatusNotFound, "proposal not found")
+		return
+	}
+
+	h.render(w, h.tmpl.proposalDetail, "layout.html", pageData{
+		Title: repoName + " / proposals / " + id,
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: "proposals", Href: "/ui/r/" + repoName + "/proposals"},
+			{Label: proposal.Title, Href: ""},
+		},
+		Body: proposalDetailPage{Repo: *repo, Proposal: proposal},
+	})
+}
+
+// handleReleases renders the releases list for a repo.
+func (h *Handler) handleReleases(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	releases, err := h.write.ListReleases(ctx, repoName, 100, "")
+	if err != nil {
+		slog.Error("ui list releases", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load releases")
+		return
+	}
+
+	h.render(w, h.tmpl.releases, "layout.html", pageData{
+		Title: repoName + " / releases",
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: "releases", Href: ""},
+		},
+		Body: releasesPage{Repo: *repo, Releases: releases},
+	})
+}
+
+// handleReleaseDetail renders the detail view for a single release.
+func (h *Handler) handleReleaseDetail(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	rname := r.PathValue("rname")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	release, err := h.write.GetRelease(ctx, repoName, rname)
+	if err != nil {
+		slog.Error("ui get release", "repo", repoName, "name", rname, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load release")
+		return
+	}
+	if release == nil {
+		h.renderError(w, http.StatusNotFound, "release not found")
+		return
+	}
+
+	h.render(w, h.tmpl.releaseDetail, "layout.html", pageData{
+		Title: repoName + " / releases / " + rname,
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: "releases", Href: "/ui/r/" + repoName + "/releases"},
+			{Label: rname, Href: ""},
+		},
+		Body: releaseDetailPage{Repo: *repo, Release: release},
+	})
 }
 
 // siblingTreeRows returns the immediate children of dir within entries, with

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -24,6 +24,11 @@ type templateSet struct {
 	commitLog      *template.Template
 	logRows        *template.Template
 	commitDetail   *template.Template
+	proposals      *template.Template
+	proposalsRows  *template.Template
+	proposalDetail *template.Template
+	releases       *template.Template
+	releaseDetail  *template.Template
 }
 
 func parseTemplates(root fs.FS) (*templateSet, error) {
@@ -93,6 +98,32 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse commit: %w", err)
 	}
+	// proposals full page pulls in proposals_rows.html as a partial.
+	proposals, err := template.New("layout.html").
+		Funcs(funcMap()).
+		ParseFS(root,
+			"templates/layout.html",
+			"templates/proposals.html",
+			"templates/proposals_rows.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse proposals: %w", err)
+	}
+	proposalsRows, err := loadFragment("proposals_rows.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse proposals_rows: %w", err)
+	}
+	proposalDetail, err := load("proposal_detail.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse proposal_detail: %w", err)
+	}
+	releases, err := load("releases.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse releases: %w", err)
+	}
+	releaseDetail, err := load("release_detail.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse release_detail: %w", err)
+	}
 	return &templateSet{
 		repos:          repos,
 		branches:       branches,
@@ -104,6 +135,11 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		commitLog:      commitLog,
 		logRows:        logRows,
 		commitDetail:   commitDetail,
+		proposals:      proposals,
+		proposalsRows:  proposalsRows,
+		proposalDetail: proposalDetail,
+		releases:       releases,
+		releaseDetail:  releaseDetail,
 	}, nil
 }
 

--- a/internal/ui/static/poll.js
+++ b/internal/ui/static/poll.js
@@ -38,6 +38,30 @@
     }
   });
 
+  // Tab switching. Clicking [data-tab-url] fetches the URL and swaps the
+  // innerHTML of the element matching [data-tab-target] on the same tab link.
+  document.addEventListener('click', function (e) {
+    var el = e.target.closest('[data-tab-url]');
+    if (!el) return;
+    var url = el.getAttribute('data-tab-url');
+    var targetSel = el.getAttribute('data-tab-target');
+    if (!url || !targetSel) return;
+    e.preventDefault();
+    var target = document.querySelector(targetSel);
+    if (!target) return;
+    // Update active class on siblings within [data-tab-group].
+    var group = el.closest('[data-tab-group]');
+    if (group) {
+      var tabs = group.querySelectorAll('[data-tab-url]');
+      for (var i = 0; i < tabs.length; i++) tabs[i].classList.remove('active');
+    }
+    el.classList.add('active');
+    fetch(url, { credentials: 'same-origin' }).then(function (r) {
+      if (!r.ok) return;
+      return r.text().then(function (t) { target.innerHTML = t; });
+    }).catch(function () {});
+  });
+
   // Branch-list filter. Hides tbody rows whose first cell text doesn't match.
   document.addEventListener('DOMContentLoaded', function () {
     var inputs = document.querySelectorAll('[data-branch-filter]');

--- a/internal/ui/static/styles.css
+++ b/internal/ui/static/styles.css
@@ -320,6 +320,25 @@ pre.code .text { white-space: pre; padding-right: 12px; }
 }
 .checks-collapsed:last-child { border-bottom: 0; }
 
+/* State filter tabs used on proposals page. */
+.tab-bar {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 14px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0;
+}
+.tab-bar .tab {
+  padding: 6px 14px;
+  color: var(--text-dim);
+  text-decoration: none;
+  font-size: 12px;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+.tab-bar .tab:hover { color: var(--text); text-decoration: none; }
+.tab-bar .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+
 .err-box {
   text-align: center;
   padding: 60px 20px;

--- a/internal/ui/templates/proposal_detail.html
+++ b/internal/ui/templates/proposal_detail.html
@@ -1,0 +1,35 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline">
+  <h1>{{.Proposal.Title}}</h1>
+  <span class="badge {{statusClass (printf "%s" .Proposal.State)}}">{{.Proposal.State}}</span>
+</div>
+
+<div class="meta" style="margin-bottom:14px">
+  by {{.Proposal.Author}} · opened {{relTime .Proposal.CreatedAt}} · updated {{relTime .Proposal.UpdatedAt}}
+</div>
+
+<h2>Details</h2>
+<div class="card">
+  <div class="row">
+    <div><strong>base branch</strong></div>
+    <div>{{.Proposal.BaseBranch}}</div>
+  </div>
+  <div class="row">
+    <div><strong>branch</strong></div>
+    <div><a href="/ui/r/{{.Repo.Name}}/b/{{.Proposal.Branch}}">{{.Proposal.Branch}}</a></div>
+  </div>
+  <div class="row">
+    <div><strong>id</strong></div>
+    <div class="meta">{{.Proposal.ID}}</div>
+  </div>
+</div>
+
+{{if .Proposal.Description}}
+<h2>Description</h2>
+<div class="card">
+  <div style="white-space:pre-wrap;color:var(--text);">{{.Proposal.Description}}</div>
+</div>
+{{end}}
+{{end}}
+{{end}}

--- a/internal/ui/templates/proposals.html
+++ b/internal/ui/templates/proposals.html
@@ -1,0 +1,27 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline">
+  <h1>{{.Repo.Name}} / proposals</h1>
+  <span class="meta">owner {{.Repo.Owner}}</span>
+</div>
+
+<div class="tab-bar" data-tab-group>
+  <a class="tab{{if eq .State "open"}} active{{end}}"
+     href="?state=open"
+     data-tab-url="/ui/_/r/{{.Repo.Name}}/proposals?state=open"
+     data-tab-target="#proposals-list">open</a>
+  <a class="tab{{if eq .State "closed"}} active{{end}}"
+     href="?state=closed"
+     data-tab-url="/ui/_/r/{{.Repo.Name}}/proposals?state=closed"
+     data-tab-target="#proposals-list">closed</a>
+  <a class="tab{{if eq .State "merged"}} active{{end}}"
+     href="?state=merged"
+     data-tab-url="/ui/_/r/{{.Repo.Name}}/proposals?state=merged"
+     data-tab-target="#proposals-list">merged</a>
+</div>
+
+<div class="card" id="proposals-list">
+{{template "proposals_rows.html" .Proposals}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/proposals_rows.html
+++ b/internal/ui/templates/proposals_rows.html
@@ -1,0 +1,18 @@
+{{define "proposals_rows.html"}}
+{{if not .}}<div class="empty">no proposals</div>{{else}}
+<table class="grid">
+  <thead><tr><th>title</th><th>state</th><th>author</th><th>base</th><th>opened</th></tr></thead>
+  <tbody>
+  {{range .}}
+  <tr>
+    <td><a href="proposals/{{.ID}}">{{.Title}}</a></td>
+    <td><span class="badge {{statusClass (printf "%s" .State)}}">{{.State}}</span></td>
+    <td>{{.Author}}</td>
+    <td>{{.BaseBranch}}</td>
+    <td class="meta">{{relTime .CreatedAt}}</td>
+  </tr>
+  {{end}}
+  </tbody>
+</table>
+{{end}}
+{{end}}

--- a/internal/ui/templates/release_detail.html
+++ b/internal/ui/templates/release_detail.html
@@ -1,0 +1,35 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline">
+  <h1>{{.Release.Name}}</h1>
+  <span class="meta">seq {{.Release.Sequence}}</span>
+</div>
+
+<div class="meta" style="margin-bottom:14px">
+  by {{.Release.CreatedBy}} · {{relTime .Release.CreatedAt}}
+</div>
+
+<h2>Details</h2>
+<div class="card">
+  <div class="row">
+    <div><strong>name</strong></div>
+    <div>{{.Release.Name}}</div>
+  </div>
+  <div class="row">
+    <div><strong>sequence</strong></div>
+    <div>{{.Release.Sequence}}</div>
+  </div>
+  <div class="row">
+    <div><strong>id</strong></div>
+    <div class="meta">{{.Release.ID}}</div>
+  </div>
+</div>
+
+{{if .Release.Body}}
+<h2>Body</h2>
+<div class="card">
+  <div style="white-space:pre-wrap;color:var(--text);">{{.Release.Body}}</div>
+</div>
+{{end}}
+{{end}}
+{{end}}

--- a/internal/ui/templates/releases.html
+++ b/internal/ui/templates/releases.html
@@ -1,0 +1,27 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline">
+  <h1>{{.Repo.Name}} / releases</h1>
+  <span class="meta">owner {{.Repo.Owner}}</span>
+</div>
+
+<div class="card">
+{{if not .Releases}}<div class="empty">no releases</div>{{else}}
+<table class="grid">
+  <thead><tr><th>name</th><th>seq</th><th>author</th><th>body</th><th>created</th></tr></thead>
+  <tbody>
+  {{range .Releases}}
+  <tr>
+    <td><a href="releases/{{.Name}}">{{.Name}}</a></td>
+    <td>{{.Sequence}}</td>
+    <td>{{.CreatedBy}}</td>
+    <td class="meta">{{if gt (len .Body) 80}}{{slice .Body 0 80}}…{{else}}{{.Body}}{{end}}</td>
+    <td class="meta">{{relTime .CreatedAt}}</td>
+  </tr>
+  {{end}}
+  </tbody>
+</table>
+{{end}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -36,6 +36,10 @@ type WriteStoreLite interface {
 	ListReviewComments(ctx context.Context, repo, branch string, path *string) ([]model.ReviewComment, error)
 	ListOrgMembers(ctx context.Context, org string) ([]model.OrgMember, error)
 	ListRoles(ctx context.Context, repo string) ([]model.Role, error)
+	ListProposals(ctx context.Context, repo string, state *model.ProposalState, branch *string) ([]*model.Proposal, error)
+	GetProposal(ctx context.Context, repo, proposalID string) (*model.Proposal, error)
+	ListReleases(ctx context.Context, repo string, limit int, afterID string) ([]model.Release, error)
+	GetRelease(ctx context.Context, repo, name string) (*model.Release, error)
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -113,5 +117,10 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/log", h.handleLogRowsPartial)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}/c/{seq}", h.handleCommitDetail)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/f/{path...}", h.handleFile)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/proposals", h.handleProposals)
+	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/proposals", h.handleProposalsPartial)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/proposals/{id}", h.handleProposalDetail)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/releases", h.handleReleases)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/releases/{rname}", h.handleReleaseDetail)
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -47,8 +47,10 @@ func (f *fakeRead) GetCommit(_ context.Context, _ string, _ int64) (*store.Commi
 }
 
 type fakeWrite struct {
-	repos []model.Repo
-	miss  bool
+	repos     []model.Repo
+	miss      bool
+	proposals []*model.Proposal
+	releases  []model.Release
 }
 
 func (f *fakeWrite) ListRepos(_ context.Context) ([]model.Repo, error) { return f.repos, nil }
@@ -71,6 +73,37 @@ func (f *fakeWrite) ListOrgMembers(_ context.Context, _ string) ([]model.OrgMemb
 	return nil, nil
 }
 func (f *fakeWrite) ListRoles(_ context.Context, _ string) ([]model.Role, error) {
+	return nil, nil
+}
+func (f *fakeWrite) ListProposals(_ context.Context, _ string, state *model.ProposalState, _ *string) ([]*model.Proposal, error) {
+	if state == nil {
+		return f.proposals, nil
+	}
+	var out []*model.Proposal
+	for _, p := range f.proposals {
+		if p.State == *state {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+func (f *fakeWrite) GetProposal(_ context.Context, _, id string) (*model.Proposal, error) {
+	for _, p := range f.proposals {
+		if p.ID == id {
+			return p, nil
+		}
+	}
+	return nil, nil
+}
+func (f *fakeWrite) ListReleases(_ context.Context, _ string, _ int, _ string) ([]model.Release, error) {
+	return f.releases, nil
+}
+func (f *fakeWrite) GetRelease(_ context.Context, _, name string) (*model.Release, error) {
+	for _, r := range f.releases {
+		if r.Name == name {
+			return &r, nil
+		}
+	}
 	return nil, nil
 }
 
@@ -242,6 +275,137 @@ func TestHandleFile_RendersTreeAndContent(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("missing %q in body", want)
 		}
+	}
+}
+
+func TestHandleProposals_RendersList(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	ps := model.ProposalOpen
+	w := &fakeWrite{
+		repos: repos,
+		proposals: []*model.Proposal{
+			{ID: "p-1", Repo: "acme/a", Branch: "feat-x", BaseBranch: "main", Title: "My Proposal", Author: "alice", State: ps, CreatedAt: time.Now()},
+		},
+	}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/proposals?state=open")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"My Proposal", "alice", "main", "open"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleProposalsPartial_ReturnsFragment(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme"}}
+	ps := model.ProposalOpen
+	w := &fakeWrite{
+		repos: repos,
+		proposals: []*model.Proposal{
+			{ID: "p-1", Title: "Frag Proposal", Author: "bob", State: ps, BaseBranch: "main", CreatedAt: time.Now()},
+		},
+	}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/_/r/acme/a/proposals?state=open")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if strings.Contains(body, "<!doctype html>") {
+		t.Errorf("expected fragment, got full layout")
+	}
+	if !strings.Contains(body, "Frag Proposal") {
+		t.Errorf("expected proposal title in fragment, got: %s", body)
+	}
+}
+
+func TestHandleProposalDetail_RendersDetail(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	ps := model.ProposalOpen
+	w := &fakeWrite{
+		repos: repos,
+		proposals: []*model.Proposal{
+			{ID: "p-abc", Repo: "acme/a", Branch: "feat-x", BaseBranch: "main", Title: "Detail Proposal", Description: "some details", Author: "carol", State: ps, CreatedAt: time.Now()},
+		},
+	}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/proposals/p-abc")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"Detail Proposal", "carol", "feat-x", "some details"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleProposalDetail_NotFound_Returns404(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	w := &fakeWrite{repos: repos}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, _ := getStatusAndBody(t, h, "/ui/r/acme/a/proposals/nonexistent")
+	if code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", code)
+	}
+}
+
+func TestHandleReleases_RendersList(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	w := &fakeWrite{
+		repos: repos,
+		releases: []model.Release{
+			{ID: "r-1", Repo: "acme/a", Name: "v1.0.0", Sequence: 42, Body: "first release", CreatedBy: "dave", CreatedAt: time.Now()},
+		},
+	}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/releases")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"v1.0.0", "42", "dave", "first release"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleReleaseDetail_RendersDetail(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	w := &fakeWrite{
+		repos: repos,
+		releases: []model.Release{
+			{ID: "r-2", Repo: "acme/a", Name: "v2.0.0", Sequence: 99, Body: "second release notes", CreatedBy: "eve", CreatedAt: time.Now()},
+		},
+	}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/releases/v2.0.0")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"v2.0.0", "99", "eve", "second release notes"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleReleaseDetail_NotFound_Returns404(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	w := &fakeWrite{repos: repos}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, _ := getStatusAndBody(t, h, "/ui/r/acme/a/releases/nonexistent")
+	if code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", code)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Proposals list** (`GET /ui/r/{owner}/{name}/proposals`) — shows title, author, state badge, base branch, created time; state filter tabs (open/closed/merged) swap content via a lightweight fetch partial at `/ui/_/r/{owner}/{name}/proposals?state=...`
- **Proposal detail** (`GET /ui/r/{owner}/{name}/proposals/{id}`) — shows title, description, author, state, base branch, linked branch (links to branch detail page)
- **Releases list** (`GET /ui/r/{owner}/{name}/releases`) — shows name, sequence, author, body preview, created time
- **Release detail** (`GET /ui/r/{owner}/{name}/releases/{rname}`) — shows name, sequence, full body, created time

## Implementation

- `internal/ui/ui.go`: Extended `WriteStoreLite` interface with `ListProposals`, `GetProposal`, `ListReleases`, `GetRelease` (signatures copied from `server.WriteStore`)
- `internal/ui/handlers.go`: Added 4 page data types + 5 handlers (`handleProposals`, `handleProposalsPartial`, `handleProposalDetail`, `handleReleases`, `handleReleaseDetail`); routes wired in `Register()`
- `internal/ui/render.go`: Added 5 template entries to `templateSet`; `proposals.html` is parsed together with `proposals_rows.html` (same pattern as `branch_detail` + `branch_checks`)
- 5 new templates in `internal/ui/templates/`
- `poll.js`: Added `data-tab-url` / `data-tab-target` tab-switching handler (no external HTMX dependency — consistent with existing project JS style)
- `styles.css`: Added `.tab-bar` / `.tab` classes
- `cmd/ui-preview/main.go`: Updated `fakeWrite` to satisfy new interface; added sample data for preview
- `internal/ui/ui_test.go`: Added 7 new test cases; updated `fakeWrite` stub

## Test plan

- [x] `go test ./... -count=1` — all pass
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean

## Notes / Opportunities

- The tab switching currently does client-side fetch but does not update `window.location` (no `pushState`). A future enhancement could add history support.
- No navigation links from the branches page to proposals/releases yet — those could be added as quick-links in `branches.html`.

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)