### PR TITLE
feat: add check run log links and attempt history to web UI

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -117,6 +117,10 @@ func (fakeWrite) ListRoles(_ context.Context, _ string) ([]model.Role, error) {
 	}, nil
 }
 
+func (fakeWrite) ListCheckRuns(_ context.Context, _, _ string, _ *int64, _ bool) ([]model.CheckRun, error) {
+	return nil, nil
+}
+
 func (fakeWrite) GetRepo(_ context.Context, name string) (*model.Repo, error) {
 	all, _ := (fakeWrite{}).ListRepos(context.Background())
 	for _, r := range all {

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -306,6 +306,37 @@ func (h *Handler) handleChecksPartial(w http.ResponseWriter, r *http.Request) {
 	h.render(w, h.tmpl.branchChecks, "branch_checks.html", actCtx)
 }
 
+// handleCheckHistoryPartial returns the attempt history for a single named
+// check as an HTML fragment (no layout wrapper) for HTMX inline expansion.
+func (h *Handler) handleCheckHistoryPartial(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	branch := r.PathValue("branch")
+	checkName := r.URL.Query().Get("check")
+	repoName := owner + "/" + name
+
+	if checkName == "" {
+		http.Error(w, "check query parameter required", http.StatusBadRequest)
+		return
+	}
+
+	runs, err := h.write.ListCheckRuns(r.Context(), repoName, branch, nil, true)
+	if err != nil {
+		slog.Error("ui list check runs history", "repo", repoName, "branch", branch, "error", err)
+		http.Error(w, "query failed", http.StatusInternalServerError)
+		return
+	}
+
+	var filtered []model.CheckRun
+	for _, run := range runs {
+		if run.CheckName == checkName {
+			filtered = append(filtered, run)
+		}
+	}
+
+	h.render(w, h.tmpl.checkHistory, "check_history.html", filtered)
+}
+
 // handleFile renders a file viewer with a sibling tree pane.
 func (h *Handler) handleFile(w http.ResponseWriter, r *http.Request) {
 	owner := r.PathValue("owner")

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -18,6 +18,7 @@ type templateSet struct {
 	branches       *template.Template
 	branchDetail   *template.Template
 	branchChecks   *template.Template
+	checkHistory   *template.Template
 	reviewComments *template.Template
 	fileView       *template.Template
 	errorPage      *template.Template
@@ -62,6 +63,10 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse branch_checks: %w", err)
 	}
+	checkHistory, err := loadFragment("check_history.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse check_history: %w", err)
+	}
 	reviewComments, err := loadFragment("review_comments.html")
 	if err != nil {
 		return nil, fmt.Errorf("parse review_comments: %w", err)
@@ -98,6 +103,7 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		branches:       branches,
 		branchDetail:   branchDetail,
 		branchChecks:   branchChecks,
+		checkHistory:   checkHistory,
 		reviewComments: reviewComments,
 		fileView:       fileView,
 		errorPage:      errorPage,

--- a/internal/ui/templates/branch_checks.html
+++ b/internal/ui/templates/branch_checks.html
@@ -4,24 +4,20 @@
 {{range .CheckRuns}}{{if eq (printf "%s" .Status) "passed"}}{{$passed = add $passed 1}}{{end}}{{end}}
 {{range .CheckRuns}}
 {{if ne (printf "%s" .Status) "passed"}}
-{{if .LogURL}}
-<a class="check-row link" href="{{.LogURL}}" target="_blank" rel="noopener">
-  <div>
-    <strong>{{.CheckName}}</strong>
-    <span class="badge {{statusClass (printf "%s" .Status)}}">{{.Status}}</span>
-    <div class="meta">{{.Reporter}} @ seq {{.Sequence}} · {{relTime .CreatedAt}}</div>
-  </div>
-  <span class="open-log">logs →</span>
-</a>
-{{else}}
 <div class="check-row">
   <div>
     <strong>{{.CheckName}}</strong>
     <span class="badge {{statusClass (printf "%s" .Status)}}">{{.Status}}</span>
     <div class="meta">{{.Reporter}} @ seq {{.Sequence}} · {{relTime .CreatedAt}}</div>
   </div>
+  <div class="check-row-actions">
+    {{if .LogURL}}<a href="{{.LogURL}}" target="_blank" rel="noopener" class="open-log">logs →</a>{{end}}
+    <button class="btn-history"
+      hx-get="/ui/_/r/{{$.Branch.Repo}}/b/{{$.Branch.Name}}/check-history?check={{.CheckName}}"
+      hx-swap="afterend"
+      hx-target="closest .check-row">history ▾</button>
+  </div>
 </div>
-{{end}}
 {{end}}
 {{end}}
 {{if gt $passed 0}}

--- a/internal/ui/templates/check_history.html
+++ b/internal/ui/templates/check_history.html
@@ -1,0 +1,28 @@
+{{define "check_history.html"}}
+{{if not .}}<div class="meta">no history found</div>{{else}}
+<table class="check-history-table">
+  <thead>
+    <tr>
+      <th>Attempt</th>
+      <th>Status</th>
+      <th>Reporter</th>
+      <th>Seq</th>
+      <th>When</th>
+      <th>Logs</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{range .}}
+    <tr>
+      <td>{{.Attempt}}</td>
+      <td><span class="badge {{statusClass (printf "%s" .Status)}}">{{.Status}}</span></td>
+      <td>{{.Reporter}}</td>
+      <td>{{.Sequence}}</td>
+      <td>{{relTime .CreatedAt}}</td>
+      <td>{{if .LogURL}}<a href="{{.LogURL}}" target="_blank" rel="noopener">logs</a>{{else}}—{{end}}</td>
+    </tr>
+    {{end}}
+  </tbody>
+</table>
+{{end}}
+{{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -36,6 +36,7 @@ type WriteStoreLite interface {
 	ListReviewComments(ctx context.Context, repo, branch string, path *string) ([]model.ReviewComment, error)
 	ListOrgMembers(ctx context.Context, org string) ([]model.OrgMember, error)
 	ListRoles(ctx context.Context, repo string) ([]model.Role, error)
+	ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64, history bool) ([]model.CheckRun, error)
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -112,6 +113,7 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}/log", h.handleCommitLog)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/log", h.handleLogRowsPartial)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}/c/{seq}", h.handleCommitDetail)
+	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/check-history", h.handleCheckHistoryPartial)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/f/{path...}", h.handleFile)
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -73,6 +73,9 @@ func (f *fakeWrite) ListOrgMembers(_ context.Context, _ string) ([]model.OrgMemb
 func (f *fakeWrite) ListRoles(_ context.Context, _ string) ([]model.Role, error) {
 	return nil, nil
 }
+func (f *fakeWrite) ListCheckRuns(_ context.Context, _, _ string, _ *int64, _ bool) ([]model.CheckRun, error) {
+	return nil, nil
+}
 
 func newFakeAssembler(branchName string) AssembleFn {
 	return func(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
@@ -217,6 +220,29 @@ func TestHandleChecksPartial_ReturnsFragment(t *testing.T) {
 	}
 	if !strings.Contains(body, "no checks yet") {
 		t.Errorf("expected empty-checks marker, got: %s", body)
+	}
+}
+
+func TestHandleCheckHistoryPartial_ReturnsFragment(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme"}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, newFakeAssembler("feat-x"))
+
+	// Missing check param → 400
+	code, _ := getStatusAndBody(t, h, "/ui/_/r/acme/a/b/feat-x/check-history")
+	if code != http.StatusBadRequest {
+		t.Fatalf("missing check param: status = %d, want 400", code)
+	}
+
+	// With check param → 200 fragment (no layout)
+	code, body := getStatusAndBody(t, h, "/ui/_/r/acme/a/b/feat-x/check-history?check=lint")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if strings.Contains(body, "<!doctype html>") {
+		t.Errorf("expected fragment, got full layout")
+	}
+	if !strings.Contains(body, "no history found") {
+		t.Errorf("expected empty-history marker, got: %s", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds direct log links on check run rows in the branch checks panel
- Adds HTMX-powered attempt history expansion for check runs (via new `check_history.html` partial and `handleCheckHistoryPartial` handler)
- Registers new route `GET /ui/_/r/{owner}/{name}/b/{branch}/check-history`

## Changes

- `internal/ui/handlers.go` — new `handleCheckHistoryPartial` handler
- `internal/ui/render.go` — render helper for check history
- `internal/ui/templates/branch_checks.html` — log links + history expand trigger
- `internal/ui/templates/check_history.html` — new partial template for attempt history
- `internal/ui/ui.go` — route registration (rebased alongside commit-log routes from main)
- `internal/ui/ui_test.go` — handler route tests
- `cmd/ui-preview/main.go` — preview wiring

## Rebase notes

Rebased onto `origin/main` (which included commit-log routes). Single conflict in `internal/ui/ui.go` — resolved by keeping both the commit-log routes from main and the check-history route from this branch.

## Test plan

- `go build ./...` — clean
- `go test ./... -count=1` — all packages pass
- `TestDockerSmoke` in `internal/server` fails due to missing GCP credentials (`docker-credential-gcloud` auth error) — pre-existing infrastructure issue unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)