### PR TITLE
feat: add accept invite page to web UI (issue #97)

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -171,6 +171,14 @@ func (fakeWrite) ListIssueComments(_ context.Context, _ string, _ int64) ([]mode
 	}, nil
 }
 
+func (fakeWrite) GetInviteByToken(_ context.Context, _, _ string) (*model.OrgInvite, error) {
+	return nil, db.ErrInviteNotFound
+}
+
+func (fakeWrite) AcceptInvite(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
 func fakeAssemble(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
 	t := time.Now()
 	vid := func(s string) *string { return &s }
@@ -250,7 +258,7 @@ func (e *notFoundErr) Error() string { return "branch not found" }
 // ---------------------------------------------------------------------------
 
 func main() {
-	h, err := ui.NewHandler(fakeRead{}, fakeWrite{}, fakeAssemble)
+	h, err := ui.NewHandler(fakeRead{}, fakeWrite{}, fakeAssemble, nil)
 	if err != nil {
 		log.Fatalf("ui init: %v", err)
 	}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1868,6 +1868,26 @@ func (s *Store) ListInvites(ctx context.Context, org string) ([]model.OrgInvite,
 	return invites, rows.Err()
 }
 
+// GetInviteByToken looks up a pending invite by org and token.
+// Returns ErrInviteNotFound if no matching invite exists.
+func (s *Store) GetInviteByToken(ctx context.Context, org, token string) (*model.OrgInvite, error) {
+	var inv model.OrgInvite
+	var roleStr string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id, org, email, role, invited_by, expires_at, created_at
+		 FROM org_invites WHERE org = $1 AND token = $2`,
+		org, token,
+	).Scan(&inv.ID, &inv.Org, &inv.Email, &roleStr, &inv.InvitedBy, &inv.ExpiresAt, &inv.CreatedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrInviteNotFound
+		}
+		return nil, fmt.Errorf("get invite by token: %w", err)
+	}
+	inv.Role = model.OrgRole(roleStr)
+	return &inv, nil
+}
+
 // AcceptInvite accepts a pending invite: verifies the token, checks expiry and email match,
 // sets accepted_at, and upserts the identity into org_members — all in one transaction.
 func (s *Store) AcceptInvite(ctx context.Context, org, token, identity string) error {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -58,6 +58,7 @@ type WriteStore interface {
 	// Org invitations
 	CreateInvite(ctx context.Context, org, email string, role model.OrgRole, invitedBy, token string, expiresAt time.Time) (*model.OrgInvite, error)
 	ListInvites(ctx context.Context, org string) ([]model.OrgInvite, error)
+	GetInviteByToken(ctx context.Context, org, token string) (*model.OrgInvite, error)
 	AcceptInvite(ctx context.Context, org, token, identity string) error
 	RevokeInvite(ctx context.Context, org, inviteID string) error
 
@@ -258,9 +259,9 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 		var uiHandler *ui.Handler
 		var err error
 		if os.Getenv("DEV_UI") != "" {
-			uiHandler, err = ui.NewHandlerDev(s.readStore, writeStore, assemble)
+			uiHandler, err = ui.NewHandlerDev(s.readStore, writeStore, assemble, IdentityFromContext)
 		} else {
-			uiHandler, err = ui.NewHandler(s.readStore, writeStore, assemble)
+			uiHandler, err = ui.NewHandler(s.readStore, writeStore, assemble, IdentityFromContext)
 		}
 		if err != nil {
 			slog.Error("ui init failed", "error", err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -313,6 +313,10 @@ func (m *mockStore) ListInvites(ctx context.Context, org string) ([]model.OrgInv
 	return []model.OrgInvite{}, nil
 }
 
+func (m *mockStore) GetInviteByToken(ctx context.Context, org, token string) (*model.OrgInvite, error) {
+	return nil, db.ErrInviteNotFound
+}
+
 func (m *mockStore) AcceptInvite(ctx context.Context, org, token, identity string) error {
 	if m.acceptInviteFn != nil {
 		return m.acceptInviteFn(ctx, org, token, identity)

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -130,6 +130,13 @@ type issueDetailPage struct {
 	Comments []model.IssueComment
 }
 
+type acceptInvitePage struct {
+	Org   string
+	Token string
+	Role  model.OrgRole
+	Err   string
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -827,6 +834,71 @@ func (h *Handler) handleCommitDetail(w http.ResponseWriter, r *http.Request) {
 			Commit: commit,
 		},
 	})
+}
+
+// handleAcceptInvite renders the invite acceptance confirmation page (GET) and
+// processes the acceptance (POST).
+func (h *Handler) handleAcceptInvite(w http.ResponseWriter, r *http.Request) {
+	org := r.PathValue("org")
+	token := r.PathValue("token")
+	ctx := r.Context()
+
+	renderPage := func(role model.OrgRole, errMsg string) {
+		h.render(w, h.tmpl.acceptInvite, "layout.html", pageData{
+			Title: "Accept invitation · " + org,
+			Breadcrumbs: []crumb{
+				{Label: "repos", Href: "/ui/"},
+			},
+			Body: acceptInvitePage{
+				Org:   org,
+				Token: token,
+				Role:  role,
+				Err:   errMsg,
+			},
+		})
+	}
+
+	// Look up invite details so we can show the role on GET and re-render on POST error.
+	invite, err := h.write.GetInviteByToken(ctx, org, token)
+	if err != nil {
+		if errors.Is(err, db.ErrInviteNotFound) {
+			h.renderError(w, http.StatusNotFound, "invite not found")
+			return
+		}
+		slog.Error("ui get invite by token", "org", org, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load invite")
+		return
+	}
+
+	if r.Method == http.MethodGet {
+		renderPage(invite.Role, "")
+		return
+	}
+
+	// POST: accept the invite.
+	var identity string
+	if h.identity != nil {
+		identity = h.identity(ctx)
+	}
+
+	if err := h.write.AcceptInvite(ctx, org, token, identity); err != nil {
+		switch {
+		case errors.Is(err, db.ErrInviteNotFound):
+			h.renderError(w, http.StatusNotFound, "invite not found")
+		case errors.Is(err, db.ErrInviteExpired):
+			renderPage(invite.Role, "This invitation has expired.")
+		case errors.Is(err, db.ErrInviteAlreadyAccepted):
+			renderPage(invite.Role, "This invitation has already been accepted.")
+		case errors.Is(err, db.ErrEmailMismatch):
+			renderPage(invite.Role, "This invitation was sent to a different email address.")
+		default:
+			slog.Error("ui accept invite", "org", org, "error", err)
+			h.renderError(w, http.StatusInternalServerError, "could not accept invite")
+		}
+		return
+	}
+
+	http.Redirect(w, r, "/ui/o/"+org, http.StatusSeeOther)
 }
 
 // chainToLogRows filters and converts ChainEntries to commitLogRows.

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -28,6 +28,7 @@ type templateSet struct {
 	issues         *template.Template
 	issuesRows     *template.Template
 	issueDetail    *template.Template
+	acceptInvite   *template.Template
 }
 
 func parseTemplates(root fs.FS) (*templateSet, error) {
@@ -119,6 +120,10 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse issue_detail: %w", err)
 	}
+	acceptInvite, err := load("accept_invite.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse accept_invite: %w", err)
+	}
 	return &templateSet{
 		repos:          repos,
 		branches:       branches,
@@ -134,6 +139,7 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		issues:         issues,
 		issuesRows:     issuesRows,
 		issueDetail:    issueDetail,
+		acceptInvite:   acceptInvite,
 	}, nil
 }
 

--- a/internal/ui/templates/accept_invite.html
+++ b/internal/ui/templates/accept_invite.html
@@ -1,0 +1,16 @@
+{{define "content"}}
+<h1>Accept invitation</h1>
+{{with .Body}}
+<div class="card">
+  <div class="row"><strong>Organisation</strong> {{.Org}}</div>
+  <div class="row"><strong>Role</strong> <span class="badge neutral">{{.Role}}</span></div>
+  {{if .Err}}
+  <div class="row"><span class="badge bad">{{.Err}}</span></div>
+  {{else}}
+  <form method="POST" action="/ui/o/{{.Org}}/invites/{{.Token}}/accept" style="padding:14px 12px 4px">
+    <button type="submit">Accept invitation</button>
+  </form>
+  {{end}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -28,7 +28,7 @@ type ReadStore interface {
 }
 
 // WriteStoreLite is the subset of server.WriteStore that the UI needs for
-// listing repos and orgs. The UI never calls mutating methods.
+// listing repos and orgs, and for org invite acceptance.
 type WriteStoreLite interface {
 	ListRepos(ctx context.Context) ([]model.Repo, error)
 	ListOrgs(ctx context.Context) ([]model.Org, error)
@@ -40,12 +40,19 @@ type WriteStoreLite interface {
 	ListIssues(ctx context.Context, repo, stateFilter, authorFilter string) ([]model.Issue, error)
 	GetIssue(ctx context.Context, repo string, number int64) (*model.Issue, error)
 	ListIssueComments(ctx context.Context, repo string, number int64) ([]model.IssueComment, error)
+	GetInviteByToken(ctx context.Context, org, token string) (*model.OrgInvite, error)
+	AcceptInvite(ctx context.Context, org, token, identity string) error
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
 // page. The server wraps *server.AssembleAgentContext with an identity lookup
 // and injects the result, so the UI never sees identity directly.
 type AssembleFn func(ctx context.Context, repo, branch string) (*model.AgentContextResponse, error)
+
+// IdentityFn extracts the authenticated caller identity from a request context.
+// It is provided by the server at Handler construction time so the UI never
+// needs to import the server package (which would create a circular dependency).
+type IdentityFn func(ctx context.Context) string
 
 //go:embed templates/*.html
 var templatesFS embed.FS
@@ -58,12 +65,13 @@ type Handler struct {
 	read      ReadStore
 	write     WriteStoreLite
 	assemble  AssembleFn
+	identity  IdentityFn
 	tmpl      *templateSet
 	staticSub fs.FS
 }
 
 // NewHandler constructs a UI handler wired to the given data sources.
-func NewHandler(read ReadStore, write WriteStoreLite, assemble AssembleFn) (*Handler, error) {
+func NewHandler(read ReadStore, write WriteStoreLite, assemble AssembleFn, identity IdentityFn) (*Handler, error) {
 	t, err := parseTemplates(templatesFS)
 	if err != nil {
 		return nil, err
@@ -76,6 +84,7 @@ func NewHandler(read ReadStore, write WriteStoreLite, assemble AssembleFn) (*Han
 		read:      read,
 		write:     write,
 		assemble:  assemble,
+		identity:  identity,
 		tmpl:      t,
 		staticSub: sub,
 	}, nil
@@ -86,7 +95,7 @@ func NewHandler(read ReadStore, write WriteStoreLite, assemble AssembleFn) (*Han
 // during development so template edits take effect on the next request without
 // recompiling. The server must be run from the repository root so that the
 // path "internal/ui" resolves correctly.
-func NewHandlerDev(read ReadStore, write WriteStoreLite, assemble AssembleFn) (*Handler, error) {
+func NewHandlerDev(read ReadStore, write WriteStoreLite, assemble AssembleFn, identity IdentityFn) (*Handler, error) {
 	root := os.DirFS("internal/ui")
 	t, err := parseTemplates(root)
 	if err != nil {
@@ -100,6 +109,7 @@ func NewHandlerDev(read ReadStore, write WriteStoreLite, assemble AssembleFn) (*
 		read:      read,
 		write:     write,
 		assemble:  assemble,
+		identity:  identity,
 		tmpl:      t,
 		staticSub: static,
 	}, nil
@@ -121,5 +131,7 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/issues", h.handleIssues)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/issues/{number}", h.handleIssueDetail)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/issues", h.handleIssuesPartial)
+	mux.HandleFunc("GET /ui/o/{org}/invites/{token}/accept", h.handleAcceptInvite)
+	mux.HandleFunc("POST /ui/o/{org}/invites/{token}/accept", h.handleAcceptInvite)
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -92,6 +92,12 @@ func (f *fakeWrite) GetIssue(_ context.Context, _ string, number int64) (*model.
 func (f *fakeWrite) ListIssueComments(_ context.Context, _ string, _ int64) ([]model.IssueComment, error) {
 	return f.issueComments, nil
 }
+func (f *fakeWrite) GetInviteByToken(_ context.Context, _, _ string) (*model.OrgInvite, error) {
+	return nil, db.ErrInviteNotFound
+}
+func (f *fakeWrite) AcceptInvite(_ context.Context, _, _, _ string) error {
+	return nil
+}
 
 func newFakeAssembler(branchName string) AssembleFn {
 	return func(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
@@ -124,7 +130,7 @@ func strPtr(s string) *string { return &s }
 
 func newTestHandler(t *testing.T, r ReadStore, w WriteStoreLite, a AssembleFn) http.Handler {
 	t.Helper()
-	h, err := NewHandler(r, w, a)
+	h, err := NewHandler(r, w, a, nil)
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Adds an accept invite page to the web UI (`GET /ui/o/{org}/invites/{token}/accept` and `POST`)
- Adds `GetInviteByToken` and `AcceptInvite` methods to `WriteStoreLite` interface
- Adds `acceptInvitePage` template data type and `accept_invite.html` template
- Rebased onto main which added issues list/detail pages — all interface methods from both sides are preserved

## Conflicts resolved

This branch was rebased onto `main` (commit `5e5ae5f` — feat: add issues list and detail pages). Conflicts in 5 files were resolved by keeping ALL interface methods and template entries from both sides:
- `WriteStoreLite` interface now includes both issues methods and invite methods
- `templateSet` struct includes all templates (issues + accept_invite)
- `fakeWrite` in tests and ui-preview implements all methods

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all pass except `TestDockerSmoke` (pre-existing failure: requires `gcloud auth` credentials for a private registry, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)