### PR TITLE
fix(ui): fix HTMX loading, tab switcher, branch-name encoding bugs

### DIFF
--- a/internal/ui/static/poll.js
+++ b/internal/ui/static/poll.js
@@ -62,6 +62,37 @@
     }).catch(function () {});
   });
 
+  // Minimal HTMX-like click handler for hx-get, hx-target, hx-swap attributes.
+  // Supports two patterns:
+  //   hx-swap="afterend" + hx-target="closest .selector" — inserts fetched HTML after closest ancestor
+  //   hx-swap="innerHTML" + hx-target="#id"              — replaces innerHTML of target element
+  document.addEventListener('click', function (e) {
+    var el = e.target.closest('[hx-get]');
+    if (!el) return;
+    var url = el.getAttribute('hx-get');
+    var targetSel = el.getAttribute('hx-target');
+    var swap = el.getAttribute('hx-swap') || 'innerHTML';
+    if (!url || !targetSel) return;
+    e.preventDefault();
+    fetch(url, { credentials: 'same-origin' }).then(function (r) {
+      if (!r.ok) return;
+      return r.text().then(function (html) {
+        if (swap === 'afterend') {
+          // targetSel is like "closest .check-row"
+          var parts = targetSel.match(/^closest\s+(.+)$/);
+          var anchor = parts ? el.closest(parts[1]) : el;
+          if (!anchor) return;
+          anchor.insertAdjacentHTML('afterend', html);
+        } else {
+          // innerHTML: targetSel is a CSS selector like "#some-id"
+          var target = document.querySelector(targetSel);
+          if (!target) return;
+          target.innerHTML = html;
+        }
+      });
+    }).catch(function () {});
+  });
+
   // Branch-list filter. Hides tbody rows whose first cell text doesn't match.
   document.addEventListener('DOMContentLoaded', function () {
     var inputs = document.querySelectorAll('[data-branch-filter]');

--- a/internal/ui/templates/branch_checks.html
+++ b/internal/ui/templates/branch_checks.html
@@ -13,7 +13,7 @@
   <div class="check-row-actions">
     {{if .LogURL}}<a href="{{.LogURL}}" target="_blank" rel="noopener" class="open-log">logs →</a>{{end}}
     <button class="btn-history"
-      hx-get="/ui/_/r/{{$.Branch.Repo}}/b/{{$.Branch.Name}}/check-history?check={{.CheckName}}"
+      hx-get="/ui/_/r/{{$.Branch.Repo}}/b/{{urlPathEscape $.Branch.Name}}/check-history?check={{.CheckName}}"
       hx-swap="afterend"
       hx-target="closest .check-row">history ▾</button>
   </div>

--- a/internal/ui/templates/branch_detail.html
+++ b/internal/ui/templates/branch_detail.html
@@ -55,13 +55,13 @@
           <div class="meta">@ seq {{.Sequence}} · {{relTime .CreatedAt}}</div>
         </div>
         <button class="btn-link"
-          hx-get="/ui/_/r/{{$page.Repo.Name}}/b/{{$ctx.Branch.Name}}/comments"
-          hx-target="#review-comments-{{$ctx.Branch.Name}}"
+          hx-get="/ui/_/r/{{$page.Repo.Name}}/b/{{urlPathEscape $ctx.Branch.Name}}/comments"
+          hx-target="#review-comments"
           hx-swap="innerHTML">inline comments ▾</button>
       </div>
       {{if .Body}}<div class="row-body">{{.Body}}</div>{{end}}
       {{end}}
-      <div id="review-comments-{{$ctx.Branch.Name}}"></div>
+      <div id="review-comments"></div>
     </div>
   </div>
 </div>

--- a/internal/ui/templates/branches.html
+++ b/internal/ui/templates/branches.html
@@ -73,7 +73,7 @@
         {{if .Draft}}<span class="badge warn">draft</span>{{end}}
         {{if .AutoMerge}}<span class="badge ok">auto-merge</span>{{end}}
       </td>
-      <td><a href="/ui/r/{{$.Repo}}/f/?branch={{urlPathEscape .Name}}">files →</a> · <a href="/ui/r/{{$.Repo}}/b/{{urlPathEscape .Name}}/log">log →</a></td>
+      <td><a href="/ui/r/{{$.Repo}}/f/?branch={{.Name}}">files →</a> · <a href="/ui/r/{{$.Repo}}/b/{{urlPathEscape .Name}}/log">log →</a></td>
     </tr>
     {{end}}
     </tbody>

--- a/internal/ui/templates/commit.html
+++ b/internal/ui/templates/commit.html
@@ -25,7 +25,7 @@
     <tbody>
     {{range .Commit.Files}}
     <tr>
-      <td><a href="/ui/r/{{$page.Repo.Name}}/f/{{.Path}}?branch={{urlPathEscape $page.Branch}}&at={{$page.Commit.Sequence}}">{{.Path}}</a></td>
+      <td><a href="/ui/r/{{$page.Repo.Name}}/f/{{.Path}}?branch={{$page.Branch}}&at={{$page.Commit.Sequence}}">{{.Path}}</a></td>
       <td><span class="badge {{diffClass .VersionID}}">{{if .VersionID}}modified{{else}}deleted{{end}}</span></td>
     </tr>
     {{end}}

--- a/internal/ui/templates/issues.html
+++ b/internal/ui/templates/issues.html
@@ -4,14 +4,14 @@
   <h1>{{.Repo.Name}} / issues</h1>
 </div>
 
-<div class="tab-bar">
+<div class="tab-bar" data-tab-group>
   <a href="/ui/r/{{.Repo.Name}}/issues?state=open"
      data-tab-url="/ui/_/r/{{.Repo.Name}}/issues?state=open"
-     data-tab-target="issues-table"
+     data-tab-target="#issues-table"
      class="tab{{if eq .State "open"}} active{{end}}">Open</a>
   <a href="/ui/r/{{.Repo.Name}}/issues?state=closed"
      data-tab-url="/ui/_/r/{{.Repo.Name}}/issues?state=closed"
-     data-tab-target="issues-table"
+     data-tab-target="#issues-table"
      class="tab{{if eq .State "closed"}} active{{end}}">Closed</a>
 </div>
 


### PR DESCRIPTION
## Summary

- Add a minimal HTMX-like click handler to `poll.js` that handles `hx-get`/`hx-target`/`hx-swap` attributes (supports `afterend` with `closest` selector and `innerHTML` with `#id` selector), fixing dead "history ▾" and "inline comments ▾" buttons without adding an external CDN dependency
- Fix issues tab switcher: `data-tab-target` was missing the `#` prefix so `document.querySelector` never matched the target element; also add `data-tab-group` so the active class toggles correctly
- Fix double-encoding of branch names in query parameter values in `branches.html` and `commit.html` — `urlPathEscape` is only correct for URL path segments, not query params which `html/template` already encodes natively
- Add `urlPathEscape` to branch name in HTMX URL path segments in `branch_detail.html` and `branch_checks.html` so branches with `/` in their names (e.g. `feature/auth`) produce valid paths
- Use a static `id="review-comments"` instead of `id="review-comments-{{branch}}"` to avoid invalid HTML ids and CSS selectors when branch names contain `/`

Closes #313

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (server tests skip without Postgres, all others pass)
- [ ] `http://localhost:8080/ui/r/demo/app/issues` returns 200, tab switcher works
- [ ] `http://localhost:8080/ui/r/demo/app/b/feature%2Fauth` returns 200, "history ▾" and "inline comments ▾" buttons work
- [ ] `http://localhost:8080/ui/r/demo/app/b/feature%2Fauth/log` returns 200
- [ ] File browser link for branches with `/` in name no longer double-encodes branch in query param

🤖 Generated with [Claude Code](https://claude.com/claude-code)