### PR TITLE
feat: add commit log and commit detail pages to web UI (issue #97)

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -51,6 +51,12 @@ func (fakeRead) GetFile(_ context.Context, _, _, path string, _ *int64) (*store.
 }
 
 func (fakeRead) GetBranch(_ context.Context, _, _ string) (*store.BranchInfo, error) { return nil, nil }
+func (fakeRead) GetChain(_ context.Context, _ string, _, _ int64) ([]store.ChainEntry, error) {
+	return nil, nil
+}
+func (fakeRead) GetCommit(_ context.Context, _ string, _ int64) (*store.CommitDetail, error) {
+	return nil, nil
+}
 
 func (fakeRead) GetFileHistory(_ context.Context, _, _, _ string, _ int, _ *int64) ([]store.FileHistoryEntry, error) {
 	t := time.Now()

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -2,11 +2,13 @@ package ui
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/model"
@@ -16,6 +18,8 @@ import (
 // ---------------------------------------------------------------------------
 // Page data types
 // ---------------------------------------------------------------------------
+
+const logPageSize = 25
 
 type reposPage struct {
 	Orgs []orgGroup
@@ -81,6 +85,36 @@ type treeRow struct {
 	Name  string
 	Path  string
 	IsDir bool
+}
+
+type commitLogRow struct {
+	Seq     int64
+	Branch  string
+	Author  string
+	Message string
+	Time    time.Time
+}
+
+type logPage struct {
+	Repo      model.Repo
+	Branch    string
+	Rows      []commitLogRow
+	HasMore   bool
+	NextAfter int64
+}
+
+type logRowsData struct {
+	Repo      model.Repo
+	Branch    string
+	Rows      []commitLogRow
+	HasMore   bool
+	NextAfter int64
+}
+
+type commitDetailPage struct {
+	Repo   model.Repo
+	Branch string
+	Commit *store.CommitDetail
 }
 
 // ---------------------------------------------------------------------------
@@ -434,3 +468,200 @@ func siblingTreeRows(entries []store.TreeEntry, dir string) []treeRow {
 	})
 	return rows
 }
+
+// handleCommitLog renders the paginated commit log for a branch.
+func (h *Handler) handleCommitLog(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	branch := r.PathValue("branch")
+	repoName := owner + "/" + name
+
+	repo, err := h.write.GetRepo(r.Context(), repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	bi, err := h.read.GetBranch(r.Context(), repoName, branch)
+	if err != nil {
+		slog.Error("ui get branch", "repo", repoName, "branch", branch, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load branch")
+		return
+	}
+	if bi == nil {
+		h.renderError(w, http.StatusNotFound, "branch not found: "+branch)
+		return
+	}
+
+	headSeq := bi.HeadSequence
+	from := headSeq - int64(logPageSize) + 1
+	if from < 1 {
+		from = 1
+	}
+
+	entries, err := h.read.GetChain(r.Context(), repoName, from, headSeq)
+	if err != nil {
+		slog.Error("ui get chain", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load commits")
+		return
+	}
+
+	rows := chainToLogRows(entries, branch)
+	slices.Reverse(rows)
+
+	var nextAfter int64
+	hasMore := from > 1
+	if hasMore {
+		nextAfter = from
+	}
+
+	h.render(w, h.tmpl.commitLog, "layout.html", pageData{
+		Title: repoName + " / " + branch + " / log",
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: branch, Href: "/ui/r/" + repoName + "/b/" + branch},
+			{Label: "log", Href: ""},
+		},
+		Body: logPage{
+			Repo:      *repo,
+			Branch:    branch,
+			Rows:      rows,
+			HasMore:   hasMore,
+			NextAfter: nextAfter,
+		},
+	})
+}
+
+// handleLogRowsPartial returns just the table rows for HTMX "load more".
+func (h *Handler) handleLogRowsPartial(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	branch := r.PathValue("branch")
+	repoName := owner + "/" + name
+
+	afterStr := r.URL.Query().Get("after")
+	if afterStr == "" {
+		http.Error(w, "after parameter required", http.StatusBadRequest)
+		return
+	}
+	after, err := strconv.ParseInt(afterStr, 10, 64)
+	if err != nil || after < 1 {
+		http.Error(w, "invalid after parameter", http.StatusBadRequest)
+		return
+	}
+
+	to := after - 1
+	if to < 1 {
+		h.render(w, h.tmpl.logRows, "log_rows.html", logRowsData{})
+		return
+	}
+
+	from := to - int64(logPageSize) + 1
+	if from < 1 {
+		from = 1
+	}
+
+	entries, err := h.read.GetChain(r.Context(), repoName, from, to)
+	if err != nil {
+		slog.Error("ui get chain partial", "repo", repoName, "error", err)
+		http.Error(w, "query failed", http.StatusInternalServerError)
+		return
+	}
+
+	rows := chainToLogRows(entries, branch)
+	slices.Reverse(rows)
+
+	var nextAfter int64
+	hasMore := from > 1
+	if hasMore {
+		nextAfter = from
+	}
+
+	repo := &model.Repo{Name: repoName, Owner: owner}
+	h.render(w, h.tmpl.logRows, "log_rows.html", logRowsData{
+		Repo:      *repo,
+		Branch:    branch,
+		Rows:      rows,
+		HasMore:   hasMore,
+		NextAfter: nextAfter,
+	})
+}
+
+// handleCommitDetail renders a single commit with its changed files.
+func (h *Handler) handleCommitDetail(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	branch := r.PathValue("branch")
+	seqStr := r.PathValue("seq")
+	repoName := owner + "/" + name
+
+	seq, err := strconv.ParseInt(seqStr, 10, 64)
+	if err != nil || seq < 1 {
+		h.renderError(w, http.StatusBadRequest, "invalid seq")
+		return
+	}
+
+	repo, err := h.write.GetRepo(r.Context(), repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	commit, err := h.read.GetCommit(r.Context(), repoName, seq)
+	if err != nil {
+		slog.Error("ui get commit", "repo", repoName, "seq", seq, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load commit")
+		return
+	}
+	if commit == nil {
+		h.renderError(w, http.StatusNotFound, fmt.Sprintf("commit %d not found", seq))
+		return
+	}
+
+	h.render(w, h.tmpl.commitDetail, "layout.html", pageData{
+		Title: fmt.Sprintf("%s / %s / commit %d", repoName, branch, seq),
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: branch, Href: "/ui/r/" + repoName + "/b/" + branch},
+			{Label: "log", Href: "/ui/r/" + repoName + "/b/" + branch + "/log"},
+			{Label: fmt.Sprintf("seq %d", seq), Href: ""},
+		},
+		Body: commitDetailPage{
+			Repo:   *repo,
+			Branch: branch,
+			Commit: commit,
+		},
+	})
+}
+
+// chainToLogRows filters and converts ChainEntries to commitLogRows.
+// Only entries for the named branch are included.
+func chainToLogRows(entries []store.ChainEntry, branch string) []commitLogRow {
+	rows := make([]commitLogRow, 0, len(entries))
+	for _, e := range entries {
+		if e.Branch != branch {
+			continue
+		}
+		rows = append(rows, commitLogRow{
+			Seq:     e.Sequence,
+			Branch:  e.Branch,
+			Author:  e.Author,
+			Message: e.Message,
+			Time:    e.CreatedAt,
+		})
+	}
+	return rows
+}
+

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -21,6 +21,9 @@ type templateSet struct {
 	reviewComments *template.Template
 	fileView       *template.Template
 	errorPage      *template.Template
+	commitLog      *template.Template
+	logRows        *template.Template
+	commitDetail   *template.Template
 }
 
 func parseTemplates(root fs.FS) (*templateSet, error) {
@@ -71,6 +74,25 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse error: %w", err)
 	}
+	// log.html pulls in log_rows.html so the initial render shows the first
+	// page of rows inline, matching the same pattern as branch_detail.
+	commitLog, err := template.New("layout.html").
+		Funcs(funcMap()).
+		ParseFS(root,
+			"templates/layout.html",
+			"templates/log.html",
+			"templates/log_rows.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse log: %w", err)
+	}
+	logRows, err := loadFragment("log_rows.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse log_rows: %w", err)
+	}
+	commitDetail, err := load("commit.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse commit: %w", err)
+	}
 	return &templateSet{
 		repos:          repos,
 		branches:       branches,
@@ -79,6 +101,9 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		reviewComments: reviewComments,
 		fileView:       fileView,
 		errorPage:      errorPage,
+		commitLog:      commitLog,
+		logRows:        logRows,
+		commitDetail:   commitDetail,
 	}, nil
 }
 

--- a/internal/ui/templates/commit.html
+++ b/internal/ui/templates/commit.html
@@ -1,0 +1,36 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline">
+  <h1>commit {{.Commit.Sequence}}</h1>
+  <span class="meta">{{.Repo.Name}} · {{.Branch}}</span>
+</div>
+
+<div class="card">
+  <div class="commit-meta">
+    <div><strong>message</strong> {{.Commit.Message}}</div>
+    <div><strong>author</strong> {{.Commit.Author}}</div>
+    <div><strong>branch</strong> {{.Commit.Branch}}</div>
+    <div><strong>when</strong> {{relTime .Commit.CreatedAt}}</div>
+  </div>
+</div>
+
+<h2>files changed ({{len .Commit.Files}})</h2>
+<div class="card">
+  {{if not .Commit.Files}}
+    <div class="empty">no files changed</div>
+  {{else}}
+  <table class="grid">
+    <thead><tr><th>path</th><th>change</th></tr></thead>
+    <tbody>
+    {{range .Commit.Files}}
+    <tr>
+      <td><a href="/ui/r/{{$.Repo.Name}}/f/{{.Path}}?branch={{$.Branch}}&at={{$.Commit.Sequence}}">{{.Path}}</a></td>
+      <td><span class="badge {{diffClass .VersionID}}">{{if .VersionID}}modified{{else}}deleted{{end}}</span></td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{end}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/log.html
+++ b/internal/ui/templates/log.html
@@ -1,0 +1,20 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline">
+  <h1>{{.Repo.Name}} / {{.Branch}} / log</h1>
+</div>
+
+<div class="card">
+  {{if not .Rows}}
+    <div class="empty">no commits yet</div>
+  {{else}}
+  <table class="grid">
+    <thead><tr><th>seq</th><th>message</th><th>author</th><th>when</th></tr></thead>
+    <tbody id="log-rows">
+      {{template "log_rows.html" .}}
+    </tbody>
+  </table>
+  {{end}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/log_rows.html
+++ b/internal/ui/templates/log_rows.html
@@ -1,0 +1,18 @@
+{{define "log_rows.html"}}
+{{range .Rows}}
+<tr>
+  <td><a href="/ui/r/{{$.Repo.Name}}/b/{{$.Branch}}/c/{{.Seq}}">{{.Seq}}</a></td>
+  <td>{{.Message}}</td>
+  <td>{{.Author}}</td>
+  <td>{{relTime .Time}}</td>
+</tr>
+{{end}}
+{{if .HasMore}}
+<tr hx-get="/ui/_/r/{{.Repo.Name}}/b/{{.Branch}}/log?after={{.NextAfter}}"
+    hx-trigger="revealed"
+    hx-target="closest tr"
+    hx-swap="outerHTML">
+  <td colspan="4" class="load-more">loading more…</td>
+</tr>
+{{end}}
+{{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -23,6 +23,8 @@ type ReadStore interface {
 	GetBranch(ctx context.Context, repo, branch string) (*store.BranchInfo, error)
 	ListBranches(ctx context.Context, repo, statusFilter string, includeDraft, onlyDraft bool) ([]store.BranchInfo, error)
 	GetFileHistory(ctx context.Context, repo, branch, path string, limit int, afterSeq *int64) ([]store.FileHistoryEntry, error)
+	GetChain(ctx context.Context, repo string, from, to int64) ([]store.ChainEntry, error)
+	GetCommit(ctx context.Context, repo string, seq int64) (*store.CommitDetail, error)
 }
 
 // WriteStoreLite is the subset of server.WriteStore that the UI needs for
@@ -107,6 +109,9 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}", h.handleBranchDetail)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/checks", h.handleChecksPartial)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/comments", h.handleReviewCommentsPartial)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}/log", h.handleCommitLog)
+	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/log", h.handleLogRowsPartial)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}/c/{seq}", h.handleCommitDetail)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/f/{path...}", h.handleFile)
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -39,6 +39,12 @@ func (f *fakeRead) ListBranches(_ context.Context, repo, _ string, _, _ bool) ([
 func (f *fakeRead) GetFileHistory(_ context.Context, _, _, _ string, _ int, _ *int64) ([]store.FileHistoryEntry, error) {
 	return nil, nil
 }
+func (f *fakeRead) GetChain(_ context.Context, _ string, _, _ int64) ([]store.ChainEntry, error) {
+	return nil, nil
+}
+func (f *fakeRead) GetCommit(_ context.Context, _ string, _ int64) (*store.CommitDetail, error) {
+	return nil, nil
+}
 
 type fakeWrite struct {
 	repos []model.Repo


### PR DESCRIPTION
## Summary

- Add `GET /ui/r/{owner}/{name}/b/{branch}/log` — paginated commit log using `store.GetChain`. Shows seq, message, author, and relative timestamp.
- Add `GET /ui/_/r/{owner}/{name}/b/{branch}/log?after={seq}` — HTMX partial that returns only `<tr>` rows for "load more"; the last visible row triggers it via `hx-trigger="revealed"`.
- Add `GET /ui/r/{owner}/{name}/b/{branch}/c/{seq}` — commit detail page using `store.GetCommit`. Shows commit metadata and the list of files changed, each linking to the file viewer at that sequence.
- Extend `ui.ReadStore` interface with `GetChain` and `GetCommit` (matching signatures from `internal/server/server.go`).
- Add stub implementations to `fakeRead` in `ui_test.go` and `cmd/ui-preview/main.go`.
- Resolve merge conflicts from upstream changes (GetFileHistory, review-comments route, ListReviewComments/ListOrgMembers/ListRoles in WriteStoreLite).

## Implementation notes

- Follows the same pattern as `handleChecksPartial`/`branch_checks.html` for the HTMX fragment.
- `log.html` pulls in `log_rows.html` at parse time (same pattern as `branch_detail.html` + `branch_checks.html`) so the initial render includes the first page inline.
- Pagination is newest-first: initial page fetches `[max(1, headSeq-24), headSeq]` and reverses; load-more fetches `[max(1, after-25), after-1]` and reverses.
- Commits are filtered by branch name so feature branch logs don't include commits from other branches in the same sequence window.

## Test plan

- [ ] `go test ./... -count=1` passes (pre-existing `TestDockerSmoke` failure is a gcloud auth issue unrelated to this change)
- [ ] `go build ./...` and `go vet ./...` pass
- [ ] Navigate to `/ui/r/{owner}/{name}/b/{branch}/log` and verify commit rows render
- [ ] Scroll to bottom to trigger HTMX load-more (if headSeq > 25)
- [ ] Click a seq link to reach `/ui/r/{owner}/{name}/b/{branch}/c/{seq}` commit detail
- [ ] Verify file links on commit detail navigate to file viewer with correct `branch` and `at` params

🤖 Generated with [Claude Code](https://claude.com/claude-code)