### PR TITLE
feat(ui): add Settings tab and page to repo UI (closes #332)

### DIFF
--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -54,8 +54,13 @@ type branchesPage struct {
 	Merged    []branchRow
 	Abandoned []branchRow
 	Members   []model.OrgMember
-	Roles     []model.Role
 	Err       string
+}
+
+type repoSettingsPage struct {
+	Repo  model.Repo
+	Roles []model.Role
+	Err   string
 }
 
 type branchRow struct {
@@ -1366,13 +1371,8 @@ func (h *Handler) renderBranchesPage(w http.ResponseWriter, r *http.Request, own
 		slog.Error("ui list org members", "org", repo.Owner, "error", err)
 		members = nil
 	}
-	roles, err := h.write.ListRoles(ctx, repoName)
-	if err != nil {
-		slog.Error("ui list roles", "repo", repoName, "error", err)
-		roles = nil
-	}
 
-	page := branchesPage{Repo: *repo, Members: members, Roles: roles, Err: errMsg}
+	page := branchesPage{Repo: *repo, Members: members, Err: errMsg}
 	for _, b := range branches {
 		row := branchRow{
 			Name:         b.Name,
@@ -1402,6 +1402,44 @@ func (h *Handler) renderBranchesPage(w http.ResponseWriter, r *http.Request, own
 	})
 }
 
+// handleRepoSettings renders the settings page for a single repo.
+func (h *Handler) handleRepoSettings(w http.ResponseWriter, r *http.Request) {
+	h.renderRepoSettingsPage(w, r, r.PathValue("owner"), r.PathValue("name"), "")
+}
+
+// renderRepoSettingsPage loads repo/role data and renders the settings page with an optional error.
+func (h *Handler) renderRepoSettingsPage(w http.ResponseWriter, r *http.Request, owner, name, errMsg string) {
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	roles, err := h.write.ListRoles(ctx, repoName)
+	if err != nil {
+		slog.Error("ui list roles", "repo", repoName, "error", err)
+		roles = nil
+	}
+
+	h.render(w, h.tmpl.repoSettings, "layout.html", pageData{
+		Title: repoName + " / settings",
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/ui/"},
+			{Label: repoName, Href: "/ui/r/" + repoName},
+			{Label: "settings", Href: ""},
+		},
+		Body: repoSettingsPage{Repo: *repo, Roles: roles, Err: errMsg},
+	})
+}
+
 // handleSetRole processes POST /ui/r/{owner}/{name}/roles to grant or update a repo role.
 func (h *Handler) handleSetRole(w http.ResponseWriter, r *http.Request) {
 	owner := r.PathValue("owner")
@@ -1410,30 +1448,30 @@ func (h *Handler) handleSetRole(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	if err := r.ParseForm(); err != nil {
-		h.renderBranchesPage(w, r, owner, name, "invalid form data")
+		h.renderRepoSettingsPage(w, r, owner, name, "invalid form data")
 		return
 	}
 	identity := strings.TrimSpace(r.FormValue("identity"))
 	role := model.RoleType(r.FormValue("role"))
 
 	if identity == "" {
-		h.renderBranchesPage(w, r, owner, name, "identity is required")
+		h.renderRepoSettingsPage(w, r, owner, name, "identity is required")
 		return
 	}
 	switch role {
 	case model.RoleReader, model.RoleWriter, model.RoleMaintainer, model.RoleAdmin:
 	default:
-		h.renderBranchesPage(w, r, owner, name, "invalid role; must be reader, writer, maintainer, or admin")
+		h.renderRepoSettingsPage(w, r, owner, name, "invalid role; must be reader, writer, maintainer, or admin")
 		return
 	}
 
 	if err := h.write.SetRole(ctx, repoName, identity, role); err != nil {
 		slog.Error("ui set role", "repo", repoName, "identity", identity, "error", err)
-		h.renderBranchesPage(w, r, owner, name, "could not set role: "+err.Error())
+		h.renderRepoSettingsPage(w, r, owner, name, "could not set role: "+err.Error())
 		return
 	}
 
-	http.Redirect(w, r, "/ui/r/"+repoName, http.StatusSeeOther)
+	http.Redirect(w, r, "/ui/r/"+repoName+"/settings", http.StatusSeeOther)
 }
 
 // handleDeleteRole processes POST /ui/r/{owner}/{name}/roles/{identity}/delete.
@@ -1447,15 +1485,15 @@ func (h *Handler) handleDeleteRole(w http.ResponseWriter, r *http.Request) {
 	if err := h.write.DeleteRole(ctx, repoName, identity); err != nil {
 		switch {
 		case errors.Is(err, db.ErrRoleNotFound):
-			h.renderBranchesPage(w, r, owner, name, "role not found")
+			h.renderRepoSettingsPage(w, r, owner, name, "role not found")
 		default:
 			slog.Error("ui delete role", "repo", repoName, "identity", identity, "error", err)
-			h.renderBranchesPage(w, r, owner, name, "could not delete role")
+			h.renderRepoSettingsPage(w, r, owner, name, "could not delete role")
 		}
 		return
 	}
 
-	http.Redirect(w, r, "/ui/r/"+repoName, http.StatusSeeOther)
+	http.Redirect(w, r, "/ui/r/"+repoName+"/settings", http.StatusSeeOther)
 }
 
 // renderReleasesPage loads releases for a repo and renders the releases page with an optional error.
@@ -2484,12 +2522,12 @@ func (h *Handler) handleUIDeleteRepo(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	if err := r.ParseForm(); err != nil {
-		h.renderBranchesPage(w, r, owner, name, "invalid form data")
+		h.renderRepoSettingsPage(w, r, owner, name, "invalid form data")
 		return
 	}
 	confirm := r.FormValue("confirm")
 	if confirm != name {
-		h.renderBranchesPage(w, r, owner, name, "confirmation does not match repo name")
+		h.renderRepoSettingsPage(w, r, owner, name, "confirmation does not match repo name")
 		return
 	}
 
@@ -2499,7 +2537,7 @@ func (h *Handler) handleUIDeleteRepo(w http.ResponseWriter, r *http.Request) {
 			h.renderError(w, http.StatusNotFound, "repo not found: "+repoName)
 		default:
 			slog.Error("ui delete repo", "repo", repoName, "error", err)
-			h.renderBranchesPage(w, r, owner, name, "could not delete repo: "+err.Error())
+			h.renderRepoSettingsPage(w, r, owner, name, "could not delete repo: "+err.Error())
 		}
 		return
 	}

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -42,6 +42,7 @@ type templateSet struct {
 	createOrg       *template.Template
 	createRepo      *template.Template
 	newCommit       *template.Template
+	repoSettings    *template.Template
 }
 
 func parseTemplates(root fs.FS) (*templateSet, error) {
@@ -191,6 +192,10 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse new_commit: %w", err)
 	}
+	repoSettings, err := load("settings.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse settings: %w", err)
+	}
 	return &templateSet{
 		repos:          repos,
 		branches:       branches,
@@ -219,6 +224,7 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		createOrg:       createOrg,
 		createRepo:      createRepo,
 		newCommit:       newCommit,
+		repoSettings:    repoSettings,
 	}, nil
 }
 

--- a/internal/ui/templates/branches.html
+++ b/internal/ui/templates/branches.html
@@ -9,6 +9,7 @@
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 
 {{if .Err}}
@@ -52,57 +53,6 @@
     </tbody>
   </table>
   {{end}}
-</div>
-
-<h2>Roles ({{len .Roles}})</h2>
-<div class="card">
-  {{if not .Roles}}<div class="empty">no roles configured</div>{{else}}
-  <table class="grid">
-    <thead><tr><th>identity</th><th>role</th><th></th></tr></thead>
-    <tbody>
-    {{range .Roles}}
-    <tr>
-      <td>{{.Identity}}</td>
-      <td><span class="badge neutral">{{.Role}}</span></td>
-      <td>
-        <form method="POST" action="/ui/r/{{$.Repo.Name}}/roles/{{.Identity}}/delete" style="display:inline">
-          <button type="submit" class="btn-danger-small">revoke</button>
-        </form>
-      </td>
-    </tr>
-    {{end}}
-    </tbody>
-  </table>
-  {{end}}
-  <details style="margin-top:12px">
-    <summary style="cursor:pointer;font-size:12px;color:var(--accent)">Grant role</summary>
-    <form method="POST" action="/ui/r/{{.Repo.Name}}/roles" style="padding:10px 0 4px;display:flex;gap:6px;align-items:center;flex-wrap:wrap">
-      <input type="text" name="identity" placeholder="identity (email)" required class="form-input" style="flex:1;min-width:180px">
-      <select name="role" class="form-input" style="width:auto">
-        <option value="reader">reader</option>
-        <option value="writer">writer</option>
-        <option value="maintainer">maintainer</option>
-        <option value="admin">admin</option>
-      </select>
-      <button type="submit" class="btn">Grant</button>
-    </form>
-  </details>
-</div>
-
-<h2 style="color:var(--bad)">Danger zone</h2>
-<div class="card" style="border-left:3px solid var(--bad)">
-  <details>
-    <summary style="cursor:pointer;font-size:0.9em;color:var(--bad)">Delete this repository</summary>
-    <p style="font-size:0.85em;color:var(--text-dim);margin:8px 0">This permanently deletes the repository and all its data. This cannot be undone.</p>
-    <form method="POST" action="/ui/r/{{.Repo.Name}}/-/delete-repo" style="padding:4px 0">
-      {{- $shortName := repoShortName .Repo.Name -}}
-      <label style="font-size:0.85em;display:block;margin-bottom:4px">Type <strong>{{$shortName}}</strong> to confirm:</label>
-      <input type="text" name="confirm" placeholder="{{$shortName}}" required
-             style="background:var(--bg-3);color:var(--text);border:1px solid var(--bad);border-radius:4px;padding:6px 10px;font-family:var(--mono);font-size:12px;margin-right:6px"
-             oninput="this.form.querySelector('button').disabled=(this.value!='{{$shortName}}')">
-      <button type="submit" class="btn-danger-small" disabled>Delete repo</button>
-    </form>
-  </details>
 </div>
 {{end}}
 {{end}}

--- a/internal/ui/templates/ci_job_detail.html
+++ b/internal/ui/templates/ci_job_detail.html
@@ -7,6 +7,7 @@
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs" class="active">ci-jobs</a>
   <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 
 <div class="headline">

--- a/internal/ui/templates/ci_jobs.html
+++ b/internal/ui/templates/ci_jobs.html
@@ -12,6 +12,7 @@
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs" class="active">ci-jobs</a>
   <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 
 <div class="tab-bar">

--- a/internal/ui/templates/issue_detail.html
+++ b/internal/ui/templates/issue_detail.html
@@ -8,6 +8,7 @@
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 
 {{if .Err}}

--- a/internal/ui/templates/issues.html
+++ b/internal/ui/templates/issues.html
@@ -12,6 +12,7 @@
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 
 <div class="tab-bar" data-tab-group>

--- a/internal/ui/templates/new_issue.html
+++ b/internal/ui/templates/new_issue.html
@@ -7,6 +7,7 @@
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 
 <h1>New Issue</h1>

--- a/internal/ui/templates/proposal_detail.html
+++ b/internal/ui/templates/proposal_detail.html
@@ -7,6 +7,7 @@
   <a href="/ui/r/{{.Repo.Name}}/proposals" class="active">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 
 <div class="headline">

--- a/internal/ui/templates/proposals.html
+++ b/internal/ui/templates/proposals.html
@@ -12,6 +12,7 @@
   <a href="/ui/r/{{.Repo.Name}}/proposals" class="active">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 
 {{if .Err}}

--- a/internal/ui/templates/release_detail.html
+++ b/internal/ui/templates/release_detail.html
@@ -7,6 +7,7 @@
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 
 <div class="headline">

--- a/internal/ui/templates/releases.html
+++ b/internal/ui/templates/releases.html
@@ -12,6 +12,7 @@
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 
 {{if .Err}}

--- a/internal/ui/templates/settings.html
+++ b/internal/ui/templates/settings.html
@@ -1,0 +1,72 @@
+{{define "content"}}
+{{with .Body}}
+<div class="headline"><h1>{{.Repo.Name}}</h1><span class="meta">owner {{.Repo.Owner}} · {{relTime .Repo.CreatedAt}}</span></div>
+
+<nav class="repo-tabs">
+  <a href="/ui/r/{{.Repo.Name}}">branches</a>
+  <a href="/ui/r/{{.Repo.Name}}/issues">issues</a>
+  <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
+  <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
+  <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
+  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/settings" class="active">settings</a>
+</nav>
+
+{{if .Err}}
+<div class="card" style="border-left: 3px solid var(--bad); margin-bottom:14px">
+  <div class="row"><span class="badge bad">error</span> <span>{{.Err}}</span></div>
+</div>
+{{end}}
+
+<h2>Roles ({{len .Roles}})</h2>
+<div class="card">
+  {{if not .Roles}}<div class="empty">no roles configured</div>{{else}}
+  <table class="grid">
+    <thead><tr><th>identity</th><th>role</th><th></th></tr></thead>
+    <tbody>
+    {{range .Roles}}
+    <tr>
+      <td>{{.Identity}}</td>
+      <td><span class="badge neutral">{{.Role}}</span></td>
+      <td>
+        <form method="POST" action="/ui/r/{{$.Repo.Name}}/roles/{{.Identity}}/delete" style="display:inline">
+          <button type="submit" class="btn-danger-small">revoke</button>
+        </form>
+      </td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{end}}
+  <details style="margin-top:12px">
+    <summary style="cursor:pointer;font-size:12px;color:var(--accent)">Grant role</summary>
+    <form method="POST" action="/ui/r/{{.Repo.Name}}/roles" style="padding:10px 0 4px;display:flex;gap:6px;align-items:center;flex-wrap:wrap">
+      <input type="text" name="identity" placeholder="identity (email)" required class="form-input" style="flex:1;min-width:180px">
+      <select name="role" class="form-input" style="width:auto">
+        <option value="reader">reader</option>
+        <option value="writer">writer</option>
+        <option value="maintainer">maintainer</option>
+        <option value="admin">admin</option>
+      </select>
+      <button type="submit" class="btn">Grant</button>
+    </form>
+  </details>
+</div>
+
+<h2 style="color:var(--bad)">Danger zone</h2>
+<div class="card" style="border-left:3px solid var(--bad)">
+  <details>
+    <summary style="cursor:pointer;font-size:0.9em;color:var(--bad)">Delete this repository</summary>
+    <p style="font-size:0.85em;color:var(--text-dim);margin:8px 0">This permanently deletes the repository and all its data. This cannot be undone.</p>
+    <form method="POST" action="/ui/r/{{.Repo.Name}}/-/delete-repo" style="padding:4px 0">
+      {{- $shortName := repoShortName .Repo.Name -}}
+      <label style="font-size:0.85em;display:block;margin-bottom:4px">Type <strong>{{$shortName}}</strong> to confirm:</label>
+      <input type="text" name="confirm" placeholder="{{$shortName}}" required
+             style="background:var(--bg-3);color:var(--text);border:1px solid var(--bad);border-radius:4px;padding:6px 10px;font-family:var(--mono);font-size:12px;margin-right:6px"
+             oninput="this.form.querySelector('button').disabled=(this.value!='{{$shortName}}')">
+      <button type="submit" class="btn-danger-small" disabled>Delete repo</button>
+    </form>
+  </details>
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -175,6 +175,7 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/{$}", h.handleRepos)
 	mux.HandleFunc("GET /ui/o/{org}", h.handleOrg)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}", h.handleBranches)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/settings", h.handleRepoSettings)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}", h.handleBranchDetail)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/checks", h.handleChecksPartial)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/comments", h.handleReviewCommentsPartial)

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1041,3 +1041,68 @@ func TestHandleNewCommit_UnknownRepo_Returns404(t *testing.T) {
 		t.Fatalf("status = %d, want 404", code)
 	}
 }
+
+func TestHandleRepoSettings_RendersPage(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/settings")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	for _, want := range []string{"settings", "Roles", "Danger zone", "Grant role", "Delete this repository"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleRepoSettings_UnknownRepo_Returns404(t *testing.T) {
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{miss: true}, nil)
+	code, _ := getStatusAndBody(t, h, "/ui/r/unknown/repo/settings")
+	if code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", code)
+	}
+}
+
+func TestHandleSetRole_RedirectsToSettings(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, _, loc := postForm(t, h, "/ui/r/acme/a/roles", url.Values{
+		"identity": {"alice@example.com"},
+		"role":     {"reader"},
+	})
+	if code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", code)
+	}
+	if loc != "/ui/r/acme/a/settings" {
+		t.Errorf("location = %q, want /ui/r/acme/a/settings", loc)
+	}
+}
+
+func TestHandleDeleteRole_RedirectsToSettings(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, _, loc := postForm(t, h, "/ui/r/acme/a/roles/alice@example.com/delete", nil)
+	if code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", code)
+	}
+	if loc != "/ui/r/acme/a/settings" {
+		t.Errorf("location = %q, want /ui/r/acme/a/settings", loc)
+	}
+}
+
+func TestHandleBranches_NoRolesOrDangerZone(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	_, body := getStatusAndBody(t, h, "/ui/r/acme/a")
+	if strings.Contains(body, "Danger zone") {
+		t.Errorf("branches page should not contain Danger zone section")
+	}
+	if strings.Contains(body, "Grant role") {
+		t.Errorf("branches page should not contain Grant role form")
+	}
+}


### PR DESCRIPTION
## Summary

- Add new `settings.html` template at `/ui/r/{owner}/{name}/settings` containing the roles table, grant-role form, and delete-repo danger zone
- Add `GET /ui/r/{owner}/{name}/settings` route and `handleRepoSettings`/`renderRepoSettingsPage` handlers
- Remove roles and danger zone sections from `branches.html` (keeps it focused on branch management)
- Add the **settings** tab to all 10 repo-level page templates
- Update `handleSetRole`, `handleDeleteRole`, and `handleUIDeleteRepo` to redirect to/re-render the settings page instead of the branches page
- Add `repoSettingsPage` struct; remove `Roles` field from `branchesPage` (no longer needed there)

## Test plan

- [x] All existing tests pass (`go test ./... -count=1`)
- [x] `go build ./...` and `go vet ./...` clean
- [x] New tests: `TestHandleRepoSettings_RendersPage`, `TestHandleRepoSettings_UnknownRepo_Returns404`, `TestHandleSetRole_RedirectsToSettings`, `TestHandleDeleteRole_RedirectsToSettings`, `TestHandleBranches_NoRolesOrDangerZone`

## Notes / Opportunities

- The Members table (org membership) currently remains on the branches page; it could logically move to settings too, but that was out of scope per the task description
- The `log` and `file` page templates don't use `.Repo.Name` in the same tab-bar pattern (they're branch-scoped), so they were not modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)