### PR TITLE
feat: add org overview page

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -121,6 +121,24 @@ func (fakeWrite) ListCheckRuns(_ context.Context, _, _ string, _ *int64, _ bool)
 	return nil, nil
 }
 
+func (fakeWrite) ListInvites(_ context.Context, _ string) ([]model.OrgInvite, error) {
+	t := time.Now()
+	return []model.OrgInvite{
+		{ID: "inv-1", Org: "acme", Email: "newbie@example.com", Role: api.OrgRoleMember, InvitedBy: "ajay@acme", ExpiresAt: t.Add(7 * 24 * time.Hour), CreatedAt: t.Add(-2 * 24 * time.Hour)},
+	}, nil
+}
+
+func (fakeWrite) ListOrgRepos(_ context.Context, owner string) ([]model.Repo, error) {
+	all, _ := (fakeWrite{}).ListRepos(context.Background())
+	var out []model.Repo
+	for _, r := range all {
+		if r.Owner == owner {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
 func (fakeWrite) GetRepo(_ context.Context, name string) (*model.Repo, error) {
 	all, _ := (fakeWrite{}).ListRepos(context.Background())
 	for _, r := range all {

--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -131,6 +131,41 @@ func (fakeWrite) GetRepo(_ context.Context, name string) (*model.Repo, error) {
 	return nil, db.ErrRepoNotFound
 }
 
+func (fakeWrite) ListProposals(_ context.Context, _ string, _ *model.ProposalState, _ *string) ([]*model.Proposal, error) {
+	t := time.Now()
+	return []*model.Proposal{
+		{ID: "p-preview-1", Repo: "acme/platform", Branch: "add-onboarding-guide", BaseBranch: "main", Title: "docs: add onboarding guide", Author: "ajay@acme", State: model.ProposalOpen, CreatedAt: t.Add(-3 * time.Hour)},
+		{ID: "p-preview-2", Repo: "acme/platform", Branch: "bump-arch-doc", BaseBranch: "main", Title: "docs: update architecture notes", Author: "sam@acme", State: model.ProposalMerged, CreatedAt: t.Add(-24 * time.Hour)},
+	}, nil
+}
+
+func (fakeWrite) GetProposal(_ context.Context, _, id string) (*model.Proposal, error) {
+	t := time.Now()
+	proposals := map[string]*model.Proposal{
+		"p-preview-1": {ID: "p-preview-1", Repo: "acme/platform", Branch: "add-onboarding-guide", BaseBranch: "main", Title: "docs: add onboarding guide", Description: "Fills the gap new contributors keep asking about in slack.", Author: "ajay@acme", State: model.ProposalOpen, CreatedAt: t.Add(-3 * time.Hour), UpdatedAt: t.Add(-30 * time.Minute)},
+		"p-preview-2": {ID: "p-preview-2", Repo: "acme/platform", Branch: "bump-arch-doc", BaseBranch: "main", Title: "docs: update architecture notes", Author: "sam@acme", State: model.ProposalMerged, CreatedAt: t.Add(-24 * time.Hour), UpdatedAt: t.Add(-24 * time.Hour)},
+	}
+	return proposals[id], nil
+}
+
+func (fakeWrite) ListReleases(_ context.Context, _ string, _ int, _ string) ([]model.Release, error) {
+	t := time.Now()
+	return []model.Release{
+		{ID: "rel-1", Repo: "acme/platform", Name: "v1.0.0", Sequence: 42, Body: "Initial stable release.\n\n- Platform foundation\n- Reviewer policy v1\n- Onboarding guide", CreatedBy: "ajay@acme", CreatedAt: t.Add(-7 * 24 * time.Hour)},
+		{ID: "rel-2", Repo: "acme/platform", Name: "v1.1.0", Sequence: 48, Body: "Minor update.\n\n- Updated architecture doc\n- Tightened reviewer policy", CreatedBy: "sam@acme", CreatedAt: t.Add(-2 * 24 * time.Hour)},
+	}, nil
+}
+
+func (fakeWrite) GetRelease(_ context.Context, _, name string) (*model.Release, error) {
+	t := time.Now()
+	releases := map[string]*model.Release{
+		"v1.0.0": {ID: "rel-1", Repo: "acme/platform", Name: "v1.0.0", Sequence: 42, Body: "Initial stable release.\n\n- Platform foundation\n- Reviewer policy v1\n- Onboarding guide", CreatedBy: "ajay@acme", CreatedAt: t.Add(-7 * 24 * time.Hour)},
+		"v1.1.0": {ID: "rel-2", Repo: "acme/platform", Name: "v1.1.0", Sequence: 48, Body: "Minor update.\n\n- Updated architecture doc\n- Tightened reviewer policy", CreatedBy: "sam@acme", CreatedAt: t.Add(-2 * 24 * time.Hour)},
+	}
+	r := releases[name]
+	return r, nil
+}
+
 func fakeAssemble(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
 	t := time.Now()
 	vid := func(s string) *string { return &s }

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -30,6 +30,13 @@ type orgGroup struct {
 	Repos []model.Repo
 }
 
+type orgPage struct {
+	Org     string
+	Repos   []model.Repo
+	Members []model.OrgMember
+	Invites []model.OrgInvite
+}
+
 type branchesPage struct {
 	Repo      model.Repo
 	Active    []branchRow
@@ -167,6 +174,51 @@ func (h *Handler) handleRepos(w http.ResponseWriter, r *http.Request) {
 		Title:       "Repos",
 		Breadcrumbs: []crumb{{Label: "repos", Href: "/ui/"}},
 		Body:        reposPage{Orgs: orgs},
+	})
+}
+
+// handleOrg renders the org overview page: repos, members, and pending invites.
+func (h *Handler) handleOrg(w http.ResponseWriter, r *http.Request) {
+	org := r.PathValue("org")
+	ctx := r.Context()
+
+	repos, err := h.write.ListOrgRepos(ctx, org)
+	if err != nil {
+		slog.Error("ui list org repos", "org", org, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repos")
+		return
+	}
+	members, err := h.write.ListOrgMembers(ctx, org)
+	if err != nil {
+		slog.Error("ui list org members", "org", org, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load members")
+		return
+	}
+	invites, err := h.write.ListInvites(ctx, org)
+	if err != nil {
+		slog.Error("ui list invites", "org", org, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load invites")
+		return
+	}
+	var pending []model.OrgInvite
+	for _, inv := range invites {
+		if inv.AcceptedAt == nil {
+			pending = append(pending, inv)
+		}
+	}
+
+	h.render(w, h.tmpl.org, "layout.html", pageData{
+		Title: org,
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: org, Href: ""},
+		},
+		Body: orgPage{
+			Org:     org,
+			Repos:   repos,
+			Members: members,
+			Invites: pending,
+		},
 	})
 }
 

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -118,6 +118,27 @@ type commitDetailPage struct {
 	Commit *store.CommitDetail
 }
 
+type proposalsPage struct {
+	Repo      model.Repo
+	Proposals []*model.Proposal
+	State     string
+}
+
+type proposalDetailPage struct {
+	Repo     model.Repo
+	Proposal *model.Proposal
+}
+
+type releasesPage struct {
+	Repo     model.Repo
+	Releases []model.Release
+}
+
+type releaseDetailPage struct {
+	Repo    model.Repo
+	Release *model.Release
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -470,6 +491,206 @@ func (h *Handler) handleReviewCommentsPartial(w http.ResponseWriter, r *http.Req
 	}
 
 	h.render(w, h.tmpl.reviewComments, "review_comments.html", groups)
+}
+
+// proposalStateFromQuery parses the "state" query param into a ProposalState
+// pointer. Unknown or empty values default to open.
+func proposalStateFromQuery(s string) (model.ProposalState, *model.ProposalState) {
+	switch s {
+	case "closed":
+		st := model.ProposalClosed
+		return st, &st
+	case "merged":
+		st := model.ProposalMerged
+		return st, &st
+	default:
+		st := model.ProposalOpen
+		return st, &st
+	}
+}
+
+// handleProposals renders the proposals list for a repo with state filter tabs.
+func (h *Handler) handleProposals(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	stateStr := r.URL.Query().Get("state")
+	if stateStr == "" {
+		stateStr = "open"
+	}
+	_, ps := proposalStateFromQuery(stateStr)
+
+	proposals, err := h.write.ListProposals(ctx, repoName, ps, nil)
+	if err != nil {
+		slog.Error("ui list proposals", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load proposals")
+		return
+	}
+
+	h.render(w, h.tmpl.proposals, "layout.html", pageData{
+		Title: repoName + " / proposals",
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: "proposals", Href: ""},
+		},
+		Body: proposalsPage{Repo: *repo, Proposals: proposals, State: stateStr},
+	})
+}
+
+// handleProposalsPartial returns just the proposals rows for HTMX tab swapping.
+func (h *Handler) handleProposalsPartial(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	stateStr := r.URL.Query().Get("state")
+	if stateStr == "" {
+		stateStr = "open"
+	}
+	_, ps := proposalStateFromQuery(stateStr)
+
+	proposals, err := h.write.ListProposals(ctx, repoName, ps, nil)
+	if err != nil {
+		slog.Error("ui list proposals partial", "repo", repoName, "error", err)
+		http.Error(w, "query failed", http.StatusInternalServerError)
+		return
+	}
+	h.render(w, h.tmpl.proposalsRows, "proposals_rows.html", proposals)
+}
+
+// handleProposalDetail renders the detail view for a single proposal.
+func (h *Handler) handleProposalDetail(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	id := r.PathValue("id")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	proposal, err := h.write.GetProposal(ctx, repoName, id)
+	if err != nil {
+		slog.Error("ui get proposal", "repo", repoName, "id", id, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load proposal")
+		return
+	}
+	if proposal == nil {
+		h.renderError(w, http.StatusNotFound, "proposal not found")
+		return
+	}
+
+	h.render(w, h.tmpl.proposalDetail, "layout.html", pageData{
+		Title: repoName + " / proposals / " + id,
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: "proposals", Href: "/ui/r/" + repoName + "/proposals"},
+			{Label: proposal.Title, Href: ""},
+		},
+		Body: proposalDetailPage{Repo: *repo, Proposal: proposal},
+	})
+}
+
+// handleReleases renders the releases list for a repo.
+func (h *Handler) handleReleases(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	releases, err := h.write.ListReleases(ctx, repoName, 100, "")
+	if err != nil {
+		slog.Error("ui list releases", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load releases")
+		return
+	}
+
+	h.render(w, h.tmpl.releases, "layout.html", pageData{
+		Title: repoName + " / releases",
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: "releases", Href: ""},
+		},
+		Body: releasesPage{Repo: *repo, Releases: releases},
+	})
+}
+
+// handleReleaseDetail renders the detail view for a single release.
+func (h *Handler) handleReleaseDetail(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	rname := r.PathValue("rname")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	release, err := h.write.GetRelease(ctx, repoName, rname)
+	if err != nil {
+		slog.Error("ui get release", "repo", repoName, "name", rname, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load release")
+		return
+	}
+	if release == nil {
+		h.renderError(w, http.StatusNotFound, "release not found")
+		return
+	}
+
+	h.render(w, h.tmpl.releaseDetail, "layout.html", pageData{
+		Title: repoName + " / releases / " + rname,
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: "releases", Href: "/ui/r/" + repoName + "/releases"},
+			{Label: rname, Href: ""},
+		},
+		Body: releaseDetailPage{Repo: *repo, Release: release},
+	})
 }
 
 // siblingTreeRows returns the immediate children of dir within entries, with

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -30,6 +30,7 @@ type templateSet struct {
 	proposalDetail *template.Template
 	releases       *template.Template
 	releaseDetail  *template.Template
+	org            *template.Template
 }
 
 func parseTemplates(root fs.FS) (*templateSet, error) {
@@ -129,6 +130,10 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse release_detail: %w", err)
 	}
+	org, err := load("org.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse org: %w", err)
+	}
 	return &templateSet{
 		repos:          repos,
 		branches:       branches,
@@ -146,6 +151,7 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		proposalDetail: proposalDetail,
 		releases:       releases,
 		releaseDetail:  releaseDetail,
+		org:            org,
 	}, nil
 }
 

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -25,6 +25,11 @@ type templateSet struct {
 	commitLog      *template.Template
 	logRows        *template.Template
 	commitDetail   *template.Template
+	proposals      *template.Template
+	proposalsRows  *template.Template
+	proposalDetail *template.Template
+	releases       *template.Template
+	releaseDetail  *template.Template
 }
 
 func parseTemplates(root fs.FS) (*templateSet, error) {
@@ -98,6 +103,32 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse commit: %w", err)
 	}
+	// proposals full page pulls in proposals_rows.html as a partial.
+	proposals, err := template.New("layout.html").
+		Funcs(funcMap()).
+		ParseFS(root,
+			"templates/layout.html",
+			"templates/proposals.html",
+			"templates/proposals_rows.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse proposals: %w", err)
+	}
+	proposalsRows, err := loadFragment("proposals_rows.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse proposals_rows: %w", err)
+	}
+	proposalDetail, err := load("proposal_detail.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse proposal_detail: %w", err)
+	}
+	releases, err := load("releases.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse releases: %w", err)
+	}
+	releaseDetail, err := load("release_detail.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse release_detail: %w", err)
+	}
 	return &templateSet{
 		repos:          repos,
 		branches:       branches,
@@ -110,6 +141,11 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		commitLog:      commitLog,
 		logRows:        logRows,
 		commitDetail:   commitDetail,
+		proposals:      proposals,
+		proposalsRows:  proposalsRows,
+		proposalDetail: proposalDetail,
+		releases:       releases,
+		releaseDetail:  releaseDetail,
 	}, nil
 }
 

--- a/internal/ui/static/poll.js
+++ b/internal/ui/static/poll.js
@@ -38,6 +38,30 @@
     }
   });
 
+  // Tab switching. Clicking [data-tab-url] fetches the URL and swaps the
+  // innerHTML of the element matching [data-tab-target] on the same tab link.
+  document.addEventListener('click', function (e) {
+    var el = e.target.closest('[data-tab-url]');
+    if (!el) return;
+    var url = el.getAttribute('data-tab-url');
+    var targetSel = el.getAttribute('data-tab-target');
+    if (!url || !targetSel) return;
+    e.preventDefault();
+    var target = document.querySelector(targetSel);
+    if (!target) return;
+    // Update active class on siblings within [data-tab-group].
+    var group = el.closest('[data-tab-group]');
+    if (group) {
+      var tabs = group.querySelectorAll('[data-tab-url]');
+      for (var i = 0; i < tabs.length; i++) tabs[i].classList.remove('active');
+    }
+    el.classList.add('active');
+    fetch(url, { credentials: 'same-origin' }).then(function (r) {
+      if (!r.ok) return;
+      return r.text().then(function (t) { target.innerHTML = t; });
+    }).catch(function () {});
+  });
+
   // Branch-list filter. Hides tbody rows whose first cell text doesn't match.
   document.addEventListener('DOMContentLoaded', function () {
     var inputs = document.querySelectorAll('[data-branch-filter]');

--- a/internal/ui/static/styles.css
+++ b/internal/ui/static/styles.css
@@ -320,6 +320,25 @@ pre.code .text { white-space: pre; padding-right: 12px; }
 }
 .checks-collapsed:last-child { border-bottom: 0; }
 
+/* State filter tabs used on proposals page. */
+.tab-bar {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 14px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0;
+}
+.tab-bar .tab {
+  padding: 6px 14px;
+  color: var(--text-dim);
+  text-decoration: none;
+  font-size: 12px;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+.tab-bar .tab:hover { color: var(--text); text-decoration: none; }
+.tab-bar .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+
 .err-box {
   text-align: center;
   padding: 60px 20px;

--- a/internal/ui/templates/org.html
+++ b/internal/ui/templates/org.html
@@ -1,0 +1,63 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline"><h1>{{.Org}}</h1></div>
+
+<h2>Repos ({{len .Repos}})</h2>
+<div class="card">
+  {{if not .Repos}}
+    <div class="empty">No repos.</div>
+  {{else}}
+  <div class="row-list">
+    {{range .Repos}}
+    <a href="/ui/r/{{.Name}}">
+      <span>{{.Name}}</span>
+      <span class="meta">by {{.CreatedBy}} · {{relTime .CreatedAt}}</span>
+    </a>
+    {{end}}
+  </div>
+  {{end}}
+</div>
+
+<h2>Members ({{len .Members}})</h2>
+<div class="card">
+  {{if not .Members}}
+    <div class="empty">No members.</div>
+  {{else}}
+  <table class="grid">
+    <thead><tr><th>identity</th><th>role</th><th>invited by</th><th>joined</th></tr></thead>
+    <tbody>
+    {{range .Members}}
+    <tr>
+      <td>{{.Identity}}</td>
+      <td><span class="badge {{statusClass .Role}}">{{.Role}}</span></td>
+      <td>{{.InvitedBy}}</td>
+      <td>{{relTime .CreatedAt}}</td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{end}}
+</div>
+
+<h2>Pending invites ({{len .Invites}})</h2>
+<div class="card">
+  {{if not .Invites}}
+    <div class="empty">No pending invites.</div>
+  {{else}}
+  <table class="grid">
+    <thead><tr><th>email</th><th>role</th><th>invited by</th><th>expires</th></tr></thead>
+    <tbody>
+    {{range .Invites}}
+    <tr>
+      <td>{{.Email}}</td>
+      <td><span class="badge {{statusClass .Role}}">{{.Role}}</span></td>
+      <td>{{.InvitedBy}}</td>
+      <td>{{relTime .ExpiresAt}}</td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{end}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/proposal_detail.html
+++ b/internal/ui/templates/proposal_detail.html
@@ -1,0 +1,35 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline">
+  <h1>{{.Proposal.Title}}</h1>
+  <span class="badge {{statusClass (printf "%s" .Proposal.State)}}">{{.Proposal.State}}</span>
+</div>
+
+<div class="meta" style="margin-bottom:14px">
+  by {{.Proposal.Author}} · opened {{relTime .Proposal.CreatedAt}} · updated {{relTime .Proposal.UpdatedAt}}
+</div>
+
+<h2>Details</h2>
+<div class="card">
+  <div class="row">
+    <div><strong>base branch</strong></div>
+    <div>{{.Proposal.BaseBranch}}</div>
+  </div>
+  <div class="row">
+    <div><strong>branch</strong></div>
+    <div><a href="/ui/r/{{.Repo.Name}}/b/{{.Proposal.Branch}}">{{.Proposal.Branch}}</a></div>
+  </div>
+  <div class="row">
+    <div><strong>id</strong></div>
+    <div class="meta">{{.Proposal.ID}}</div>
+  </div>
+</div>
+
+{{if .Proposal.Description}}
+<h2>Description</h2>
+<div class="card">
+  <div style="white-space:pre-wrap;color:var(--text);">{{.Proposal.Description}}</div>
+</div>
+{{end}}
+{{end}}
+{{end}}

--- a/internal/ui/templates/proposals.html
+++ b/internal/ui/templates/proposals.html
@@ -1,0 +1,27 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline">
+  <h1>{{.Repo.Name}} / proposals</h1>
+  <span class="meta">owner {{.Repo.Owner}}</span>
+</div>
+
+<div class="tab-bar" data-tab-group>
+  <a class="tab{{if eq .State "open"}} active{{end}}"
+     href="?state=open"
+     data-tab-url="/ui/_/r/{{.Repo.Name}}/proposals?state=open"
+     data-tab-target="#proposals-list">open</a>
+  <a class="tab{{if eq .State "closed"}} active{{end}}"
+     href="?state=closed"
+     data-tab-url="/ui/_/r/{{.Repo.Name}}/proposals?state=closed"
+     data-tab-target="#proposals-list">closed</a>
+  <a class="tab{{if eq .State "merged"}} active{{end}}"
+     href="?state=merged"
+     data-tab-url="/ui/_/r/{{.Repo.Name}}/proposals?state=merged"
+     data-tab-target="#proposals-list">merged</a>
+</div>
+
+<div class="card" id="proposals-list">
+{{template "proposals_rows.html" .Proposals}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/proposals_rows.html
+++ b/internal/ui/templates/proposals_rows.html
@@ -1,0 +1,18 @@
+{{define "proposals_rows.html"}}
+{{if not .}}<div class="empty">no proposals</div>{{else}}
+<table class="grid">
+  <thead><tr><th>title</th><th>state</th><th>author</th><th>base</th><th>opened</th></tr></thead>
+  <tbody>
+  {{range .}}
+  <tr>
+    <td><a href="proposals/{{.ID}}">{{.Title}}</a></td>
+    <td><span class="badge {{statusClass (printf "%s" .State)}}">{{.State}}</span></td>
+    <td>{{.Author}}</td>
+    <td>{{.BaseBranch}}</td>
+    <td class="meta">{{relTime .CreatedAt}}</td>
+  </tr>
+  {{end}}
+  </tbody>
+</table>
+{{end}}
+{{end}}

--- a/internal/ui/templates/release_detail.html
+++ b/internal/ui/templates/release_detail.html
@@ -1,0 +1,35 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline">
+  <h1>{{.Release.Name}}</h1>
+  <span class="meta">seq {{.Release.Sequence}}</span>
+</div>
+
+<div class="meta" style="margin-bottom:14px">
+  by {{.Release.CreatedBy}} · {{relTime .Release.CreatedAt}}
+</div>
+
+<h2>Details</h2>
+<div class="card">
+  <div class="row">
+    <div><strong>name</strong></div>
+    <div>{{.Release.Name}}</div>
+  </div>
+  <div class="row">
+    <div><strong>sequence</strong></div>
+    <div>{{.Release.Sequence}}</div>
+  </div>
+  <div class="row">
+    <div><strong>id</strong></div>
+    <div class="meta">{{.Release.ID}}</div>
+  </div>
+</div>
+
+{{if .Release.Body}}
+<h2>Body</h2>
+<div class="card">
+  <div style="white-space:pre-wrap;color:var(--text);">{{.Release.Body}}</div>
+</div>
+{{end}}
+{{end}}
+{{end}}

--- a/internal/ui/templates/releases.html
+++ b/internal/ui/templates/releases.html
@@ -1,0 +1,27 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline">
+  <h1>{{.Repo.Name}} / releases</h1>
+  <span class="meta">owner {{.Repo.Owner}}</span>
+</div>
+
+<div class="card">
+{{if not .Releases}}<div class="empty">no releases</div>{{else}}
+<table class="grid">
+  <thead><tr><th>name</th><th>seq</th><th>author</th><th>body</th><th>created</th></tr></thead>
+  <tbody>
+  {{range .Releases}}
+  <tr>
+    <td><a href="releases/{{.Name}}">{{.Name}}</a></td>
+    <td>{{.Sequence}}</td>
+    <td>{{.CreatedBy}}</td>
+    <td class="meta">{{if gt (len .Body) 80}}{{slice .Body 0 80}}…{{else}}{{.Body}}{{end}}</td>
+    <td class="meta">{{relTime .CreatedAt}}</td>
+  </tr>
+  {{end}}
+  </tbody>
+</table>
+{{end}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/repos.html
+++ b/internal/ui/templates/repos.html
@@ -6,7 +6,7 @@
 {{else}}
   {{range .Orgs}}
   <div class="card">
-    <h2>{{.Name}}</h2>
+    <h2><a href="/ui/o/{{.Name}}">{{.Name}}</a></h2>
     <div class="row-list">
       {{range .Repos}}
       <a href="/ui/r/{{.Name}}">

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -41,6 +41,8 @@ type WriteStoreLite interface {
 	GetProposal(ctx context.Context, repo, proposalID string) (*model.Proposal, error)
 	ListReleases(ctx context.Context, repo string, limit int, afterID string) ([]model.Release, error)
 	GetRelease(ctx context.Context, repo, name string) (*model.Release, error)
+	ListInvites(ctx context.Context, org string) ([]model.OrgInvite, error)
+	ListOrgRepos(ctx context.Context, owner string) ([]model.Repo, error)
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -110,6 +112,7 @@ func NewHandlerDev(read ReadStore, write WriteStoreLite, assemble AssembleFn) (*
 // placing this mux behind the same middleware chain used by the JSON API.
 func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/{$}", h.handleRepos)
+	mux.HandleFunc("GET /ui/o/{org}", h.handleOrg)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}", h.handleBranches)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}", h.handleBranchDetail)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/checks", h.handleChecksPartial)

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -37,6 +37,10 @@ type WriteStoreLite interface {
 	ListOrgMembers(ctx context.Context, org string) ([]model.OrgMember, error)
 	ListRoles(ctx context.Context, repo string) ([]model.Role, error)
 	ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64, history bool) ([]model.CheckRun, error)
+	ListProposals(ctx context.Context, repo string, state *model.ProposalState, branch *string) ([]*model.Proposal, error)
+	GetProposal(ctx context.Context, repo, proposalID string) (*model.Proposal, error)
+	ListReleases(ctx context.Context, repo string, limit int, afterID string) ([]model.Release, error)
+	GetRelease(ctx context.Context, repo, name string) (*model.Release, error)
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -115,5 +119,10 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}/c/{seq}", h.handleCommitDetail)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/check-history", h.handleCheckHistoryPartial)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/f/{path...}", h.handleFile)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/proposals", h.handleProposals)
+	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/proposals", h.handleProposalsPartial)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/proposals/{id}", h.handleProposalDetail)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/releases", h.handleReleases)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/releases/{rname}", h.handleReleaseDetail)
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -47,8 +47,10 @@ func (f *fakeRead) GetCommit(_ context.Context, _ string, _ int64) (*store.Commi
 }
 
 type fakeWrite struct {
-	repos []model.Repo
-	miss  bool
+	repos     []model.Repo
+	miss      bool
+	proposals []*model.Proposal
+	releases  []model.Release
 }
 
 func (f *fakeWrite) ListRepos(_ context.Context) ([]model.Repo, error) { return f.repos, nil }
@@ -74,6 +76,37 @@ func (f *fakeWrite) ListRoles(_ context.Context, _ string) ([]model.Role, error)
 	return nil, nil
 }
 func (f *fakeWrite) ListCheckRuns(_ context.Context, _, _ string, _ *int64, _ bool) ([]model.CheckRun, error) {
+	return nil, nil
+}
+func (f *fakeWrite) ListProposals(_ context.Context, _ string, state *model.ProposalState, _ *string) ([]*model.Proposal, error) {
+	if state == nil {
+		return f.proposals, nil
+	}
+	var out []*model.Proposal
+	for _, p := range f.proposals {
+		if p.State == *state {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+func (f *fakeWrite) GetProposal(_ context.Context, _, id string) (*model.Proposal, error) {
+	for _, p := range f.proposals {
+		if p.ID == id {
+			return p, nil
+		}
+	}
+	return nil, nil
+}
+func (f *fakeWrite) ListReleases(_ context.Context, _ string, _ int, _ string) ([]model.Release, error) {
+	return f.releases, nil
+}
+func (f *fakeWrite) GetRelease(_ context.Context, _, name string) (*model.Release, error) {
+	for _, r := range f.releases {
+		if r.Name == name {
+			return &r, nil
+		}
+	}
 	return nil, nil
 }
 
@@ -268,6 +301,137 @@ func TestHandleFile_RendersTreeAndContent(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("missing %q in body", want)
 		}
+	}
+}
+
+func TestHandleProposals_RendersList(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	ps := model.ProposalOpen
+	w := &fakeWrite{
+		repos: repos,
+		proposals: []*model.Proposal{
+			{ID: "p-1", Repo: "acme/a", Branch: "feat-x", BaseBranch: "main", Title: "My Proposal", Author: "alice", State: ps, CreatedAt: time.Now()},
+		},
+	}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/proposals?state=open")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"My Proposal", "alice", "main", "open"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleProposalsPartial_ReturnsFragment(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme"}}
+	ps := model.ProposalOpen
+	w := &fakeWrite{
+		repos: repos,
+		proposals: []*model.Proposal{
+			{ID: "p-1", Title: "Frag Proposal", Author: "bob", State: ps, BaseBranch: "main", CreatedAt: time.Now()},
+		},
+	}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/_/r/acme/a/proposals?state=open")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if strings.Contains(body, "<!doctype html>") {
+		t.Errorf("expected fragment, got full layout")
+	}
+	if !strings.Contains(body, "Frag Proposal") {
+		t.Errorf("expected proposal title in fragment, got: %s", body)
+	}
+}
+
+func TestHandleProposalDetail_RendersDetail(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	ps := model.ProposalOpen
+	w := &fakeWrite{
+		repos: repos,
+		proposals: []*model.Proposal{
+			{ID: "p-abc", Repo: "acme/a", Branch: "feat-x", BaseBranch: "main", Title: "Detail Proposal", Description: "some details", Author: "carol", State: ps, CreatedAt: time.Now()},
+		},
+	}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/proposals/p-abc")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"Detail Proposal", "carol", "feat-x", "some details"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleProposalDetail_NotFound_Returns404(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	w := &fakeWrite{repos: repos}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, _ := getStatusAndBody(t, h, "/ui/r/acme/a/proposals/nonexistent")
+	if code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", code)
+	}
+}
+
+func TestHandleReleases_RendersList(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	w := &fakeWrite{
+		repos: repos,
+		releases: []model.Release{
+			{ID: "r-1", Repo: "acme/a", Name: "v1.0.0", Sequence: 42, Body: "first release", CreatedBy: "dave", CreatedAt: time.Now()},
+		},
+	}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/releases")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"v1.0.0", "42", "dave", "first release"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleReleaseDetail_RendersDetail(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	w := &fakeWrite{
+		repos: repos,
+		releases: []model.Release{
+			{ID: "r-2", Repo: "acme/a", Name: "v2.0.0", Sequence: 99, Body: "second release notes", CreatedBy: "eve", CreatedAt: time.Now()},
+		},
+	}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/releases/v2.0.0")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"v2.0.0", "99", "eve", "second release notes"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleReleaseDetail_NotFound_Returns404(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	w := &fakeWrite{repos: repos}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, _ := getStatusAndBody(t, h, "/ui/r/acme/a/releases/nonexistent")
+	if code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", code)
 	}
 }
 

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -90,6 +90,18 @@ func (f *fakeWrite) ListProposals(_ context.Context, _ string, state *model.Prop
 	}
 	return out, nil
 }
+func (f *fakeWrite) ListInvites(_ context.Context, _ string) ([]model.OrgInvite, error) {
+	return nil, nil
+}
+func (f *fakeWrite) ListOrgRepos(_ context.Context, owner string) ([]model.Repo, error) {
+	var out []model.Repo
+	for _, r := range f.repos {
+		if r.Owner == owner {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
 func (f *fakeWrite) GetProposal(_ context.Context, _, id string) (*model.Proposal, error) {
 	for _, p := range f.proposals {
 		if p.ID == id {
@@ -323,6 +335,28 @@ func TestHandleProposals_RendersList(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)
 		}
+	}
+}
+
+func TestHandleOrg_RendersReposMembersInvites(t *testing.T) {
+	repos := []model.Repo{
+		{Name: "acme/a", Owner: "acme", CreatedBy: "me", CreatedAt: time.Now().Add(-1 * time.Hour)},
+		{Name: "acme/b", Owner: "acme", CreatedBy: "me", CreatedAt: time.Now()},
+		{Name: "beta/x", Owner: "beta", CreatedBy: "you", CreatedAt: time.Now()},
+	}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/o/acme")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200. body=%s", code, body)
+	}
+	for _, want := range []string{"acme/a", "acme/b", "Members", "Pending invites"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+	if strings.Contains(body, "beta/x") {
+		t.Errorf("body should not contain repo from different org")
 	}
 }
 


### PR DESCRIPTION
Rebased onto work/jolly-hawk (which is rebased onto main).

Adds org overview page at GET /ui/o/{org} showing repos, members, and pending invites.

## Changes
- Org overview page with repos list, members table, and invites table
- New interface methods: `ListInvites`, `ListOrgRepos` on `WriteStoreLite`
- org.html template

## Rebase notes
Resolved conflicts in `render.go`, `ui.go`, `ui_test.go`, `cmd/ui-preview/main.go` keeping all interface methods and implementations from both sides.

Depends on #303 (proposals+releases pages).