### PR TITLE
feat(ui): add repo nav tabs, CI jobs pages, issue refs, and checks retry (issue #313)

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -232,6 +232,29 @@ func (fakeWrite) GetRelease(_ context.Context, _, name string) (*model.Release, 
 	return r, nil
 }
 
+func (fakeWrite) ListIssueRefs(_ context.Context, _ string, _ int64) ([]model.IssueRef, error) {
+	return nil, nil
+}
+
+func (fakeWrite) ListCIJobs(_ context.Context, _ string, _, _ *string, _ int) ([]model.CIJob, error) {
+	t := time.Now()
+	logURL := "https://ci.example/logs/42"
+	return []model.CIJob{
+		{ID: "job-aabbccdd-1111-2222-3333-444455556666", Repo: "acme/platform", Branch: "add-onboarding-guide", Sequence: 47, Status: "passed", TriggerType: "push", TriggerBranch: "add-onboarding-guide", CreatedAt: t.Add(-30 * time.Minute), LogURL: &logURL},
+		{ID: "job-bbccddee-2222-3333-4444-555566667777", Repo: "acme/platform", Branch: "main", Sequence: 42, Status: "queued", TriggerType: "push", TriggerBranch: "main", CreatedAt: t.Add(-5 * time.Minute)},
+	}, nil
+}
+
+func (fakeWrite) GetCIJob(_ context.Context, id string) (*model.CIJob, error) {
+	t := time.Now()
+	logURL := "https://ci.example/logs/42"
+	jobs := map[string]*model.CIJob{
+		"job-aabbccdd-1111-2222-3333-444455556666": {ID: "job-aabbccdd-1111-2222-3333-444455556666", Repo: "acme/platform", Branch: "add-onboarding-guide", Sequence: 47, Status: "passed", TriggerType: "push", TriggerBranch: "add-onboarding-guide", CreatedAt: t.Add(-30 * time.Minute), LogURL: &logURL},
+		"job-bbccddee-2222-3333-4444-555566667777": {ID: "job-bbccddee-2222-3333-4444-555566667777", Repo: "acme/platform", Branch: "main", Sequence: 42, Status: "queued", TriggerType: "push", TriggerBranch: "main", CreatedAt: t.Add(-5 * time.Minute)},
+	}
+	return jobs[id], nil
+}
+
 func fakeAssemble(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
 	t := time.Now()
 	vid := func(s string) *string { return &s }

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -135,6 +135,7 @@ type issueDetailPage struct {
 	Repo     model.Repo
 	Issue    *model.Issue
 	Comments []model.IssueComment
+	Refs     []model.IssueRef
 }
 
 type acceptInvitePage struct {
@@ -163,6 +164,17 @@ type releasesPage struct {
 type releaseDetailPage struct {
 	Repo    model.Repo
 	Release *model.Release
+}
+
+type ciJobsPage struct {
+	Repo   model.Repo
+	Jobs   []model.CIJob
+	Status string
+}
+
+type ciJobDetailPage struct {
+	Repo model.Repo
+	Job  *model.CIJob
 }
 
 // ---------------------------------------------------------------------------
@@ -678,7 +690,14 @@ func (h *Handler) handleIssueDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	page := issueDetailPage{Repo: *repo, Issue: issue, Comments: comments}
+	refs, err := h.write.ListIssueRefs(ctx, repoName, number)
+	if err != nil {
+		slog.Error("ui list issue refs", "repo", repoName, "number", number, "error", err)
+		// Non-fatal: render page without refs.
+		refs = nil
+	}
+
+	page := issueDetailPage{Repo: *repo, Issue: issue, Comments: comments, Refs: refs}
 	h.render(w, h.tmpl.issueDetail, "layout.html", pageData{
 		Title: repoName + " / issue #" + numberStr,
 		Breadcrumbs: []crumb{
@@ -888,6 +907,91 @@ func (h *Handler) handleReleaseDetail(w http.ResponseWriter, r *http.Request) {
 			{Label: rname, Href: ""},
 		},
 		Body: releaseDetailPage{Repo: *repo, Release: release},
+	})
+}
+
+// handleCIJobs renders the CI jobs list for a repo with optional status filter.
+func (h *Handler) handleCIJobs(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	statusFilter := r.URL.Query().Get("status")
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	var statusPtr *string
+	if statusFilter != "" {
+		statusPtr = &statusFilter
+	}
+
+	jobs, err := h.write.ListCIJobs(ctx, repoName, nil, statusPtr, 100)
+	if err != nil {
+		slog.Error("ui list ci jobs", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load ci jobs")
+		return
+	}
+
+	h.render(w, h.tmpl.ciJobs, "layout.html", pageData{
+		Title: repoName + " / ci-jobs",
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: "ci-jobs", Href: ""},
+		},
+		Body: ciJobsPage{Repo: *repo, Jobs: jobs, Status: statusFilter},
+	})
+}
+
+// handleCIJobDetail renders the detail view for a single CI job.
+func (h *Handler) handleCIJobDetail(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	id := r.PathValue("id")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	job, err := h.write.GetCIJob(ctx, id)
+	if err != nil {
+		slog.Error("ui get ci job", "id", id, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load ci job")
+		return
+	}
+	if job == nil {
+		h.renderError(w, http.StatusNotFound, "ci job not found")
+		return
+	}
+
+	h.render(w, h.tmpl.ciJobDetail, "layout.html", pageData{
+		Title: repoName + " / ci-jobs / " + id,
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: "ci-jobs", Href: "/ui/r/" + repoName + "/ci-jobs"},
+			{Label: id[:8], Href: ""},
+		},
+		Body: ciJobDetailPage{Repo: *repo, Job: job},
 	})
 }
 

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -36,6 +36,8 @@ type templateSet struct {
 	proposalDetail  *template.Template
 	releases        *template.Template
 	releaseDetail   *template.Template
+	ciJobs          *template.Template
+	ciJobDetail     *template.Template
 }
 
 func parseTemplates(root fs.FS) (*templateSet, error) {
@@ -161,6 +163,14 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse release_detail: %w", err)
 	}
+	ciJobs, err := load("ci_jobs.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse ci_jobs: %w", err)
+	}
+	ciJobDetail, err := load("ci_job_detail.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse ci_job_detail: %w", err)
+	}
 	return &templateSet{
 		repos:          repos,
 		branches:       branches,
@@ -183,6 +193,8 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		proposalDetail:  proposalDetail,
 		releases:        releases,
 		releaseDetail:   releaseDetail,
+		ciJobs:          ciJobs,
+		ciJobDetail:     ciJobDetail,
 	}, nil
 }
 

--- a/internal/ui/templates/branch_detail.html
+++ b/internal/ui/templates/branch_detail.html
@@ -42,6 +42,23 @@
     <div class="card" data-poll-url="/ui/_/r/{{.Repo.Name}}/b/{{urlPathEscape $ctx.Branch.Name}}/checks" data-poll-interval="10000">
       {{template "branch_checks.html" $ctx}}
     </div>
+    {{if $ctx.CheckRuns}}
+    <div style="margin-top:8px">
+      <button class="btn-link" id="retry-checks-btn" onclick="(function(){
+        var btn = document.getElementById('retry-checks-btn');
+        btn.disabled = true;
+        btn.textContent = 'retrying…';
+        fetch('/repos/{{$page.Repo.Name}}/-/checks/retry', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({branch: '{{$ctx.Branch.Name}}', sequence: {{$ctx.Branch.HeadSequence}}, checks: []})
+        }).then(function(r){
+          if(r.ok){ btn.textContent = 'retried'; setTimeout(function(){ location.reload(); }, 1000); }
+          else { btn.textContent = 'retry failed'; btn.disabled = false; }
+        }).catch(function(){ btn.textContent = 'retry failed'; btn.disabled = false; });
+      })()">retry all checks</button>
+    </div>
+    {{end}}
   </div>
   <div>
     <h2>Reviews ({{len $ctx.Reviews}})</h2>

--- a/internal/ui/templates/branches.html
+++ b/internal/ui/templates/branches.html
@@ -3,10 +3,11 @@
 <div class="headline"><h1>{{.Repo.Name}}</h1><span class="meta">owner {{.Repo.Owner}} · {{relTime .Repo.CreatedAt}} · <a href="/repos/{{.Repo.Name}}/-/archive">download archive</a></span></div>
 
 <nav class="repo-tabs">
-  <a href="/ui/r/{{.Repo.Name}}">branches</a>
+  <a href="/ui/r/{{.Repo.Name}}" class="active">branches</a>
   <a href="/ui/r/{{.Repo.Name}}/issues">issues</a>
   <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
+  <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
 </nav>
 

--- a/internal/ui/templates/ci_job_detail.html
+++ b/internal/ui/templates/ci_job_detail.html
@@ -1,0 +1,97 @@
+{{define "content"}}
+{{with .Body}}
+<nav class="repo-tabs">
+  <a href="/ui/r/{{.Repo.Name}}">branches</a>
+  <a href="/ui/r/{{.Repo.Name}}/issues">issues</a>
+  <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
+  <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
+  <a href="/ui/r/{{.Repo.Name}}/ci-jobs" class="active">ci-jobs</a>
+  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+</nav>
+
+<div class="headline">
+  <h1>CI Job {{slice .Job.ID 0 8}}</h1>
+  <span class="badge {{statusClass .Job.Status}}">{{.Job.Status}}</span>
+</div>
+
+<div class="meta" style="margin-bottom:14px">
+  created {{relTime .Job.CreatedAt}}
+</div>
+
+<h2>Details</h2>
+<div class="card">
+  <div class="row">
+    <div><strong>id</strong></div>
+    <div class="meta">{{.Job.ID}}</div>
+  </div>
+  <div class="row">
+    <div><strong>repo</strong></div>
+    <div>{{.Job.Repo}}</div>
+  </div>
+  <div class="row">
+    <div><strong>branch</strong></div>
+    <div><a href="/ui/r/{{.Repo.Name}}/b/{{urlPathEscape .Job.Branch}}">{{.Job.Branch}}</a></div>
+  </div>
+  <div class="row">
+    <div><strong>sequence</strong></div>
+    <div>{{.Job.Sequence}}</div>
+  </div>
+  <div class="row">
+    <div><strong>status</strong></div>
+    <div><span class="badge {{statusClass .Job.Status}}">{{.Job.Status}}</span></div>
+  </div>
+  <div class="row">
+    <div><strong>trigger type</strong></div>
+    <div class="meta">{{.Job.TriggerType}}</div>
+  </div>
+  {{if .Job.TriggerBranch}}
+  <div class="row">
+    <div><strong>trigger branch</strong></div>
+    <div><a href="/ui/r/{{.Repo.Name}}/b/{{urlPathEscape .Job.TriggerBranch}}">{{.Job.TriggerBranch}}</a></div>
+  </div>
+  {{end}}
+  {{if .Job.TriggerBaseBranch}}
+  <div class="row">
+    <div><strong>trigger base branch</strong></div>
+    <div>{{.Job.TriggerBaseBranch}}</div>
+  </div>
+  {{end}}
+  {{if .Job.TriggerProposalID}}
+  <div class="row">
+    <div><strong>trigger proposal</strong></div>
+    <div><a href="/ui/r/{{.Repo.Name}}/proposals/{{.Job.TriggerProposalID}}">{{.Job.TriggerProposalID}}</a></div>
+  </div>
+  {{end}}
+  {{if .Job.WorkerPod}}
+  <div class="row">
+    <div><strong>worker pod</strong></div>
+    <div class="meta">{{.Job.WorkerPod}}</div>
+  </div>
+  {{end}}
+  {{if .Job.ClaimedAt}}
+  <div class="row">
+    <div><strong>claimed</strong></div>
+    <div class="meta">{{relTimep .Job.ClaimedAt}}</div>
+  </div>
+  {{end}}
+  {{if .Job.LastHeartbeatAt}}
+  <div class="row">
+    <div><strong>last heartbeat</strong></div>
+    <div class="meta">{{relTimep .Job.LastHeartbeatAt}}</div>
+  </div>
+  {{end}}
+  {{if .Job.LogURL}}
+  <div class="row">
+    <div><strong>log</strong></div>
+    <div><a href="{{.Job.LogURL}}" target="_blank" rel="noopener">view logs →</a></div>
+  </div>
+  {{end}}
+  {{if .Job.ErrorMessage}}
+  <div class="row">
+    <div><strong>error</strong></div>
+    <div class="meta" style="color:var(--bad)">{{.Job.ErrorMessage}}</div>
+  </div>
+  {{end}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/ci_jobs.html
+++ b/internal/ui/templates/ci_jobs.html
@@ -1,0 +1,54 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline">
+  <h1>{{.Repo.Name}} / ci-jobs</h1>
+  <span class="meta">owner {{.Repo.Owner}}</span>
+</div>
+
+<nav class="repo-tabs">
+  <a href="/ui/r/{{.Repo.Name}}">branches</a>
+  <a href="/ui/r/{{.Repo.Name}}/issues">issues</a>
+  <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
+  <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
+  <a href="/ui/r/{{.Repo.Name}}/ci-jobs" class="active">ci-jobs</a>
+  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+</nav>
+
+<div class="tab-bar">
+  <a class="tab{{if eq .Status ""}} active{{end}}" href="?">all</a>
+  <a class="tab{{if eq .Status "queued"}} active{{end}}" href="?status=queued">queued</a>
+  <a class="tab{{if eq .Status "claimed"}} active{{end}}" href="?status=claimed">running</a>
+  <a class="tab{{if eq .Status "passed"}} active{{end}}" href="?status=passed">passed</a>
+  <a class="tab{{if eq .Status "failed"}} active{{end}}" href="?status=failed">failed</a>
+</div>
+
+<div class="card">
+{{if not .Jobs}}<div class="empty">no ci jobs found</div>{{else}}
+<table class="grid">
+  <thead>
+    <tr>
+      <th>id</th>
+      <th>branch</th>
+      <th>seq</th>
+      <th>trigger</th>
+      <th>status</th>
+      <th>created</th>
+    </tr>
+  </thead>
+  <tbody>
+  {{range .Jobs}}
+  <tr>
+    <td><a href="ci-jobs/{{.ID}}">{{slice .ID 0 8}}</a></td>
+    <td><a href="/ui/r/{{$.Repo.Name}}/b/{{urlPathEscape .Branch}}">{{.Branch}}</a></td>
+    <td>{{.Sequence}}</td>
+    <td class="meta">{{.TriggerType}}{{if .TriggerBranch}} / {{.TriggerBranch}}{{end}}</td>
+    <td><span class="badge {{statusClass .Status}}">{{.Status}}</span></td>
+    <td class="meta">{{relTime .CreatedAt}}</td>
+  </tr>
+  {{end}}
+  </tbody>
+</table>
+{{end}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/issue_detail.html
+++ b/internal/ui/templates/issue_detail.html
@@ -1,5 +1,14 @@
 {{define "content"}}
 {{with .Body}}
+<nav class="repo-tabs">
+  <a href="/ui/r/{{.Repo.Name}}">branches</a>
+  <a href="/ui/r/{{.Repo.Name}}/issues" class="active">issues</a>
+  <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
+  <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
+  <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
+  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+</nav>
+
 <div class="headline">
   <h1>#{{.Issue.Number}} {{.Issue.Title}}</h1>
   <span class="badge {{statusClass (printf "%s" .Issue.State)}}">{{.Issue.State}}</span>
@@ -33,5 +42,26 @@
   {{if .Body}}<div class="row-body">{{.Body}}</div>{{end}}
   {{end}}
 </div>
+
+{{if .Refs}}
+<h2>References ({{len .Refs}})</h2>
+<div class="card">
+  {{range .Refs}}
+  <div class="row">
+    <div>
+      <span class="badge neutral">{{.RefType}}</span>
+      {{if eq (printf "%s" .RefType) "proposal"}}
+        <a href="/ui/r/{{$.Repo.Name}}/proposals/{{.RefID}}">{{.RefID}}</a>
+      {{else if eq (printf "%s" .RefType) "commit"}}
+        <a href="/ui/r/{{$.Repo.Name}}/b/main/c/{{.RefID}}">seq {{.RefID}}</a>
+      {{else}}
+        <span>{{.RefID}}</span>
+      {{end}}
+    </div>
+    <span class="meta">{{relTime .CreatedAt}}</span>
+  </div>
+  {{end}}
+</div>
+{{end}}
 {{end}}
 {{end}}

--- a/internal/ui/templates/issues.html
+++ b/internal/ui/templates/issues.html
@@ -4,6 +4,15 @@
   <h1>{{.Repo.Name}} / issues</h1>
 </div>
 
+<nav class="repo-tabs">
+  <a href="/ui/r/{{.Repo.Name}}">branches</a>
+  <a href="/ui/r/{{.Repo.Name}}/issues" class="active">issues</a>
+  <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
+  <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
+  <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
+  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+</nav>
+
 <div class="tab-bar" data-tab-group>
   <a href="/ui/r/{{.Repo.Name}}/issues?state=open"
      data-tab-url="/ui/_/r/{{.Repo.Name}}/issues?state=open"

--- a/internal/ui/templates/proposal_detail.html
+++ b/internal/ui/templates/proposal_detail.html
@@ -1,5 +1,14 @@
 {{define "content"}}
 {{with .Body}}
+<nav class="repo-tabs">
+  <a href="/ui/r/{{.Repo.Name}}">branches</a>
+  <a href="/ui/r/{{.Repo.Name}}/issues">issues</a>
+  <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
+  <a href="/ui/r/{{.Repo.Name}}/proposals" class="active">proposals</a>
+  <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
+  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+</nav>
+
 <div class="headline">
   <h1>{{.Proposal.Title}}</h1>
   <span class="badge {{statusClass (printf "%s" .Proposal.State)}}">{{.Proposal.State}}</span>

--- a/internal/ui/templates/proposals.html
+++ b/internal/ui/templates/proposals.html
@@ -5,6 +5,15 @@
   <span class="meta">owner {{.Repo.Owner}}</span>
 </div>
 
+<nav class="repo-tabs">
+  <a href="/ui/r/{{.Repo.Name}}">branches</a>
+  <a href="/ui/r/{{.Repo.Name}}/issues">issues</a>
+  <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
+  <a href="/ui/r/{{.Repo.Name}}/proposals" class="active">proposals</a>
+  <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
+  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+</nav>
+
 <div class="tab-bar" data-tab-group>
   <a class="tab{{if eq .State "open"}} active{{end}}"
      href="?state=open"

--- a/internal/ui/templates/release_detail.html
+++ b/internal/ui/templates/release_detail.html
@@ -1,5 +1,14 @@
 {{define "content"}}
 {{with .Body}}
+<nav class="repo-tabs">
+  <a href="/ui/r/{{.Repo.Name}}">branches</a>
+  <a href="/ui/r/{{.Repo.Name}}/issues">issues</a>
+  <a href="/ui/r/{{.Repo.Name}}/releases" class="active">releases</a>
+  <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
+  <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
+  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+</nav>
+
 <div class="headline">
   <h1>{{.Release.Name}}</h1>
   <span class="meta">seq {{.Release.Sequence}}</span>

--- a/internal/ui/templates/releases.html
+++ b/internal/ui/templates/releases.html
@@ -5,6 +5,15 @@
   <span class="meta">owner {{.Repo.Owner}}</span>
 </div>
 
+<nav class="repo-tabs">
+  <a href="/ui/r/{{.Repo.Name}}">branches</a>
+  <a href="/ui/r/{{.Repo.Name}}/issues">issues</a>
+  <a href="/ui/r/{{.Repo.Name}}/releases" class="active">releases</a>
+  <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
+  <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
+  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+</nav>
+
 <div class="card">
 {{if not .Releases}}<div class="empty">no releases</div>{{else}}
 <table class="grid">

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -48,6 +48,9 @@ type WriteStoreLite interface {
 	GetProposal(ctx context.Context, repo, proposalID string) (*model.Proposal, error)
 	ListReleases(ctx context.Context, repo string, limit int, afterID string) ([]model.Release, error)
 	GetRelease(ctx context.Context, repo, name string) (*model.Release, error)
+	ListIssueRefs(ctx context.Context, repo string, number int64) ([]model.IssueRef, error)
+	ListCIJobs(ctx context.Context, repo string, branch, status *string, limit int) ([]model.CIJob, error)
+	GetCIJob(ctx context.Context, id string) (*model.CIJob, error)
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -143,6 +146,8 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/proposals/{id}", h.handleProposalDetail)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/releases", h.handleReleases)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/releases/{rname}", h.handleReleaseDetail)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/ci-jobs", h.handleCIJobs)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/ci-jobs/{id}", h.handleCIJobDetail)
 	mux.HandleFunc("GET /ui/o/{org}/invites/{token}/accept", h.handleAcceptInvite)
 	mux.HandleFunc("POST /ui/o/{org}/invites/{token}/accept", h.handleAcceptInvite)
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -143,6 +143,15 @@ func (f *fakeWrite) GetRelease(_ context.Context, _, name string) (*model.Releas
 	}
 	return nil, nil
 }
+func (f *fakeWrite) ListIssueRefs(_ context.Context, _ string, _ int64) ([]model.IssueRef, error) {
+	return nil, nil
+}
+func (f *fakeWrite) ListCIJobs(_ context.Context, _ string, _, _ *string, _ int) ([]model.CIJob, error) {
+	return nil, nil
+}
+func (f *fakeWrite) GetCIJob(_ context.Context, _ string) (*model.CIJob, error) {
+	return nil, nil
+}
 
 func newFakeAssembler(branchName string) AssembleFn {
 	return func(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {


### PR DESCRIPTION
## Summary

- Add repo-level navigation tab bar (branches / issues / releases / proposals / ci-jobs / log) to all secondary repo pages (issues, proposals, releases list and all detail pages) with correct `active` class on the current section
- Add CI jobs list page (`GET /ui/r/{owner}/{name}/ci-jobs`) with status filter tabs (all/queued/running/passed/failed) and a CI job detail page showing all fields plus a link to the log URL
- Add a "References" section to the issue detail page showing linked proposals and commits with navigation links (fetched via `ListIssueRefs`)
- Add a "retry all checks" button to the branch detail checks section that POSTs JSON to `/repos/{repo}/-/checks/retry` and reloads the page on success
- Extend `WriteStoreLite` interface with `ListIssueRefs`, `ListCIJobs`, and `GetCIJob`

Closes #313

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./internal/ui/... -count=1` passes
- [ ] `GET /ui/r/{owner}/{name}/issues` shows repo-tabs nav with "issues" active
- [ ] `GET /ui/r/{owner}/{name}/proposals` shows repo-tabs nav with "proposals" active
- [ ] `GET /ui/r/{owner}/{name}/releases` shows repo-tabs nav with "releases" active
- [ ] Detail pages (issue, proposal, release) show repo-tabs nav with parent section active
- [ ] `GET /ui/r/{owner}/{name}/ci-jobs` renders list page with status filter tabs
- [ ] `GET /ui/r/{owner}/{name}/ci-jobs/{id}` renders job detail page
- [ ] Issue detail page shows "References" section when refs exist
- [ ] Branch detail "retry all checks" button POSTs to the checks/retry API

🤖 Generated with [Claude Code](https://claude.com/claude-code)