### PR TITLE
feat(ui): polish and consistency pass across write forms (issue #320)

### DIFF
--- a/internal/ui/static/styles.css
+++ b/internal/ui/static/styles.css
@@ -417,3 +417,45 @@ details.form-section > summary {
 }
 details.form-section > summary:hover { text-decoration: underline; }
 details.form-section > summary::-webkit-details-marker { display: none; }
+
+/* Active state for repo-level navigation tabs. */
+.repo-tabs a.active { color: var(--text); background: var(--bg-3); }
+
+/* Standalone danger button (e.g. "Delete release"). */
+.btn-danger {
+  background: var(--bad-bg);
+  color: var(--bad);
+  border: 1px solid var(--bad);
+  border-radius: 4px;
+  padding: 5px 12px;
+  font-family: var(--mono);
+  font-size: 12px;
+  cursor: pointer;
+}
+.btn-danger:hover { background: var(--bad); color: var(--bg); }
+
+/* Compact danger button for inline revoke/remove actions. */
+.btn-danger-small {
+  background: transparent;
+  color: var(--bad);
+  border: 1px solid var(--bad);
+  border-radius: 3px;
+  padding: 2px 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+  cursor: pointer;
+}
+.btn-danger-small:hover { background: var(--bad-bg); }
+
+/* Link-styled button for subtle inline actions. */
+.btn-link {
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: none;
+}
+.btn-link:hover { text-decoration: underline; }

--- a/internal/ui/templates/branches.html
+++ b/internal/ui/templates/branches.html
@@ -31,9 +31,9 @@
 
 <div class="filter-bar"><input type="search" data-branch-filter placeholder="filter branches by name…" autocomplete="off"></div>
 
-{{template "branchSection" (dict "Title" "Active" "Rows" .Active "Repo" .Repo.Name)}}
-{{template "branchSection" (dict "Title" "Merged" "Rows" .Merged "Repo" .Repo.Name)}}
-{{template "branchSection" (dict "Title" "Abandoned" "Rows" .Abandoned "Repo" .Repo.Name)}}
+{{template "branchSection" (dict "Title" "Active" "EmptyMsg" "no active branches — create one above" "Rows" .Active "Repo" .Repo.Name)}}
+{{template "branchSection" (dict "Title" "Merged" "EmptyMsg" "no merged branches" "Rows" .Merged "Repo" .Repo.Name)}}
+{{template "branchSection" (dict "Title" "Abandoned" "EmptyMsg" "no abandoned branches" "Rows" .Abandoned "Repo" .Repo.Name)}}
 
 <h2>Members ({{len .Members}})</h2>
 <div class="card">
@@ -75,16 +75,16 @@
   </table>
   {{end}}
   <details style="margin-top:12px">
-    <summary style="cursor:pointer;font-size:0.9em">Grant role</summary>
-    <form method="POST" action="/ui/r/{{.Repo.Name}}/roles" style="padding:10px 0 4px">
-      <input type="text" name="identity" placeholder="identity (email)" required style="margin-right:6px">
-      <select name="role" style="margin-right:6px">
+    <summary style="cursor:pointer;font-size:12px;color:var(--accent)">Grant role</summary>
+    <form method="POST" action="/ui/r/{{.Repo.Name}}/roles" style="padding:10px 0 4px;display:flex;gap:6px;align-items:center;flex-wrap:wrap">
+      <input type="text" name="identity" placeholder="identity (email)" required class="form-input" style="flex:1;min-width:180px">
+      <select name="role" class="form-input" style="width:auto">
         <option value="reader">reader</option>
         <option value="writer">writer</option>
         <option value="maintainer">maintainer</option>
         <option value="admin">admin</option>
       </select>
-      <button type="submit">Grant</button>
+      <button type="submit" class="btn">Grant</button>
     </form>
   </details>
 </div>
@@ -95,7 +95,7 @@
 <h2>{{.Title}} ({{len .Rows}})</h2>
 <div class="card">
   {{if not .Rows}}
-    <div class="empty">none</div>
+    <div class="empty">{{.EmptyMsg}}</div>
   {{else}}
   <table class="grid">
     <thead><tr><th>branch</th><th>status</th><th>head</th><th>base</th><th>flags</th><th>links</th><th>actions</th></tr></thead>

--- a/internal/ui/templates/ci_jobs.html
+++ b/internal/ui/templates/ci_jobs.html
@@ -23,7 +23,7 @@
 </div>
 
 <div class="card">
-{{if not .Jobs}}<div class="empty">no ci jobs found</div>{{else}}
+{{if not .Jobs}}<div class="empty">no CI jobs found — jobs are triggered automatically when commits are pushed</div>{{else}}
 <table class="grid">
   <thead>
     <tr>

--- a/internal/ui/templates/issues_rows.html
+++ b/internal/ui/templates/issues_rows.html
@@ -1,6 +1,6 @@
 {{define "issues_rows.html"}}
 <div class="card">
-  {{if not .Issues}}<div class="empty">no {{.State}} issues</div>{{else}}
+  {{if not .Issues}}<div class="empty">no {{.State}} issues{{if eq .State "open"}} — <a href="/ui/r/{{.Repo.Name}}/issues/new">open one</a>{{end}}</div>{{else}}
   <table class="grid">
     <thead><tr><th>#</th><th>title</th><th>author</th><th>state</th><th>opened</th></tr></thead>
     <tbody>

--- a/internal/ui/templates/org.html
+++ b/internal/ui/templates/org.html
@@ -3,7 +3,9 @@
 <div class="headline"><h1>{{.Org}}</h1></div>
 
 {{if .Err}}
-<div class="card" style="margin-bottom:12px"><span class="badge bad">{{.Err}}</span></div>
+<div class="card" style="border-color:var(--bad);margin-bottom:14px">
+  <div class="row"><span class="badge bad">error</span> <span>{{.Err}}</span></div>
+</div>
 {{end}}
 
 <h2>Repos ({{len .Repos}})</h2>
@@ -47,14 +49,14 @@
   </table>
   {{end}}
   <details style="margin-top:12px">
-    <summary style="cursor:pointer;font-size:0.9em">Add member</summary>
-    <form method="POST" action="/ui/o/{{.Org}}/members" style="padding:10px 0 4px">
-      <input type="text" name="identity" placeholder="identity (email)" required style="margin-right:6px">
-      <select name="role" style="margin-right:6px">
+    <summary style="cursor:pointer;font-size:12px;color:var(--accent)">Add member</summary>
+    <form method="POST" action="/ui/o/{{.Org}}/members" style="padding:10px 0 4px;display:flex;gap:6px;align-items:center;flex-wrap:wrap">
+      <input type="text" name="identity" placeholder="identity (email)" required class="form-input" style="flex:1;min-width:180px">
+      <select name="role" class="form-input" style="width:auto">
         <option value="member">member</option>
         <option value="owner">owner</option>
       </select>
-      <button type="submit">Add</button>
+      <button type="submit" class="btn">Add</button>
     </form>
   </details>
 </div>
@@ -84,14 +86,14 @@
   </table>
   {{end}}
   <details style="margin-top:12px">
-    <summary style="cursor:pointer;font-size:0.9em">Create invite</summary>
-    <form method="POST" action="/ui/o/{{.Org}}/invites" style="padding:10px 0 4px">
-      <input type="email" name="email" placeholder="email address" required style="margin-right:6px">
-      <select name="role" style="margin-right:6px">
+    <summary style="cursor:pointer;font-size:12px;color:var(--accent)">Create invite</summary>
+    <form method="POST" action="/ui/o/{{.Org}}/invites" style="padding:10px 0 4px;display:flex;gap:6px;align-items:center;flex-wrap:wrap">
+      <input type="email" name="email" placeholder="email address" required class="form-input" style="flex:1;min-width:180px">
+      <select name="role" class="form-input" style="width:auto">
         <option value="member">member</option>
         <option value="owner">owner</option>
       </select>
-      <button type="submit">Create invite</button>
+      <button type="submit" class="btn">Create invite</button>
     </form>
   </details>
 </div>

--- a/internal/ui/templates/proposal_detail.html
+++ b/internal/ui/templates/proposal_detail.html
@@ -19,7 +19,9 @@
 </div>
 
 {{if .Err}}
-<div class="card" style="margin-bottom:14px"><span class="badge bad">{{.Err}}</span></div>
+<div class="card" style="border-color:var(--bad);margin-bottom:14px">
+  <div class="row"><span class="badge bad">error</span> <span>{{.Err}}</span></div>
+</div>
 {{end}}
 
 <h2>Details</h2>
@@ -47,25 +49,25 @@
 
 <h2>Edit proposal</h2>
 <div class="card">
-  <form method="POST" action="/ui/r/{{.Repo.Name}}/proposals/{{.Proposal.ID}}/edit" style="padding:14px 12px 4px">
+  <form method="POST" action="/ui/r/{{.Repo.Name}}/proposals/{{.Proposal.ID}}/edit" style="padding:8px 4px 4px">
     <div style="margin-bottom:10px">
-      <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Title</label>
-      <input type="text" name="title" value="{{.Proposal.Title}}" required style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);box-sizing:border-box">
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Title</label>
+      <input type="text" name="title" value="{{.Proposal.Title}}" required class="form-input">
     </div>
     <div style="margin-bottom:10px">
-      <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Description</label>
-      <textarea name="description" rows="4" style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);resize:vertical;box-sizing:border-box">{{.Proposal.Description}}</textarea>
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Description</label>
+      <textarea name="description" rows="4" class="form-input">{{.Proposal.Description}}</textarea>
     </div>
-    <button type="submit">Save changes</button>
+    <button type="submit" class="btn">Save changes</button>
   </form>
 </div>
 
 {{if eq (printf "%s" .Proposal.State) "open"}}
 <h2>Close proposal</h2>
 <div class="card">
-  <form method="POST" action="/ui/r/{{.Repo.Name}}/proposals/{{.Proposal.ID}}/close" style="padding:14px 12px 4px">
-    <p style="margin:0 0 10px;color:var(--text-muted);font-size:0.9em">Closing this proposal will mark it as closed and it will no longer appear in the open proposals list.</p>
-    <button type="submit">Close proposal</button>
+  <form method="POST" action="/ui/r/{{.Repo.Name}}/proposals/{{.Proposal.ID}}/close" style="padding:8px 4px 4px">
+    <p style="margin:0 0 10px;color:var(--text-dim);font-size:12px">Closing this proposal marks it as closed and removes it from the open list.</p>
+    <button type="submit" class="btn">Close proposal</button>
   </form>
 </div>
 {{end}}

--- a/internal/ui/templates/proposals.html
+++ b/internal/ui/templates/proposals.html
@@ -15,7 +15,9 @@
 </nav>
 
 {{if .Err}}
-<div class="card" style="margin-bottom:14px"><span class="badge bad">{{.Err}}</span></div>
+<div class="card" style="border-color:var(--bad);margin-bottom:14px">
+  <div class="row"><span class="badge bad">error</span> <span>{{.Err}}</span></div>
+</div>
 {{end}}
 
 <div class="tab-bar" data-tab-group>
@@ -39,24 +41,24 @@
 
 <h2>New proposal</h2>
 <div class="card">
-  <form method="POST" action="/ui/r/{{.Repo.Name}}/proposals" style="padding:14px 12px 4px">
+  <form method="POST" action="/ui/r/{{.Repo.Name}}/proposals" style="padding:8px 4px 4px">
     <div style="margin-bottom:10px">
-      <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Branch</label>
-      <input type="text" name="branch" required placeholder="e.g. feature-x" style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);box-sizing:border-box">
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Branch</label>
+      <input type="text" name="branch" required placeholder="e.g. feature-x" class="form-input">
     </div>
     <div style="margin-bottom:10px">
-      <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Base branch</label>
-      <input type="text" name="base_branch" value="main" required style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);box-sizing:border-box">
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Base branch</label>
+      <input type="text" name="base_branch" value="main" required class="form-input">
     </div>
     <div style="margin-bottom:10px">
-      <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Title</label>
-      <input type="text" name="title" required placeholder="Proposal title" style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);box-sizing:border-box">
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Title</label>
+      <input type="text" name="title" required placeholder="Proposal title" class="form-input">
     </div>
     <div style="margin-bottom:10px">
-      <label style="display:block;margin-bottom:4px;font-size:0.85em;color:var(--text-muted)">Description (optional)</label>
-      <textarea name="description" rows="4" style="width:100%;padding:6px 8px;background:var(--bg-input,var(--bg2));border:1px solid var(--border);border-radius:4px;color:var(--text);resize:vertical;box-sizing:border-box"></textarea>
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Description <span style="text-transform:none;letter-spacing:normal">(optional)</span></label>
+      <textarea name="description" rows="4" class="form-input"></textarea>
     </div>
-    <button type="submit">Create proposal</button>
+    <button type="submit" class="btn">Create proposal</button>
   </form>
 </div>
 {{end}}

--- a/internal/ui/templates/proposals_rows.html
+++ b/internal/ui/templates/proposals_rows.html
@@ -1,5 +1,5 @@
 {{define "proposals_rows.html"}}
-{{if not .}}<div class="empty">no proposals</div>{{else}}
+{{if not .}}<div class="empty">no proposals in this state</div>{{else}}
 <table class="grid">
   <thead><tr><th>title</th><th>state</th><th>author</th><th>base</th><th>opened</th></tr></thead>
   <tbody>

--- a/internal/ui/templates/releases.html
+++ b/internal/ui/templates/releases.html
@@ -15,11 +15,13 @@
 </nav>
 
 {{if .Err}}
-<div class="card" style="margin-bottom:12px"><span class="badge bad">{{.Err}}</span></div>
+<div class="card" style="border-color:var(--bad);margin-bottom:14px">
+  <div class="row"><span class="badge bad">error</span> <span>{{.Err}}</span></div>
+</div>
 {{end}}
 
 <div class="card">
-{{if not .Releases}}<div class="empty">no releases</div>{{else}}
+{{if not .Releases}}<div class="empty">no releases yet — create the first one below</div>{{else}}
 <table class="grid">
   <thead><tr><th>name</th><th>seq</th><th>author</th><th>body</th><th>created</th></tr></thead>
   <tbody>
@@ -39,20 +41,20 @@
 
 <h2>Create release</h2>
 <div class="card">
-  <form method="POST" action="/ui/r/{{.Repo.Name}}/releases" style="padding:4px 0">
-    <div style="margin-bottom:8px">
-      <label style="display:block;margin-bottom:4px;font-size:0.9em">Name <span style="color:var(--meta)">(required)</span></label>
-      <input type="text" name="name" placeholder="e.g. v1.0.0" required style="width:240px">
+  <form method="POST" action="/ui/r/{{.Repo.Name}}/releases" style="padding:8px 4px 4px">
+    <div style="margin-bottom:10px">
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Name <span style="text-transform:none;letter-spacing:normal">(required)</span></label>
+      <input type="text" name="name" placeholder="e.g. v1.0.0" required class="form-input" style="max-width:320px">
     </div>
-    <div style="margin-bottom:8px">
-      <label style="display:block;margin-bottom:4px;font-size:0.9em">Sequence <span style="color:var(--meta)">(optional — defaults to main head)</span></label>
-      <input type="number" name="sequence" placeholder="leave blank for main head" min="1" style="width:240px">
+    <div style="margin-bottom:10px">
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Sequence <span style="text-transform:none;letter-spacing:normal">(optional — defaults to main head)</span></label>
+      <input type="number" name="sequence" placeholder="leave blank for main head" min="1" class="form-input" style="max-width:320px">
     </div>
-    <div style="margin-bottom:8px">
-      <label style="display:block;margin-bottom:4px;font-size:0.9em">Release notes</label>
-      <textarea name="body" rows="4" style="width:400px;resize:vertical"></textarea>
+    <div style="margin-bottom:10px">
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Release notes</label>
+      <textarea name="body" rows="4" class="form-input"></textarea>
     </div>
-    <button type="submit">Create release</button>
+    <button type="submit" class="btn">Create release</button>
   </form>
 </div>
 {{end}}


### PR DESCRIPTION
## Summary

- **CSS**: Added missing `.btn-danger`, `.btn-danger-small`, `.btn-link` classes (referenced in templates but previously undefined), and `.repo-tabs a.active` so the active tab gets a visible highlight
- **Form styling**: Replaced all inline-styled `<input>`/`<textarea>`/`<select>` elements with `.form-input` class, and added `.btn` class to bare submit buttons — across `proposals.html`, `releases.html`, `proposal_detail.html`, `branches.html` (grant role), and `org.html` (add member / create invite)
- **Error banners**: Standardized to `border-color:var(--bad)` + `.badge.bad` pattern across all affected pages, matching `new_issue.html` / `issue_detail.html`
- **Empty states**: Issues list links to "open one" when no open issues; releases shows "create the first one below"; CI jobs explains jobs are auto-triggered; branch sections use descriptive per-section messages; proposals shows "no proposals in this state"
- **Info counts**: Org page and branches page already show member/role/invite counts — no handler changes needed

## Test plan

- [x] `go test ./... -count=1` — all pass
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [ ] Visual review: start server with `DEV_UI=1` and check each changed page

Closes / references #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)