### PR TITLE
feat(ui): server-side markdown rendering for issue/proposal/release content

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -143,6 +143,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
+	github.com/yuin/goldmark v1.8.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.39.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,8 @@ github.com/yashtewari/glob-intersection v0.2.0 h1:8iuHdN88yYuCzCdjt0gDe+6bAhUwBe
 github.com/yashtewari/glob-intersection v0.2.0/go.mod h1:LK7pIC3piUjovexikBbJ26Yml7g8xa5bsjfx2v1fwok=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/yuin/goldmark"
 )
 
 // templateSet holds the parsed template tree. Each page has its own *Template
@@ -306,7 +308,25 @@ func funcMap() template.FuncMap {
 		"urlPathEscape":  url.PathEscape,
 		"joinStrings":    strings.Join,
 		"repoShortName":  repoShortName,
+		"markdown":       renderMarkdown,
 	}
+}
+
+// renderMarkdown converts a markdown string to sanitized HTML.
+// It uses goldmark's safe defaults (no html.WithUnsafe), which means:
+// - Raw HTML in markdown is stripped (not passed through)
+// - Dangerous URL schemes (javascript:, vbscript:, etc.) are omitted from links
+// The returned template.HTML is safe to use directly in templates.
+func renderMarkdown(s string) template.HTML {
+	if s == "" {
+		return ""
+	}
+	var buf bytes.Buffer
+	md := goldmark.New()
+	if err := md.Convert([]byte(s), &buf); err != nil {
+		return template.HTML(template.HTMLEscapeString(s))
+	}
+	return template.HTML(buf.String())
 }
 
 // repoShortName returns the short name portion of a full "owner/name" repo

--- a/internal/ui/templates/branch_detail.html
+++ b/internal/ui/templates/branch_detail.html
@@ -153,7 +153,7 @@
           hx-target="#review-comments"
           hx-swap="innerHTML">inline comments ▾</button>
       </div>
-      {{if .Body}}<div class="row-body">{{.Body}}</div>{{end}}
+      {{if .Body}}<div class="row-body markdown-body">{{markdown .Body}}</div>{{end}}
       {{end}}
       <div id="review-comments"></div>
     </div>
@@ -226,7 +226,7 @@
     </div>
     <span class="badge {{statusClass (printf "%s" .State)}}">{{.State}}</span>
   </div>
-  {{if .Description}}<div class="row-body">{{.Description}}</div>{{end}}
+  {{if .Description}}<div class="row-body markdown-body">{{markdown .Description}}</div>{{end}}
   {{end}}
 </div>
 

--- a/internal/ui/templates/issue_detail.html
+++ b/internal/ui/templates/issue_detail.html
@@ -49,7 +49,7 @@
 
 {{if .Issue.Body}}
 <div class="card" style="margin-bottom:16px">
-  <div class="row-body">{{.Issue.Body}}</div>
+  <div class="row-body markdown-body">{{markdown .Issue.Body}}</div>
 </div>
 {{end}}
 
@@ -87,7 +87,7 @@
       <button type="submit" class="btn danger" style="font-size:11px;padding:3px 8px">delete</button>
     </form>
   </div>
-  {{if .Body}}<div class="row-body">{{.Body}}</div>{{end}}
+  {{if .Body}}<div class="row-body markdown-body">{{markdown .Body}}</div>{{end}}
   <details class="form-section" style="padding:4px 4px 8px">
     <summary>edit comment</summary>
     <form method="POST" action="/ui/r/{{$d.Repo.Name}}/issues/{{$d.Issue.Number}}/comments/{{.ID}}/edit" style="padding-top:8px">

--- a/internal/ui/templates/proposal_detail.html
+++ b/internal/ui/templates/proposal_detail.html
@@ -43,7 +43,7 @@
 {{if .Proposal.Description}}
 <h2>Description</h2>
 <div class="card">
-  <div style="white-space:pre-wrap;color:var(--text);">{{.Proposal.Description}}</div>
+  <div class="markdown-body">{{markdown .Proposal.Description}}</div>
 </div>
 {{end}}
 

--- a/internal/ui/templates/release_detail.html
+++ b/internal/ui/templates/release_detail.html
@@ -37,7 +37,7 @@
 {{if .Release.Body}}
 <h2>Body</h2>
 <div class="card">
-  <div style="white-space:pre-wrap;color:var(--text);">{{.Release.Body}}</div>
+  <div class="markdown-body">{{markdown .Release.Body}}</div>
 </div>
 {{end}}
 

--- a/internal/ui/templates/releases.html
+++ b/internal/ui/templates/releases.html
@@ -30,7 +30,7 @@
     <td><a href="releases/{{.Name}}">{{.Name}}</a></td>
     <td>{{.Sequence}}</td>
     <td>{{.CreatedBy}}</td>
-    <td class="meta">{{if gt (len .Body) 80}}{{slice .Body 0 80}}…{{else}}{{.Body}}{{end}}</td>
+    <td class="meta markdown-body">{{markdown .Body}}</td>
     <td class="meta">{{relTime .CreatedAt}}</td>
   </tr>
   {{end}}


### PR DESCRIPTION
## Summary

Closes #332.

- Added `github.com/yuin/goldmark` as a dependency (upgraded from existing indirect v1.2.1 → v1.8.2)
- Added `renderMarkdown(s string) template.HTML` helper in `internal/ui/render.go` using goldmark's safe defaults (no `html.WithUnsafe`), which strips raw HTML from markdown input and omits dangerous URL schemes (`javascript:`, etc.) — preventing XSS without needing a separate sanitizer library
- Registered it as the `markdown` template func in `funcMap()`
- Applied in templates:
  - `issue_detail.html`: issue body and comment bodies
  - `proposal_detail.html`: proposal description
  - `release_detail.html`: release notes body
  - `releases.html`: release notes body in list table (truncation removed since truncating rendered HTML produces broken markup)
  - `branch_detail.html`: review body and proposal description snippet
- Empty string input returns `""`, preserving existing plain-text fallback for unpopulated fields
- All existing tests pass

## Test plan

- [x] `go test ./internal/ui/... -count=1` passes
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual: navigate to an issue with markdown body (e.g. `**bold** and _italic_`) — should render formatted HTML, not raw asterisks
- [ ] XSS: body containing `<script>alert(1)</script>` should be stripped; `[click](javascript:alert(1))` should produce empty `href`

## Opportunities noted (not implemented)

- Could add `markdown-body` CSS styles to `internal/ui/static/` for better typography of rendered markdown (headings, code blocks, lists, etc.)
- The releases list table now shows full rendered release notes — a future pass could show a condensed plain-text excerpt alongside a link to the full detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)