### PR TITLE
feat(ui): add create org and repo forms to web UI

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -255,6 +255,14 @@ func (fakeWrite) GetCIJob(_ context.Context, id string) (*model.CIJob, error) {
 	return jobs[id], nil
 }
 
+func (fakeWrite) CreateOrg(_ context.Context, name, _ string) (*model.Org, error) {
+	return &model.Org{Name: name}, nil
+}
+
+func (fakeWrite) CreateRepo(_ context.Context, req model.CreateRepoRequest) (*model.Repo, error) {
+	return &model.Repo{Name: req.FullName(), Owner: req.Owner}, nil
+}
+
 func fakeAssemble(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
 	t := time.Now()
 	vid := func(s string) *string { return &s }

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -177,6 +177,18 @@ type ciJobDetailPage struct {
 	Job  *model.CIJob
 }
 
+type createOrgPage struct {
+	Name string
+	Err  string
+}
+
+type createRepoPage struct {
+	Owner string
+	Name  string
+	Orgs  []model.Org
+	Err   string
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -1276,6 +1288,110 @@ func (h *Handler) handleAcceptInvite(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r, "/ui/o/"+org, http.StatusSeeOther)
+}
+
+// handleCreateOrg renders the new-org form (GET) and creates the org (POST).
+func (h *Handler) handleCreateOrg(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	renderPage := func(name, errMsg string) {
+		h.render(w, h.tmpl.createOrg, "layout.html", pageData{
+			Title: "New organisation",
+			Breadcrumbs: []crumb{
+				{Label: "repos", Href: "/ui/"},
+				{Label: "new org", Href: ""},
+			},
+			Body: createOrgPage{Name: name, Err: errMsg},
+		})
+	}
+
+	if r.Method == http.MethodGet {
+		renderPage("", "")
+		return
+	}
+
+	// POST: create the org.
+	name := strings.TrimSpace(r.FormValue("name"))
+	if name == "" {
+		renderPage("", "Organisation name is required.")
+		return
+	}
+
+	var identity string
+	if h.identity != nil {
+		identity = h.identity(ctx)
+	}
+
+	if _, err := h.write.CreateOrg(ctx, name, identity); err != nil {
+		switch {
+		case errors.Is(err, db.ErrOrgExists):
+			renderPage(name, "An organisation with that name already exists.")
+		default:
+			slog.Error("ui create org", "name", name, "error", err)
+			renderPage(name, "Could not create organisation: "+err.Error())
+		}
+		return
+	}
+
+	http.Redirect(w, r, "/ui/o/"+name, http.StatusSeeOther)
+}
+
+// handleCreateRepo renders the new-repo form (GET) and creates the repo (POST).
+func (h *Handler) handleCreateRepo(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	orgs, err := h.write.ListOrgs(ctx)
+	if err != nil {
+		slog.Error("ui create repo list orgs", "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load organisations")
+		return
+	}
+
+	renderPage := func(owner, name, errMsg string) {
+		h.render(w, h.tmpl.createRepo, "layout.html", pageData{
+			Title: "New repository",
+			Breadcrumbs: []crumb{
+				{Label: "repos", Href: "/ui/"},
+				{Label: "new repo", Href: ""},
+			},
+			Body: createRepoPage{Owner: owner, Name: name, Orgs: orgs, Err: errMsg},
+		})
+	}
+
+	if r.Method == http.MethodGet {
+		renderPage("", "", "")
+		return
+	}
+
+	// POST: create the repo.
+	owner := strings.TrimSpace(r.FormValue("owner"))
+	name := strings.TrimSpace(r.FormValue("name"))
+
+	if owner == "" || name == "" {
+		renderPage(owner, name, "Organisation and repository name are both required.")
+		return
+	}
+
+	var identity string
+	if h.identity != nil {
+		identity = h.identity(ctx)
+	}
+
+	req := model.CreateRepoRequest{Owner: owner, Name: name, CreatedBy: identity}
+	if _, err := h.write.CreateRepo(ctx, req); err != nil {
+		switch {
+		case errors.Is(err, db.ErrRepoExists):
+			renderPage(owner, name, "A repository with that name already exists in this organisation.")
+		case errors.Is(err, db.ErrOrgNotFound):
+			renderPage(owner, name, "Organisation not found.")
+		default:
+			slog.Error("ui create repo", "owner", owner, "name", name, "error", err)
+			renderPage(owner, name, "Could not create repository: "+err.Error())
+		}
+		return
+	}
+
+	http.Redirect(w, r, "/ui/r/"+owner+"/"+name, http.StatusSeeOther)
 }
 
 // chainToLogRows filters and converts ChainEntries to commitLogRows.

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -38,6 +38,8 @@ type templateSet struct {
 	releaseDetail   *template.Template
 	ciJobs          *template.Template
 	ciJobDetail     *template.Template
+	createOrg       *template.Template
+	createRepo      *template.Template
 }
 
 func parseTemplates(root fs.FS) (*templateSet, error) {
@@ -171,6 +173,14 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse ci_job_detail: %w", err)
 	}
+	createOrg, err := load("create_org.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse create_org: %w", err)
+	}
+	createRepo, err := load("create_repo.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse create_repo: %w", err)
+	}
 	return &templateSet{
 		repos:          repos,
 		branches:       branches,
@@ -195,6 +205,8 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		releaseDetail:   releaseDetail,
 		ciJobs:          ciJobs,
 		ciJobDetail:     ciJobDetail,
+		createOrg:       createOrg,
+		createRepo:      createRepo,
 	}, nil
 }
 

--- a/internal/ui/templates/create_org.html
+++ b/internal/ui/templates/create_org.html
@@ -1,0 +1,19 @@
+{{define "content"}}
+<h1>New organisation</h1>
+{{with .Body}}
+<div class="card">
+  {{if .Err}}
+  <div class="row"><span class="badge bad">{{.Err}}</span></div>
+  {{end}}
+  <form method="POST" action="/ui/orgs/new" style="padding:14px 12px 4px">
+    <div class="row">
+      <label for="name">Name</label>
+      <input id="name" name="name" type="text" value="{{.Name}}" placeholder="my-org" required autofocus style="margin-left:8px">
+    </div>
+    <div class="row" style="padding-top:8px">
+      <button type="submit">Create organisation</button>
+    </div>
+  </form>
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/create_repo.html
+++ b/internal/ui/templates/create_repo.html
@@ -1,0 +1,32 @@
+{{define "content"}}
+<h1>New repository</h1>
+{{with .Body}}
+<div class="card">
+  {{if .Err}}
+  <div class="row"><span class="badge bad">{{.Err}}</span></div>
+  {{end}}
+  <form method="POST" action="/ui/repos/new" style="padding:14px 12px 4px">
+    <div class="row">
+      <label for="owner">Organisation</label>
+      {{if .Orgs}}
+      <select id="owner" name="owner" style="margin-left:8px" required>
+        <option value="">— select —</option>
+        {{range .Orgs}}
+        <option value="{{.Name}}"{{if eq $.Body.Owner .Name}} selected{{end}}>{{.Name}}</option>
+        {{end}}
+      </select>
+      {{else}}
+      <input id="owner" name="owner" type="text" value="{{.Owner}}" placeholder="my-org" required style="margin-left:8px">
+      {{end}}
+    </div>
+    <div class="row" style="padding-top:8px">
+      <label for="name">Name</label>
+      <input id="name" name="name" type="text" value="{{.Name}}" placeholder="my-repo" required autofocus style="margin-left:8px">
+    </div>
+    <div class="row" style="padding-top:8px">
+      <button type="submit">Create repository</button>
+    </div>
+  </form>
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/repos.html
+++ b/internal/ui/templates/repos.html
@@ -1,8 +1,12 @@
 {{define "content"}}
 <h1>Repos</h1>
 {{with .Body}}
+<div style="margin-bottom:12px">
+  <a href="/ui/orgs/new"><button>New org</button></a>
+  <a href="/ui/repos/new" style="margin-left:8px"><button>New repo</button></a>
+</div>
 {{if not .Orgs}}
-  <div class="card empty">No repos yet. Use <code>ds repos create</code> to add one.</div>
+  <div class="card empty">No repos yet.</div>
 {{else}}
   {{range .Orgs}}
   <div class="card">

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -51,6 +51,8 @@ type WriteStoreLite interface {
 	ListIssueRefs(ctx context.Context, repo string, number int64) ([]model.IssueRef, error)
 	ListCIJobs(ctx context.Context, repo string, branch, status *string, limit int) ([]model.CIJob, error)
 	GetCIJob(ctx context.Context, id string) (*model.CIJob, error)
+	CreateOrg(ctx context.Context, name, createdBy string) (*model.Org, error)
+	CreateRepo(ctx context.Context, req model.CreateRepoRequest) (*model.Repo, error)
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -150,5 +152,9 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/ci-jobs/{id}", h.handleCIJobDetail)
 	mux.HandleFunc("GET /ui/o/{org}/invites/{token}/accept", h.handleAcceptInvite)
 	mux.HandleFunc("POST /ui/o/{org}/invites/{token}/accept", h.handleAcceptInvite)
+	mux.HandleFunc("GET /ui/orgs/new", h.handleCreateOrg)
+	mux.HandleFunc("POST /ui/orgs/new", h.handleCreateOrg)
+	mux.HandleFunc("GET /ui/repos/new", h.handleCreateRepo)
+	mux.HandleFunc("POST /ui/repos/new", h.handleCreateRepo)
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -151,6 +152,18 @@ func (f *fakeWrite) ListCIJobs(_ context.Context, _ string, _, _ *string, _ int)
 }
 func (f *fakeWrite) GetCIJob(_ context.Context, _ string) (*model.CIJob, error) {
 	return nil, nil
+}
+func (f *fakeWrite) CreateOrg(_ context.Context, name, _ string) (*model.Org, error) {
+	if f.miss {
+		return nil, db.ErrOrgExists
+	}
+	return &model.Org{Name: name}, nil
+}
+func (f *fakeWrite) CreateRepo(_ context.Context, req model.CreateRepoRequest) (*model.Repo, error) {
+	if f.miss {
+		return nil, db.ErrRepoExists
+	}
+	return &model.Repo{Name: req.FullName(), Owner: req.Owner}, nil
 }
 
 func newFakeAssembler(branchName string) AssembleFn {
@@ -618,5 +631,122 @@ func TestHandleReleaseDetail_NotFound_Returns404(t *testing.T) {
 	code, _ := getStatusAndBody(t, h, "/ui/r/acme/a/releases/nonexistent")
 	if code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", code)
+	}
+}
+
+// postForm issues a POST with application/x-www-form-urlencoded body.
+// It does not follow redirects; the raw response is returned.
+func postForm(t *testing.T, h http.Handler, target string, vals url.Values) (int, string, string) {
+	t.Helper()
+	body := vals.Encode()
+	req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec.Code, rec.Body.String(), rec.Header().Get("Location")
+}
+
+func TestHandleCreateOrg_GET_RendersForm(t *testing.T) {
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{}, nil)
+	code, body := getStatusAndBody(t, h, "/ui/orgs/new")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"New organisation", `name="name"`, "Create organisation"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleCreateOrg_POST_RedirectsOnSuccess(t *testing.T) {
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{}, nil)
+	code, _, loc := postForm(t, h, "/ui/orgs/new", url.Values{"name": {"acme"}})
+	if code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", code)
+	}
+	if loc != "/ui/o/acme" {
+		t.Errorf("location = %q, want /ui/o/acme", loc)
+	}
+}
+
+func TestHandleCreateOrg_POST_EmptyName_ReturnsError(t *testing.T) {
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{}, nil)
+	code, body, _ := postForm(t, h, "/ui/orgs/new", url.Values{"name": {""}})
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 with error", code)
+	}
+	if !strings.Contains(body, "required") {
+		t.Errorf("expected required error in body: %s", body)
+	}
+}
+
+func TestHandleCreateOrg_POST_DuplicateName_ReturnsError(t *testing.T) {
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{miss: true}, nil)
+	code, body, _ := postForm(t, h, "/ui/orgs/new", url.Values{"name": {"acme"}})
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 with error", code)
+	}
+	if !strings.Contains(body, "already exists") {
+		t.Errorf("expected already-exists error in body: %s", body)
+	}
+}
+
+func TestHandleCreateRepo_GET_RendersForm(t *testing.T) {
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{}, nil)
+	code, body := getStatusAndBody(t, h, "/ui/repos/new")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"New repository", `name="name"`, "Create repository"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleCreateRepo_POST_RedirectsOnSuccess(t *testing.T) {
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{}, nil)
+	code, _, loc := postForm(t, h, "/ui/repos/new", url.Values{"owner": {"acme"}, "name": {"myrepo"}})
+	if code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", code)
+	}
+	if loc != "/ui/r/acme/myrepo" {
+		t.Errorf("location = %q, want /ui/r/acme/myrepo", loc)
+	}
+}
+
+func TestHandleCreateRepo_POST_MissingFields_ReturnsError(t *testing.T) {
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{}, nil)
+	code, body, _ := postForm(t, h, "/ui/repos/new", url.Values{"owner": {"acme"}, "name": {""}})
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 with error", code)
+	}
+	if !strings.Contains(body, "required") {
+		t.Errorf("expected required error in body: %s", body)
+	}
+}
+
+func TestHandleCreateRepo_POST_DuplicateRepo_ReturnsError(t *testing.T) {
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{miss: true}, nil)
+	code, body, _ := postForm(t, h, "/ui/repos/new", url.Values{"owner": {"acme"}, "name": {"myrepo"}})
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 with error", code)
+	}
+	if !strings.Contains(body, "already exists") {
+		t.Errorf("expected already-exists error in body: %s", body)
+	}
+}
+
+func TestHandleRepos_ShowsNewButtons(t *testing.T) {
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{}, nil)
+	code, body := getStatusAndBody(t, h, "/ui/")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	for _, want := range []string{"/ui/orgs/new", "/ui/repos/new"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing link %q", want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #320.

- Adds **GET/POST `/ui/orgs/new`** — single-field form to create a new organisation; redirects to `/ui/o/{name}` on success
- Adds **GET/POST `/ui/repos/new`** — two-field form (org dropdown + repo name) to create a new repository; redirects to `/ui/r/{owner}/{name}` on success
- Both forms display inline error messages for validation failures (missing fields, duplicate names, org not found)
- Repos landing page (`/ui/`) now shows "New org" and "New repo" buttons
- `WriteStoreLite` interface extended with `CreateOrg` and `CreateRepo`
- `cmd/ui-preview` fake store updated to implement the new interface methods
- 9 new tests added; all existing UI tests pass

## Test plan

- [ ] `go test ./internal/ui/... -count=1` passes
- [ ] `go build ./...` and `go vet ./...` clean
- [ ] GET `/ui/orgs/new` renders form with name input
- [ ] POST `/ui/orgs/new` with valid name redirects to `/ui/o/{name}`
- [ ] POST `/ui/orgs/new` with empty name shows validation error
- [ ] POST `/ui/orgs/new` with duplicate name shows "already exists" error
- [ ] GET `/ui/repos/new` renders form with org dropdown and name input
- [ ] POST `/ui/repos/new` with valid owner+name redirects to `/ui/r/{owner}/{name}`
- [ ] POST `/ui/repos/new` with missing fields shows validation error
- [ ] `/ui/` landing page shows "New org" and "New repo" buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)