### PR TITLE
feat(ui): add review, comment, and proposal write operations

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -292,7 +292,20 @@ func (fakeWrite) CreateOrg(_ context.Context, name, _ string) (*model.Org, error
 func (fakeWrite) CreateRepo(_ context.Context, req model.CreateRepoRequest) (*model.Repo, error) {
 	return &model.Repo{Name: req.FullName(), Owner: req.Owner}, nil
 }
-
+func (fakeWrite) CreateReview(_ context.Context, _, _, _ string, _ model.ReviewStatus, _ string) (*model.Review, error) {
+	return &model.Review{}, nil
+}
+func (fakeWrite) CreateReviewComment(_ context.Context, _, _, _, _, _, _ string, _ *string) (*model.ReviewComment, error) {
+	return &model.ReviewComment{}, nil
+}
+func (fakeWrite) DeleteReviewComment(_ context.Context, _, _ string) error { return nil }
+func (fakeWrite) CreateProposal(_ context.Context, _, _, _, _, _, _ string) (*model.Proposal, error) {
+	return &model.Proposal{ID: "new-p"}, nil
+}
+func (fakeWrite) UpdateProposal(_ context.Context, _, _ string, _, _ *string) (*model.Proposal, error) {
+	return &model.Proposal{ID: "updated-p", Title: "updated"}, nil
+}
+func (fakeWrite) CloseProposal(_ context.Context, _, _ string) error { return nil }
 func fakeAssemble(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
 	t := time.Now()
 	vid := func(s string) *string { return &s }

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -62,6 +62,12 @@ type reviewCommentGroup struct {
 	Comments []model.ReviewComment
 }
 
+type reviewCommentsData struct {
+	RepoName string
+	Branch   string
+	Groups   []reviewCommentGroup
+}
+
 type branchDetailPage struct {
 	Repo            model.Repo
 	Ctx             *model.AgentContextResponse
@@ -161,11 +167,13 @@ type proposalsPage struct {
 	Repo      model.Repo
 	Proposals []*model.Proposal
 	State     string
+	Err       string
 }
 
 type proposalDetailPage struct {
 	Repo     model.Repo
 	Proposal *model.Proposal
+	Err      string
 }
 
 type releasesPage struct {
@@ -350,68 +358,7 @@ func (h *Handler) handleBranchDetail(w http.ResponseWriter, r *http.Request) {
 	owner := r.PathValue("owner")
 	name := r.PathValue("name")
 	branch := r.PathValue("branch")
-	repoName := owner + "/" + name
-
-	repo, err := h.write.GetRepo(r.Context(), repoName)
-	if err != nil {
-		if errors.Is(err, db.ErrRepoNotFound) {
-			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
-			return
-		}
-		slog.Error("ui get repo", "repo", repoName, "error", err)
-		h.renderError(w, http.StatusInternalServerError, "could not load repo")
-		return
-	}
-
-	if h.assemble == nil {
-		h.renderError(w, http.StatusServiceUnavailable, "agent context assembler not configured")
-		return
-	}
-	actCtx, err := h.assemble(r.Context(), repoName, branch)
-	if err != nil {
-		// Matches the sentinel message from server.ErrAgentContextBranchNotFound.
-		// We avoid importing internal/server to stay free of circular deps.
-		if strings.Contains(err.Error(), "branch not found") {
-			h.renderError(w, http.StatusNotFound, "branch not found: "+branch)
-			return
-		}
-		slog.Error("ui assemble agent context", "repo", repoName, "branch", branch, "error", err)
-		h.renderError(w, http.StatusInternalServerError, "could not load branch")
-		return
-	}
-
-	page := branchDetailPage{Repo: *repo, Ctx: actCtx, Err: r.URL.Query().Get("err")}
-	for _, p := range actCtx.Policies {
-		if !p.Pass {
-			reason := p.Reason
-			if reason == "" {
-				reason = p.Name
-			}
-			page.Blockers = append(page.Blockers, reason)
-		}
-	}
-	for _, c := range actCtx.CheckRuns {
-		switch c.Status {
-		case model.CheckRunPassed:
-			page.PassedCheckCnt++
-		case model.CheckRunPending:
-			page.PendingCheckCnt++
-			page.Blockers = append(page.Blockers, c.CheckName+" pending")
-		case model.CheckRunFailed:
-			page.FailedCheckCnt++
-			page.Blockers = append(page.Blockers, c.CheckName+" failed")
-		}
-	}
-
-	h.render(w, h.tmpl.branchDetail, "layout.html", pageData{
-		Title: repoName + " / " + branch,
-		Breadcrumbs: []crumb{
-			{Label: "repos", Href: "/ui/"},
-			{Label: repoName, Href: "/ui/r/" + repoName},
-			{Label: branch, Href: ""},
-		},
-		Body: page,
-	})
+	h.renderBranchDetail(w, r, owner+"/"+name, branch, "")
 }
 
 // handleChecksPartial returns just the checks table for HTMX polling.
@@ -668,7 +615,11 @@ func (h *Handler) handleReviewCommentsPartial(w http.ResponseWriter, r *http.Req
 		groups = append(groups, reviewCommentGroup{Path: p, Comments: byPath[p]})
 	}
 
-	h.render(w, h.tmpl.reviewComments, "review_comments.html", groups)
+	h.render(w, h.tmpl.reviewComments, "review_comments.html", reviewCommentsData{
+		RepoName: repoName,
+		Branch:   branch,
+		Groups:   groups,
+	})
 }
 
 // handleIssueDetail renders the detail view for a single issue.
@@ -1874,6 +1825,312 @@ func (h *Handler) handleUISetAutoMerge(w http.ResponseWriter, r *http.Request) {
 	}
 
 }
+
+
+// Write handlers (POST forms)
+// ---------------------------------------------------------------------------
+
+// renderBranchDetail is the shared helper that loads and renders the branch
+// detail page. It is called by the GET handler and by POST handlers on error.
+func (h *Handler) renderBranchDetail(w http.ResponseWriter, r *http.Request, repoName, branch, errMsg string) {
+	repo, err := h.write.GetRepo(r.Context(), repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	if h.assemble == nil {
+		h.renderError(w, http.StatusServiceUnavailable, "agent context assembler not configured")
+		return
+	}
+	actCtx, err := h.assemble(r.Context(), repoName, branch)
+	if err != nil {
+		if strings.Contains(err.Error(), "branch not found") {
+			h.renderError(w, http.StatusNotFound, "branch not found: "+branch)
+			return
+		}
+		slog.Error("ui assemble agent context", "repo", repoName, "branch", branch, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load branch")
+		return
+	}
+
+	page := branchDetailPage{Repo: *repo, Ctx: actCtx, Err: errMsg}
+	for _, p := range actCtx.Policies {
+		if !p.Pass {
+			reason := p.Reason
+			if reason == "" {
+				reason = p.Name
+			}
+			page.Blockers = append(page.Blockers, reason)
+		}
+	}
+	for _, c := range actCtx.CheckRuns {
+		switch c.Status {
+		case model.CheckRunPassed:
+			page.PassedCheckCnt++
+		case model.CheckRunPending:
+			page.PendingCheckCnt++
+			page.Blockers = append(page.Blockers, c.CheckName+" pending")
+		case model.CheckRunFailed:
+			page.FailedCheckCnt++
+			page.Blockers = append(page.Blockers, c.CheckName+" failed")
+		}
+	}
+
+	h.render(w, h.tmpl.branchDetail, "layout.html", pageData{
+		Title: repoName + " / " + branch,
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: branch, Href: ""},
+		},
+		Body: page,
+	})
+}
+
+// handleSubmitReview processes a POST form to submit a review on a branch.
+func (h *Handler) handleSubmitReview(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	branch := r.PathValue("branch")
+	repoName := owner + "/" + name
+
+	if err := r.ParseForm(); err != nil {
+		h.renderError(w, http.StatusBadRequest, "invalid form data")
+		return
+	}
+
+	status := model.ReviewStatus(r.FormValue("status"))
+	body := r.FormValue("body")
+
+	if status == "" {
+		h.renderBranchDetail(w, r, repoName, branch, "status is required")
+		return
+	}
+
+	var identity string
+	if h.identity != nil {
+		identity = h.identity(r.Context())
+	}
+
+	if _, err := h.write.CreateReview(r.Context(), repoName, branch, identity, status, body); err != nil {
+		slog.Error("ui create review", "repo", repoName, "branch", branch, "error", err)
+		h.renderBranchDetail(w, r, repoName, branch, "could not submit review: "+err.Error())
+		return
+	}
+
+	http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+url.PathEscape(branch), http.StatusSeeOther)
+}
+
+// handlePostComment processes a POST form to add an inline review comment.
+func (h *Handler) handlePostComment(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	branch := r.PathValue("branch")
+	repoName := owner + "/" + name
+
+	if err := r.ParseForm(); err != nil {
+		h.renderError(w, http.StatusBadRequest, "invalid form data")
+		return
+	}
+
+	path := r.FormValue("path")
+	versionID := r.FormValue("version_id")
+	body := r.FormValue("body")
+
+	if path == "" || versionID == "" || body == "" {
+		h.renderBranchDetail(w, r, repoName, branch, "path, version_id, and body are required")
+		return
+	}
+
+	var identity string
+	if h.identity != nil {
+		identity = h.identity(r.Context())
+	}
+
+	if _, err := h.write.CreateReviewComment(r.Context(), repoName, branch, path, versionID, body, identity, nil); err != nil {
+		slog.Error("ui create review comment", "repo", repoName, "branch", branch, "error", err)
+		h.renderBranchDetail(w, r, repoName, branch, "could not post comment: "+err.Error())
+		return
+	}
+
+	http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+url.PathEscape(branch), http.StatusSeeOther)
+}
+
+// handleDeleteComment processes a POST form to delete an inline review comment.
+func (h *Handler) handleDeleteComment(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	branch := r.PathValue("branch")
+	id := r.PathValue("id")
+	repoName := owner + "/" + name
+
+	if err := h.write.DeleteReviewComment(r.Context(), repoName, id); err != nil {
+		slog.Error("ui delete review comment", "repo", repoName, "id", id, "error", err)
+		h.renderBranchDetail(w, r, repoName, branch, "could not delete comment: "+err.Error())
+		return
+	}
+
+	http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+url.PathEscape(branch), http.StatusSeeOther)
+}
+
+// handleCreateProposalUI processes a POST form to create a new proposal.
+func (h *Handler) handleCreateProposalUI(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	if err := r.ParseForm(); err != nil {
+		h.renderError(w, http.StatusBadRequest, "invalid form data")
+		return
+	}
+
+	branch := r.FormValue("branch")
+	baseBranch := r.FormValue("base_branch")
+	title := r.FormValue("title")
+	description := r.FormValue("description")
+
+	renderWithErr := func(errMsg string) {
+		repo, err := h.write.GetRepo(ctx, repoName)
+		if err != nil {
+			h.renderError(w, http.StatusInternalServerError, "could not load repo")
+			return
+		}
+		stateStr := "open"
+		_, ps := proposalStateFromQuery(stateStr)
+		proposals, err := h.write.ListProposals(ctx, repoName, ps, nil)
+		if err != nil {
+			proposals = nil
+		}
+		h.render(w, h.tmpl.proposals, "layout.html", pageData{
+			Title: repoName + " / proposals",
+			Breadcrumbs: []crumb{
+				{Label: "repos", Href: "/ui/"},
+				{Label: repoName, Href: "/ui/r/" + repoName},
+				{Label: "proposals", Href: ""},
+			},
+			Body: proposalsPage{Repo: *repo, Proposals: proposals, State: stateStr, Err: errMsg},
+		})
+	}
+
+	if branch == "" || baseBranch == "" || title == "" {
+		renderWithErr("branch, base_branch, and title are required")
+		return
+	}
+
+	var identity string
+	if h.identity != nil {
+		identity = h.identity(ctx)
+	}
+
+	proposal, err := h.write.CreateProposal(ctx, repoName, branch, baseBranch, title, description, identity)
+	if err != nil {
+		slog.Error("ui create proposal", "repo", repoName, "error", err)
+		renderWithErr("could not create proposal: " + err.Error())
+		return
+	}
+
+	http.Redirect(w, r, "/ui/r/"+repoName+"/proposals/"+proposal.ID, http.StatusSeeOther)
+}
+
+// handleEditProposal processes a POST form to update a proposal's title/description.
+func (h *Handler) handleEditProposal(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	id := r.PathValue("id")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	if err := r.ParseForm(); err != nil {
+		h.renderError(w, http.StatusBadRequest, "invalid form data")
+		return
+	}
+
+	titleVal := r.FormValue("title")
+	descVal := r.FormValue("description")
+
+	renderWithErr := func(proposal *model.Proposal, errMsg string) {
+		repo, err := h.write.GetRepo(ctx, repoName)
+		if err != nil {
+			h.renderError(w, http.StatusInternalServerError, "could not load repo")
+			return
+		}
+		h.render(w, h.tmpl.proposalDetail, "layout.html", pageData{
+			Title: repoName + " / proposals / " + id,
+			Breadcrumbs: []crumb{
+				{Label: "repos", Href: "/ui/"},
+				{Label: repoName, Href: "/ui/r/" + repoName},
+				{Label: "proposals", Href: "/ui/r/" + repoName + "/proposals"},
+				{Label: proposal.Title, Href: ""},
+			},
+			Body: proposalDetailPage{Repo: *repo, Proposal: proposal, Err: errMsg},
+		})
+	}
+
+	// Load current proposal for error re-render.
+	proposal, err := h.write.GetProposal(ctx, repoName, id)
+	if err != nil || proposal == nil {
+		h.renderError(w, http.StatusNotFound, "proposal not found")
+		return
+	}
+
+	if titleVal == "" {
+		renderWithErr(proposal, "title is required")
+		return
+	}
+
+	updated, err := h.write.UpdateProposal(ctx, repoName, id, &titleVal, &descVal)
+	if err != nil {
+		slog.Error("ui update proposal", "repo", repoName, "id", id, "error", err)
+		renderWithErr(proposal, "could not update proposal: "+err.Error())
+		return
+	}
+
+	http.Redirect(w, r, "/ui/r/"+repoName+"/proposals/"+updated.ID, http.StatusSeeOther)
+}
+
+// handleCloseProposalUI processes a POST form to close a proposal.
+func (h *Handler) handleCloseProposalUI(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	id := r.PathValue("id")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	if err := h.write.CloseProposal(ctx, repoName, id); err != nil {
+		slog.Error("ui close proposal", "repo", repoName, "id", id, "error", err)
+
+		// Re-render proposal detail with error.
+		proposal, getErr := h.write.GetProposal(ctx, repoName, id)
+		if getErr != nil || proposal == nil {
+			h.renderError(w, http.StatusInternalServerError, "could not close proposal")
+			return
+		}
+		repo, getErr := h.write.GetRepo(ctx, repoName)
+		if getErr != nil {
+			h.renderError(w, http.StatusInternalServerError, "could not load repo")
+			return
+		}
+		h.render(w, h.tmpl.proposalDetail, "layout.html", pageData{
+			Title: repoName + " / proposals / " + id,
+			Breadcrumbs: []crumb{
+				{Label: "repos", Href: "/ui/"},
+				{Label: repoName, Href: "/ui/r/" + repoName},
+				{Label: "proposals", Href: "/ui/r/" + repoName + "/proposals"},
+				{Label: proposal.Title, Href: ""},
+			},
+			Body: proposalDetailPage{Repo: *repo, Proposal: proposal, Err: "could not close proposal: " + err.Error()},
+		})
+		return
+	}
+
+	http.Redirect(w, r, "/ui/r/"+repoName+"/proposals/"+id, http.StatusSeeOther)}
 
 // chainToLogRows filters and converts ChainEntries to commitLogRows.
 // Only entries for the named branch are included.

--- a/internal/ui/templates/branch_detail.html
+++ b/internal/ui/templates/branch_detail.html
@@ -156,7 +156,48 @@
       {{end}}
       <div id="review-comments"></div>
     </div>
+
+    <h2>Submit review</h2>
+    <div class="card">
+      <form method="POST" action="/ui/r/{{$page.Repo.Name}}/b/{{urlPathEscape $ctx.Branch.Name}}/review" style="padding:14px 12px 4px">
+        <div style="margin-bottom:10px">
+          <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Status</label>
+          <select name="status" style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text)">
+            <option value="approved">approved</option>
+            <option value="rejected">rejected</option>
+            <option value="dismissed">dismissed</option>
+          </select>
+        </div>
+        <div style="margin-bottom:10px">
+          <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Comment (optional)</label>
+          <textarea name="body" rows="3" style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);resize:vertical;box-sizing:border-box"></textarea>
+        </div>
+        <button type="submit">Submit review</button>
+      </form>
+    </div>
   </div>
+</div>
+
+<h2>Add comment</h2>
+<div class="card">
+  <form method="POST" action="/ui/r/{{$page.Repo.Name}}/b/{{urlPathEscape $ctx.Branch.Name}}/comment" style="padding:14px 12px 4px">
+    <div style="margin-bottom:10px">
+      <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">File path</label>
+      <input type="text" name="path" list="diff-paths" placeholder="e.g. docs/hello.md" style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);box-sizing:border-box">
+      <datalist id="diff-paths">
+        {{range $ctx.Diff.BranchChanges}}{{if .VersionID}}<option value="{{.Path}}">{{end}}{{end}}
+      </datalist>
+    </div>
+    <div style="margin-bottom:10px">
+      <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Version ID</label>
+      <input type="text" name="version_id" placeholder="e.g. v-abc123" style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);box-sizing:border-box">
+    </div>
+    <div style="margin-bottom:10px">
+      <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Comment</label>
+      <textarea name="body" rows="3" style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);resize:vertical;box-sizing:border-box"></textarea>
+    </div>
+    <button type="submit">Post comment</button>
+  </form>
 </div>
 
 <h2>Diff</h2>

--- a/internal/ui/templates/proposal_detail.html
+++ b/internal/ui/templates/proposal_detail.html
@@ -18,6 +18,10 @@
   by {{.Proposal.Author}} · opened {{relTime .Proposal.CreatedAt}} · updated {{relTime .Proposal.UpdatedAt}}
 </div>
 
+{{if .Err}}
+<div class="card" style="margin-bottom:14px"><span class="badge bad">{{.Err}}</span></div>
+{{end}}
+
 <h2>Details</h2>
 <div class="card">
   <div class="row">
@@ -38,6 +42,31 @@
 <h2>Description</h2>
 <div class="card">
   <div style="white-space:pre-wrap;color:var(--text);">{{.Proposal.Description}}</div>
+</div>
+{{end}}
+
+<h2>Edit proposal</h2>
+<div class="card">
+  <form method="POST" action="/ui/r/{{.Repo.Name}}/proposals/{{.Proposal.ID}}/edit" style="padding:14px 12px 4px">
+    <div style="margin-bottom:10px">
+      <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Title</label>
+      <input type="text" name="title" value="{{.Proposal.Title}}" required style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);box-sizing:border-box">
+    </div>
+    <div style="margin-bottom:10px">
+      <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Description</label>
+      <textarea name="description" rows="4" style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);resize:vertical;box-sizing:border-box">{{.Proposal.Description}}</textarea>
+    </div>
+    <button type="submit">Save changes</button>
+  </form>
+</div>
+
+{{if eq (printf "%s" .Proposal.State) "open"}}
+<h2>Close proposal</h2>
+<div class="card">
+  <form method="POST" action="/ui/r/{{.Repo.Name}}/proposals/{{.Proposal.ID}}/close" style="padding:14px 12px 4px">
+    <p style="margin:0 0 10px;color:var(--text-muted);font-size:0.9em">Closing this proposal will mark it as closed and it will no longer appear in the open proposals list.</p>
+    <button type="submit">Close proposal</button>
+  </form>
 </div>
 {{end}}
 {{end}}

--- a/internal/ui/templates/proposals.html
+++ b/internal/ui/templates/proposals.html
@@ -14,6 +14,10 @@
   <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
 </nav>
 
+{{if .Err}}
+<div class="card" style="margin-bottom:14px"><span class="badge bad">{{.Err}}</span></div>
+{{end}}
+
 <div class="tab-bar" data-tab-group>
   <a class="tab{{if eq .State "open"}} active{{end}}"
      href="?state=open"
@@ -31,6 +35,29 @@
 
 <div class="card" id="proposals-list">
 {{template "proposals_rows.html" .Proposals}}
+</div>
+
+<h2>New proposal</h2>
+<div class="card">
+  <form method="POST" action="/ui/r/{{.Repo.Name}}/proposals" style="padding:14px 12px 4px">
+    <div style="margin-bottom:10px">
+      <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Branch</label>
+      <input type="text" name="branch" required placeholder="e.g. feature-x" style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);box-sizing:border-box">
+    </div>
+    <div style="margin-bottom:10px">
+      <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Base branch</label>
+      <input type="text" name="base_branch" value="main" required style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);box-sizing:border-box">
+    </div>
+    <div style="margin-bottom:10px">
+      <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Title</label>
+      <input type="text" name="title" required placeholder="Proposal title" style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);box-sizing:border-box">
+    </div>
+    <div style="margin-bottom:10px">
+      <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Description (optional)</label>
+      <textarea name="description" rows="4" style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);resize:vertical;box-sizing:border-box"></textarea>
+    </div>
+    <button type="submit">Create proposal</button>
+  </form>
 </div>
 {{end}}
 {{end}}

--- a/internal/ui/templates/review_comments.html
+++ b/internal/ui/templates/review_comments.html
@@ -1,8 +1,8 @@
 {{define "review_comments.html"}}
-{{if not .}}
+{{if not .Groups}}
 <div class="empty">no inline comments on this branch</div>
 {{else}}
-{{range .}}
+{{range .Groups}}
 <div class="comment-file-group">
   <div class="comment-file-path">{{.Path}}</div>
   {{range .Comments}}
@@ -11,8 +11,11 @@
       <strong>{{.Author}}</strong>
       <span class="meta">@ seq {{.Sequence}} · {{relTime .CreatedAt}}</span>
     </div>
-    <div class="row-body">{{.Body}}</div>
+    <form method="POST" action="/ui/r/{{$.RepoName}}/b/{{urlPathEscape $.Branch}}/comment/{{.ID}}/delete" style="display:inline">
+      <button type="submit" class="btn-link" style="color:var(--text-muted)">delete</button>
+    </form>
   </div>
+  <div class="row-body">{{.Body}}</div>
   {{end}}
 </div>
 {{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -29,7 +29,7 @@ type ReadStore interface {
 
 // WriteStoreLite is the subset of server.WriteStore that the UI needs for
 // listing repos and orgs, org invite acceptance, issue write operations,
-// and branch write operations.
+// branch write operations, and review/comment/proposal write operations.
 type WriteStoreLite interface {
 	ListRepos(ctx context.Context) ([]model.Repo, error)
 	ListOrgs(ctx context.Context) ([]model.Org, error)
@@ -70,6 +70,14 @@ type WriteStoreLite interface {
 	UpdateBranchDraft(ctx context.Context, repo, name string, draft bool) error
 	DeleteBranch(ctx context.Context, repo, name string) error
 	SetBranchAutoMerge(ctx context.Context, repo, name string, autoMerge bool) error
+
+	// Review/comment/proposal write operations.
+	CreateReview(ctx context.Context, repo, branch, reviewer string, status model.ReviewStatus, body string) (*model.Review, error)
+	CreateReviewComment(ctx context.Context, repo, branch, path, versionID, body, author string, reviewID *string) (*model.ReviewComment, error)
+	DeleteReviewComment(ctx context.Context, repo, id string) error
+	CreateProposal(ctx context.Context, repo, branch, baseBranch, title, description, author string) (*model.Proposal, error)
+	UpdateProposal(ctx context.Context, repo, proposalID string, title, description *string) (*model.Proposal, error)
+	CloseProposal(ctx context.Context, repo, proposalID string) error
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -188,5 +196,14 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("POST /ui/r/{owner}/{name}/-/delete-branch", h.handleUIDeleteBranch)
 	mux.HandleFunc("POST /ui/r/{owner}/{name}/-/promote-branch", h.handleUIPromoteBranch)
 	mux.HandleFunc("POST /ui/r/{owner}/{name}/-/set-auto-merge", h.handleUISetAutoMerge)
+
+	// Write operations — POST forms from branch detail and proposals pages.
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/b/{branch}/review", h.handleSubmitReview)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/b/{branch}/comment", h.handlePostComment)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/b/{branch}/comment/{id}/delete", h.handleDeleteComment)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/proposals", h.handleCreateProposalUI)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/proposals/{id}/edit", h.handleEditProposal)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/proposals/{id}/close", h.handleCloseProposalUI)
+
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -203,6 +203,23 @@ func (f *fakeWrite) SetBranchAutoMerge(_ context.Context, _, _ string, _ bool) e
 	return nil
 }
 
+func (f *fakeWrite) CreateReview(_ context.Context, _, _, _ string, _ model.ReviewStatus, _ string) (*model.Review, error) {
+	return &model.Review{}, nil
+}
+func (f *fakeWrite) CreateReviewComment(_ context.Context, _, _, _, _, _, _ string, _ *string) (*model.ReviewComment, error) {
+	return &model.ReviewComment{}, nil
+}
+func (f *fakeWrite) DeleteReviewComment(_ context.Context, _, _ string) error { return nil }
+func (f *fakeWrite) CreateProposal(_ context.Context, _, _, _, _, _, _ string) (*model.Proposal, error) {
+	return &model.Proposal{ID: "new-p"}, nil
+}
+func (f *fakeWrite) UpdateProposal(_ context.Context, _, _ string, _, _ *string) (*model.Proposal, error) {
+	if len(f.proposals) > 0 {
+		return f.proposals[0], nil
+	}
+	return &model.Proposal{ID: "updated-p", Title: "updated"}, nil
+}
+func (f *fakeWrite) CloseProposal(_ context.Context, _, _ string) error { return nil }
 func newFakeAssembler(branchName string) AssembleFn {
 	return func(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
 		if branch != branchName {
@@ -786,4 +803,140 @@ func TestHandleRepos_ShowsNewButtons(t *testing.T) {
 			t.Errorf("body missing link %q", want)
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Write handler tests
+// ---------------------------------------------------------------------------
+
+func TestHandleSubmitReview_RedirectsOnSuccess(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, newFakeAssembler("feat-x"))
+
+	code, _, _ := postForm(t, h, "/ui/r/acme/a/b/feat-x/review", url.Values{
+		"status": {"approved"},
+		"body": {"looks good"},
+	})
+	if code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (redirect)", code)
+	}
+}
+
+func TestHandleSubmitReview_MissingStatus_RerendersPage(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, newFakeAssembler("feat-x"))
+
+	code, body, _ := postForm(t, h, "/ui/r/acme/a/b/feat-x/review", url.Values{})
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if !strings.Contains(body, "status is required") {
+		t.Errorf("expected error message in body, got: %s", body)
+	}
+}
+
+func TestHandlePostComment_RedirectsOnSuccess(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, newFakeAssembler("feat-x"))
+
+	code, _, _ := postForm(t, h, "/ui/r/acme/a/b/feat-x/comment", url.Values{
+		"path": {"docs/hello.md"},
+		"version_id": {"v-abc"},
+		"body": {"nice file"},
+	})
+	if code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (redirect)", code)
+	}
+}
+
+func TestHandlePostComment_MissingFields_RerendersPage(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, newFakeAssembler("feat-x"))
+
+	code, body, _ := postForm(t, h, "/ui/r/acme/a/b/feat-x/comment", url.Values{
+		"path": {"docs/hello.md"},
+		// missing version_id and body
+	})
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if !strings.Contains(body, "path, version_id, and body are required") {
+		t.Errorf("expected error message in body, got: %s", body)
+	}
+}
+
+func TestHandleDeleteComment_RedirectsOnSuccess(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, newFakeAssembler("feat-x"))
+
+	code, _, _ := postForm(t, h, "/ui/r/acme/a/b/feat-x/comment/cmt-1/delete", nil)
+	if code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (redirect)", code)
+	}
+}
+
+func TestHandleCreateProposalUI_RedirectsOnSuccess(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, _, _ := postForm(t, h, "/ui/r/acme/a/proposals", url.Values{
+		"branch": {"feat-x"},
+		"base_branch": {"main"},
+		"title": {"My proposal"},
+	})
+	if code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (redirect)", code)
+	}
+}
+
+func TestHandleCreateProposalUI_MissingFields_RerendersPage(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, body, _ := postForm(t, h, "/ui/r/acme/a/proposals", url.Values{
+		"branch": {"feat-x"},
+		// missing base_branch and title
+	})
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if !strings.Contains(body, "branch, base_branch, and title are required") {
+		t.Errorf("expected error message in body, got: %s", body)
+	}
+}
+
+func TestHandleEditProposal_RedirectsOnSuccess(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	ps := model.ProposalOpen
+	w := &fakeWrite{
+		repos: repos,
+		proposals: []*model.Proposal{
+			{ID: "p-1", Repo: "acme/a", Branch: "feat-x", BaseBranch: "main", Title: "Old title", Author: "alice", State: ps, CreatedAt: time.Now()},
+		},
+	}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, _, _ := postForm(t, h, "/ui/r/acme/a/proposals/p-1/edit", url.Values{
+		"title": {"New title"},
+		"description": {"updated description"},
+	})
+	if code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (redirect)", code)
+	}
+}
+
+func TestHandleCloseProposalUI_RedirectsOnSuccess(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	ps := model.ProposalOpen
+	w := &fakeWrite{
+		repos: repos,
+		proposals: []*model.Proposal{
+			{ID: "p-1", Repo: "acme/a", Branch: "feat-x", BaseBranch: "main", Title: "My proposal", Author: "alice", State: ps, CreatedAt: time.Now()},
+		},
+	}
+	h := newTestHandler(t, &fakeRead{}, w, nil)
+
+	code, _, _ := postForm(t, h, "/ui/r/acme/a/proposals/p-1/close", nil)
+	if code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (redirect)", code)	}
 }


### PR DESCRIPTION
## Summary

Closes #320

Adds POST form handlers and templates for all required write operations in the web UI:

- **Submit review**: `POST /ui/r/{owner}/{name}/b/{branch}/review` — review form on branch detail page with status dropdown (approved/rejected/dismissed) and optional body
- **Post inline comment**: `POST /ui/r/{owner}/{name}/b/{branch}/comment` — comment form on branch detail page with file path (datalist from diff), version_id, and body
- **Delete inline comment**: `POST /ui/r/{owner}/{name}/b/{branch}/comment/{id}/delete` — delete button on each comment in the review_comments partial
- **Create proposal**: `POST /ui/r/{owner}/{name}/proposals` — new-proposal form on proposals list page
- **Edit proposal**: `POST /ui/r/{owner}/{name}/proposals/{id}/edit` — edit form pre-filled on proposal detail page
- **Close proposal**: `POST /ui/r/{owner}/{name}/proposals/{id}/close` — close button (shown only when state=open) on proposal detail page

## Implementation notes

- All POST forms follow the `accept_invite.html` pattern: parse form data, call store method, redirect on success, re-render page with inline error on failure
- Extended `WriteStoreLite` interface with 6 write methods; both test fakes updated accordingly
- Refactored `handleBranchDetail` into a shared `renderBranchDetail` helper (reused for error re-rendering by POST handlers)
- `review_comments.html` template data changed from `[]reviewCommentGroup` to a `reviewCommentsData` struct that includes `RepoName` and `Branch` for constructing delete form URLs
- `branchDetailPage`, `proposalsPage`, and `proposalDetailPage` each gained an `Err string` field for inline error display
- 9 new tests covering success redirects and validation error re-renders for all 6 handlers

## Test plan

- [x] `go test ./internal/ui/... -count=1` — all tests pass including 9 new ones
- [x] `go build ./...` — clean build
- [x] `go vet ./...` — no issues

## Opportunities noted (out of scope)

- The comment form currently requires the user to supply `version_id` manually; a JS enhancement could auto-fill it when a path is chosen from the datalist
- `review_comments.html` delete buttons work but the partial is currently only loaded on click (existing pattern); HTMX auto-load on page ready would improve UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)