### PR TITLE
feat: add repo nav tabs and branch log links to UI

### DIFF
--- a/internal/ui/static/styles.css
+++ b/internal/ui/static/styles.css
@@ -98,6 +98,22 @@ h2:first-child { margin-top: 0; }
 }
 .headline h1 { margin: 0; }
 
+.repo-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 8px;
+}
+.repo-tabs a {
+  padding: 4px 10px;
+  font-size: 13px;
+  color: var(--text-dim);
+  text-decoration: none;
+  border-radius: 3px;
+}
+.repo-tabs a:hover { color: var(--text); background: var(--bg-3); }
+
 .card {
   background: var(--bg-2);
   border: 1px solid var(--border);

--- a/internal/ui/templates/branches.html
+++ b/internal/ui/templates/branches.html
@@ -2,6 +2,14 @@
 {{with .Body}}
 <div class="headline"><h1>{{.Repo.Name}}</h1><span class="meta">owner {{.Repo.Owner}} · {{relTime .Repo.CreatedAt}}</span></div>
 
+<nav class="repo-tabs">
+  <a href="/ui/r/{{.Repo.Name}}">branches</a>
+  <a href="/ui/r/{{.Repo.Name}}/issues">issues</a>
+  <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
+  <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
+  <a href="/ui/r/{{.Repo.Name}}/log">log</a>
+</nav>
+
 <div class="filter-bar"><input type="search" data-branch-filter placeholder="filter branches by name…" autocomplete="off"></div>
 
 {{template "branchSection" (dict "Title" "Active" "Rows" .Active "Repo" .Repo.Name)}}
@@ -29,7 +37,7 @@
         {{if .Draft}}<span class="badge warn">draft</span>{{end}}
         {{if .AutoMerge}}<span class="badge ok">auto-merge</span>{{end}}
       </td>
-      <td><a href="/ui/r/{{$.Repo}}/f/?branch={{.Name}}">files →</a></td>
+      <td><a href="/ui/r/{{$.Repo}}/f/?branch={{.Name}}">files →</a> · <a href="/ui/r/{{$.Repo}}/b/{{.Name}}/log">log →</a></td>
     </tr>
     {{end}}
     </tbody>


### PR DESCRIPTION
## Summary

- Adds navigation tabs (branches / issues / releases / proposals / log) below the repo headline on `/ui/r/{owner}/{name}`
- Adds a `log →` link alongside the existing `files →` link in each branch row
- Adds minimal `.repo-tabs` CSS to `styles.css` for tab layout

The tab links point to planned routes per issue #97. No new handlers were added — these are forward-looking anchor links.

## Changes

- `internal/ui/templates/branches.html`: add `<nav class="repo-tabs">` after headline, add `log →` link in branch table rows
- `internal/ui/static/styles.css`: add `.repo-tabs` flex layout + link styles

## Opportunities for follow-up

- Active tab highlighting (mark current tab as active based on URL)
- Implement the actual handlers for issues, releases, proposals, and log pages (per #97)

Closes part of #97.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` passes (all packages, including `internal/ui`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)