### PR TITLE
fix(rbac): add missing roleAllows cases for check, review, checks/retry

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -260,6 +260,16 @@ func roleAllows(role model.RoleType, method, subPath string, r *http.Request) bo
 		return role == model.RoleWriter || role == model.RoleMaintainer || role == model.RoleAdmin
 	}
 
+	// POST /check — writer+.
+	if method == http.MethodPost && subPath == "check" {
+		return role == model.RoleWriter || role == model.RoleMaintainer || role == model.RoleAdmin
+	}
+
+	// POST /review — writer+.
+	if method == http.MethodPost && subPath == "review" {
+		return role == model.RoleWriter || role == model.RoleMaintainer || role == model.RoleAdmin
+	}
+
 	// POST /proposals — writer+.
 	if method == http.MethodPost && subPath == "proposals" {
 		return role == model.RoleWriter || role == model.RoleMaintainer || role == model.RoleAdmin
@@ -295,6 +305,11 @@ func roleAllows(role model.RoleType, method, subPath string, r *http.Request) bo
 
 	// POST /branch, /merge, /rebase — maintainer+.
 	if method == http.MethodPost && (subPath == "branch" || subPath == "merge" || subPath == "rebase") {
+		return role == model.RoleMaintainer || role == model.RoleAdmin
+	}
+
+	// POST /checks/retry — maintainer+.
+	if method == http.MethodPost && subPath == "checks/retry" {
 		return role == model.RoleMaintainer || role == model.RoleAdmin
 	}
 

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -766,6 +766,80 @@ func TestRBACMiddleware_ReaderUpgradedToWriter(t *testing.T) {
 	}
 }
 
+func TestRBACMiddleware_CheckAndReviewAccess(t *testing.T) {
+	// Reader cannot POST /check or /review.
+	storeR := &mockRoleStore{
+		getRoleFn: func(_ context.Context, repo, identity string) (*model.Role, error) {
+			return &model.Role{Identity: identity, Role: model.RoleReader}, nil
+		},
+	}
+	hR := rbacTestServer(storeR, "", "alice@example.com")
+
+	rec := rbacDo(t, hR, http.MethodPost, "/repos/myrepo/myrepo/-/check", `{}`)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("reader POST check: expected 403, got %d", rec.Code)
+	}
+	rec = rbacDo(t, hR, http.MethodPost, "/repos/myrepo/myrepo/-/review", `{}`)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("reader POST review: expected 403, got %d", rec.Code)
+	}
+
+	// Writer can POST /check and /review.
+	storeW := &mockRoleStore{
+		getRoleFn: func(_ context.Context, repo, identity string) (*model.Role, error) {
+			return &model.Role{Identity: identity, Role: model.RoleWriter}, nil
+		},
+	}
+	hW := rbacTestServer(storeW, "", "bob@example.com")
+
+	rec = rbacDo(t, hW, http.MethodPost, "/repos/myrepo/myrepo/-/check", `{}`)
+	if rec.Code != http.StatusOK {
+		t.Errorf("writer POST check: expected 200, got %d", rec.Code)
+	}
+	rec = rbacDo(t, hW, http.MethodPost, "/repos/myrepo/myrepo/-/review", `{}`)
+	if rec.Code != http.StatusOK {
+		t.Errorf("writer POST review: expected 200, got %d", rec.Code)
+	}
+}
+
+func TestRBACMiddleware_ChecksRetryAccess(t *testing.T) {
+	// Reader cannot POST /checks/retry.
+	storeR := &mockRoleStore{
+		getRoleFn: func(_ context.Context, repo, identity string) (*model.Role, error) {
+			return &model.Role{Identity: identity, Role: model.RoleReader}, nil
+		},
+	}
+	hR := rbacTestServer(storeR, "", "alice@example.com")
+	rec := rbacDo(t, hR, http.MethodPost, "/repos/myrepo/myrepo/-/checks/retry", `{}`)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("reader POST checks/retry: expected 403, got %d", rec.Code)
+	}
+
+	// Writer cannot POST /checks/retry.
+	storeW := &mockRoleStore{
+		getRoleFn: func(_ context.Context, repo, identity string) (*model.Role, error) {
+			return &model.Role{Identity: identity, Role: model.RoleWriter}, nil
+		},
+	}
+	hW := rbacTestServer(storeW, "", "bob@example.com")
+	rec = rbacDo(t, hW, http.MethodPost, "/repos/myrepo/myrepo/-/checks/retry", `{}`)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("writer POST checks/retry: expected 403, got %d", rec.Code)
+	}
+
+	// Maintainer can POST /checks/retry.
+	storeM := &mockRoleStore{
+		getRoleFn: func(_ context.Context, repo, identity string) (*model.Role, error) {
+			return &model.Role{Identity: identity, Role: model.RoleMaintainer}, nil
+		},
+	}
+	hM := rbacTestServer(storeM, "", "carol@example.com")
+	rec = rbacDo(t, hM, http.MethodPost, "/repos/myrepo/myrepo/-/checks/retry", `{}`)
+	if rec.Code != http.StatusOK {
+		t.Errorf("maintainer POST checks/retry: expected 200, got %d", rec.Code)
+	}
+}
+
 func TestRBACMiddleware_ReleasesAccess(t *testing.T) {
 	store := &mockRoleStore{
 		getRoleFn: func(_ context.Context, repo, identity string) (*model.Role, error) {


### PR DESCRIPTION
## Summary

- `POST /check` and `POST /review` were always returning 403 because `roleAllows` in `internal/server/middleware.go` had no cases for these sub-paths — they fell through to `return false`
- `POST /checks/retry` had the same problem

## Changes

Added three missing cases to `roleAllows`:
- `POST /check` — writer+ (placed with other writer+ POST handlers)
- `POST /review` — writer+ (placed with other writer+ POST handlers)
- `POST /checks/retry` — maintainer+ (placed with other maintainer+ POST handlers like `branch`/`merge`/`rebase`)

Also added unit tests in `middleware_test.go` (`TestRBACMiddleware_CheckAndReviewAccess`, `TestRBACMiddleware_ChecksRetryAccess`) covering reader/writer/maintainer access for all three endpoints.

## Test plan

- [x] `go test ./internal/server/ -run TestRBACMiddleware_Check` — new tests pass
- [x] `go build ./... && go vet ./...` — clean
- [x] Full `go test ./...` — all pass except `TestDockerSmoke` which is a pre-existing failure requiring gcloud credentials for a private Docker registry (unrelated to this change)

Fixes #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)