### PR TITLE
feat(ui): add org member/invite management, repo roles, and releases write ops (issue #320)

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -306,6 +306,23 @@ func (fakeWrite) UpdateProposal(_ context.Context, _, _ string, _, _ *string) (*
 	return &model.Proposal{ID: "updated-p", Title: "updated"}, nil
 }
 func (fakeWrite) CloseProposal(_ context.Context, _, _ string) error { return nil }
+func (fakeWrite) AddOrgMember(_ context.Context, _, _ string, _ model.OrgRole, _ string) error {
+	return nil
+}
+func (fakeWrite) RemoveOrgMember(_ context.Context, _, _ string) error { return nil }
+func (fakeWrite) CreateInvite(_ context.Context, _, _ string, _ model.OrgRole, _, _ string, _ time.Time) (*model.OrgInvite, error) {
+	return &model.OrgInvite{}, nil
+}
+func (fakeWrite) RevokeInvite(_ context.Context, _, _ string) error { return nil }
+func (fakeWrite) SetRole(_ context.Context, _, _ string, _ model.RoleType) error {
+	return nil
+}
+func (fakeWrite) DeleteRole(_ context.Context, _, _ string) error { return nil }
+func (fakeWrite) CreateRelease(_ context.Context, _, _ string, _ int64, _, _ string) (*model.Release, error) {
+	return &model.Release{}, nil
+}
+func (fakeWrite) DeleteRelease(_ context.Context, _, _ string) error { return nil }
+
 func fakeAssemble(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
 	t := time.Now()
 	vid := func(s string) *string { return &s }

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -36,6 +38,7 @@ type orgPage struct {
 	Repos   []model.Repo
 	Members []model.OrgMember
 	Invites []model.OrgInvite
+	Err     string
 }
 
 type branchesPage struct {
@@ -179,6 +182,7 @@ type proposalDetailPage struct {
 type releasesPage struct {
 	Repo     model.Repo
 	Releases []model.Release
+	Err      string
 }
 
 type releaseDetailPage struct {
@@ -242,115 +246,12 @@ func (h *Handler) handleRepos(w http.ResponseWriter, r *http.Request) {
 
 // handleOrg renders the org overview page: repos, members, and pending invites.
 func (h *Handler) handleOrg(w http.ResponseWriter, r *http.Request) {
-	org := r.PathValue("org")
-	ctx := r.Context()
-
-	repos, err := h.write.ListOrgRepos(ctx, org)
-	if err != nil {
-		slog.Error("ui list org repos", "org", org, "error", err)
-		h.renderError(w, http.StatusInternalServerError, "could not load repos")
-		return
-	}
-	members, err := h.write.ListOrgMembers(ctx, org)
-	if err != nil {
-		slog.Error("ui list org members", "org", org, "error", err)
-		h.renderError(w, http.StatusInternalServerError, "could not load members")
-		return
-	}
-	invites, err := h.write.ListInvites(ctx, org)
-	if err != nil {
-		slog.Error("ui list invites", "org", org, "error", err)
-		h.renderError(w, http.StatusInternalServerError, "could not load invites")
-		return
-	}
-	var pending []model.OrgInvite
-	for _, inv := range invites {
-		if inv.AcceptedAt == nil {
-			pending = append(pending, inv)
-		}
-	}
-
-	h.render(w, h.tmpl.org, "layout.html", pageData{
-		Title: org,
-		Breadcrumbs: []crumb{
-			{Label: "repos", Href: "/ui/"},
-			{Label: org, Href: ""},
-		},
-		Body: orgPage{
-			Org:     org,
-			Repos:   repos,
-			Members: members,
-			Invites: pending,
-		},
-	})
+	h.renderOrgPage(w, r, r.PathValue("org"), "")
 }
 
 // handleBranches renders the branch list for a single repo.
 func (h *Handler) handleBranches(w http.ResponseWriter, r *http.Request) {
-	owner := r.PathValue("owner")
-	name := r.PathValue("name")
-	repoName := owner + "/" + name
-	ctx := r.Context()
-
-	repo, err := h.write.GetRepo(ctx, repoName)
-	if err != nil {
-		if errors.Is(err, db.ErrRepoNotFound) {
-			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
-			return
-		}
-		slog.Error("ui get repo", "repo", repoName, "error", err)
-		h.renderError(w, http.StatusInternalServerError, "could not load repo")
-		return
-	}
-
-	branches, err := h.read.ListBranches(ctx, repoName, "", true, false)
-	if err != nil {
-		slog.Error("ui list branches", "repo", repoName, "error", err)
-		h.renderError(w, http.StatusInternalServerError, "could not load branches")
-		return
-	}
-
-	members, err := h.write.ListOrgMembers(ctx, repo.Owner)
-	if err != nil {
-		slog.Error("ui list org members", "org", repo.Owner, "error", err)
-		// Non-fatal: render page without members.
-		members = nil
-	}
-	roles, err := h.write.ListRoles(ctx, repoName)
-	if err != nil {
-		slog.Error("ui list roles", "repo", repoName, "error", err)
-		// Non-fatal: render page without roles.
-		roles = nil
-	}
-
-	page := branchesPage{Repo: *repo, Members: members, Roles: roles, Err: r.URL.Query().Get("err")}
-	for _, b := range branches {
-		row := branchRow{
-			Name:         b.Name,
-			HeadSequence: b.HeadSequence,
-			BaseSequence: b.BaseSequence,
-			Draft:        b.Draft,
-			AutoMerge:    b.AutoMerge,
-			Status:       b.Status,
-		}
-		switch b.Status {
-		case "merged":
-			page.Merged = append(page.Merged, row)
-		case "abandoned":
-			page.Abandoned = append(page.Abandoned, row)
-		default:
-			page.Active = append(page.Active, row)
-		}
-	}
-
-	h.render(w, h.tmpl.branches, "layout.html", pageData{
-		Title: repoName + " / branches",
-		Breadcrumbs: []crumb{
-			{Label: "repos", Href: "/ui/"},
-			{Label: repoName, Href: "/ui/r/" + repoName},
-		},
-		Body: page,
-	})
+	h.renderBranchesPage(w, r, r.PathValue("owner"), r.PathValue("name"), "")
 }
 
 // handleBranchDetail renders the diff + reviews + checks + policy view.
@@ -812,38 +713,7 @@ func (h *Handler) handleProposalDetail(w http.ResponseWriter, r *http.Request) {
 
 // handleReleases renders the releases list for a repo.
 func (h *Handler) handleReleases(w http.ResponseWriter, r *http.Request) {
-	owner := r.PathValue("owner")
-	name := r.PathValue("name")
-	repoName := owner + "/" + name
-	ctx := r.Context()
-
-	repo, err := h.write.GetRepo(ctx, repoName)
-	if err != nil {
-		if errors.Is(err, db.ErrRepoNotFound) {
-			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
-			return
-		}
-		slog.Error("ui get repo", "repo", repoName, "error", err)
-		h.renderError(w, http.StatusInternalServerError, "could not load repo")
-		return
-	}
-
-	releases, err := h.write.ListReleases(ctx, repoName, 100, "")
-	if err != nil {
-		slog.Error("ui list releases", "repo", repoName, "error", err)
-		h.renderError(w, http.StatusInternalServerError, "could not load releases")
-		return
-	}
-
-	h.render(w, h.tmpl.releases, "layout.html", pageData{
-		Title: repoName + " / releases",
-		Breadcrumbs: []crumb{
-			{Label: "repos", Href: "/ui/"},
-			{Label: repoName, Href: "/ui/r/" + repoName},
-			{Label: "releases", Href: ""},
-		},
-		Body: releasesPage{Repo: *repo, Releases: releases},
-	})
+	h.renderReleasesPage(w, r, r.PathValue("owner"), r.PathValue("name"), "")
 }
 
 // handleReleaseDetail renders the detail view for a single release.
@@ -1254,6 +1124,411 @@ func (h *Handler) handleAcceptInvite(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r, "/ui/o/"+org, http.StatusSeeOther)
+}
+
+// generateInviteToken returns a 32-byte random hex string for use as an invite token.
+func generateInviteToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// renderOrgPage loads org data and renders the org page, optionally with an error message.
+func (h *Handler) renderOrgPage(w http.ResponseWriter, r *http.Request, org, errMsg string) {
+	ctx := r.Context()
+
+	repos, err := h.write.ListOrgRepos(ctx, org)
+	if err != nil {
+		slog.Error("ui list org repos", "org", org, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repos")
+		return
+	}
+	members, err := h.write.ListOrgMembers(ctx, org)
+	if err != nil {
+		slog.Error("ui list org members", "org", org, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load members")
+		return
+	}
+	invites, err := h.write.ListInvites(ctx, org)
+	if err != nil {
+		slog.Error("ui list invites", "org", org, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load invites")
+		return
+	}
+	var pending []model.OrgInvite
+	for _, inv := range invites {
+		if inv.AcceptedAt == nil {
+			pending = append(pending, inv)
+		}
+	}
+
+	h.render(w, h.tmpl.org, "layout.html", pageData{
+		Title: org,
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: org, Href: ""},
+		},
+		Body: orgPage{
+			Org:     org,
+			Repos:   repos,
+			Members: members,
+			Invites: pending,
+			Err:     errMsg,
+		},
+	})
+}
+
+// handleAddOrgMember processes POST /ui/o/{org}/members to add an org member.
+func (h *Handler) handleAddOrgMember(w http.ResponseWriter, r *http.Request) {
+	org := r.PathValue("org")
+	ctx := r.Context()
+
+	if err := r.ParseForm(); err != nil {
+		h.renderOrgPage(w, r, org, "invalid form data")
+		return
+	}
+	identity := strings.TrimSpace(r.FormValue("identity"))
+	role := model.OrgRole(r.FormValue("role"))
+
+	if identity == "" {
+		h.renderOrgPage(w, r, org, "identity is required")
+		return
+	}
+	switch role {
+	case model.OrgRoleOwner, model.OrgRoleMember:
+	default:
+		h.renderOrgPage(w, r, org, "invalid role; must be 'owner' or 'member'")
+		return
+	}
+
+	var invitedBy string
+	if h.identity != nil {
+		invitedBy = h.identity(ctx)
+	}
+
+	if err := h.write.AddOrgMember(ctx, org, identity, role, invitedBy); err != nil {
+		slog.Error("ui add org member", "org", org, "identity", identity, "error", err)
+		h.renderOrgPage(w, r, org, "could not add member: "+err.Error())
+		return
+	}
+
+	http.Redirect(w, r, "/ui/o/"+org, http.StatusSeeOther)
+}
+
+// handleRemoveOrgMember processes POST /ui/o/{org}/members/{identity}/remove.
+func (h *Handler) handleRemoveOrgMember(w http.ResponseWriter, r *http.Request) {
+	org := r.PathValue("org")
+	identity := r.PathValue("identity")
+	ctx := r.Context()
+
+	if err := h.write.RemoveOrgMember(ctx, org, identity); err != nil {
+		switch {
+		case errors.Is(err, db.ErrOrgMemberNotFound):
+			h.renderOrgPage(w, r, org, "member not found")
+		default:
+			slog.Error("ui remove org member", "org", org, "identity", identity, "error", err)
+			h.renderOrgPage(w, r, org, "could not remove member")
+		}
+		return
+	}
+
+	http.Redirect(w, r, "/ui/o/"+org, http.StatusSeeOther)
+}
+
+// handleCreateInvite processes POST /ui/o/{org}/invites to create an org invite.
+func (h *Handler) handleCreateInvite(w http.ResponseWriter, r *http.Request) {
+	org := r.PathValue("org")
+	ctx := r.Context()
+
+	if err := r.ParseForm(); err != nil {
+		h.renderOrgPage(w, r, org, "invalid form data")
+		return
+	}
+	email := strings.TrimSpace(r.FormValue("email"))
+	role := model.OrgRole(r.FormValue("role"))
+
+	if email == "" {
+		h.renderOrgPage(w, r, org, "email is required")
+		return
+	}
+	switch role {
+	case model.OrgRoleOwner, model.OrgRoleMember:
+	default:
+		h.renderOrgPage(w, r, org, "invalid role; must be 'owner' or 'member'")
+		return
+	}
+
+	token, err := generateInviteToken()
+	if err != nil {
+		slog.Error("ui generate invite token", "org", org, "error", err)
+		h.renderOrgPage(w, r, org, "could not generate invite token")
+		return
+	}
+
+	var invitedBy string
+	if h.identity != nil {
+		invitedBy = h.identity(ctx)
+	}
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+
+	if _, err := h.write.CreateInvite(ctx, org, email, role, invitedBy, token, expiresAt); err != nil {
+		slog.Error("ui create invite", "org", org, "email", email, "error", err)
+		h.renderOrgPage(w, r, org, "could not create invite: "+err.Error())
+		return
+	}
+
+	http.Redirect(w, r, "/ui/o/"+org, http.StatusSeeOther)
+}
+
+// handleRevokeInvite processes POST /ui/o/{org}/invites/{id}/revoke.
+func (h *Handler) handleRevokeInvite(w http.ResponseWriter, r *http.Request) {
+	org := r.PathValue("org")
+	inviteID := r.PathValue("id")
+	ctx := r.Context()
+
+	if err := h.write.RevokeInvite(ctx, org, inviteID); err != nil {
+		switch {
+		case errors.Is(err, db.ErrInviteNotFound):
+			h.renderOrgPage(w, r, org, "invite not found")
+		default:
+			slog.Error("ui revoke invite", "org", org, "invite_id", inviteID, "error", err)
+			h.renderOrgPage(w, r, org, "could not revoke invite")
+		}
+		return
+	}
+
+	http.Redirect(w, r, "/ui/o/"+org, http.StatusSeeOther)
+}
+
+// renderBranchesPage loads repo/branch/member/role data and renders the branches page with an optional error.
+func (h *Handler) renderBranchesPage(w http.ResponseWriter, r *http.Request, owner, name, errMsg string) {
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	branches, err := h.read.ListBranches(ctx, repoName, "", true, false)
+	if err != nil {
+		slog.Error("ui list branches", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load branches")
+		return
+	}
+
+	members, err := h.write.ListOrgMembers(ctx, repo.Owner)
+	if err != nil {
+		slog.Error("ui list org members", "org", repo.Owner, "error", err)
+		members = nil
+	}
+	roles, err := h.write.ListRoles(ctx, repoName)
+	if err != nil {
+		slog.Error("ui list roles", "repo", repoName, "error", err)
+		roles = nil
+	}
+
+	page := branchesPage{Repo: *repo, Members: members, Roles: roles, Err: errMsg}
+	for _, b := range branches {
+		row := branchRow{
+			Name:         b.Name,
+			HeadSequence: b.HeadSequence,
+			BaseSequence: b.BaseSequence,
+			Draft:        b.Draft,
+			AutoMerge:    b.AutoMerge,
+			Status:       b.Status,
+		}
+		switch b.Status {
+		case "merged":
+			page.Merged = append(page.Merged, row)
+		case "abandoned":
+			page.Abandoned = append(page.Abandoned, row)
+		default:
+			page.Active = append(page.Active, row)
+		}
+	}
+
+	h.render(w, h.tmpl.branches, "layout.html", pageData{
+		Title: repoName + " / branches",
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+		},
+		Body: page,
+	})
+}
+
+// handleSetRole processes POST /ui/r/{owner}/{name}/roles to grant or update a repo role.
+func (h *Handler) handleSetRole(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	if err := r.ParseForm(); err != nil {
+		h.renderBranchesPage(w, r, owner, name, "invalid form data")
+		return
+	}
+	identity := strings.TrimSpace(r.FormValue("identity"))
+	role := model.RoleType(r.FormValue("role"))
+
+	if identity == "" {
+		h.renderBranchesPage(w, r, owner, name, "identity is required")
+		return
+	}
+	switch role {
+	case model.RoleReader, model.RoleWriter, model.RoleMaintainer, model.RoleAdmin:
+	default:
+		h.renderBranchesPage(w, r, owner, name, "invalid role; must be reader, writer, maintainer, or admin")
+		return
+	}
+
+	if err := h.write.SetRole(ctx, repoName, identity, role); err != nil {
+		slog.Error("ui set role", "repo", repoName, "identity", identity, "error", err)
+		h.renderBranchesPage(w, r, owner, name, "could not set role: "+err.Error())
+		return
+	}
+
+	http.Redirect(w, r, "/ui/r/"+repoName, http.StatusSeeOther)
+}
+
+// handleDeleteRole processes POST /ui/r/{owner}/{name}/roles/{identity}/delete.
+func (h *Handler) handleDeleteRole(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	identity := r.PathValue("identity")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	if err := h.write.DeleteRole(ctx, repoName, identity); err != nil {
+		switch {
+		case errors.Is(err, db.ErrRoleNotFound):
+			h.renderBranchesPage(w, r, owner, name, "role not found")
+		default:
+			slog.Error("ui delete role", "repo", repoName, "identity", identity, "error", err)
+			h.renderBranchesPage(w, r, owner, name, "could not delete role")
+		}
+		return
+	}
+
+	http.Redirect(w, r, "/ui/r/"+repoName, http.StatusSeeOther)
+}
+
+// renderReleasesPage loads releases for a repo and renders the releases page with an optional error.
+func (h *Handler) renderReleasesPage(w http.ResponseWriter, r *http.Request, owner, name, errMsg string) {
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	releases, err := h.write.ListReleases(ctx, repoName, 100, "")
+	if err != nil {
+		slog.Error("ui list releases", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load releases")
+		return
+	}
+
+	h.render(w, h.tmpl.releases, "layout.html", pageData{
+		Title: repoName + " / releases",
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: "releases", Href: ""},
+		},
+		Body: releasesPage{Repo: *repo, Releases: releases, Err: errMsg},
+	})
+}
+
+// handleCreateRelease processes POST /ui/r/{owner}/{name}/releases to create a release.
+func (h *Handler) handleCreateRelease(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	if err := r.ParseForm(); err != nil {
+		h.renderReleasesPage(w, r, owner, name, "invalid form data")
+		return
+	}
+	relName := strings.TrimSpace(r.FormValue("name"))
+	body := r.FormValue("body")
+	seqStr := strings.TrimSpace(r.FormValue("sequence"))
+
+	if relName == "" {
+		h.renderReleasesPage(w, r, owner, name, "release name is required")
+		return
+	}
+
+	var sequence int64
+	if seqStr != "" {
+		n, err := strconv.ParseInt(seqStr, 10, 64)
+		if err != nil || n < 1 {
+			h.renderReleasesPage(w, r, owner, name, "invalid sequence number")
+			return
+		}
+		sequence = n
+	} else {
+		// Default to main branch head.
+		bi, err := h.read.GetBranch(ctx, repoName, "main")
+		if err != nil || bi == nil {
+			slog.Error("ui create release get main head", "repo", repoName, "error", err)
+			h.renderReleasesPage(w, r, owner, name, "could not resolve main branch head")
+			return
+		}
+		sequence = bi.HeadSequence
+	}
+
+	var createdBy string
+	if h.identity != nil {
+		createdBy = h.identity(ctx)
+	}
+
+	if _, err := h.write.CreateRelease(ctx, repoName, relName, sequence, body, createdBy); err != nil {
+		slog.Error("ui create release", "repo", repoName, "release", relName, "error", err)
+		h.renderReleasesPage(w, r, owner, name, "could not create release: "+err.Error())
+		return
+	}
+
+	http.Redirect(w, r, "/ui/r/"+repoName+"/releases", http.StatusSeeOther)
+}
+
+// handleDeleteRelease processes POST /ui/r/{owner}/{name}/releases/{rname}/delete.
+func (h *Handler) handleDeleteRelease(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	rname := r.PathValue("rname")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	if err := h.write.DeleteRelease(ctx, repoName, rname); err != nil {
+		switch {
+		case errors.Is(err, db.ErrReleaseNotFound):
+			h.renderError(w, http.StatusNotFound, "release not found")
+		default:
+			slog.Error("ui delete release", "repo", repoName, "release", rname, "error", err)
+			h.renderError(w, http.StatusInternalServerError, "could not delete release")
+		}
+		return
+	}
+
+	http.Redirect(w, r, "/ui/r/"+repoName+"/releases", http.StatusSeeOther)
 }
 
 // handleCreateOrg renders the new-org form (GET) and creates the org (POST).

--- a/internal/ui/templates/branches.html
+++ b/internal/ui/templates/branches.html
@@ -58,17 +58,35 @@
 <div class="card">
   {{if not .Roles}}<div class="empty">no roles configured</div>{{else}}
   <table class="grid">
-    <thead><tr><th>identity</th><th>role</th></tr></thead>
+    <thead><tr><th>identity</th><th>role</th><th></th></tr></thead>
     <tbody>
     {{range .Roles}}
     <tr>
       <td>{{.Identity}}</td>
       <td><span class="badge neutral">{{.Role}}</span></td>
+      <td>
+        <form method="POST" action="/ui/r/{{$.Repo.Name}}/roles/{{.Identity}}/delete" style="display:inline">
+          <button type="submit" class="btn-danger-small">revoke</button>
+        </form>
+      </td>
     </tr>
     {{end}}
     </tbody>
   </table>
   {{end}}
+  <details style="margin-top:12px">
+    <summary style="cursor:pointer;font-size:0.9em">Grant role</summary>
+    <form method="POST" action="/ui/r/{{.Repo.Name}}/roles" style="padding:10px 0 4px">
+      <input type="text" name="identity" placeholder="identity (email)" required style="margin-right:6px">
+      <select name="role" style="margin-right:6px">
+        <option value="reader">reader</option>
+        <option value="writer">writer</option>
+        <option value="maintainer">maintainer</option>
+        <option value="admin">admin</option>
+      </select>
+      <button type="submit">Grant</button>
+    </form>
+  </details>
 </div>
 {{end}}
 {{end}}

--- a/internal/ui/templates/org.html
+++ b/internal/ui/templates/org.html
@@ -2,6 +2,10 @@
 {{with .Body}}
 <div class="headline"><h1>{{.Org}}</h1></div>
 
+{{if .Err}}
+<div class="card" style="margin-bottom:12px"><span class="badge bad">{{.Err}}</span></div>
+{{end}}
+
 <h2>Repos ({{len .Repos}})</h2>
 <div class="card">
   {{if not .Repos}}
@@ -24,7 +28,7 @@
     <div class="empty">No members.</div>
   {{else}}
   <table class="grid">
-    <thead><tr><th>identity</th><th>role</th><th>invited by</th><th>joined</th></tr></thead>
+    <thead><tr><th>identity</th><th>role</th><th>invited by</th><th>joined</th><th></th></tr></thead>
     <tbody>
     {{range .Members}}
     <tr>
@@ -32,11 +36,27 @@
       <td><span class="badge {{statusClass .Role}}">{{.Role}}</span></td>
       <td>{{.InvitedBy}}</td>
       <td>{{relTime .CreatedAt}}</td>
+      <td>
+        <form method="POST" action="/ui/o/{{$.Org}}/members/{{.Identity}}/remove" style="display:inline">
+          <button type="submit" class="btn-danger-small">remove</button>
+        </form>
+      </td>
     </tr>
     {{end}}
     </tbody>
   </table>
   {{end}}
+  <details style="margin-top:12px">
+    <summary style="cursor:pointer;font-size:0.9em">Add member</summary>
+    <form method="POST" action="/ui/o/{{.Org}}/members" style="padding:10px 0 4px">
+      <input type="text" name="identity" placeholder="identity (email)" required style="margin-right:6px">
+      <select name="role" style="margin-right:6px">
+        <option value="member">member</option>
+        <option value="owner">owner</option>
+      </select>
+      <button type="submit">Add</button>
+    </form>
+  </details>
 </div>
 
 <h2>Pending invites ({{len .Invites}})</h2>
@@ -45,7 +65,7 @@
     <div class="empty">No pending invites.</div>
   {{else}}
   <table class="grid">
-    <thead><tr><th>email</th><th>role</th><th>invited by</th><th>expires</th></tr></thead>
+    <thead><tr><th>email</th><th>role</th><th>invited by</th><th>expires</th><th></th></tr></thead>
     <tbody>
     {{range .Invites}}
     <tr>
@@ -53,11 +73,27 @@
       <td><span class="badge {{statusClass .Role}}">{{.Role}}</span></td>
       <td>{{.InvitedBy}}</td>
       <td>{{relTime .ExpiresAt}}</td>
+      <td>
+        <form method="POST" action="/ui/o/{{$.Org}}/invites/{{.ID}}/revoke" style="display:inline">
+          <button type="submit" class="btn-danger-small">revoke</button>
+        </form>
+      </td>
     </tr>
     {{end}}
     </tbody>
   </table>
   {{end}}
+  <details style="margin-top:12px">
+    <summary style="cursor:pointer;font-size:0.9em">Create invite</summary>
+    <form method="POST" action="/ui/o/{{.Org}}/invites" style="padding:10px 0 4px">
+      <input type="email" name="email" placeholder="email address" required style="margin-right:6px">
+      <select name="role" style="margin-right:6px">
+        <option value="member">member</option>
+        <option value="owner">owner</option>
+      </select>
+      <button type="submit">Create invite</button>
+    </form>
+  </details>
 </div>
 {{end}}
 {{end}}

--- a/internal/ui/templates/release_detail.html
+++ b/internal/ui/templates/release_detail.html
@@ -40,5 +40,13 @@
   <div style="white-space:pre-wrap;color:var(--text);">{{.Release.Body}}</div>
 </div>
 {{end}}
+
+<h2>Danger zone</h2>
+<div class="card">
+  <form method="POST" action="/ui/r/{{.Repo.Name}}/releases/{{.Release.Name}}/delete" style="padding:4px 0">
+    <p style="margin:0 0 8px;font-size:0.9em;color:var(--meta)">Permanently deletes this release. This action cannot be undone.</p>
+    <button type="submit" class="btn-danger">Delete release</button>
+  </form>
+</div>
 {{end}}
 {{end}}

--- a/internal/ui/templates/releases.html
+++ b/internal/ui/templates/releases.html
@@ -14,6 +14,10 @@
   <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
 </nav>
 
+{{if .Err}}
+<div class="card" style="margin-bottom:12px"><span class="badge bad">{{.Err}}</span></div>
+{{end}}
+
 <div class="card">
 {{if not .Releases}}<div class="empty">no releases</div>{{else}}
 <table class="grid">
@@ -31,6 +35,25 @@
   </tbody>
 </table>
 {{end}}
+</div>
+
+<h2>Create release</h2>
+<div class="card">
+  <form method="POST" action="/ui/r/{{.Repo.Name}}/releases" style="padding:4px 0">
+    <div style="margin-bottom:8px">
+      <label style="display:block;margin-bottom:4px;font-size:0.9em">Name <span style="color:var(--meta)">(required)</span></label>
+      <input type="text" name="name" placeholder="e.g. v1.0.0" required style="width:240px">
+    </div>
+    <div style="margin-bottom:8px">
+      <label style="display:block;margin-bottom:4px;font-size:0.9em">Sequence <span style="color:var(--meta)">(optional — defaults to main head)</span></label>
+      <input type="number" name="sequence" placeholder="leave blank for main head" min="1" style="width:240px">
+    </div>
+    <div style="margin-bottom:8px">
+      <label style="display:block;margin-bottom:4px;font-size:0.9em">Release notes</label>
+      <textarea name="body" rows="4" style="width:400px;resize:vertical"></textarea>
+    </div>
+    <button type="submit">Create release</button>
+  </form>
 </div>
 {{end}}
 {{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/store"
@@ -78,6 +79,15 @@ type WriteStoreLite interface {
 	CreateProposal(ctx context.Context, repo, branch, baseBranch, title, description, author string) (*model.Proposal, error)
 	UpdateProposal(ctx context.Context, repo, proposalID string, title, description *string) (*model.Proposal, error)
 	CloseProposal(ctx context.Context, repo, proposalID string) error
+	// Org member/invite, role, and release write operations.
+	AddOrgMember(ctx context.Context, org, identity string, role model.OrgRole, invitedBy string) error
+	RemoveOrgMember(ctx context.Context, org, identity string) error
+	CreateInvite(ctx context.Context, org, email string, role model.OrgRole, invitedBy, token string, expiresAt time.Time) (*model.OrgInvite, error)
+	RevokeInvite(ctx context.Context, org, inviteID string) error
+	SetRole(ctx context.Context, repo, identity string, role model.RoleType) error
+	DeleteRole(ctx context.Context, repo, identity string) error
+	CreateRelease(ctx context.Context, repo, name string, sequence int64, body, createdBy string) (*model.Release, error)
+	DeleteRelease(ctx context.Context, repo, name string) error
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -204,6 +214,18 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("POST /ui/r/{owner}/{name}/proposals", h.handleCreateProposalUI)
 	mux.HandleFunc("POST /ui/r/{owner}/{name}/proposals/{id}/edit", h.handleEditProposal)
 	mux.HandleFunc("POST /ui/r/{owner}/{name}/proposals/{id}/close", h.handleCloseProposalUI)
+	// Write operations: org members.
+	mux.HandleFunc("POST /ui/o/{org}/members", h.handleAddOrgMember)
+	mux.HandleFunc("POST /ui/o/{org}/members/{identity}/remove", h.handleRemoveOrgMember)
+	// Write operations: org invites.
+	mux.HandleFunc("POST /ui/o/{org}/invites", h.handleCreateInvite)
+	mux.HandleFunc("POST /ui/o/{org}/invites/{id}/revoke", h.handleRevokeInvite)
+	// Write operations: repo roles.
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/roles", h.handleSetRole)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/roles/{identity}/delete", h.handleDeleteRole)
+	// Write operations: releases.
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/releases", h.handleCreateRelease)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/releases/{rname}/delete", h.handleDeleteRelease)
 
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -202,6 +202,25 @@ func (f *fakeWrite) DeleteBranch(_ context.Context, _, _ string) error {
 func (f *fakeWrite) SetBranchAutoMerge(_ context.Context, _, _ string, _ bool) error {
 	return nil
 }
+func (f *fakeWrite) AddOrgMember(_ context.Context, _, _ string, _ model.OrgRole, _ string) error {
+	return nil
+}
+func (f *fakeWrite) RemoveOrgMember(_ context.Context, _, _ string) error { return nil }
+func (f *fakeWrite) CreateInvite(_ context.Context, _, _ string, _ model.OrgRole, _, _ string, _ time.Time) (*model.OrgInvite, error) {
+	return &model.OrgInvite{}, nil
+}
+func (f *fakeWrite) RevokeInvite(_ context.Context, _, _ string) error { return nil }
+func (f *fakeWrite) SetRole(_ context.Context, _, _ string, _ model.RoleType) error {
+	return nil
+}
+func (f *fakeWrite) DeleteRole(_ context.Context, _, _ string) error { return nil }
+func (f *fakeWrite) CreateRelease(_ context.Context, _, _ string, _ int64, _, _ string) (*model.Release, error) {
+	return &model.Release{}, nil
+}
+func (f *fakeWrite) DeleteRelease(_ context.Context, _, _ string) error { return nil }
+
+// Compile-time check that fakeWrite satisfies WriteStoreLite.
+var _ WriteStoreLite = (*fakeWrite)(nil)
 
 func (f *fakeWrite) CreateReview(_ context.Context, _, _, _ string, _ model.ReviewStatus, _ string) (*model.Review, error) {
 	return &model.Review{}, nil


### PR DESCRIPTION
## Summary

- Adds write operations to the web UI per issue #320: org member add/remove, org invite create/revoke, repo role grant/revoke, and release create/delete
- All POST handlers use the redirect-after-POST pattern and re-render with error display on failure
- `WriteStoreLite` interface extended with 8 new mutating methods; 14 new POST routes registered

## Changes

**Org overview page (`/ui/o/{org}`):**
- Members table gains a "remove" button per row (POST to `/ui/o/{org}/members/{identity}/remove`)
- Collapsible "Add member" form: identity input + role selector → POST `/ui/o/{org}/members`
- Pending invites table gains a "revoke" button per row (POST to `/ui/o/{org}/invites/{id}/revoke`)
- Collapsible "Create invite" form: email input + role selector → POST `/ui/o/{org}/invites`

**Repo branches page (`/ui/r/{owner}/{name}`):**
- Roles table gains a "revoke" button per row (POST to `/ui/r/{owner}/{name}/roles/{identity}/delete`)
- Collapsible "Grant role" form: identity input + role selector → POST `/ui/r/{owner}/{name}/roles`

**Releases list page (`/ui/r/{owner}/{name}/releases`):**
- New "Create release" section with name (required), optional sequence, and release notes fields

**Release detail page (`/ui/r/{owner}/{name}/releases/{name}`):**
- "Danger zone" section with delete button → POST `/ui/r/{owner}/{name}/releases/{name}/delete`

**Error display:** pages gain an `Err string` field; POST handlers re-render the originating page with an error badge on failure rather than redirecting to a bare error page.

## Test plan

- [x] `go test ./internal/ui/ -count=1` — all existing tests pass
- [x] `go build ./...` — clean build
- [x] `go vet ./...` — no issues
- [x] Pre-existing server package test failure confirmed unrelated to this change (flaky/network-dependent integration tests)

Closes #320 (in conjunction with PR #322 which added create-org/create-repo forms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)