### PR TITLE
fix(ui): encode branch names in URL paths and fix commit detail 500

### DIFF
--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -253,8 +254,9 @@ func funcMap() template.FuncMap {
 		"safeContent": safeContent,
 		"hasPrefix":   strings.HasPrefix,
 		"lines":       splitLines,
-		"dict":        dict,
-		"add":         func(a, b int) int { return a + b },
+		"dict":           dict,
+		"add":            func(a, b int) int { return a + b },
+		"urlPathEscape":  url.PathEscape,
 	}
 }
 

--- a/internal/ui/templates/branch_detail.html
+++ b/internal/ui/templates/branch_detail.html
@@ -39,7 +39,7 @@
 <div class="two-col">
   <div>
     <h2>Checks ({{len $ctx.CheckRuns}})</h2>
-    <div class="card" data-poll-url="/ui/_/r/{{.Repo.Name}}/b/{{$ctx.Branch.Name}}/checks" data-poll-interval="10000">
+    <div class="card" data-poll-url="/ui/_/r/{{.Repo.Name}}/b/{{urlPathEscape $ctx.Branch.Name}}/checks" data-poll-interval="10000">
       {{template "branch_checks.html" $ctx}}
     </div>
   </div>
@@ -116,7 +116,7 @@
     <tbody>
     {{range $ctx.RecentCommits}}
     <tr>
-      <td>{{.Sequence}}</td>
+      <td><a href="/ui/r/{{$page.Repo.Name}}/b/{{urlPathEscape $ctx.Branch.Name}}/c/{{.Sequence}}">{{.Sequence}}</a></td>
       <td>{{.Message}}</td>
       <td>{{.Author}}</td>
       <td class="meta">{{relTime .CreatedAt}}</td>

--- a/internal/ui/templates/branches.html
+++ b/internal/ui/templates/branches.html
@@ -7,7 +7,7 @@
   <a href="/ui/r/{{.Repo.Name}}/issues">issues</a>
   <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
-  <a href="/ui/r/{{.Repo.Name}}/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
 </nav>
 
 <div class="filter-bar"><input type="search" data-branch-filter placeholder="filter branches by name…" autocomplete="off"></div>
@@ -65,7 +65,7 @@
     <tbody>
     {{range .Rows}}
     <tr>
-      <td><a href="/ui/r/{{$.Repo}}/b/{{.Name}}">{{.Name}}</a></td>
+      <td><a href="/ui/r/{{$.Repo}}/b/{{urlPathEscape .Name}}">{{.Name}}</a></td>
       <td><span class="badge {{statusClass .Status}}">{{.Status}}</span></td>
       <td>{{.HeadSequence}}</td>
       <td>{{.BaseSequence}}</td>
@@ -73,7 +73,7 @@
         {{if .Draft}}<span class="badge warn">draft</span>{{end}}
         {{if .AutoMerge}}<span class="badge ok">auto-merge</span>{{end}}
       </td>
-      <td><a href="/ui/r/{{$.Repo}}/f/?branch={{.Name}}">files →</a> · <a href="/ui/r/{{$.Repo}}/b/{{.Name}}/log">log →</a></td>
+      <td><a href="/ui/r/{{$.Repo}}/f/?branch={{urlPathEscape .Name}}">files →</a> · <a href="/ui/r/{{$.Repo}}/b/{{urlPathEscape .Name}}/log">log →</a></td>
     </tr>
     {{end}}
     </tbody>

--- a/internal/ui/templates/commit.html
+++ b/internal/ui/templates/commit.html
@@ -1,5 +1,6 @@
 {{define "content"}}
 {{with .Body}}
+{{$page := .}}
 <div class="headline">
   <h1>commit {{.Commit.Sequence}}</h1>
   <span class="meta">{{.Repo.Name}} · {{.Branch}}</span>
@@ -24,7 +25,7 @@
     <tbody>
     {{range .Commit.Files}}
     <tr>
-      <td><a href="/ui/r/{{$.Repo.Name}}/f/{{.Path}}?branch={{$.Branch}}&at={{$.Commit.Sequence}}">{{.Path}}</a></td>
+      <td><a href="/ui/r/{{$page.Repo.Name}}/f/{{.Path}}?branch={{urlPathEscape $page.Branch}}&at={{$page.Commit.Sequence}}">{{.Path}}</a></td>
       <td><span class="badge {{diffClass .VersionID}}">{{if .VersionID}}modified{{else}}deleted{{end}}</span></td>
     </tr>
     {{end}}

--- a/internal/ui/templates/file.html
+++ b/internal/ui/templates/file.html
@@ -44,7 +44,7 @@
         <tbody>
         {{range $page.FileHistory}}
         <tr>
-          <td><a href="/ui/r/{{$page.Repo.Name}}/b/{{$page.Branch}}/c/{{.Sequence}}">{{.Sequence}}</a></td>
+          <td><a href="/ui/r/{{$page.Repo.Name}}/b/{{urlPathEscape $page.Branch}}/c/{{.Sequence}}">{{.Sequence}}</a></td>
           <td>{{.Message}}</td>
           <td>{{.Author}}</td>
           <td class="meta">{{relTime .CreatedAt}}</td>

--- a/internal/ui/templates/log_rows.html
+++ b/internal/ui/templates/log_rows.html
@@ -1,14 +1,14 @@
 {{define "log_rows.html"}}
 {{range .Rows}}
 <tr>
-  <td><a href="/ui/r/{{$.Repo.Name}}/b/{{$.Branch}}/c/{{.Seq}}">{{.Seq}}</a></td>
+  <td><a href="/ui/r/{{$.Repo.Name}}/b/{{urlPathEscape $.Branch}}/c/{{.Seq}}">{{.Seq}}</a></td>
   <td>{{.Message}}</td>
   <td>{{.Author}}</td>
   <td>{{relTime .Time}}</td>
 </tr>
 {{end}}
 {{if .HasMore}}
-<tr hx-get="/ui/_/r/{{.Repo.Name}}/b/{{.Branch}}/log?after={{.NextAfter}}"
+<tr hx-get="/ui/_/r/{{.Repo.Name}}/b/{{urlPathEscape .Branch}}/log?after={{.NextAfter}}"
     hx-trigger="revealed"
     hx-target="closest tr"
     hx-swap="outerHTML">

--- a/internal/ui/templates/proposal_detail.html
+++ b/internal/ui/templates/proposal_detail.html
@@ -17,7 +17,7 @@
   </div>
   <div class="row">
     <div><strong>branch</strong></div>
-    <div><a href="/ui/r/{{.Repo.Name}}/b/{{.Proposal.Branch}}">{{.Proposal.Branch}}</a></div>
+    <div><a href="/ui/r/{{.Repo.Name}}/b/{{urlPathEscape .Proposal.Branch}}">{{.Proposal.Branch}}</a></div>
   </div>
   <div class="row">
     <div><strong>id</strong></div>


### PR DESCRIPTION
## Summary

Five bugs found during post-merge visual review of the new UI pages:

- **Slashed branch names 404 throughout the UI** — branch names like `feature/auth` were interpolated raw into URL path segments, producing broken links everywhere (branch detail, commit log, commit detail, proposal detail, file history). Fix: add `urlPathEscape` to the template FuncMap and apply it in `branches.html`, `branch_detail.html`, `log_rows.html`, `proposal_detail.html`, and `file.html`.
- **Commit detail always 500** — `commit.html` used `$.Repo.Name`, `$.Branch`, `$.Commit.Sequence` inside a `{{range}}` loop where `$` resolves to `pageData`, not the page body. Fix: capture `{{$page := .}}` before the range, matching the pattern already used in `file.html`.
- **Repo "log" nav tab was a 404** — linked to `/ui/r/{repo}/log` which has no registered route. Fix: point to `/b/main/log`.
- **HTMX checks poll URL used raw branch name** — same encoding issue on the `data-poll-url` attribute in `branch_detail.html`.
- **Recent commits had no links** — sequence numbers in the branch detail commits table were plain text. Fix: link each to the commit detail page.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./internal/ui/... -count=1` — all pass
- [x] Verified via curl: commit detail returns 200, branch links contain `%2F` for slashed names, proposal branch link encoded, log tab points to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)