### PR TITLE
feat: add org overview page at GET /ui/o/{org}

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -117,6 +117,24 @@ func (fakeWrite) ListRoles(_ context.Context, _ string) ([]model.Role, error) {
 	}, nil
 }
 
+func (fakeWrite) ListInvites(_ context.Context, _ string) ([]model.OrgInvite, error) {
+	t := time.Now()
+	return []model.OrgInvite{
+		{ID: "inv-1", Org: "acme", Email: "newbie@example.com", Role: api.OrgRoleMember, InvitedBy: "ajay@acme", ExpiresAt: t.Add(7 * 24 * time.Hour), CreatedAt: t.Add(-2 * 24 * time.Hour)},
+	}, nil
+}
+
+func (fakeWrite) ListOrgRepos(_ context.Context, owner string) ([]model.Repo, error) {
+	all, _ := (fakeWrite{}).ListRepos(context.Background())
+	var out []model.Repo
+	for _, r := range all {
+		if r.Owner == owner {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
 func (fakeWrite) GetRepo(_ context.Context, name string) (*model.Repo, error) {
 	all, _ := (fakeWrite{}).ListRepos(context.Background())
 	for _, r := range all {

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -30,6 +30,13 @@ type orgGroup struct {
 	Repos []model.Repo
 }
 
+type orgPage struct {
+	Org     string
+	Repos   []model.Repo
+	Members []model.OrgMember
+	Invites []model.OrgInvite
+}
+
 type branchesPage struct {
 	Repo      model.Repo
 	Active    []branchRow
@@ -146,6 +153,51 @@ func (h *Handler) handleRepos(w http.ResponseWriter, r *http.Request) {
 		Title:       "Repos",
 		Breadcrumbs: []crumb{{Label: "repos", Href: "/ui/"}},
 		Body:        reposPage{Orgs: orgs},
+	})
+}
+
+// handleOrg renders the org overview page: repos, members, and pending invites.
+func (h *Handler) handleOrg(w http.ResponseWriter, r *http.Request) {
+	org := r.PathValue("org")
+	ctx := r.Context()
+
+	repos, err := h.write.ListOrgRepos(ctx, org)
+	if err != nil {
+		slog.Error("ui list org repos", "org", org, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repos")
+		return
+	}
+	members, err := h.write.ListOrgMembers(ctx, org)
+	if err != nil {
+		slog.Error("ui list org members", "org", org, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load members")
+		return
+	}
+	invites, err := h.write.ListInvites(ctx, org)
+	if err != nil {
+		slog.Error("ui list invites", "org", org, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load invites")
+		return
+	}
+	var pending []model.OrgInvite
+	for _, inv := range invites {
+		if inv.AcceptedAt == nil {
+			pending = append(pending, inv)
+		}
+	}
+
+	h.render(w, h.tmpl.org, "layout.html", pageData{
+		Title: org,
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: org, Href: ""},
+		},
+		Body: orgPage{
+			Org:     org,
+			Repos:   repos,
+			Members: members,
+			Invites: pending,
+		},
 	})
 }
 

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -24,6 +24,7 @@ type templateSet struct {
 	commitLog      *template.Template
 	logRows        *template.Template
 	commitDetail   *template.Template
+	org            *template.Template
 }
 
 func parseTemplates(root fs.FS) (*templateSet, error) {
@@ -93,6 +94,10 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse commit: %w", err)
 	}
+	org, err := load("org.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse org: %w", err)
+	}
 	return &templateSet{
 		repos:          repos,
 		branches:       branches,
@@ -104,6 +109,7 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		commitLog:      commitLog,
 		logRows:        logRows,
 		commitDetail:   commitDetail,
+		org:            org,
 	}, nil
 }
 

--- a/internal/ui/templates/org.html
+++ b/internal/ui/templates/org.html
@@ -1,0 +1,63 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline"><h1>{{.Org}}</h1></div>
+
+<h2>Repos ({{len .Repos}})</h2>
+<div class="card">
+  {{if not .Repos}}
+    <div class="empty">No repos.</div>
+  {{else}}
+  <div class="row-list">
+    {{range .Repos}}
+    <a href="/ui/r/{{.Name}}">
+      <span>{{.Name}}</span>
+      <span class="meta">by {{.CreatedBy}} · {{relTime .CreatedAt}}</span>
+    </a>
+    {{end}}
+  </div>
+  {{end}}
+</div>
+
+<h2>Members ({{len .Members}})</h2>
+<div class="card">
+  {{if not .Members}}
+    <div class="empty">No members.</div>
+  {{else}}
+  <table class="grid">
+    <thead><tr><th>identity</th><th>role</th><th>invited by</th><th>joined</th></tr></thead>
+    <tbody>
+    {{range .Members}}
+    <tr>
+      <td>{{.Identity}}</td>
+      <td><span class="badge {{statusClass .Role}}">{{.Role}}</span></td>
+      <td>{{.InvitedBy}}</td>
+      <td>{{relTime .CreatedAt}}</td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{end}}
+</div>
+
+<h2>Pending invites ({{len .Invites}})</h2>
+<div class="card">
+  {{if not .Invites}}
+    <div class="empty">No pending invites.</div>
+  {{else}}
+  <table class="grid">
+    <thead><tr><th>email</th><th>role</th><th>invited by</th><th>expires</th></tr></thead>
+    <tbody>
+    {{range .Invites}}
+    <tr>
+      <td>{{.Email}}</td>
+      <td><span class="badge {{statusClass .Role}}">{{.Role}}</span></td>
+      <td>{{.InvitedBy}}</td>
+      <td>{{relTime .ExpiresAt}}</td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{end}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/repos.html
+++ b/internal/ui/templates/repos.html
@@ -6,7 +6,7 @@
 {{else}}
   {{range .Orgs}}
   <div class="card">
-    <h2>{{.Name}}</h2>
+    <h2><a href="/ui/o/{{.Name}}">{{.Name}}</a></h2>
     <div class="row-list">
       {{range .Repos}}
       <a href="/ui/r/{{.Name}}">

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -36,6 +36,8 @@ type WriteStoreLite interface {
 	ListReviewComments(ctx context.Context, repo, branch string, path *string) ([]model.ReviewComment, error)
 	ListOrgMembers(ctx context.Context, org string) ([]model.OrgMember, error)
 	ListRoles(ctx context.Context, repo string) ([]model.Role, error)
+	ListInvites(ctx context.Context, org string) ([]model.OrgInvite, error)
+	ListOrgRepos(ctx context.Context, owner string) ([]model.Repo, error)
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -105,6 +107,7 @@ func NewHandlerDev(read ReadStore, write WriteStoreLite, assemble AssembleFn) (*
 // placing this mux behind the same middleware chain used by the JSON API.
 func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/{$}", h.handleRepos)
+	mux.HandleFunc("GET /ui/o/{org}", h.handleOrg)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}", h.handleBranches)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}", h.handleBranchDetail)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/checks", h.handleChecksPartial)

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -73,6 +73,18 @@ func (f *fakeWrite) ListOrgMembers(_ context.Context, _ string) ([]model.OrgMemb
 func (f *fakeWrite) ListRoles(_ context.Context, _ string) ([]model.Role, error) {
 	return nil, nil
 }
+func (f *fakeWrite) ListInvites(_ context.Context, _ string) ([]model.OrgInvite, error) {
+	return nil, nil
+}
+func (f *fakeWrite) ListOrgRepos(_ context.Context, owner string) ([]model.Repo, error) {
+	var out []model.Repo
+	for _, r := range f.repos {
+		if r.Owner == owner {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
 
 func newFakeAssembler(branchName string) AssembleFn {
 	return func(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
@@ -242,6 +254,28 @@ func TestHandleFile_RendersTreeAndContent(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("missing %q in body", want)
 		}
+	}
+}
+
+func TestHandleOrg_RendersReposMembersInvites(t *testing.T) {
+	repos := []model.Repo{
+		{Name: "acme/a", Owner: "acme", CreatedBy: "me", CreatedAt: time.Now().Add(-1 * time.Hour)},
+		{Name: "acme/b", Owner: "acme", CreatedBy: "me", CreatedAt: time.Now()},
+		{Name: "beta/x", Owner: "beta", CreatedBy: "you", CreatedAt: time.Now()},
+	}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/o/acme")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200. body=%s", code, body)
+	}
+	for _, want := range []string{"acme/a", "acme/b", "Members", "Pending invites"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+	if strings.Contains(body, "beta/x") {
+		t.Errorf("body should not contain repo from different org")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds new web UI page `GET /ui/o/{org}` showing three sections: repos (with links), members (identity/role/invited_by/joined), and pending invites (email/role/invited_by/expires)
- Extends `WriteStoreLite` interface with `ListOrgMembers`, `ListInvites`, `ListOrgRepos` to match signatures from `server.WriteStore`
- Links org name headings on the repos landing page (`/ui/`) to the new org page
- Resolves merge conflicts from concurrent branch changes (adds both `reviewComments`/`ListReviewComments`/`ListRoles` from upstream and org fields from this branch)

Closes #97

## Test plan

- [ ] `go test ./... -count=1` passes
- [ ] `go build ./... && go vet ./...` clean
- [ ] New `TestHandleOrg_RendersReposMembersInvites` test verifies org page renders repos scoped to the org and shows Members/Pending invites sections
- [ ] Org headings on `/ui/` now link to `/ui/o/{org}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)