### PR TITLE
feat(ui): personalized 'your orgs' landing page (issue #320)

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -109,6 +109,13 @@ func (fakeWrite) ListOrgMembers(_ context.Context, _ string) ([]model.OrgMember,
 	}, nil
 }
 
+func (fakeWrite) ListOrgMemberships(_ context.Context, _ string) ([]model.OrgMember, error) {
+	t := time.Now()
+	return []model.OrgMember{
+		{Org: "acme", Identity: "ajay@acme", Role: api.OrgRoleOwner, InvitedBy: "system", CreatedAt: t.Add(-30 * 24 * time.Hour)},
+	}, nil
+}
+
 func (fakeWrite) ListRoles(_ context.Context, _ string) ([]model.Role, error) {
 	return []model.Role{
 		{Identity: "ajay@acme", Role: model.RoleAdmin},

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1841,6 +1841,29 @@ func (s *Store) ListOrgMembers(ctx context.Context, org string) ([]model.OrgMemb
 	return members, rows.Err()
 }
 
+// ListOrgMemberships returns all org memberships for the given identity, ordered by org.
+func (s *Store) ListOrgMemberships(ctx context.Context, identity string) ([]model.OrgMember, error) {
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT org, identity, role, invited_by, created_at FROM org_members WHERE identity = $1 ORDER BY org",
+		identity,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var members []model.OrgMember
+	for rows.Next() {
+		var m model.OrgMember
+		var roleStr string
+		if err := rows.Scan(&m.Org, &m.Identity, &roleStr, &m.InvitedBy, &m.CreatedAt); err != nil {
+			return nil, err
+		}
+		m.Role = model.OrgRole(roleStr)
+		members = append(members, m)
+	}
+	return members, rows.Err()
+}
+
 // ---------------------------------------------------------------------------
 // Org invitations
 // ---------------------------------------------------------------------------

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -54,6 +54,7 @@ type WriteStore interface {
 	AddOrgMember(ctx context.Context, org, identity string, role model.OrgRole, invitedBy string) error
 	RemoveOrgMember(ctx context.Context, org, identity string) error
 	ListOrgMembers(ctx context.Context, org string) ([]model.OrgMember, error)
+	ListOrgMemberships(ctx context.Context, identity string) ([]model.OrgMember, error)
 
 	// Org invitations
 	CreateInvite(ctx context.Context, org, email string, role model.OrgRole, invitedBy, token string, expiresAt time.Time) (*model.OrgInvite, error)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -299,6 +299,10 @@ func (m *mockStore) ListOrgMembers(ctx context.Context, org string) ([]model.Org
 	return []model.OrgMember{}, nil
 }
 
+func (m *mockStore) ListOrgMemberships(_ context.Context, _ string) ([]model.OrgMember, error) {
+	return []model.OrgMember{}, nil
+}
+
 func (m *mockStore) CreateInvite(ctx context.Context, org, email string, role model.OrgRole, invitedBy, token string, expiresAt time.Time) (*model.OrgInvite, error) {
 	if m.createInviteFn != nil {
 		return m.createInviteFn(ctx, org, email, role, invitedBy, token, expiresAt)

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -24,8 +24,15 @@ import (
 
 const logPageSize = 25
 
+type myOrgEntry struct {
+	Name      string
+	Role      model.OrgRole
+	RepoCount int
+}
+
 type reposPage struct {
-	Orgs []orgGroup
+	MyOrgs []myOrgEntry
+	Orgs   []orgGroup
 }
 
 type orgGroup struct {
@@ -246,10 +253,30 @@ func (h *Handler) handleRepos(w http.ResponseWriter, r *http.Request) {
 	}
 	slices.SortFunc(orgs, func(a, b orgGroup) int { return strings.Compare(a.Name, b.Name) })
 
+	var myOrgs []myOrgEntry
+	if h.identity != nil {
+		identity := h.identity(ctx)
+		if identity != "" {
+			memberships, merr := h.write.ListOrgMemberships(ctx, identity)
+			if merr != nil {
+				slog.Error("ui list org memberships", "error", merr)
+				// non-fatal: render page without personalised section
+			} else {
+				for _, m := range memberships {
+					myOrgs = append(myOrgs, myOrgEntry{
+						Name:      m.Org,
+						Role:      m.Role,
+						RepoCount: len(byOrg[m.Org]),
+					})
+				}
+			}
+		}
+	}
+
 	h.render(w, h.tmpl.repos, "layout.html", pageData{
 		Title:       "Repos",
 		Breadcrumbs: []crumb{{Label: "repos", Href: "/ui/"}},
-		Body:        reposPage{Orgs: orgs},
+		Body:        reposPage{MyOrgs: myOrgs, Orgs: orgs},
 	})
 }
 

--- a/internal/ui/templates/repos.html
+++ b/internal/ui/templates/repos.html
@@ -5,22 +5,37 @@
   <a href="/ui/orgs/new"><button>New org</button></a>
   <a href="/ui/repos/new" style="margin-left:8px"><button>New repo</button></a>
 </div>
-{{if not .Orgs}}
-  <div class="card empty">No repos yet.</div>
-{{else}}
-  {{range .Orgs}}
-  <div class="card">
-    <h2><a href="/ui/o/{{.Name}}">{{.Name}}</a></h2>
-    <div class="row-list">
-      {{range .Repos}}
-      <a href="/ui/r/{{.Name}}">
-        <span>{{.Name}}</span>
-        <span class="meta">by {{.CreatedBy}} · {{relTime .CreatedAt}}</span>
-      </a>
-      {{end}}
-    </div>
-  </div>
+{{if .MyOrgs}}
+<h2>Your orgs</h2>
+<div class="row-list" style="margin-bottom:24px">
+  {{range .MyOrgs}}
+  <a href="/ui/o/{{.Name}}">
+    <span>{{.Name}}</span>
+    <span class="meta">
+      <span class="badge">{{.Role}}</span>
+      · {{.RepoCount}} {{if eq .RepoCount 1}}repo{{else}}repos{{end}}
+    </span>
+  </a>
   {{end}}
+</div>
+{{end}}
+{{if .Orgs}}
+<h2>All orgs</h2>
+{{range .Orgs}}
+<div class="card">
+  <h2><a href="/ui/o/{{.Name}}">{{.Name}}</a></h2>
+  <div class="row-list">
+    {{range .Repos}}
+    <a href="/ui/r/{{.Name}}">
+      <span>{{.Name}}</span>
+      <span class="meta">by {{.CreatedBy}} · {{relTime .CreatedAt}}</span>
+    </a>
+    {{end}}
+  </div>
+</div>
+{{end}}
+{{else}}
+<div class="card empty">No repos yet.</div>
 {{end}}
 {{end}}
 {{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -37,6 +37,7 @@ type WriteStoreLite interface {
 	GetRepo(ctx context.Context, name string) (*model.Repo, error)
 	ListReviewComments(ctx context.Context, repo, branch string, path *string) ([]model.ReviewComment, error)
 	ListOrgMembers(ctx context.Context, org string) ([]model.OrgMember, error)
+	ListOrgMemberships(ctx context.Context, identity string) ([]model.OrgMember, error)
 	ListRoles(ctx context.Context, repo string) ([]model.Role, error)
 	ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64, history bool) ([]model.CheckRun, error)
 	ListIssues(ctx context.Context, repo, stateFilter, authorFilter string) ([]model.Issue, error)

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -75,6 +75,9 @@ func (f *fakeWrite) ListReviewComments(_ context.Context, _, _ string, _ *string
 func (f *fakeWrite) ListOrgMembers(_ context.Context, _ string) ([]model.OrgMember, error) {
 	return nil, nil
 }
+func (f *fakeWrite) ListOrgMemberships(_ context.Context, _ string) ([]model.OrgMember, error) {
+	return nil, nil
+}
 func (f *fakeWrite) ListRoles(_ context.Context, _ string) ([]model.Role, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary

- Add `ListOrgMemberships(ctx, identity)` to `db.Store`, `server.WriteStore`, and `ui.WriteStoreLite` — queries `org_members WHERE identity = $1 ORDER BY org`
- In `handleRepos`, call `ListOrgMemberships` with the current user's identity to populate a new `MyOrgs` section on the landing page
- Rework `repos.html` to show two sections: **Your orgs** (top, with role badge + repo count, each linking to `/ui/o/{org}`) and **All orgs** (below, existing layout)
- Gracefully skip the personalised section when identity is unavailable or the query fails (non-fatal, error logged)
- Add `ListOrgMemberships` stubs to `fakeWrite` in `ui_test.go` and `cmd/ui-preview/main.go`, and to `mockStore` in `server_test.go`

## Test plan

- [x] `go test ./... -count=1` — all packages pass
- [x] `go build ./...` and `go vet ./...` — clean
- [ ] Manual visual check via `go run ./cmd/ui-preview` or dev server with `DEV_IDENTITY`

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)