### PR TITLE
feat(ui): add issue write operations to web UI

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -235,6 +235,30 @@ func (fakeWrite) GetRelease(_ context.Context, _, name string) (*model.Release, 
 func (fakeWrite) ListIssueRefs(_ context.Context, _ string, _ int64) ([]model.IssueRef, error) {
 	return nil, nil
 }
+func (fakeWrite) CreateIssue(_ context.Context, _, _, _, _ string, _ []string) (*model.Issue, error) {
+	return &model.Issue{ID: "new-id", Number: 99, Title: "new", Author: "test", State: "open"}, nil
+}
+func (fakeWrite) UpdateIssue(_ context.Context, _ string, _ int64, _, _ *string, _ *[]string) (*model.Issue, error) {
+	return nil, nil
+}
+func (fakeWrite) CloseIssue(_ context.Context, _ string, _ int64, _ model.IssueCloseReason, _ string) (*model.Issue, error) {
+	return nil, nil
+}
+func (fakeWrite) ReopenIssue(_ context.Context, _ string, _ int64) (*model.Issue, error) {
+	return nil, nil
+}
+func (fakeWrite) CreateIssueComment(_ context.Context, _ string, _ int64, _, _ string) (*model.IssueComment, error) {
+	return &model.IssueComment{ID: "c-new"}, nil
+}
+func (fakeWrite) UpdateIssueComment(_ context.Context, _, _, _ string) (*model.IssueComment, error) {
+	return nil, nil
+}
+func (fakeWrite) DeleteIssueComment(_ context.Context, _, _ string) error {
+	return nil
+}
+func (fakeWrite) CreateIssueRef(_ context.Context, _ string, _ int64, _ model.IssueRefType, _ string) (*model.IssueRef, error) {
+	return &model.IssueRef{ID: "r-new"}, nil
+}
 
 func (fakeWrite) ListCIJobs(_ context.Context, _ string, _, _ *string, _ int) ([]model.CIJob, error) {
 	t := time.Now()

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -136,6 +137,15 @@ type issueDetailPage struct {
 	Issue    *model.Issue
 	Comments []model.IssueComment
 	Refs     []model.IssueRef
+	Err      string
+}
+
+type newIssuePage struct {
+	Repo       model.Repo
+	Err        string
+	FormTitle  string
+	FormBody   string
+	FormLabels string
 }
 
 type acceptInvitePage struct {
@@ -710,6 +720,9 @@ func (h *Handler) handleIssueDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	page := issueDetailPage{Repo: *repo, Issue: issue, Comments: comments, Refs: refs}
+	if errMsg := r.URL.Query().Get("error"); errMsg != "" {
+		page.Err = errMsg
+	}
 	h.render(w, h.tmpl.issueDetail, "layout.html", pageData{
 		Title: repoName + " / issue #" + numberStr,
 		Breadcrumbs: []crumb{
@@ -1392,6 +1405,326 @@ func (h *Handler) handleCreateRepo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r, "/ui/r/"+owner+"/"+name, http.StatusSeeOther)
+}
+
+// issueURL returns the UI URL for a specific issue detail page.
+func issueURL(repoName, numberStr string) string {
+	return "/ui/r/" + repoName + "/issues/" + numberStr
+}
+
+// handleNewIssue renders the new-issue form (GET) and creates an issue (POST).
+func (h *Handler) handleNewIssue(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	renderForm := func(formTitle, formBody, formLabels, errMsg string) {
+		h.render(w, h.tmpl.newIssue, "layout.html", pageData{
+			Title: repoName + " / new issue",
+			Breadcrumbs: []crumb{
+				{Label: "repos", Href: "/ui/"},
+				{Label: repoName, Href: "/ui/r/" + repoName},
+				{Label: "issues", Href: "/ui/r/" + repoName + "/issues"},
+				{Label: "new", Href: ""},
+			},
+			Body: newIssuePage{
+				Repo:       *repo,
+				Err:        errMsg,
+				FormTitle:  formTitle,
+				FormBody:   formBody,
+				FormLabels: formLabels,
+			},
+		})
+	}
+
+	if r.Method == http.MethodGet {
+		renderForm("", "", "", "")
+		return
+	}
+
+	// POST: create the issue.
+	if err := r.ParseForm(); err != nil {
+		renderForm("", "", "", "invalid form data")
+		return
+	}
+	title := strings.TrimSpace(r.FormValue("title"))
+	body := strings.TrimSpace(r.FormValue("body"))
+	labelsStr := strings.TrimSpace(r.FormValue("labels"))
+
+	if title == "" {
+		renderForm(title, body, labelsStr, "title is required")
+		return
+	}
+
+	var labels []string
+	for _, l := range strings.Split(labelsStr, ",") {
+		if l = strings.TrimSpace(l); l != "" {
+			labels = append(labels, l)
+		}
+	}
+
+	var identity string
+	if h.identity != nil {
+		identity = h.identity(ctx)
+	}
+
+	iss, err := h.write.CreateIssue(ctx, repoName, title, body, identity, labels)
+	if err != nil {
+		slog.Error("ui create issue", "repo", repoName, "error", err)
+		renderForm(title, body, labelsStr, "could not create issue")
+		return
+	}
+
+	http.Redirect(w, r, fmt.Sprintf("/ui/r/%s/issues/%d", repoName, iss.Number), http.StatusSeeOther)
+}
+
+// handleEditIssue processes the edit-issue form POST, updating title/body/labels.
+func (h *Handler) handleEditIssue(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	numberStr := r.PathValue("number")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	number, err := strconv.ParseInt(numberStr, 10, 64)
+	if err != nil {
+		h.renderError(w, http.StatusBadRequest, "invalid issue number")
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error=invalid+form", http.StatusSeeOther)
+		return
+	}
+
+	title := strings.TrimSpace(r.FormValue("title"))
+	if title == "" {
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error=title+is+required", http.StatusSeeOther)
+		return
+	}
+
+	body := r.FormValue("body")
+	labelsStr := r.FormValue("labels")
+	var labels []string
+	for _, l := range strings.Split(labelsStr, ",") {
+		if l = strings.TrimSpace(l); l != "" {
+			labels = append(labels, l)
+		}
+	}
+	labelsPtr := &labels
+
+	if _, err := h.write.UpdateIssue(ctx, repoName, number, &title, &body, labelsPtr); err != nil {
+		slog.Error("ui edit issue", "repo", repoName, "number", number, "error", err)
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error="+url.QueryEscape("could not update issue"), http.StatusSeeOther)
+		return
+	}
+
+	http.Redirect(w, r, issueURL(repoName, numberStr), http.StatusSeeOther)
+}
+
+// handleIssueClose processes the close-issue form POST.
+func (h *Handler) handleIssueClose(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	numberStr := r.PathValue("number")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	number, err := strconv.ParseInt(numberStr, 10, 64)
+	if err != nil {
+		h.renderError(w, http.StatusBadRequest, "invalid issue number")
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error=invalid+form", http.StatusSeeOther)
+		return
+	}
+
+	reason := model.IssueCloseReason(r.FormValue("reason"))
+	switch reason {
+	case model.IssueCloseReasonCompleted, model.IssueCloseReasonNotPlanned, model.IssueCloseReasonDuplicate:
+		// valid
+	default:
+		reason = model.IssueCloseReasonCompleted
+	}
+
+	var identity string
+	if h.identity != nil {
+		identity = h.identity(ctx)
+	}
+
+	if _, err := h.write.CloseIssue(ctx, repoName, number, reason, identity); err != nil {
+		slog.Error("ui close issue", "repo", repoName, "number", number, "error", err)
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error="+url.QueryEscape("could not close issue"), http.StatusSeeOther)
+		return
+	}
+
+	http.Redirect(w, r, issueURL(repoName, numberStr), http.StatusSeeOther)
+}
+
+// handleIssueReopen processes the reopen-issue form POST.
+func (h *Handler) handleIssueReopen(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	numberStr := r.PathValue("number")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	number, err := strconv.ParseInt(numberStr, 10, 64)
+	if err != nil {
+		h.renderError(w, http.StatusBadRequest, "invalid issue number")
+		return
+	}
+
+	if _, err := h.write.ReopenIssue(ctx, repoName, number); err != nil {
+		slog.Error("ui reopen issue", "repo", repoName, "number", number, "error", err)
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error="+url.QueryEscape("could not reopen issue"), http.StatusSeeOther)
+		return
+	}
+
+	http.Redirect(w, r, issueURL(repoName, numberStr), http.StatusSeeOther)
+}
+
+// handleCreateIssueComment processes the add-comment form POST.
+func (h *Handler) handleCreateIssueComment(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	numberStr := r.PathValue("number")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	number, err := strconv.ParseInt(numberStr, 10, 64)
+	if err != nil {
+		h.renderError(w, http.StatusBadRequest, "invalid issue number")
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error=invalid+form", http.StatusSeeOther)
+		return
+	}
+
+	body := strings.TrimSpace(r.FormValue("body"))
+	if body == "" {
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error=comment+body+is+required", http.StatusSeeOther)
+		return
+	}
+
+	var identity string
+	if h.identity != nil {
+		identity = h.identity(ctx)
+	}
+
+	if _, err := h.write.CreateIssueComment(ctx, repoName, number, body, identity); err != nil {
+		slog.Error("ui create issue comment", "repo", repoName, "number", number, "error", err)
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error="+url.QueryEscape("could not post comment"), http.StatusSeeOther)
+		return
+	}
+
+	http.Redirect(w, r, issueURL(repoName, numberStr), http.StatusSeeOther)
+}
+
+// handleEditIssueComment processes the edit-comment form POST.
+func (h *Handler) handleEditIssueComment(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	numberStr := r.PathValue("number")
+	commentID := r.PathValue("id")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	if err := r.ParseForm(); err != nil {
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error=invalid+form", http.StatusSeeOther)
+		return
+	}
+
+	body := strings.TrimSpace(r.FormValue("body"))
+	if body == "" {
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error=comment+body+is+required", http.StatusSeeOther)
+		return
+	}
+
+	if _, err := h.write.UpdateIssueComment(ctx, repoName, commentID, body); err != nil {
+		slog.Error("ui edit issue comment", "repo", repoName, "comment", commentID, "error", err)
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error="+url.QueryEscape("could not update comment"), http.StatusSeeOther)
+		return
+	}
+
+	http.Redirect(w, r, issueURL(repoName, numberStr), http.StatusSeeOther)
+}
+
+// handleDeleteIssueComment processes the delete-comment form POST.
+func (h *Handler) handleDeleteIssueComment(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	numberStr := r.PathValue("number")
+	commentID := r.PathValue("id")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	if err := h.write.DeleteIssueComment(ctx, repoName, commentID); err != nil {
+		slog.Error("ui delete issue comment", "repo", repoName, "comment", commentID, "error", err)
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error="+url.QueryEscape("could not delete comment"), http.StatusSeeOther)
+		return
+	}
+
+	http.Redirect(w, r, issueURL(repoName, numberStr), http.StatusSeeOther)
+}
+
+// handleAddIssueRef processes the add-reference form POST.
+func (h *Handler) handleAddIssueRef(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	numberStr := r.PathValue("number")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	number, err := strconv.ParseInt(numberStr, 10, 64)
+	if err != nil {
+		h.renderError(w, http.StatusBadRequest, "invalid issue number")
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error=invalid+form", http.StatusSeeOther)
+		return
+	}
+
+	refType := model.IssueRefType(r.FormValue("ref_type"))
+	refID := strings.TrimSpace(r.FormValue("ref_id"))
+
+	if refID == "" {
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error=ref+ID+is+required", http.StatusSeeOther)
+		return
+	}
+	switch refType {
+	case model.IssueRefTypeProposal, model.IssueRefTypeCommit:
+		// valid
+	default:
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error=invalid+ref+type", http.StatusSeeOther)
+		return
+	}
+
+	if _, err := h.write.CreateIssueRef(ctx, repoName, number, refType, refID); err != nil {
+		slog.Error("ui add issue ref", "repo", repoName, "number", number, "error", err)
+		http.Redirect(w, r, issueURL(repoName, numberStr)+"?error="+url.QueryEscape("could not add reference"), http.StatusSeeOther)
+		return
+	}
+
+	http.Redirect(w, r, issueURL(repoName, numberStr), http.StatusSeeOther)
 }
 
 // chainToLogRows filters and converts ChainEntries to commitLogRows.

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -28,7 +28,8 @@ type templateSet struct {
 	commitDetail   *template.Template
 	issues         *template.Template
 	issuesRows     *template.Template
-	issueDetail     *template.Template
+	issueDetail    *template.Template
+	newIssue       *template.Template
 	acceptInvite    *template.Template
 	org             *template.Template
 	proposals       *template.Template
@@ -131,6 +132,10 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse issue_detail: %w", err)
 	}
+	newIssue, err := load("new_issue.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse new_issue: %w", err)
+	}
 	acceptInvite, err := load("accept_invite.html")
 	if err != nil {
 		return nil, fmt.Errorf("parse accept_invite: %w", err)
@@ -195,8 +200,9 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		commitDetail:   commitDetail,
 		issues:         issues,
 		issuesRows:     issuesRows,
-		issueDetail:     issueDetail,
-		acceptInvite:    acceptInvite,
+		issueDetail:    issueDetail,
+		newIssue:       newIssue,
+		acceptInvite:   acceptInvite,
 		org:             org,
 		proposals:       proposals,
 		proposalsRows:   proposalsRows,
@@ -281,6 +287,7 @@ func funcMap() template.FuncMap {
 		"dict":           dict,
 		"add":            func(a, b int) int { return a + b },
 		"urlPathEscape":  url.PathEscape,
+		"joinStrings":    strings.Join,
 	}
 }
 

--- a/internal/ui/static/styles.css
+++ b/internal/ui/static/styles.css
@@ -373,3 +373,47 @@ pre.code .text { white-space: pre; padding-right: 12px; }
   border-color: var(--border);
   border-bottom-color: var(--bg-2);
 }
+
+/* Form inputs and selects shared by issue write forms. */
+.form-input {
+  width: 100%;
+  background: var(--bg-3);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px 10px;
+  font-family: var(--mono);
+  font-size: 12px;
+  box-sizing: border-box;
+}
+.form-input:focus { outline: none; border-color: var(--accent); }
+textarea.form-input { resize: vertical; }
+
+/* Generic action button (not the nav theme-toggle). */
+.btn {
+  background: var(--bg-3);
+  color: var(--text);
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  padding: 5px 12px;
+  font-family: var(--mono);
+  font-size: 12px;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+  line-height: 1.45;
+}
+.btn:hover { border-color: var(--accent); color: var(--accent); text-decoration: none; }
+.btn.danger { border-color: var(--bad); color: var(--bad); }
+.btn.danger:hover { background: var(--bad-bg); text-decoration: none; }
+
+/* Disclosure widget used for inline edit forms. */
+details.form-section > summary {
+  cursor: pointer;
+  color: var(--accent);
+  font-size: 12px;
+  user-select: none;
+  list-style: none;
+}
+details.form-section > summary:hover { text-decoration: underline; }
+details.form-section > summary::-webkit-details-marker { display: none; }

--- a/internal/ui/templates/issue_detail.html
+++ b/internal/ui/templates/issue_detail.html
@@ -1,5 +1,6 @@
 {{define "content"}}
 {{with .Body}}
+{{$d := .}}
 <nav class="repo-tabs">
   <a href="/ui/r/{{.Repo.Name}}">branches</a>
   <a href="/ui/r/{{.Repo.Name}}/issues" class="active">issues</a>
@@ -9,10 +10,33 @@
   <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
 </nav>
 
-<div class="headline">
-  <h1>#{{.Issue.Number}} {{.Issue.Title}}</h1>
-  <span class="badge {{statusClass (printf "%s" .Issue.State)}}">{{.Issue.State}}</span>
+{{if .Err}}
+<div class="card" style="border-color:var(--bad);margin-bottom:14px">
+  <div class="row"><span class="badge bad">{{.Err}}</span></div>
 </div>
+{{end}}
+
+<div class="headline">
+  <div style="flex:1">
+    <h1>#{{.Issue.Number}} {{.Issue.Title}}</h1>
+  </div>
+  <span class="badge {{statusClass (printf "%s" .Issue.State)}}">{{.Issue.State}}</span>
+  {{if eq (printf "%s" .Issue.State) "open"}}
+  <form method="POST" action="/ui/r/{{.Repo.Name}}/issues/{{.Issue.Number}}/close" style="display:flex;gap:6px;align-items:center">
+    <select name="reason" class="form-input" style="width:auto">
+      <option value="completed">completed</option>
+      <option value="not_planned">not planned</option>
+      <option value="duplicate">duplicate</option>
+    </select>
+    <button type="submit" class="btn">Close issue</button>
+  </form>
+  {{else}}
+  <form method="POST" action="/ui/r/{{.Repo.Name}}/issues/{{.Issue.Number}}/reopen">
+    <button type="submit" class="btn">Reopen issue</button>
+  </form>
+  {{end}}
+</div>
+
 <div class="meta" style="margin-bottom:14px">
   by {{.Issue.Author}} · opened {{relTime .Issue.CreatedAt}}{{if .Issue.ClosedAt}} · closed {{relTimep .Issue.ClosedAt}}{{end}}
 </div>
@@ -29,6 +53,27 @@
 </div>
 {{end}}
 
+<details class="form-section" style="margin-bottom:16px">
+  <summary>Edit issue</summary>
+  <div class="card" style="margin-top:8px">
+    <form method="POST" action="/ui/r/{{.Repo.Name}}/issues/{{.Issue.Number}}/edit" style="padding:8px 4px 4px">
+      <div style="margin-bottom:10px">
+        <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Title</label>
+        <input name="title" type="text" required value="{{.Issue.Title}}" class="form-input">
+      </div>
+      <div style="margin-bottom:10px">
+        <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Body</label>
+        <textarea name="body" rows="5" class="form-input">{{.Issue.Body}}</textarea>
+      </div>
+      <div style="margin-bottom:10px">
+        <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Labels <span style="text-transform:none;letter-spacing:normal">(comma-separated)</span></label>
+        <input name="labels" type="text" value="{{joinStrings .Issue.Labels ", "}}" class="form-input">
+      </div>
+      <button type="submit" class="btn">Save changes</button>
+    </form>
+  </div>
+</details>
+
 <h2>Comments ({{len .Comments}})</h2>
 <div class="card">
   {{if not .Comments}}<div class="empty">no comments yet</div>{{end}}
@@ -38,9 +83,30 @@
       <strong>{{.Author}}</strong>
       <span class="meta">{{relTime .CreatedAt}}{{if .EditedAt}} · edited{{end}}</span>
     </div>
+    <form method="POST" action="/ui/r/{{$d.Repo.Name}}/issues/{{$d.Issue.Number}}/comments/{{.ID}}/delete">
+      <button type="submit" class="btn danger" style="font-size:11px;padding:3px 8px">delete</button>
+    </form>
   </div>
   {{if .Body}}<div class="row-body">{{.Body}}</div>{{end}}
+  <details class="form-section" style="padding:4px 4px 8px">
+    <summary>edit comment</summary>
+    <form method="POST" action="/ui/r/{{$d.Repo.Name}}/issues/{{$d.Issue.Number}}/comments/{{.ID}}/edit" style="padding-top:8px">
+      <textarea name="body" rows="3" required class="form-input">{{.Body}}</textarea>
+      <div style="margin-top:6px">
+        <button type="submit" class="btn" style="font-size:11px;padding:3px 8px">Save</button>
+      </div>
+    </form>
+  </details>
   {{end}}
+</div>
+
+<div class="card" style="margin-top:4px">
+  <form method="POST" action="/ui/r/{{.Repo.Name}}/issues/{{.Issue.Number}}/comments" style="padding:8px 4px 4px">
+    <div style="margin-bottom:8px">
+      <textarea name="body" rows="3" placeholder="Write a comment..." required class="form-input"></textarea>
+    </div>
+    <button type="submit" class="btn">Post comment</button>
+  </form>
 </div>
 
 {{if .Refs}}
@@ -51,9 +117,9 @@
     <div>
       <span class="badge neutral">{{.RefType}}</span>
       {{if eq (printf "%s" .RefType) "proposal"}}
-        <a href="/ui/r/{{$.Repo.Name}}/proposals/{{.RefID}}">{{.RefID}}</a>
+        <a href="/ui/r/{{$d.Repo.Name}}/proposals/{{.RefID}}">{{.RefID}}</a>
       {{else if eq (printf "%s" .RefType) "commit"}}
-        <a href="/ui/r/{{$.Repo.Name}}/b/main/c/{{.RefID}}">seq {{.RefID}}</a>
+        <a href="/ui/r/{{$d.Repo.Name}}/b/main/c/{{.RefID}}">seq {{.RefID}}</a>
       {{else}}
         <span>{{.RefID}}</span>
       {{end}}
@@ -63,5 +129,20 @@
   {{end}}
 </div>
 {{end}}
+
+<details class="form-section" style="margin-top:4px">
+  <summary>Add reference</summary>
+  <div class="card" style="margin-top:8px">
+    <form method="POST" action="/ui/r/{{.Repo.Name}}/issues/{{.Issue.Number}}/refs" style="padding:8px 4px 4px;display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+      <select name="ref_type" class="form-input" style="width:auto">
+        <option value="proposal">proposal</option>
+        <option value="commit">commit</option>
+      </select>
+      <input name="ref_id" type="text" placeholder="ID" required class="form-input" style="flex:1;min-width:180px">
+      <button type="submit" class="btn">Add reference</button>
+    </form>
+  </div>
+</details>
+
 {{end}}
 {{end}}

--- a/internal/ui/templates/issues.html
+++ b/internal/ui/templates/issues.html
@@ -2,6 +2,7 @@
 {{with .Body}}
 <div class="headline">
   <h1>{{.Repo.Name}} / issues</h1>
+  <a href="/ui/r/{{.Repo.Name}}/issues/new" class="btn">New Issue</a>
 </div>
 
 <nav class="repo-tabs">

--- a/internal/ui/templates/new_issue.html
+++ b/internal/ui/templates/new_issue.html
@@ -1,0 +1,39 @@
+{{define "content"}}
+{{with .Body}}
+<nav class="repo-tabs">
+  <a href="/ui/r/{{.Repo.Name}}">branches</a>
+  <a href="/ui/r/{{.Repo.Name}}/issues" class="active">issues</a>
+  <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
+  <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
+  <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
+  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+</nav>
+
+<h1>New Issue</h1>
+
+{{if .Err}}
+<div class="card" style="border-color:var(--bad);margin-bottom:14px">
+  <div class="row"><span class="badge bad">{{.Err}}</span></div>
+</div>
+{{end}}
+
+<div class="card">
+  <form method="POST" action="/ui/r/{{.Repo.Name}}/issues/new" style="padding:8px 4px 4px">
+    <div style="margin-bottom:12px">
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Title</label>
+      <input name="title" type="text" required value="{{.FormTitle}}" class="form-input">
+    </div>
+    <div style="margin-bottom:12px">
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Body</label>
+      <textarea name="body" rows="6" class="form-input">{{.FormBody}}</textarea>
+    </div>
+    <div style="margin-bottom:14px">
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Labels <span style="text-transform:none;letter-spacing:normal">(comma-separated)</span></label>
+      <input name="labels" type="text" value="{{.FormLabels}}" class="form-input">
+    </div>
+    <button type="submit" class="btn">Create Issue</button>
+    <a href="/ui/r/{{.Repo.Name}}/issues" style="margin-left:12px;font-size:12px">cancel</a>
+  </form>
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -28,7 +28,7 @@ type ReadStore interface {
 }
 
 // WriteStoreLite is the subset of server.WriteStore that the UI needs for
-// listing repos and orgs, and for org invite acceptance.
+// listing repos and orgs, org invite acceptance, and issue write operations.
 type WriteStoreLite interface {
 	ListRepos(ctx context.Context) ([]model.Repo, error)
 	ListOrgs(ctx context.Context) ([]model.Org, error)
@@ -53,6 +53,16 @@ type WriteStoreLite interface {
 	GetCIJob(ctx context.Context, id string) (*model.CIJob, error)
 	CreateOrg(ctx context.Context, name, createdBy string) (*model.Org, error)
 	CreateRepo(ctx context.Context, req model.CreateRepoRequest) (*model.Repo, error)
+
+	// Issue write operations.
+	CreateIssue(ctx context.Context, repo, title, body, author string, labels []string) (*model.Issue, error)
+	UpdateIssue(ctx context.Context, repo string, number int64, title, body *string, labels *[]string) (*model.Issue, error)
+	CloseIssue(ctx context.Context, repo string, number int64, reason model.IssueCloseReason, closedBy string) (*model.Issue, error)
+	ReopenIssue(ctx context.Context, repo string, number int64) (*model.Issue, error)
+	CreateIssueComment(ctx context.Context, repo string, number int64, body, author string) (*model.IssueComment, error)
+	UpdateIssueComment(ctx context.Context, repo, id, body string) (*model.IssueComment, error)
+	DeleteIssueComment(ctx context.Context, repo, id string) error
+	CreateIssueRef(ctx context.Context, repo string, number int64, refType model.IssueRefType, refID string) (*model.IssueRef, error)
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -141,7 +151,16 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/check-history", h.handleCheckHistoryPartial)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/f/{path...}", h.handleFile)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/issues", h.handleIssues)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/issues/new", h.handleNewIssue)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/issues/new", h.handleNewIssue)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/issues/{number}", h.handleIssueDetail)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/issues/{number}/edit", h.handleEditIssue)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/issues/{number}/close", h.handleIssueClose)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/issues/{number}/reopen", h.handleIssueReopen)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/issues/{number}/comments", h.handleCreateIssueComment)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/issues/{number}/comments/{id}/edit", h.handleEditIssueComment)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/issues/{number}/comments/{id}/delete", h.handleDeleteIssueComment)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/issues/{number}/refs", h.handleAddIssueRef)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/issues", h.handleIssuesPartial)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/proposals", h.handleProposals)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/proposals", h.handleProposalsPartial)

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -147,6 +147,31 @@ func (f *fakeWrite) GetRelease(_ context.Context, _, name string) (*model.Releas
 func (f *fakeWrite) ListIssueRefs(_ context.Context, _ string, _ int64) ([]model.IssueRef, error) {
 	return nil, nil
 }
+func (f *fakeWrite) CreateIssue(_ context.Context, _, _, _, _ string, _ []string) (*model.Issue, error) {
+	iss := &model.Issue{ID: "new-id", Number: 99, Title: "new", Author: "test", State: "open"}
+	return iss, nil
+}
+func (f *fakeWrite) UpdateIssue(_ context.Context, _ string, _ int64, _, _ *string, _ *[]string) (*model.Issue, error) {
+	return nil, nil
+}
+func (f *fakeWrite) CloseIssue(_ context.Context, _ string, _ int64, _ model.IssueCloseReason, _ string) (*model.Issue, error) {
+	return nil, nil
+}
+func (f *fakeWrite) ReopenIssue(_ context.Context, _ string, _ int64) (*model.Issue, error) {
+	return nil, nil
+}
+func (f *fakeWrite) CreateIssueComment(_ context.Context, _ string, _ int64, _, _ string) (*model.IssueComment, error) {
+	return &model.IssueComment{ID: "c-new"}, nil
+}
+func (f *fakeWrite) UpdateIssueComment(_ context.Context, _, _, _ string) (*model.IssueComment, error) {
+	return nil, nil
+}
+func (f *fakeWrite) DeleteIssueComment(_ context.Context, _, _ string) error {
+	return nil
+}
+func (f *fakeWrite) CreateIssueRef(_ context.Context, _ string, _ int64, _ model.IssueRefType, _ string) (*model.IssueRef, error) {
+	return &model.IssueRef{ID: "r-new"}, nil
+}
 func (f *fakeWrite) ListCIJobs(_ context.Context, _ string, _, _ *string, _ int) ([]model.CIJob, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary

Closes #320. Adds full issue write operations to the web UI:

- **Create issue**: "New Issue" button on issues list → dedicated form page (`GET/POST /ui/r/{owner}/{name}/issues/new`)
- **Edit issue**: inline `<details>` form on issue detail (title, body, labels) → `POST .../issues/{number}/edit`
- **Close issue**: close-reason select + button on headline → `POST .../issues/{number}/close`
- **Reopen issue**: button on closed issue headline → `POST .../issues/{number}/reopen`
- **Post comment**: textarea form at bottom of issue detail → `POST .../issues/{number}/comments`
- **Edit comment**: inline `<details>` form per comment → `POST .../issues/{number}/comments/{id}/edit`
- **Delete comment**: per-comment button form → `POST .../issues/{number}/comments/{id}/delete`
- **Add reference**: inline `<details>` form (proposal/commit) → `POST .../issues/{number}/refs`

All mutations use POST + redirect-get. Errors from inline actions are surfaced via `?error=` on the issue detail page. The create-issue form re-renders inline with errors.

## Implementation notes

- `WriteStoreLite` interface extended with 8 issue write methods (already satisfied by `server.WriteStore`)
- `issueDetailPage.Err` field populated from `?error=` query param on GET
- Template variable `{{$d := .}}` used inside range loops to correctly reference outer `issueDetailPage` fields
- New CSS classes: `.form-input`, `.btn`, `.btn.danger`, `details.form-section`
- `joinStrings` template helper added to render labels as comma-separated string
- `fakeWrite` in `ui_test.go` and `cmd/ui-preview/main.go` updated with stub implementations

## Test plan

- [x] `go test ./internal/ui/... -count=1` — all existing tests pass
- [x] `go build ./...` — clean build
- [x] `go vet ./...` — no issues
- Pre-existing Postgres-dependent test failures in `internal/db`, `internal/server`, etc. are unrelated to this change (Docker not available in this environment)

## Opportunities for follow-up

- HTMX-based optimistic UI for comment post/delete (no page reload)
- Label autocomplete on the issue form
- Confirmation dialog for comment deletion (currently no confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)