### PR TITLE
feat: add issues list and detail pages to web UI

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -131,6 +131,46 @@ func (fakeWrite) GetRepo(_ context.Context, name string) (*model.Repo, error) {
 	return nil, db.ErrRepoNotFound
 }
 
+func (fakeWrite) ListIssues(_ context.Context, repo, state, _ string) ([]model.Issue, error) {
+	t := time.Now()
+	if state == "closed" {
+		return []model.Issue{
+			{ID: "i3", Repo: repo, Number: 3, Title: "closed issue example", Author: "sam@acme",
+				State: "closed", Labels: []string{"wontfix"}, CreatedAt: t.Add(-10 * 24 * time.Hour)},
+		}, nil
+	}
+	return []model.Issue{
+		{ID: "i1", Repo: repo, Number: 1, Title: "add pagination to file tree", Author: "ajay@acme",
+			State: "open", Labels: []string{"enhancement"}, Body: "The file tree doesn't paginate yet.", CreatedAt: t.Add(-2 * 24 * time.Hour)},
+		{ID: "i2", Repo: repo, Number: 2, Title: "branch detail page flickers on reload", Author: "lee@beta",
+			State: "open", Labels: []string{"bug"}, Body: "Seen in Chrome 124.", CreatedAt: t.Add(-5 * time.Hour)},
+	}, nil
+}
+
+func (fakeWrite) GetIssue(_ context.Context, repo string, number int64) (*model.Issue, error) {
+	all, _ := (fakeWrite{}).ListIssues(context.Background(), repo, "open", "")
+	for _, iss := range all {
+		if iss.Number == number {
+			return &iss, nil
+		}
+	}
+	closed, _ := (fakeWrite{}).ListIssues(context.Background(), repo, "closed", "")
+	for _, iss := range closed {
+		if iss.Number == number {
+			return &iss, nil
+		}
+	}
+	return nil, db.ErrIssueNotFound
+}
+
+func (fakeWrite) ListIssueComments(_ context.Context, _ string, _ int64) ([]model.IssueComment, error) {
+	t := time.Now()
+	return []model.IssueComment{
+		{ID: "c1", Body: "Agreed, this would be very helpful.", Author: "sam@acme", CreatedAt: t.Add(-1 * time.Hour)},
+		{ID: "c2", Body: "I can take this one.", Author: "ajay@acme", CreatedAt: t.Add(-30 * time.Minute)},
+	}, nil
+}
+
 func fakeAssemble(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
 	t := time.Now()
 	vid := func(s string) *string { return &s }

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -118,6 +118,18 @@ type commitDetailPage struct {
 	Commit *store.CommitDetail
 }
 
+type issuesPage struct {
+	Repo   model.Repo
+	Issues []model.Issue
+	State  string
+}
+
+type issueDetailPage struct {
+	Repo     model.Repo
+	Issue    *model.Issue
+	Comments []model.IssueComment
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -440,6 +452,77 @@ func (h *Handler) handleFile(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleIssues renders the issues list page for a repo with open/closed tab state.
+func (h *Handler) handleIssues(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	state := r.URL.Query().Get("state")
+	if state != "open" && state != "closed" {
+		state = "open"
+	}
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	issues, err := h.write.ListIssues(ctx, repoName, state, "")
+	if err != nil {
+		slog.Error("ui list issues", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load issues")
+		return
+	}
+
+	page := issuesPage{Repo: *repo, Issues: issues, State: state}
+	h.render(w, h.tmpl.issues, "layout.html", pageData{
+		Title: repoName + " / issues",
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: "issues", Href: ""},
+		},
+		Body: page,
+	})
+}
+
+// handleIssuesPartial returns just the issues table rows for tab-filter swapping.
+func (h *Handler) handleIssuesPartial(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	state := r.URL.Query().Get("state")
+	if state != "open" && state != "closed" {
+		state = "open"
+	}
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		slog.Error("ui issues partial get repo", "repo", repoName, "error", err)
+		http.Error(w, "query failed", http.StatusInternalServerError)
+		return
+	}
+
+	issues, err := h.write.ListIssues(ctx, repoName, state, "")
+	if err != nil {
+		slog.Error("ui issues partial list", "repo", repoName, "error", err)
+		http.Error(w, "query failed", http.StatusInternalServerError)
+		return
+	}
+
+	h.render(w, h.tmpl.issuesRows, "issues_rows.html", issuesPage{Repo: *repo, Issues: issues, State: state})
+}
+
 // handleReviewCommentsPartial returns the inline review comments for a branch,
 // grouped by file path, as an HTMX partial.
 func (h *Handler) handleReviewCommentsPartial(w http.ResponseWriter, r *http.Request) {
@@ -470,6 +553,62 @@ func (h *Handler) handleReviewCommentsPartial(w http.ResponseWriter, r *http.Req
 	}
 
 	h.render(w, h.tmpl.reviewComments, "review_comments.html", groups)
+}
+
+// handleIssueDetail renders the detail view for a single issue.
+func (h *Handler) handleIssueDetail(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	numberStr := r.PathValue("number")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	number, err := strconv.ParseInt(numberStr, 10, 64)
+	if err != nil {
+		h.renderError(w, http.StatusBadRequest, "invalid issue number")
+		return
+	}
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	issue, err := h.write.GetIssue(ctx, repoName, number)
+	if err != nil {
+		if errors.Is(err, db.ErrIssueNotFound) {
+			h.renderError(w, http.StatusNotFound, "issue not found")
+			return
+		}
+		slog.Error("ui get issue", "repo", repoName, "number", number, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load issue")
+		return
+	}
+
+	comments, err := h.write.ListIssueComments(ctx, repoName, number)
+	if err != nil {
+		slog.Error("ui list issue comments", "repo", repoName, "number", number, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load comments")
+		return
+	}
+
+	page := issueDetailPage{Repo: *repo, Issue: issue, Comments: comments}
+	h.render(w, h.tmpl.issueDetail, "layout.html", pageData{
+		Title: repoName + " / issue #" + numberStr,
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: "issues", Href: "/ui/r/" + repoName + "/issues"},
+			{Label: "#" + numberStr, Href: ""},
+		},
+		Body: page,
+	})
 }
 
 // siblingTreeRows returns the immediate children of dir within entries, with

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -25,6 +25,9 @@ type templateSet struct {
 	commitLog      *template.Template
 	logRows        *template.Template
 	commitDetail   *template.Template
+	issues         *template.Template
+	issuesRows     *template.Template
+	issueDetail    *template.Template
 }
 
 func parseTemplates(root fs.FS) (*templateSet, error) {
@@ -98,6 +101,24 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse commit: %w", err)
 	}
+	// issues pulls in issues_rows.html so the initial page render includes the table.
+	issues, err := template.New("layout.html").
+		Funcs(funcMap()).
+		ParseFS(root,
+			"templates/layout.html",
+			"templates/issues.html",
+			"templates/issues_rows.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse issues: %w", err)
+	}
+	issuesRows, err := loadFragment("issues_rows.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse issues_rows: %w", err)
+	}
+	issueDetail, err := load("issue_detail.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse issue_detail: %w", err)
+	}
 	return &templateSet{
 		repos:          repos,
 		branches:       branches,
@@ -110,6 +131,9 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		commitLog:      commitLog,
 		logRows:        logRows,
 		commitDetail:   commitDetail,
+		issues:         issues,
+		issuesRows:     issuesRows,
+		issueDetail:    issueDetail,
 	}, nil
 }
 
@@ -172,16 +196,17 @@ type errorInfo struct {
 
 func funcMap() template.FuncMap {
 	return template.FuncMap{
-		"relTime":    relTime,
-		"shortHash":  shortHash,
+		"relTime":     relTime,
+		"relTimep":    relTimep,
+		"shortHash":   shortHash,
 		"statusClass": statusClass,
-		"diffClass":  diffClass,
-		"joinPath":   joinPath,
+		"diffClass":   diffClass,
+		"joinPath":    joinPath,
 		"safeContent": safeContent,
-		"hasPrefix":  strings.HasPrefix,
-		"lines":      splitLines,
-		"dict":       dict,
-		"add":        func(a, b int) int { return a + b },
+		"hasPrefix":   strings.HasPrefix,
+		"lines":       splitLines,
+		"dict":        dict,
+		"add":         func(a, b int) int { return a + b },
 	}
 }
 
@@ -216,6 +241,13 @@ func relTime(t time.Time) string {
 	default:
 		return t.Format("2006-01-02")
 	}
+}
+
+func relTimep(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return relTime(*t)
 }
 
 func shortHash(s string) string {

--- a/internal/ui/static/poll.js
+++ b/internal/ui/static/poll.js
@@ -38,6 +38,27 @@
     }
   });
 
+  // Tab navigation. Clicks on [data-tab-url] fetch the URL and replace the
+  // innerHTML of the element with id matching [data-tab-target].
+  document.addEventListener('click', function (e) {
+    var el = e.target.closest('[data-tab-url]');
+    if (!el) return;
+    e.preventDefault();
+    var url = el.getAttribute('data-tab-url');
+    var targetId = el.getAttribute('data-tab-target');
+    if (!url || !targetId) return;
+    var siblings = el.parentElement ? el.parentElement.querySelectorAll('[data-tab-url]') : [];
+    for (var i = 0; i < siblings.length; i++) siblings[i].classList.remove('active');
+    el.classList.add('active');
+    fetch(url, { credentials: 'same-origin' }).then(function (r) {
+      if (!r.ok) return;
+      return r.text().then(function (t) {
+        var target = document.getElementById(targetId);
+        if (target) target.innerHTML = t;
+      });
+    }).catch(function () {});
+  });
+
   // Branch-list filter. Hides tbody rows whose first cell text doesn't match.
   document.addEventListener('DOMContentLoaded', function () {
     var inputs = document.querySelectorAll('[data-branch-filter]');

--- a/internal/ui/static/styles.css
+++ b/internal/ui/static/styles.css
@@ -326,3 +326,31 @@ pre.code .text { white-space: pre; padding-right: 12px; }
 }
 .err-box h1 { font-size: 24px; }
 .err-box p { color: var(--text-dim); }
+
+/* Issue tab bar */
+.tab-bar {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 14px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0;
+}
+.tab {
+  display: inline-block;
+  padding: 6px 14px;
+  font-size: 12px;
+  color: var(--text-dim);
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: 4px 4px 0 0;
+  cursor: pointer;
+  margin-bottom: -1px;
+  text-decoration: none;
+}
+.tab:hover { color: var(--text); text-decoration: none; }
+.tab.active {
+  color: var(--text);
+  background: var(--bg-2);
+  border-color: var(--border);
+  border-bottom-color: var(--bg-2);
+}

--- a/internal/ui/templates/issue_detail.html
+++ b/internal/ui/templates/issue_detail.html
@@ -1,0 +1,37 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline">
+  <h1>#{{.Issue.Number}} {{.Issue.Title}}</h1>
+  <span class="badge {{statusClass (printf "%s" .Issue.State)}}">{{.Issue.State}}</span>
+</div>
+<div class="meta" style="margin-bottom:14px">
+  by {{.Issue.Author}} · opened {{relTime .Issue.CreatedAt}}{{if .Issue.ClosedAt}} · closed {{relTimep .Issue.ClosedAt}}{{end}}
+</div>
+
+{{if .Issue.Labels}}
+<div style="margin-bottom:12px">
+  {{range .Issue.Labels}}<span class="badge neutral">{{.}}</span> {{end}}
+</div>
+{{end}}
+
+{{if .Issue.Body}}
+<div class="card" style="margin-bottom:16px">
+  <div class="row-body">{{.Issue.Body}}</div>
+</div>
+{{end}}
+
+<h2>Comments ({{len .Comments}})</h2>
+<div class="card">
+  {{if not .Comments}}<div class="empty">no comments yet</div>{{end}}
+  {{range .Comments}}
+  <div class="row">
+    <div>
+      <strong>{{.Author}}</strong>
+      <span class="meta">{{relTime .CreatedAt}}{{if .EditedAt}} · edited{{end}}</span>
+    </div>
+  </div>
+  {{if .Body}}<div class="row-body">{{.Body}}</div>{{end}}
+  {{end}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/issues.html
+++ b/internal/ui/templates/issues.html
@@ -1,0 +1,22 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline">
+  <h1>{{.Repo.Name}} / issues</h1>
+</div>
+
+<div class="tab-bar">
+  <a href="/ui/r/{{.Repo.Name}}/issues?state=open"
+     data-tab-url="/ui/_/r/{{.Repo.Name}}/issues?state=open"
+     data-tab-target="issues-table"
+     class="tab{{if eq .State "open"}} active{{end}}">Open</a>
+  <a href="/ui/r/{{.Repo.Name}}/issues?state=closed"
+     data-tab-url="/ui/_/r/{{.Repo.Name}}/issues?state=closed"
+     data-tab-target="issues-table"
+     class="tab{{if eq .State "closed"}} active{{end}}">Closed</a>
+</div>
+
+<div id="issues-table">
+  {{template "issues_rows.html" .}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/issues_rows.html
+++ b/internal/ui/templates/issues_rows.html
@@ -1,0 +1,20 @@
+{{define "issues_rows.html"}}
+<div class="card">
+  {{if not .Issues}}<div class="empty">no {{.State}} issues</div>{{else}}
+  <table class="grid">
+    <thead><tr><th>#</th><th>title</th><th>author</th><th>state</th><th>opened</th></tr></thead>
+    <tbody>
+    {{range .Issues}}
+    <tr>
+      <td><a href="/ui/r/{{$.Repo.Name}}/issues/{{.Number}}">#{{.Number}}</a></td>
+      <td><a href="/ui/r/{{$.Repo.Name}}/issues/{{.Number}}">{{.Title}}</a></td>
+      <td>{{.Author}}</td>
+      <td><span class="badge {{statusClass (printf "%s" .State)}}">{{.State}}</span></td>
+      <td class="meta">{{relTime .CreatedAt}}</td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{end}}
+</div>
+{{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -37,6 +37,9 @@ type WriteStoreLite interface {
 	ListOrgMembers(ctx context.Context, org string) ([]model.OrgMember, error)
 	ListRoles(ctx context.Context, repo string) ([]model.Role, error)
 	ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64, history bool) ([]model.CheckRun, error)
+	ListIssues(ctx context.Context, repo, stateFilter, authorFilter string) ([]model.Issue, error)
+	GetIssue(ctx context.Context, repo string, number int64) (*model.Issue, error)
+	ListIssueComments(ctx context.Context, repo string, number int64) ([]model.IssueComment, error)
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -115,5 +118,8 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}/c/{seq}", h.handleCommitDetail)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/check-history", h.handleCheckHistoryPartial)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/f/{path...}", h.handleFile)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/issues", h.handleIssues)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/issues/{number}", h.handleIssueDetail)
+	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/issues", h.handleIssuesPartial)
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -47,8 +47,10 @@ func (f *fakeRead) GetCommit(_ context.Context, _ string, _ int64) (*store.Commi
 }
 
 type fakeWrite struct {
-	repos []model.Repo
-	miss  bool
+	repos         []model.Repo
+	issues        []model.Issue
+	issueComments []model.IssueComment
+	miss          bool
 }
 
 func (f *fakeWrite) ListRepos(_ context.Context) ([]model.Repo, error) { return f.repos, nil }
@@ -75,6 +77,20 @@ func (f *fakeWrite) ListRoles(_ context.Context, _ string) ([]model.Role, error)
 }
 func (f *fakeWrite) ListCheckRuns(_ context.Context, _, _ string, _ *int64, _ bool) ([]model.CheckRun, error) {
 	return nil, nil
+}
+func (f *fakeWrite) ListIssues(_ context.Context, _, _, _ string) ([]model.Issue, error) {
+	return f.issues, nil
+}
+func (f *fakeWrite) GetIssue(_ context.Context, _ string, number int64) (*model.Issue, error) {
+	for _, iss := range f.issues {
+		if iss.Number == number {
+			return &iss, nil
+		}
+	}
+	return nil, db.ErrIssueNotFound
+}
+func (f *fakeWrite) ListIssueComments(_ context.Context, _ string, _ int64) ([]model.IssueComment, error) {
+	return f.issueComments, nil
 }
 
 func newFakeAssembler(branchName string) AssembleFn {
@@ -268,6 +284,108 @@ func TestHandleFile_RendersTreeAndContent(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("missing %q in body", want)
 		}
+	}
+}
+
+func TestHandleIssues_RendersTable(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	issues := []model.Issue{
+		{ID: "i1", Repo: "acme/a", Number: 1, Title: "first bug", Author: "alice", State: "open", CreatedAt: time.Now()},
+		{ID: "i2", Repo: "acme/a", Number: 2, Title: "second bug", Author: "bob", State: "open", CreatedAt: time.Now()},
+	}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos, issues: issues}, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/issues")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"first bug", "second bug", "alice", "bob", "#1", "#2"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleIssues_DefaultsToOpen(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/issues")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	// Active tab should be "open"
+	if !strings.Contains(body, `tab active`) {
+		t.Errorf("expected active tab in body")
+	}
+}
+
+func TestHandleIssues_UnknownRepo_Returns404(t *testing.T) {
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{miss: true}, nil)
+	code, _ := getStatusAndBody(t, h, "/ui/r/unknown/repo/issues")
+	if code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", code)
+	}
+}
+
+func TestHandleIssuesPartial_ReturnsFragment(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	issues := []model.Issue{
+		{ID: "i1", Repo: "acme/a", Number: 3, Title: "partial issue", Author: "carol", State: "closed", CreatedAt: time.Now()},
+	}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos, issues: issues}, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/_/r/acme/a/issues?state=closed")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if strings.Contains(body, "<!doctype html>") {
+		t.Errorf("expected fragment, got full layout")
+	}
+	if !strings.Contains(body, "partial issue") {
+		t.Errorf("expected issue title in fragment, got: %s", body)
+	}
+}
+
+func TestHandleIssueDetail_RendersIssueAndComments(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	issues := []model.Issue{
+		{ID: "i1", Repo: "acme/a", Number: 7, Title: "detail issue", Author: "dave", State: "open",
+			Body: "some description", Labels: []string{"bug", "priority"}, CreatedAt: time.Now()},
+	}
+	comments := []model.IssueComment{
+		{ID: "c1", IssueID: "i1", Repo: "acme/a", Body: "nice comment", Author: "eve", CreatedAt: time.Now()},
+	}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos, issues: issues, issueComments: comments}, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/issues/7")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"detail issue", "dave", "some description", "bug", "priority", "nice comment", "eve"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleIssueDetail_NotFound_Returns404(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, _ := getStatusAndBody(t, h, "/ui/r/acme/a/issues/999")
+	if code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", code)
+	}
+}
+
+func TestHandleIssueDetail_InvalidNumber_Returns400(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, _ := getStatusAndBody(t, h, "/ui/r/acme/a/issues/notanumber")
+	if code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", code)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extends `WriteStoreLite` interface with `ListIssues`, `GetIssue`, `ListIssueComments` (signatures copied from `server.WriteStore`)
- Adds `handleIssues` (full list page), `handleIssuesPartial` (HTMX-style table fragment), `handleIssueDetail` (issue body + comments)
- New templates: `issues.html` (tab bar + table), `issues_rows.html` (partial for tab swap), `issue_detail.html` (issue + threaded comments)
- Routes wired: `GET /ui/r/{owner}/{name}/issues`, `GET /ui/r/{owner}/{name}/issues/{number}`, `GET /ui/_/r/{owner}/{name}/issues`
- Tab filter uses vanilla JS fetch+innerHTML swap (consistent with existing `poll.js` approach; no HTMX lib dependency)
- Updated `cmd/ui-preview` fake store to satisfy the expanded interface with sample data
- Six new tests covering: list render, default-to-open state, 404 on unknown repo, partial fragment, detail render, 404/400 edge cases

## Test plan

- [x] `go test ./... -count=1` — all pass
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [ ] Manual: `go run ./cmd/ui-preview`, visit `/ui/r/acme/platform/issues` — verify open/closed tabs and detail page

## Notes for future

- Tab navigation could be extended to support author filtering (the `authorFilter` param is already threaded through `ListIssues`)
- Issue body is rendered as plain text; markdown rendering would improve readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)