### PR TITLE
feat: add org overview page at GET /ui/o/{org}

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -121,6 +121,24 @@ func (fakeWrite) ListCheckRuns(_ context.Context, _, _ string, _ *int64, _ bool)
 	return nil, nil
 }
 
+func (fakeWrite) ListInvites(_ context.Context, _ string) ([]model.OrgInvite, error) {
+	t := time.Now()
+	return []model.OrgInvite{
+		{ID: "inv-1", Org: "acme", Email: "newbie@example.com", Role: api.OrgRoleMember, InvitedBy: "ajay@acme", ExpiresAt: t.Add(7 * 24 * time.Hour), CreatedAt: t.Add(-2 * 24 * time.Hour)},
+	}, nil
+}
+
+func (fakeWrite) ListOrgRepos(_ context.Context, owner string) ([]model.Repo, error) {
+	all, _ := (fakeWrite{}).ListRepos(context.Background())
+	var out []model.Repo
+	for _, r := range all {
+		if r.Owner == owner {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
 func (fakeWrite) GetRepo(_ context.Context, name string) (*model.Repo, error) {
 	all, _ := (fakeWrite{}).ListRepos(context.Background())
 	for _, r := range all {

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -30,6 +30,13 @@ type orgGroup struct {
 	Repos []model.Repo
 }
 
+type orgPage struct {
+	Org     string
+	Repos   []model.Repo
+	Members []model.OrgMember
+	Invites []model.OrgInvite
+}
+
 type branchesPage struct {
 	Repo      model.Repo
 	Active    []branchRow
@@ -165,6 +172,51 @@ func (h *Handler) handleRepos(w http.ResponseWriter, r *http.Request) {
 		Title:       "Repos",
 		Breadcrumbs: []crumb{{Label: "repos", Href: "/ui/"}},
 		Body:        reposPage{Orgs: orgs},
+	})
+}
+
+// handleOrg renders the org overview page: repos, members, and pending invites.
+func (h *Handler) handleOrg(w http.ResponseWriter, r *http.Request) {
+	org := r.PathValue("org")
+	ctx := r.Context()
+
+	repos, err := h.write.ListOrgRepos(ctx, org)
+	if err != nil {
+		slog.Error("ui list org repos", "org", org, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repos")
+		return
+	}
+	members, err := h.write.ListOrgMembers(ctx, org)
+	if err != nil {
+		slog.Error("ui list org members", "org", org, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load members")
+		return
+	}
+	invites, err := h.write.ListInvites(ctx, org)
+	if err != nil {
+		slog.Error("ui list invites", "org", org, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load invites")
+		return
+	}
+	var pending []model.OrgInvite
+	for _, inv := range invites {
+		if inv.AcceptedAt == nil {
+			pending = append(pending, inv)
+		}
+	}
+
+	h.render(w, h.tmpl.org, "layout.html", pageData{
+		Title: org,
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: org, Href: ""},
+		},
+		Body: orgPage{
+			Org:     org,
+			Repos:   repos,
+			Members: members,
+			Invites: pending,
+		},
 	})
 }
 

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -29,6 +29,7 @@ type templateSet struct {
 	issuesRows     *template.Template
 	issueDetail    *template.Template
 	acceptInvite   *template.Template
+	org            *template.Template
 }
 
 func parseTemplates(root fs.FS) (*templateSet, error) {
@@ -124,6 +125,10 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse accept_invite: %w", err)
 	}
+	org, err := load("org.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse org: %w", err)
+	}
 	return &templateSet{
 		repos:          repos,
 		branches:       branches,
@@ -140,6 +145,7 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		issuesRows:     issuesRows,
 		issueDetail:    issueDetail,
 		acceptInvite:   acceptInvite,
+		org:            org,
 	}, nil
 }
 

--- a/internal/ui/templates/org.html
+++ b/internal/ui/templates/org.html
@@ -1,0 +1,63 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline"><h1>{{.Org}}</h1></div>
+
+<h2>Repos ({{len .Repos}})</h2>
+<div class="card">
+  {{if not .Repos}}
+    <div class="empty">No repos.</div>
+  {{else}}
+  <div class="row-list">
+    {{range .Repos}}
+    <a href="/ui/r/{{.Name}}">
+      <span>{{.Name}}</span>
+      <span class="meta">by {{.CreatedBy}} · {{relTime .CreatedAt}}</span>
+    </a>
+    {{end}}
+  </div>
+  {{end}}
+</div>
+
+<h2>Members ({{len .Members}})</h2>
+<div class="card">
+  {{if not .Members}}
+    <div class="empty">No members.</div>
+  {{else}}
+  <table class="grid">
+    <thead><tr><th>identity</th><th>role</th><th>invited by</th><th>joined</th></tr></thead>
+    <tbody>
+    {{range .Members}}
+    <tr>
+      <td>{{.Identity}}</td>
+      <td><span class="badge {{statusClass .Role}}">{{.Role}}</span></td>
+      <td>{{.InvitedBy}}</td>
+      <td>{{relTime .CreatedAt}}</td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{end}}
+</div>
+
+<h2>Pending invites ({{len .Invites}})</h2>
+<div class="card">
+  {{if not .Invites}}
+    <div class="empty">No pending invites.</div>
+  {{else}}
+  <table class="grid">
+    <thead><tr><th>email</th><th>role</th><th>invited by</th><th>expires</th></tr></thead>
+    <tbody>
+    {{range .Invites}}
+    <tr>
+      <td>{{.Email}}</td>
+      <td><span class="badge {{statusClass .Role}}">{{.Role}}</span></td>
+      <td>{{.InvitedBy}}</td>
+      <td>{{relTime .ExpiresAt}}</td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{end}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/repos.html
+++ b/internal/ui/templates/repos.html
@@ -6,7 +6,7 @@
 {{else}}
   {{range .Orgs}}
   <div class="card">
-    <h2>{{.Name}}</h2>
+    <h2><a href="/ui/o/{{.Name}}">{{.Name}}</a></h2>
     <div class="row-list">
       {{range .Repos}}
       <a href="/ui/r/{{.Name}}">

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -42,6 +42,8 @@ type WriteStoreLite interface {
 	ListIssueComments(ctx context.Context, repo string, number int64) ([]model.IssueComment, error)
 	GetInviteByToken(ctx context.Context, org, token string) (*model.OrgInvite, error)
 	AcceptInvite(ctx context.Context, org, token, identity string) error
+	ListInvites(ctx context.Context, org string) ([]model.OrgInvite, error)
+	ListOrgRepos(ctx context.Context, owner string) ([]model.Repo, error)
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -119,6 +121,7 @@ func NewHandlerDev(read ReadStore, write WriteStoreLite, assemble AssembleFn, id
 // placing this mux behind the same middleware chain used by the JSON API.
 func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/{$}", h.handleRepos)
+	mux.HandleFunc("GET /ui/o/{org}", h.handleOrg)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}", h.handleBranches)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}", h.handleBranchDetail)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/checks", h.handleChecksPartial)

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -98,6 +98,18 @@ func (f *fakeWrite) GetInviteByToken(_ context.Context, _, _ string) (*model.Org
 func (f *fakeWrite) AcceptInvite(_ context.Context, _, _, _ string) error {
 	return nil
 }
+func (f *fakeWrite) ListInvites(_ context.Context, _ string) ([]model.OrgInvite, error) {
+	return nil, nil
+}
+func (f *fakeWrite) ListOrgRepos(_ context.Context, owner string) ([]model.Repo, error) {
+	var out []model.Repo
+	for _, r := range f.repos {
+		if r.Owner == owner {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
 
 func newFakeAssembler(branchName string) AssembleFn {
 	return func(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
@@ -392,6 +404,28 @@ func TestHandleIssueDetail_InvalidNumber_Returns400(t *testing.T) {
 	code, _ := getStatusAndBody(t, h, "/ui/r/acme/a/issues/notanumber")
 	if code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", code)
+	}
+}
+
+func TestHandleOrg_RendersReposMembersInvites(t *testing.T) {
+	repos := []model.Repo{
+		{Name: "acme/a", Owner: "acme", CreatedBy: "me", CreatedAt: time.Now().Add(-1 * time.Hour)},
+		{Name: "acme/b", Owner: "acme", CreatedBy: "me", CreatedAt: time.Now()},
+		{Name: "beta/x", Owner: "beta", CreatedBy: "you", CreatedAt: time.Now()},
+	}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/o/acme")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200. body=%s", code, body)
+	}
+	for _, want := range []string{"acme/a", "acme/b", "Members", "Pending invites"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+	if strings.Contains(body, "beta/x") {
+		t.Errorf("body should not contain repo from different org")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a new org overview page at `GET /ui/o/{org}` showing repos, members, and pending invites for an org
- Extends `WriteStoreLite` interface with `ListInvites` and `ListOrgRepos` methods needed by the org handler
- Adds `org.html` template and wires `handleOrg` into the UI router

## Conflict resolution notes

Rebased onto current main (which added issues list/detail pages). Conflicts in 4 files were resolved by keeping ALL interface methods and fake implementations from both sides:

- `internal/ui/ui.go`: `WriteStoreLite` now includes both the issues methods (from main) and `ListInvites`/`ListOrgRepos` (from this branch)
- `internal/ui/render.go`: `templateSet` includes both issues templates and `org` template
- `internal/ui/ui_test.go`: all issue tests and the new `TestHandleOrg_*` test are present
- `cmd/ui-preview/main.go`: `fakeWrite` implements all interface methods

## Test plan

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./... -count=1` — all packages pass; `TestDockerSmoke` in `internal/server` fails due to missing gcloud credentials (pre-existing infrastructure issue unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)