### PR TITLE
feat(ui): add delete org and delete repo danger-zone forms (issue #320)

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -322,6 +322,8 @@ func (fakeWrite) CreateRelease(_ context.Context, _, _ string, _ int64, _, _ str
 	return &model.Release{}, nil
 }
 func (fakeWrite) DeleteRelease(_ context.Context, _, _ string) error { return nil }
+func (fakeWrite) DeleteOrg(_ context.Context, _ string) error        { return nil }
+func (fakeWrite) DeleteRepo(_ context.Context, _ string) error       { return nil }
 
 func fakeAssemble(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
 	t := time.Now()

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -2407,6 +2407,70 @@ func (h *Handler) handleCloseProposalUI(w http.ResponseWriter, r *http.Request) 
 
 	http.Redirect(w, r, "/ui/r/"+repoName+"/proposals/"+id, http.StatusSeeOther)}
 
+// handleUIDeleteOrg processes POST /ui/o/{org}/delete to delete an org.
+// The form must include a "confirm" field matching the org name.
+func (h *Handler) handleUIDeleteOrg(w http.ResponseWriter, r *http.Request) {
+	org := r.PathValue("org")
+	ctx := r.Context()
+
+	if err := r.ParseForm(); err != nil {
+		h.renderOrgPage(w, r, org, "invalid form data")
+		return
+	}
+	confirm := r.FormValue("confirm")
+	if confirm != org {
+		h.renderOrgPage(w, r, org, "confirmation does not match org name")
+		return
+	}
+
+	if err := h.write.DeleteOrg(ctx, org); err != nil {
+		switch {
+		case errors.Is(err, db.ErrOrgNotFound):
+			h.renderError(w, http.StatusNotFound, "org not found: "+org)
+		case errors.Is(err, db.ErrOrgHasRepos):
+			h.renderOrgPage(w, r, org, "cannot delete org: org still has repos; delete them first")
+		default:
+			slog.Error("ui delete org", "org", org, "error", err)
+			h.renderOrgPage(w, r, org, "could not delete org: "+err.Error())
+		}
+		return
+	}
+
+	http.Redirect(w, r, "/ui/", http.StatusSeeOther)
+}
+
+// handleUIDeleteRepo processes POST /ui/r/{owner}/{name}/-/delete-repo to delete a repo.
+// The form must include a "confirm" field matching the short repo name.
+func (h *Handler) handleUIDeleteRepo(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	if err := r.ParseForm(); err != nil {
+		h.renderBranchesPage(w, r, owner, name, "invalid form data")
+		return
+	}
+	confirm := r.FormValue("confirm")
+	if confirm != name {
+		h.renderBranchesPage(w, r, owner, name, "confirmation does not match repo name")
+		return
+	}
+
+	if err := h.write.DeleteRepo(ctx, repoName); err != nil {
+		switch {
+		case errors.Is(err, db.ErrRepoNotFound):
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+		default:
+			slog.Error("ui delete repo", "repo", repoName, "error", err)
+			h.renderBranchesPage(w, r, owner, name, "could not delete repo: "+err.Error())
+		}
+		return
+	}
+
+	http.Redirect(w, r, "/ui/", http.StatusSeeOther)
+}
+
 // chainToLogRows filters and converts ChainEntries to commitLogRows.
 // Only entries for the named branch are included.
 func chainToLogRows(entries []store.ChainEntry, branch string) []commitLogRow {

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -288,7 +288,17 @@ func funcMap() template.FuncMap {
 		"add":            func(a, b int) int { return a + b },
 		"urlPathEscape":  url.PathEscape,
 		"joinStrings":    strings.Join,
+		"repoShortName":  repoShortName,
 	}
+}
+
+// repoShortName returns the short name portion of a full "owner/name" repo
+// name. If there is no slash it returns the input unchanged.
+func repoShortName(fullName string) string {
+	if i := strings.LastIndex(fullName, "/"); i >= 0 {
+		return fullName[i+1:]
+	}
+	return fullName
 }
 
 // dict builds a map from alternating key/value pairs for template composition:

--- a/internal/ui/templates/branches.html
+++ b/internal/ui/templates/branches.html
@@ -88,6 +88,22 @@
     </form>
   </details>
 </div>
+
+<h2 style="color:var(--bad)">Danger zone</h2>
+<div class="card" style="border-left:3px solid var(--bad)">
+  <details>
+    <summary style="cursor:pointer;font-size:0.9em;color:var(--bad)">Delete this repository</summary>
+    <p style="font-size:0.85em;color:var(--text-dim);margin:8px 0">This permanently deletes the repository and all its data. This cannot be undone.</p>
+    <form method="POST" action="/ui/r/{{.Repo.Name}}/-/delete-repo" style="padding:4px 0">
+      {{- $shortName := repoShortName .Repo.Name -}}
+      <label style="font-size:0.85em;display:block;margin-bottom:4px">Type <strong>{{$shortName}}</strong> to confirm:</label>
+      <input type="text" name="confirm" placeholder="{{$shortName}}" required
+             style="background:var(--bg-3);color:var(--text);border:1px solid var(--bad);border-radius:4px;padding:6px 10px;font-family:var(--mono);font-size:12px;margin-right:6px"
+             oninput="this.form.querySelector('button').disabled=(this.value!='{{$shortName}}')">
+      <button type="submit" class="btn-danger-small" disabled>Delete repo</button>
+    </form>
+  </details>
+</div>
 {{end}}
 {{end}}
 

--- a/internal/ui/templates/org.html
+++ b/internal/ui/templates/org.html
@@ -95,5 +95,20 @@
     </form>
   </details>
 </div>
+
+<h2 style="color:var(--bad)">Danger zone</h2>
+<div class="card" style="border-left:3px solid var(--bad)">
+  <details>
+    <summary style="cursor:pointer;font-size:0.9em;color:var(--bad)">Delete this organisation</summary>
+    <p style="font-size:0.85em;color:var(--text-dim);margin:8px 0">This permanently deletes the org and cannot be undone. The org must have no repos.</p>
+    <form method="POST" action="/ui/o/{{.Org}}/delete" style="padding:4px 0">
+      <label style="font-size:0.85em;display:block;margin-bottom:4px">Type <strong>{{.Org}}</strong> to confirm:</label>
+      <input type="text" name="confirm" placeholder="{{.Org}}" required
+             style="background:var(--bg-3);color:var(--text);border:1px solid var(--bad);border-radius:4px;padding:6px 10px;font-family:var(--mono);font-size:12px;margin-right:6px"
+             oninput="this.form.querySelector('button').disabled=(this.value!='{{.Org}}')">
+      <button type="submit" class="btn-danger-small" disabled>Delete org</button>
+    </form>
+  </details>
+</div>
 {{end}}
 {{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -88,6 +88,10 @@ type WriteStoreLite interface {
 	DeleteRole(ctx context.Context, repo, identity string) error
 	CreateRelease(ctx context.Context, repo, name string, sequence int64, body, createdBy string) (*model.Release, error)
 	DeleteRelease(ctx context.Context, repo, name string) error
+
+	// Org/repo delete operations.
+	DeleteOrg(ctx context.Context, name string) error
+	DeleteRepo(ctx context.Context, name string) error
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -226,6 +230,9 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	// Write operations: releases.
 	mux.HandleFunc("POST /ui/r/{owner}/{name}/releases", h.handleCreateRelease)
 	mux.HandleFunc("POST /ui/r/{owner}/{name}/releases/{rname}/delete", h.handleDeleteRelease)
+	// Write operations: delete org/repo.
+	mux.HandleFunc("POST /ui/o/{org}/delete", h.handleUIDeleteOrg)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/-/delete-repo", h.handleUIDeleteRepo)
 
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -218,6 +218,8 @@ func (f *fakeWrite) CreateRelease(_ context.Context, _, _ string, _ int64, _, _ 
 	return &model.Release{}, nil
 }
 func (f *fakeWrite) DeleteRelease(_ context.Context, _, _ string) error { return nil }
+func (f *fakeWrite) DeleteOrg(_ context.Context, _ string) error       { return nil }
+func (f *fakeWrite) DeleteRepo(_ context.Context, _ string) error      { return nil }
 
 // Compile-time check that fakeWrite satisfies WriteStoreLite.
 var _ WriteStoreLite = (*fakeWrite)(nil)


### PR DESCRIPTION
## Summary

Closes #320 (delete org and delete repo UI forms).

- **Extended `WriteStoreLite`** with `DeleteOrg` and `DeleteRepo` methods so UI handlers can call the underlying store
- **New routes**:
  - `POST /ui/o/{org}/delete` — delete an org
  - `POST /ui/r/{owner}/{name}/-/delete-repo` — delete a repo
- **Danger-zone section on org page** (`org.html`): collapsible `<details>` block. User must type the org name to confirm; the submit button is disabled until JS verifies the text matches. Server also validates the `confirm` field. Shows error `"cannot delete org: org still has repos; delete them first"` on `ErrOrgHasRepos`. Redirects to `/ui/` on success.
- **Danger-zone section on repo branches page** (`branches.html`): same pattern — type the short repo name to confirm. Redirects to `/ui/` on success.
- **`repoShortName` template helper** added to `render.go` — extracts the short name (after `/`) from a full `owner/name` repo name for use in confirmation text/placeholder
- **Updated `fakeWrite`** in `ui_test.go` and `cmd/ui-preview/main.go` to implement the two new interface methods

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all 16 packages pass (including all existing UI tests)

## Notes / future opportunities

- The confirmation is client-side (JS `oninput`) + server-side (`confirm != name`). No CSRF tokens are used, consistent with other write forms in this UI.
- The "type name to confirm" pattern could be extracted into a shared template partial if more danger-zone forms are added later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)