### PR TITLE
feat(ui): add branch write operations to web UI

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -278,6 +278,12 @@ func (fakeWrite) GetCIJob(_ context.Context, id string) (*model.CIJob, error) {
 	}
 	return jobs[id], nil
 }
+func (fakeWrite) CreateBranch(_ context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error) {
+	return &model.CreateBranchResponse{Name: req.Name}, nil
+}
+func (fakeWrite) UpdateBranchDraft(_ context.Context, _, _ string, _ bool) error { return nil }
+func (fakeWrite) DeleteBranch(_ context.Context, _, _ string) error               { return nil }
+func (fakeWrite) SetBranchAutoMerge(_ context.Context, _, _ string, _ bool) error { return nil }
 
 func (fakeWrite) CreateOrg(_ context.Context, name, _ string) (*model.Org, error) {
 	return &model.Org{Name: name}, nil

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -45,6 +45,7 @@ type branchesPage struct {
 	Abandoned []branchRow
 	Members   []model.OrgMember
 	Roles     []model.Role
+	Err       string
 }
 
 type branchRow struct {
@@ -68,6 +69,7 @@ type branchDetailPage struct {
 	PassedCheckCnt  int
 	PendingCheckCnt int
 	FailedCheckCnt  int
+	Err             string
 }
 
 type filePage struct {
@@ -313,7 +315,7 @@ func (h *Handler) handleBranches(w http.ResponseWriter, r *http.Request) {
 		roles = nil
 	}
 
-	page := branchesPage{Repo: *repo, Members: members, Roles: roles}
+	page := branchesPage{Repo: *repo, Members: members, Roles: roles, Err: r.URL.Query().Get("err")}
 	for _, b := range branches {
 		row := branchRow{
 			Name:         b.Name,
@@ -378,7 +380,7 @@ func (h *Handler) handleBranchDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	page := branchDetailPage{Repo: *repo, Ctx: actCtx}
+	page := branchDetailPage{Repo: *repo, Ctx: actCtx, Err: r.URL.Query().Get("err")}
 	for _, p := range actCtx.Policies {
 		if !p.Pass {
 			reason := p.Reason
@@ -1725,6 +1727,152 @@ func (h *Handler) handleAddIssueRef(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r, issueURL(repoName, numberStr), http.StatusSeeOther)
+}
+
+// ---------------------------------------------------------------------------
+// Branch write handlers (POST-redirect-GET pattern)
+// ---------------------------------------------------------------------------
+
+// handleUICreateBranch processes the create-branch form on the branch list page.
+func (h *Handler) handleUICreateBranch(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+
+	if err := r.ParseForm(); err != nil {
+		http.Redirect(w, r, "/ui/r/"+repoName+"?err=invalid+form", http.StatusSeeOther)
+		return
+	}
+
+	branchName := strings.TrimSpace(r.FormValue("branch_name"))
+	if branchName == "" {
+		http.Redirect(w, r, "/ui/r/"+repoName+"?err=branch+name+is+required", http.StatusSeeOther)
+		return
+	}
+
+	draft := r.FormValue("draft") == "1"
+	_, err := h.write.CreateBranch(r.Context(), model.CreateBranchRequest{
+		Repo:  repoName,
+		Name:  branchName,
+		Draft: draft,
+	})
+	if err != nil {
+		slog.Error("ui create branch", "repo", repoName, "branch", branchName, "error", err)
+		errMsg := "create failed: " + err.Error()
+		http.Redirect(w, r, "/ui/r/"+repoName+"?err="+url.QueryEscape(errMsg), http.StatusSeeOther)
+		return
+	}
+
+	http.Redirect(w, r, "/ui/r/"+repoName, http.StatusSeeOther)
+}
+
+// handleUIDeleteBranch processes the delete-branch form on the branch list and detail pages.
+func (h *Handler) handleUIDeleteBranch(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+
+	if err := r.ParseForm(); err != nil {
+		http.Redirect(w, r, "/ui/r/"+repoName+"?err=invalid+form", http.StatusSeeOther)
+		return
+	}
+
+	branchName := strings.TrimSpace(r.FormValue("branch"))
+	if branchName == "" {
+		http.Redirect(w, r, "/ui/r/"+repoName+"?err=branch+name+is+required", http.StatusSeeOther)
+		return
+	}
+
+	if err := h.write.DeleteBranch(r.Context(), repoName, branchName); err != nil {
+		slog.Error("ui delete branch", "repo", repoName, "branch", branchName, "error", err)
+		errMsg := "delete failed: " + err.Error()
+		// Redirect to detail page if coming from there, otherwise branch list.
+		ref := r.FormValue("ref")
+		if ref == "detail" {
+			http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+url.PathEscape(branchName)+"?err="+url.QueryEscape(errMsg), http.StatusSeeOther)
+		} else {
+			http.Redirect(w, r, "/ui/r/"+repoName+"?err="+url.QueryEscape(errMsg), http.StatusSeeOther)
+		}
+		return
+	}
+
+	http.Redirect(w, r, "/ui/r/"+repoName, http.StatusSeeOther)
+}
+
+// handleUIPromoteBranch promotes a draft branch to active (sets draft=false).
+func (h *Handler) handleUIPromoteBranch(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+
+	if err := r.ParseForm(); err != nil {
+		http.Redirect(w, r, "/ui/r/"+repoName+"?err=invalid+form", http.StatusSeeOther)
+		return
+	}
+
+	branchName := strings.TrimSpace(r.FormValue("branch"))
+	if branchName == "" {
+		http.Redirect(w, r, "/ui/r/"+repoName+"?err=branch+name+is+required", http.StatusSeeOther)
+		return
+	}
+
+	if err := h.write.UpdateBranchDraft(r.Context(), repoName, branchName, false); err != nil {
+		slog.Error("ui promote branch", "repo", repoName, "branch", branchName, "error", err)
+		errMsg := "promote failed: " + err.Error()
+		ref := r.FormValue("ref")
+		if ref == "detail" {
+			http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+url.PathEscape(branchName)+"?err="+url.QueryEscape(errMsg), http.StatusSeeOther)
+		} else {
+			http.Redirect(w, r, "/ui/r/"+repoName+"?err="+url.QueryEscape(errMsg), http.StatusSeeOther)
+		}
+		return
+	}
+
+	ref := r.FormValue("ref")
+	if ref == "detail" {
+		http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+url.PathEscape(branchName), http.StatusSeeOther)
+	} else {
+		http.Redirect(w, r, "/ui/r/"+repoName, http.StatusSeeOther)
+	}
+}
+
+// handleUISetAutoMerge enables or disables auto-merge on a branch.
+func (h *Handler) handleUISetAutoMerge(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+
+	if err := r.ParseForm(); err != nil {
+		http.Redirect(w, r, "/ui/r/"+repoName+"?err=invalid+form", http.StatusSeeOther)
+		return
+	}
+
+	branchName := strings.TrimSpace(r.FormValue("branch"))
+	if branchName == "" {
+		http.Redirect(w, r, "/ui/r/"+repoName+"?err=branch+name+is+required", http.StatusSeeOther)
+		return
+	}
+
+	enable := r.FormValue("enable") == "1"
+	if err := h.write.SetBranchAutoMerge(r.Context(), repoName, branchName, enable); err != nil {
+		slog.Error("ui set auto-merge", "repo", repoName, "branch", branchName, "enable", enable, "error", err)
+		errMsg := "auto-merge update failed: " + err.Error()
+		ref := r.FormValue("ref")
+		if ref == "detail" {
+			http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+url.PathEscape(branchName)+"?err="+url.QueryEscape(errMsg), http.StatusSeeOther)
+		} else {
+			http.Redirect(w, r, "/ui/r/"+repoName+"?err="+url.QueryEscape(errMsg), http.StatusSeeOther)
+		}
+		return
+	}
+
+	ref := r.FormValue("ref")
+	if ref == "detail" {
+		http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+url.PathEscape(branchName), http.StatusSeeOther)
+	} else {
+		http.Redirect(w, r, "/ui/r/"+repoName, http.StatusSeeOther)
+	}
+
 }
 
 // chainToLogRows filters and converts ChainEntries to commitLogRows.

--- a/internal/ui/templates/branch_detail.html
+++ b/internal/ui/templates/branch_detail.html
@@ -12,6 +12,82 @@
 </div>
 <div class="meta" style="margin-bottom:14px">head {{$ctx.Branch.HeadSequence}} · base {{$ctx.Branch.BaseSequence}}</div>
 
+{{if $page.Err}}
+<div class="card" style="border-left: 3px solid var(--bad); margin-bottom:14px">
+  <div class="row"><span class="badge bad">error</span> <span>{{$page.Err}}</span></div>
+</div>
+{{end}}
+
+{{if eq (printf "%s" $ctx.Branch.Status) "active"}}
+<div class="card" style="margin-bottom:14px">
+  <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;padding:4px 0">
+    {{if $ctx.Branch.Draft}}
+    <form method="POST" action="/ui/r/{{$page.Repo.Name}}/-/promote-branch" style="display:inline">
+      <input type="hidden" name="branch" value="{{$ctx.Branch.Name}}">
+      <input type="hidden" name="ref" value="detail">
+      <button type="submit">promote to active</button>
+    </form>
+    {{else}}
+    <button id="merge-btn" onclick="(function(){
+      var btn = document.getElementById('merge-btn');
+      var errDiv = document.getElementById('action-err');
+      btn.disabled = true; btn.textContent = 'merging…';
+      fetch('/repos/{{$page.Repo.Name}}/-/merge', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({branch: '{{$ctx.Branch.Name}}'})
+      }).then(function(r){
+        if(r.ok){ location.reload(); }
+        else { r.json().then(function(j){
+          errDiv.textContent = j.error || JSON.stringify(j);
+          errDiv.style.display = '';
+          btn.disabled = false; btn.textContent = 'merge';
+        }).catch(function(){ errDiv.textContent = 'merge failed (status ' + r.status + ')'; errDiv.style.display = ''; btn.disabled = false; btn.textContent = 'merge'; }); }
+      }).catch(function(e){ errDiv.textContent = String(e); errDiv.style.display = ''; btn.disabled = false; btn.textContent = 'merge'; });
+    })()">merge</button>
+    {{end}}
+    <button id="rebase-btn" onclick="(function(){
+      var btn = document.getElementById('rebase-btn');
+      var errDiv = document.getElementById('action-err');
+      btn.disabled = true; btn.textContent = 'rebasing…';
+      fetch('/repos/{{$page.Repo.Name}}/-/rebase', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({branch: '{{$ctx.Branch.Name}}'})
+      }).then(function(r){
+        if(r.ok){ location.reload(); }
+        else { r.json().then(function(j){
+          errDiv.textContent = j.error || JSON.stringify(j);
+          errDiv.style.display = '';
+          btn.disabled = false; btn.textContent = 'rebase';
+        }).catch(function(){ errDiv.textContent = 'rebase failed (status ' + r.status + ')'; errDiv.style.display = ''; btn.disabled = false; btn.textContent = 'rebase'; }); }
+      }).catch(function(e){ errDiv.textContent = String(e); errDiv.style.display = ''; btn.disabled = false; btn.textContent = 'rebase'; });
+    })()">rebase</button>
+    {{if $ctx.Branch.AutoMerge}}
+    <form method="POST" action="/ui/r/{{$page.Repo.Name}}/-/set-auto-merge" style="display:inline">
+      <input type="hidden" name="branch" value="{{$ctx.Branch.Name}}">
+      <input type="hidden" name="enable" value="0">
+      <input type="hidden" name="ref" value="detail">
+      <button type="submit">disable auto-merge</button>
+    </form>
+    {{else}}
+    <form method="POST" action="/ui/r/{{$page.Repo.Name}}/-/set-auto-merge" style="display:inline">
+      <input type="hidden" name="branch" value="{{$ctx.Branch.Name}}">
+      <input type="hidden" name="enable" value="1">
+      <input type="hidden" name="ref" value="detail">
+      <button type="submit">enable auto-merge</button>
+    </form>
+    {{end}}
+    <form method="POST" action="/ui/r/{{$page.Repo.Name}}/-/delete-branch" style="display:inline">
+      <input type="hidden" name="branch" value="{{$ctx.Branch.Name}}">
+      <input type="hidden" name="ref" value="detail">
+      <button type="submit" style="color:var(--bad)" onclick="return confirm('Abandon branch {{$ctx.Branch.Name}}?')">delete</button>
+    </form>
+  </div>
+  <div id="action-err" style="display:none;color:var(--bad);font-size:12px;margin-top:6px"></div>
+</div>
+{{end}}
+
 {{if $ctx.Mergeable}}
 <div class="summary-hero ok">
   <span class="verdict">✓ Mergeable</span>

--- a/internal/ui/templates/branches.html
+++ b/internal/ui/templates/branches.html
@@ -11,6 +11,24 @@
   <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
 </nav>
 
+{{if .Err}}
+<div class="card" style="border-left: 3px solid var(--bad); margin-bottom:14px">
+  <div class="row"><span class="badge bad">error</span> <span>{{.Err}}</span></div>
+</div>
+{{end}}
+
+<h2>Create branch</h2>
+<div class="card">
+  <form method="POST" action="/ui/r/{{.Repo.Name}}/-/create-branch" style="display:flex;gap:8px;align-items:center;padding:4px 0">
+    <input type="text" name="branch_name" placeholder="branch name" required
+           style="flex:1;background:var(--bg-3);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:6px 10px;font-family:var(--mono);font-size:12px">
+    <label style="display:flex;align-items:center;gap:4px;font-size:12px;color:var(--text-dim)">
+      <input type="checkbox" name="draft" value="1"> draft
+    </label>
+    <button type="submit">create</button>
+  </form>
+</div>
+
 <div class="filter-bar"><input type="search" data-branch-filter placeholder="filter branches by name…" autocomplete="off"></div>
 
 {{template "branchSection" (dict "Title" "Active" "Rows" .Active "Repo" .Repo.Name)}}
@@ -62,7 +80,7 @@
     <div class="empty">none</div>
   {{else}}
   <table class="grid">
-    <thead><tr><th>branch</th><th>status</th><th>head</th><th>base</th><th>flags</th><th></th></tr></thead>
+    <thead><tr><th>branch</th><th>status</th><th>head</th><th>base</th><th>flags</th><th>links</th><th>actions</th></tr></thead>
     <tbody>
     {{range .Rows}}
     <tr>
@@ -75,6 +93,33 @@
         {{if .AutoMerge}}<span class="badge ok">auto-merge</span>{{end}}
       </td>
       <td><a href="/ui/r/{{$.Repo}}/f/?branch={{.Name}}">files →</a> · <a href="/ui/r/{{$.Repo}}/b/{{urlPathEscape .Name}}/log">log →</a></td>
+      <td>
+        {{if eq .Status "active"}}
+        {{if .Draft}}
+        <form method="POST" action="/ui/r/{{$.Repo}}/-/promote-branch" style="display:inline">
+          <input type="hidden" name="branch" value="{{.Name}}">
+          <button type="submit" class="btn-link" style="font-size:11px">promote</button>
+        </form> ·
+        {{end}}
+        {{if .AutoMerge}}
+        <form method="POST" action="/ui/r/{{$.Repo}}/-/set-auto-merge" style="display:inline">
+          <input type="hidden" name="branch" value="{{.Name}}">
+          <input type="hidden" name="enable" value="0">
+          <button type="submit" class="btn-link" style="font-size:11px">disable auto-merge</button>
+        </form> ·
+        {{else}}
+        <form method="POST" action="/ui/r/{{$.Repo}}/-/set-auto-merge" style="display:inline">
+          <input type="hidden" name="branch" value="{{.Name}}">
+          <input type="hidden" name="enable" value="1">
+          <button type="submit" class="btn-link" style="font-size:11px">enable auto-merge</button>
+        </form> ·
+        {{end}}
+        <form method="POST" action="/ui/r/{{$.Repo}}/-/delete-branch" style="display:inline">
+          <input type="hidden" name="branch" value="{{.Name}}">
+          <button type="submit" class="btn-link" style="font-size:11px;color:var(--bad)" onclick="return confirm('Abandon branch {{.Name}}?')">delete</button>
+        </form>
+        {{end}}
+      </td>
     </tr>
     {{end}}
     </tbody>

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -28,7 +28,8 @@ type ReadStore interface {
 }
 
 // WriteStoreLite is the subset of server.WriteStore that the UI needs for
-// listing repos and orgs, org invite acceptance, and issue write operations.
+// listing repos and orgs, org invite acceptance, issue write operations,
+// and branch write operations.
 type WriteStoreLite interface {
 	ListRepos(ctx context.Context) ([]model.Repo, error)
 	ListOrgs(ctx context.Context) ([]model.Org, error)
@@ -63,6 +64,12 @@ type WriteStoreLite interface {
 	UpdateIssueComment(ctx context.Context, repo, id, body string) (*model.IssueComment, error)
 	DeleteIssueComment(ctx context.Context, repo, id string) error
 	CreateIssueRef(ctx context.Context, repo string, number int64, refType model.IssueRefType, refID string) (*model.IssueRef, error)
+
+	// Branch write operations.
+	CreateBranch(ctx context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error)
+	UpdateBranchDraft(ctx context.Context, repo, name string, draft bool) error
+	DeleteBranch(ctx context.Context, repo, name string) error
+	SetBranchAutoMerge(ctx context.Context, repo, name string, autoMerge bool) error
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -175,5 +182,11 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("POST /ui/orgs/new", h.handleCreateOrg)
 	mux.HandleFunc("GET /ui/repos/new", h.handleCreateRepo)
 	mux.HandleFunc("POST /ui/repos/new", h.handleCreateRepo)
+
+	// Branch write operations (POST-redirect-GET pattern).
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/-/create-branch", h.handleUICreateBranch)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/-/delete-branch", h.handleUIDeleteBranch)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/-/promote-branch", h.handleUIPromoteBranch)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/-/set-auto-merge", h.handleUISetAutoMerge)
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -190,6 +190,18 @@ func (f *fakeWrite) CreateRepo(_ context.Context, req model.CreateRepoRequest) (
 	}
 	return &model.Repo{Name: req.FullName(), Owner: req.Owner}, nil
 }
+func (f *fakeWrite) CreateBranch(_ context.Context, req model.CreateBranchRequest) (*model.CreateBranchResponse, error) {
+	return &model.CreateBranchResponse{Name: req.Name}, nil
+}
+func (f *fakeWrite) UpdateBranchDraft(_ context.Context, _, _ string, _ bool) error {
+	return nil
+}
+func (f *fakeWrite) DeleteBranch(_ context.Context, _, _ string) error {
+	return nil
+}
+func (f *fakeWrite) SetBranchAutoMerge(_ context.Context, _, _ string, _ bool) error {
+	return nil
+}
 
 func newFakeAssembler(branchName string) AssembleFn {
 	return func(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {


### PR DESCRIPTION
## Summary

Closes #320

Adds full branch lifecycle management to the web UI:

- **Create branch** — form at the top of the branches list page (with optional draft flag)
- **Promote draft→active** — button on branch list rows and branch detail page
- **Delete branch** — confirmation-gated form on both pages, redirects to list on success
- **Set/clear auto-merge** — toggle buttons on both pages
- **Merge branch** — JavaScript fetch button on branch detail page (calls the JSON API at `/repos/.../-/merge` to keep server-side policy evaluation intact, same pattern as existing "retry checks" button)
- **Rebase branch** — JavaScript fetch button on branch detail page (same approach)

## Implementation

- Extended `WriteStoreLite` interface with 4 write methods: `CreateBranch`, `UpdateBranchDraft`, `DeleteBranch`, `SetBranchAutoMerge`
- Added 4 POST routes under `/ui/r/{owner}/{name}/-/` using POST-redirect-GET pattern; errors surface via `?err=` query param shown as an inline error banner
- Merge and rebase intentionally use `fetch()` against the existing JSON API rather than going through the store directly — this preserves server-side policy evaluation (`evaluateMergePolicy`) that only runs at the HTTP handler layer
- Updated `fakeWrite` in `internal/ui/ui_test.go` and `cmd/ui-preview/main.go` to satisfy the extended interface

## Test plan

- [x] `go test ./internal/ui/... -count=1` passes
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] Manually verify create/delete/promote/auto-merge/merge/rebase in browser with a live server

## Notes / opportunities

- The action buttons inherit browser-default button styling; a future pass could add `.btn` / `.btn-danger` CSS classes
- Branch names containing `/` are URL-encoded in links but the POST handlers use form fields, so slash branches work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)