### PR TITLE
feat(ui): add commit form to web UI (issue #320)

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -324,6 +324,9 @@ func (fakeWrite) CreateRelease(_ context.Context, _, _ string, _ int64, _, _ str
 func (fakeWrite) DeleteRelease(_ context.Context, _, _ string) error { return nil }
 func (fakeWrite) DeleteOrg(_ context.Context, _ string) error        { return nil }
 func (fakeWrite) DeleteRepo(_ context.Context, _ string) error       { return nil }
+func (fakeWrite) Commit(_ context.Context, _ model.CommitRequest) (*model.CommitResponse, error) {
+	return &model.CommitResponse{Sequence: 999}, nil
+}
 
 func fakeAssemble(_ context.Context, _, branch string) (*model.AgentContextResponse, error) {
 	t := time.Now()

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -213,6 +213,15 @@ type createRepoPage struct {
 	Err   string
 }
 
+type commitFormPage struct {
+	Repo            model.Repo
+	Branch          string
+	FormMessage     string
+	FormFilePath    string
+	FormFileContent string
+	Err             string
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -2472,6 +2481,92 @@ func (h *Handler) handleUIDeleteRepo(w http.ResponseWriter, r *http.Request) {
 }
 
 // chainToLogRows filters and converts ChainEntries to commitLogRows.
+// handleNewCommit renders the commit form (GET) and submits a commit (POST).
+func (h *Handler) handleNewCommit(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	branch := r.PathValue("branch")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	renderForm := func(formMessage, formFilePath, formFileContent, errMsg string) {
+		h.render(w, h.tmpl.newCommit, "layout.html", pageData{
+			Title: repoName + " / " + branch + " / commit",
+			Breadcrumbs: []crumb{
+				{Label: "repos", Href: "/ui/"},
+				{Label: repoName, Href: "/ui/r/" + repoName},
+				{Label: branch, Href: "/ui/r/" + repoName + "/b/" + url.PathEscape(branch)},
+				{Label: "commit", Href: ""},
+			},
+			Body: commitFormPage{
+				Repo:            *repo,
+				Branch:          branch,
+				FormMessage:     formMessage,
+				FormFilePath:    formFilePath,
+				FormFileContent: formFileContent,
+				Err:             errMsg,
+			},
+		})
+	}
+
+	if r.Method == http.MethodGet {
+		renderForm("", "", "", "")
+		return
+	}
+
+	// POST: submit the commit.
+	if err := r.ParseForm(); err != nil {
+		renderForm("", "", "", "invalid form data")
+		return
+	}
+
+	message := strings.TrimSpace(r.FormValue("message"))
+	filePath := strings.TrimSpace(r.FormValue("file_path"))
+	fileContent := r.FormValue("file_content")
+
+	if message == "" {
+		renderForm(message, filePath, fileContent, "message is required")
+		return
+	}
+	if filePath == "" {
+		renderForm(message, filePath, fileContent, "file path is required")
+		return
+	}
+
+	var identity string
+	if h.identity != nil {
+		identity = h.identity(ctx)
+	}
+
+	req := model.CommitRequest{
+		Repo:    repoName,
+		Branch:  branch,
+		Message: message,
+		Author:  identity,
+		Files: []model.FileChange{
+			{Path: filePath, Content: []byte(fileContent)},
+		},
+	}
+	if _, err := h.write.Commit(ctx, req); err != nil {
+		slog.Error("ui commit", "repo", repoName, "branch", branch, "error", err)
+		renderForm(message, filePath, fileContent, "could not commit: "+err.Error())
+		return
+	}
+
+	http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+url.PathEscape(branch), http.StatusSeeOther)
+}
+
 // Only entries for the named branch are included.
 func chainToLogRows(entries []store.ChainEntry, branch string) []commitLogRow {
 	rows := make([]commitLogRow, 0, len(entries))

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -41,6 +41,7 @@ type templateSet struct {
 	ciJobDetail     *template.Template
 	createOrg       *template.Template
 	createRepo      *template.Template
+	newCommit       *template.Template
 }
 
 func parseTemplates(root fs.FS) (*templateSet, error) {
@@ -186,6 +187,10 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse create_repo: %w", err)
 	}
+	newCommit, err := load("new_commit.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse new_commit: %w", err)
+	}
 	return &templateSet{
 		repos:          repos,
 		branches:       branches,
@@ -213,6 +218,7 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		ciJobDetail:     ciJobDetail,
 		createOrg:       createOrg,
 		createRepo:      createRepo,
+		newCommit:       newCommit,
 	}, nil
 }
 

--- a/internal/ui/templates/branch_detail.html
+++ b/internal/ui/templates/branch_detail.html
@@ -78,6 +78,7 @@
       <button type="submit">enable auto-merge</button>
     </form>
     {{end}}
+    <a href="/ui/r/{{$page.Repo.Name}}/b/{{urlPathEscape $ctx.Branch.Name}}/commit" class="btn" style="font-size:12px">new commit</a>
     <form method="POST" action="/ui/r/{{$page.Repo.Name}}/-/delete-branch" style="display:inline">
       <input type="hidden" name="branch" value="{{$ctx.Branch.Name}}">
       <input type="hidden" name="ref" value="detail">

--- a/internal/ui/templates/new_commit.html
+++ b/internal/ui/templates/new_commit.html
@@ -1,0 +1,37 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline">
+  <h1>New commit — {{.Branch}}</h1>
+  <span class="meta">{{.Repo.Name}}</span>
+</div>
+
+{{if .Err}}
+<div class="card" style="border-color:var(--bad);margin-bottom:14px">
+  <div class="row"><span class="badge bad">{{.Err}}</span></div>
+</div>
+{{end}}
+
+<div class="card">
+  <form method="POST" action="/ui/r/{{.Repo.Name}}/b/{{urlPathEscape .Branch}}/commit" style="padding:8px 4px 4px">
+    <div style="margin-bottom:12px">
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Branch</label>
+      <input name="branch" type="text" value="{{.Branch}}" readonly class="form-input" style="opacity:0.6">
+    </div>
+    <div style="margin-bottom:12px">
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Commit message</label>
+      <input name="message" type="text" required value="{{.FormMessage}}" placeholder="describe your change" class="form-input">
+    </div>
+    <div style="margin-bottom:6px">
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">File path</label>
+      <input name="file_path" type="text" required value="{{.FormFilePath}}" placeholder="e.g. docs/hello.md" class="form-input">
+    </div>
+    <div style="margin-bottom:14px">
+      <label style="display:block;margin-bottom:4px;font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">File content</label>
+      <textarea name="file_content" rows="10" class="form-input" style="font-family:var(--font-mono,monospace)">{{.FormFileContent}}</textarea>
+    </div>
+    <button type="submit" class="btn">Commit</button>
+    <a href="/ui/r/{{.Repo.Name}}/b/{{urlPathEscape .Branch}}" style="margin-left:12px;font-size:12px">cancel</a>
+  </form>
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -92,6 +92,9 @@ type WriteStoreLite interface {
 	// Org/repo delete operations.
 	DeleteOrg(ctx context.Context, name string) error
 	DeleteRepo(ctx context.Context, name string) error
+
+	// Commit write operation.
+	Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error)
 }
 
 // AssembleFn builds the full branch context snapshot used by the branch detail
@@ -233,6 +236,9 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	// Write operations: delete org/repo.
 	mux.HandleFunc("POST /ui/o/{org}/delete", h.handleUIDeleteOrg)
 	mux.HandleFunc("POST /ui/r/{owner}/{name}/-/delete-repo", h.handleUIDeleteRepo)
+	// Commit form.
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}/commit", h.handleNewCommit)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/b/{branch}/commit", h.handleNewCommit)
 
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -220,6 +220,9 @@ func (f *fakeWrite) CreateRelease(_ context.Context, _, _ string, _ int64, _, _ 
 func (f *fakeWrite) DeleteRelease(_ context.Context, _, _ string) error { return nil }
 func (f *fakeWrite) DeleteOrg(_ context.Context, _ string) error       { return nil }
 func (f *fakeWrite) DeleteRepo(_ context.Context, _ string) error      { return nil }
+func (f *fakeWrite) Commit(_ context.Context, _ model.CommitRequest) (*model.CommitResponse, error) {
+	return &model.CommitResponse{Sequence: 1}, nil
+}
 
 // Compile-time check that fakeWrite satisfies WriteStoreLite.
 var _ WriteStoreLite = (*fakeWrite)(nil)
@@ -960,4 +963,78 @@ func TestHandleCloseProposalUI_RedirectsOnSuccess(t *testing.T) {
 	code, _, _ := postForm(t, h, "/ui/r/acme/a/proposals/p-1/close", nil)
 	if code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want 303 (redirect)", code)	}
+}
+
+func TestHandleNewCommit_GET_RendersForm(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/b/feat-x/commit")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"feat-x", "Commit message", `name="file_path"`, `name="file_content"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleNewCommit_POST_RedirectsOnSuccess(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, _, loc := postForm(t, h, "/ui/r/acme/a/b/feat-x/commit", url.Values{
+		"message":      {"add a file"},
+		"file_path":    {"docs/hello.md"},
+		"file_content": {"hello world"},
+	})
+	if code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (redirect)", code)
+	}
+	if loc != "/ui/r/acme/a/b/feat-x" {
+		t.Errorf("location = %q, want /ui/r/acme/a/b/feat-x", loc)
+	}
+}
+
+func TestHandleNewCommit_POST_MissingMessage_RerendersForm(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, body, _ := postForm(t, h, "/ui/r/acme/a/b/feat-x/commit", url.Values{
+		"file_path":    {"docs/hello.md"},
+		"file_content": {"content"},
+		// message omitted
+	})
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 with error", code)
+	}
+	if !strings.Contains(body, "message is required") {
+		t.Errorf("expected error in body, got: %s", body)
+	}
+}
+
+func TestHandleNewCommit_POST_MissingFilePath_RerendersForm(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, body, _ := postForm(t, h, "/ui/r/acme/a/b/feat-x/commit", url.Values{
+		"message":      {"add something"},
+		"file_content": {"content"},
+		// file_path omitted
+	})
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 with error", code)
+	}
+	if !strings.Contains(body, "file path is required") {
+		t.Errorf("expected error in body, got: %s", body)
+	}
+}
+
+func TestHandleNewCommit_UnknownRepo_Returns404(t *testing.T) {
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{miss: true}, nil)
+	code, _ := getStatusAndBody(t, h, "/ui/r/unknown/repo/b/feat-x/commit")
+	if code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", code)
+	}
 }


### PR DESCRIPTION
## Summary

- Adds a commit form to the branch detail page in the web UI
- Adds `WriteStoreLite.Commit` method for creating commits via the store interface
- Updates `fakeWrite` in tests to support the new Commit operation
- Adds `ui_test.go` coverage for the commit form handler

## Changes

This is a re-implementation of the work from `work/clever-squirrel`, rebased cleanly onto current `main` (via cherry-pick of commit `26c9938`).

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` passes (all packages green)

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)