### PR TITLE
feat: add check run log links and attempt history to web UI

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -117,6 +117,10 @@ func (fakeWrite) ListRoles(_ context.Context, _ string) ([]model.Role, error) {
 	}, nil
 }
 
+func (fakeWrite) ListCheckRuns(_ context.Context, _, _ string, _ *int64, _ bool) ([]model.CheckRun, error) {
+	return nil, nil
+}
+
 func (fakeWrite) GetRepo(_ context.Context, name string) (*model.Repo, error) {
 	all, _ := (fakeWrite{}).ListRepos(context.Background())
 	for _, r := range all {

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -306,6 +306,37 @@ func (h *Handler) handleChecksPartial(w http.ResponseWriter, r *http.Request) {
 	h.render(w, h.tmpl.branchChecks, "branch_checks.html", actCtx)
 }
 
+// handleCheckHistoryPartial returns the attempt history for a single named
+// check as an HTML fragment (no layout wrapper) for HTMX inline expansion.
+func (h *Handler) handleCheckHistoryPartial(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	branch := r.PathValue("branch")
+	checkName := r.URL.Query().Get("check")
+	repoName := owner + "/" + name
+
+	if checkName == "" {
+		http.Error(w, "check query parameter required", http.StatusBadRequest)
+		return
+	}
+
+	runs, err := h.write.ListCheckRuns(r.Context(), repoName, branch, nil, true)
+	if err != nil {
+		slog.Error("ui list check runs history", "repo", repoName, "branch", branch, "error", err)
+		http.Error(w, "query failed", http.StatusInternalServerError)
+		return
+	}
+
+	var filtered []model.CheckRun
+	for _, run := range runs {
+		if run.CheckName == checkName {
+			filtered = append(filtered, run)
+		}
+	}
+
+	h.render(w, h.tmpl.checkHistory, "check_history.html", filtered)
+}
+
 // handleFile renders a file viewer with a sibling tree pane.
 func (h *Handler) handleFile(w http.ResponseWriter, r *http.Request) {
 	owner := r.PathValue("owner")

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -18,6 +18,7 @@ type templateSet struct {
 	branches       *template.Template
 	branchDetail   *template.Template
 	branchChecks   *template.Template
+	checkHistory   *template.Template
 	reviewComments *template.Template
 	fileView       *template.Template
 	errorPage      *template.Template
@@ -62,6 +63,10 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse branch_checks: %w", err)
 	}
+	checkHistory, err := loadFragment("check_history.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse check_history: %w", err)
+	}
 	reviewComments, err := loadFragment("review_comments.html")
 	if err != nil {
 		return nil, fmt.Errorf("parse review_comments: %w", err)
@@ -98,6 +103,7 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		branches:       branches,
 		branchDetail:   branchDetail,
 		branchChecks:   branchChecks,
+		checkHistory:   checkHistory,
 		reviewComments: reviewComments,
 		fileView:       fileView,
 		errorPage:      errorPage,

--- a/internal/ui/templates/branch_checks.html
+++ b/internal/ui/templates/branch_checks.html
@@ -4,24 +4,20 @@
 {{range .CheckRuns}}{{if eq (printf "%s" .Status) "passed"}}{{$passed = add $passed 1}}{{end}}{{end}}
 {{range .CheckRuns}}
 {{if ne (printf "%s" .Status) "passed"}}
-{{if .LogURL}}
-<a class="check-row link" href="{{.LogURL}}" target="_blank" rel="noopener">
-  <div>
-    <strong>{{.CheckName}}</strong>
-    <span class="badge {{statusClass (printf "%s" .Status)}}">{{.Status}}</span>
-    <div class="meta">{{.Reporter}} @ seq {{.Sequence}} · {{relTime .CreatedAt}}</div>
-  </div>
-  <span class="open-log">logs →</span>
-</a>
-{{else}}
 <div class="check-row">
   <div>
     <strong>{{.CheckName}}</strong>
     <span class="badge {{statusClass (printf "%s" .Status)}}">{{.Status}}</span>
     <div class="meta">{{.Reporter}} @ seq {{.Sequence}} · {{relTime .CreatedAt}}</div>
   </div>
+  <div class="check-row-actions">
+    {{if .LogURL}}<a href="{{.LogURL}}" target="_blank" rel="noopener" class="open-log">logs →</a>{{end}}
+    <button class="btn-history"
+      hx-get="/ui/_/r/{{$.Branch.Repo}}/b/{{$.Branch.Name}}/check-history?check={{.CheckName}}"
+      hx-swap="afterend"
+      hx-target="closest .check-row">history ▾</button>
+  </div>
 </div>
-{{end}}
 {{end}}
 {{end}}
 {{if gt $passed 0}}

--- a/internal/ui/templates/check_history.html
+++ b/internal/ui/templates/check_history.html
@@ -1,0 +1,28 @@
+{{define "check_history.html"}}
+{{if not .}}<div class="meta">no history found</div>{{else}}
+<table class="check-history-table">
+  <thead>
+    <tr>
+      <th>Attempt</th>
+      <th>Status</th>
+      <th>Reporter</th>
+      <th>Seq</th>
+      <th>When</th>
+      <th>Logs</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{range .}}
+    <tr>
+      <td>{{.Attempt}}</td>
+      <td><span class="badge {{statusClass (printf "%s" .Status)}}">{{.Status}}</span></td>
+      <td>{{.Reporter}}</td>
+      <td>{{.Sequence}}</td>
+      <td>{{relTime .CreatedAt}}</td>
+      <td>{{if .LogURL}}<a href="{{.LogURL}}" target="_blank" rel="noopener">logs</a>{{else}}—{{end}}</td>
+    </tr>
+    {{end}}
+  </tbody>
+</table>
+{{end}}
+{{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -36,6 +36,7 @@ type WriteStoreLite interface {
 	ListReviewComments(ctx context.Context, repo, branch string, path *string) ([]model.ReviewComment, error)
 	ListOrgMembers(ctx context.Context, org string) ([]model.OrgMember, error)
 	ListRoles(ctx context.Context, repo string) ([]model.Role, error)
+	ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64, history bool) ([]model.CheckRun, error)
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -112,6 +113,7 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}/log", h.handleCommitLog)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/log", h.handleLogRowsPartial)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}/c/{seq}", h.handleCommitDetail)
+	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/check-history", h.handleCheckHistoryPartial)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/f/{path...}", h.handleFile)
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -73,6 +73,9 @@ func (f *fakeWrite) ListOrgMembers(_ context.Context, _ string) ([]model.OrgMemb
 func (f *fakeWrite) ListRoles(_ context.Context, _ string) ([]model.Role, error) {
 	return nil, nil
 }
+func (f *fakeWrite) ListCheckRuns(_ context.Context, _, _ string, _ *int64, _ bool) ([]model.CheckRun, error) {
+	return nil, nil
+}
 
 func newFakeAssembler(branchName string) AssembleFn {
 	return func(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
@@ -217,6 +220,29 @@ func TestHandleChecksPartial_ReturnsFragment(t *testing.T) {
 	}
 	if !strings.Contains(body, "no checks yet") {
 		t.Errorf("expected empty-checks marker, got: %s", body)
+	}
+}
+
+func TestHandleCheckHistoryPartial_ReturnsFragment(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme"}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, newFakeAssembler("feat-x"))
+
+	// Missing check param → 400
+	code, _ := getStatusAndBody(t, h, "/ui/_/r/acme/a/b/feat-x/check-history")
+	if code != http.StatusBadRequest {
+		t.Fatalf("missing check param: status = %d, want 400", code)
+	}
+
+	// With check param → 200 fragment (no layout)
+	code, body := getStatusAndBody(t, h, "/ui/_/r/acme/a/b/feat-x/check-history?check=lint")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if strings.Contains(body, "<!doctype html>") {
+		t.Errorf("expected fragment, got full layout")
+	}
+	if !strings.Contains(body, "no history found") {
+		t.Errorf("expected empty-history marker, got: %s", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #97. Two targeted improvements to the branch checks partial in the web UI:

- **Log links**: Each non-passed check row now shows a `logs →` link when `CheckRun.LogURL` is set
- **Attempt history toggle**: A `history ▾` button per check row fires an HTMX request to the new partial endpoint and swaps in a table of all past attempts inline (no page reload)

## Changes

- `internal/ui/ui.go`: Added `ListCheckRuns` to `WriteStoreLite` interface; registered new `GET /ui/_/r/{owner}/{name}/b/{branch}/check-history` route
- `internal/ui/handlers.go`: Added `handleCheckHistoryPartial` — queries `ListCheckRuns` with `history=true`, filters to the named check, renders the fragment
- `internal/ui/templates/check_history.html`: New fragment-only template showing attempt#, status, reporter, seq, when, and log link per row
- `internal/ui/templates/branch_checks.html`: Replaced the old `<a class="check-row link">` pattern with a flex row containing a separate `logs →` link and a `history ▾` HTMX button
- `internal/ui/render.go`: Added `checkHistory` to `templateSet` and loading in `parseTemplates`
- `internal/ui/ui_test.go`: Added `TestHandleCheckHistoryPartial_ReturnsFragment`; updated `fakeWrite` to implement new interface methods
- `cmd/ui-preview/main.go`: Updated `fakeWrite` to satisfy the updated interface
- Resolved merge conflicts with upstream PR adding review comments partial

## Test plan

- [x] `go test ./internal/ui/... -count=1` — all 9 tests pass including new `TestHandleCheckHistoryPartial_ReturnsFragment`
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `TestDockerSmoke` failure in `internal/server` is pre-existing (requires GCP credentials, not related to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)