### PR TITLE
feat(ui): add label filtering to issues list (closes #332)

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -160,7 +160,7 @@ func (fakeWrite) GetRepo(_ context.Context, name string) (*model.Repo, error) {
 	return nil, db.ErrRepoNotFound
 }
 
-func (fakeWrite) ListIssues(_ context.Context, repo, state, _ string) ([]model.Issue, error) {
+func (fakeWrite) ListIssues(_ context.Context, repo, state, _, _ string) ([]model.Issue, error) {
 	t := time.Now()
 	if state == "closed" {
 		return []model.Issue{
@@ -177,13 +177,13 @@ func (fakeWrite) ListIssues(_ context.Context, repo, state, _ string) ([]model.I
 }
 
 func (fakeWrite) GetIssue(_ context.Context, repo string, number int64) (*model.Issue, error) {
-	all, _ := (fakeWrite{}).ListIssues(context.Background(), repo, "open", "")
+	all, _ := (fakeWrite{}).ListIssues(context.Background(), repo, "open", "", "")
 	for _, iss := range all {
 		if iss.Number == number {
 			return &iss, nil
 		}
 	}
-	closed, _ := (fakeWrite{}).ListIssues(context.Background(), repo, "closed", "")
+	closed, _ := (fakeWrite{}).ListIssues(context.Background(), repo, "closed", "", "")
 	for _, iss := range closed {
 		if iss.Number == number {
 			return &iss, nil

--- a/internal/db/issues.go
+++ b/internal/db/issues.go
@@ -134,7 +134,8 @@ func (s *Store) GetIssue(ctx context.Context, repo string, number int64) (*model
 
 // ListIssues returns issues for a repo ordered by number DESC.
 // stateFilter, if non-empty, restricts to that state. authorFilter, if non-empty, restricts to that author.
-func (s *Store) ListIssues(ctx context.Context, repo, stateFilter, authorFilter string) ([]model.Issue, error) {
+// labelFilter, if non-empty, restricts to issues whose labels array contains that label.
+func (s *Store) ListIssues(ctx context.Context, repo, stateFilter, authorFilter, labelFilter string) ([]model.Issue, error) {
 	q := `SELECT ` + issueColumns + ` FROM issues WHERE repo = $1`
 	args := []any{repo}
 	if stateFilter != "" {
@@ -144,6 +145,10 @@ func (s *Store) ListIssues(ctx context.Context, repo, stateFilter, authorFilter 
 	if authorFilter != "" {
 		args = append(args, authorFilter)
 		q += fmt.Sprintf(" AND author = $%d", len(args))
+	}
+	if labelFilter != "" {
+		args = append(args, labelFilter)
+		q += fmt.Sprintf(" AND $%d = ANY(labels)", len(args))
 	}
 	q += " ORDER BY number DESC"
 

--- a/internal/server/handlers_issues.go
+++ b/internal/server/handlers_issues.go
@@ -100,8 +100,9 @@ func (s *server) handleListIssues(w http.ResponseWriter, r *http.Request) {
 		stateFilter = ""
 	}
 	authorFilter := r.URL.Query().Get("author")
+	labelFilter := r.URL.Query().Get("label")
 
-	issues, err := s.commitStore.ListIssues(r.Context(), repo, stateFilter, authorFilter)
+	issues, err := s.commitStore.ListIssues(r.Context(), repo, stateFilter, authorFilter, labelFilter)
 	if err != nil {
 		slog.Error("internal error", "op", "list_issues", "repo", repo, "error", err)
 		writeAPIError(w, ErrCodeInternalError, http.StatusInternalServerError, "internal server error")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -131,7 +131,7 @@ type WriteStore interface {
 	// Issue management
 	CreateIssue(ctx context.Context, repo, title, body, author string, labels []string) (*model.Issue, error)
 	GetIssue(ctx context.Context, repo string, number int64) (*model.Issue, error)
-	ListIssues(ctx context.Context, repo, stateFilter, authorFilter string) ([]model.Issue, error)
+	ListIssues(ctx context.Context, repo, stateFilter, authorFilter, labelFilter string) ([]model.Issue, error)
 	UpdateIssue(ctx context.Context, repo string, number int64, title, body *string, labels *[]string) (*model.Issue, error)
 	CloseIssue(ctx context.Context, repo string, number int64, reason model.IssueCloseReason, closedBy string) (*model.Issue, error)
 	ReopenIssue(ctx context.Context, repo string, number int64) (*model.Issue, error)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -486,7 +486,7 @@ func (m *mockStore) CreateIssue(_ context.Context, _, _, _, _ string, _ []string
 func (m *mockStore) GetIssue(_ context.Context, _ string, _ int64) (*model.Issue, error) {
 	return nil, db.ErrIssueNotFound
 }
-func (m *mockStore) ListIssues(_ context.Context, _, _, _ string) ([]model.Issue, error) {
+func (m *mockStore) ListIssues(_ context.Context, _, _, _, _ string) ([]model.Issue, error) {
 	return []model.Issue{}, nil
 }
 func (m *mockStore) UpdateIssue(_ context.Context, _ string, _ int64, _, _ *string, _ *[]string) (*model.Issue, error) {

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -155,6 +155,7 @@ type issuesPage struct {
 	Repo   model.Repo
 	Issues []model.Issue
 	State  string
+	Label  string
 }
 
 type issueDetailPage struct {
@@ -509,6 +510,7 @@ func (h *Handler) handleIssues(w http.ResponseWriter, r *http.Request) {
 	if state != "open" && state != "closed" {
 		state = "open"
 	}
+	label := r.URL.Query().Get("label")
 
 	repo, err := h.write.GetRepo(ctx, repoName)
 	if err != nil {
@@ -521,14 +523,14 @@ func (h *Handler) handleIssues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	issues, err := h.write.ListIssues(ctx, repoName, state, "")
+	issues, err := h.write.ListIssues(ctx, repoName, state, "", label)
 	if err != nil {
 		slog.Error("ui list issues", "repo", repoName, "error", err)
 		h.renderError(w, r, http.StatusInternalServerError, "could not load issues")
 		return
 	}
 
-	page := issuesPage{Repo: *repo, Issues: issues, State: state}
+	page := issuesPage{Repo: *repo, Issues: issues, State: state, Label: label}
 	h.render(w, r, h.tmpl.issues, "layout.html", pageData{
 		Title: repoName + " / issues",
 		Breadcrumbs: []crumb{
@@ -551,6 +553,7 @@ func (h *Handler) handleIssuesPartial(w http.ResponseWriter, r *http.Request) {
 	if state != "open" && state != "closed" {
 		state = "open"
 	}
+	label := r.URL.Query().Get("label")
 
 	repo, err := h.write.GetRepo(ctx, repoName)
 	if err != nil {
@@ -559,14 +562,14 @@ func (h *Handler) handleIssuesPartial(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	issues, err := h.write.ListIssues(ctx, repoName, state, "")
+	issues, err := h.write.ListIssues(ctx, repoName, state, "", label)
 	if err != nil {
 		slog.Error("ui issues partial list", "repo", repoName, "error", err)
 		http.Error(w, "query failed", http.StatusInternalServerError)
 		return
 	}
 
-	h.render(w, r, h.tmpl.issuesRows, "issues_rows.html", issuesPage{Repo: *repo, Issues: issues, State: state})
+	h.render(w, r, h.tmpl.issuesRows, "issues_rows.html", issuesPage{Repo: *repo, Issues: issues, State: state, Label: label})
 }
 
 // handleReviewCommentsPartial returns the inline review comments for a branch,

--- a/internal/ui/static/styles.css
+++ b/internal/ui/static/styles.css
@@ -460,3 +460,38 @@ details.form-section > summary::-webkit-details-marker { display: none; }
   text-decoration: none;
 }
 .btn-link:hover { text-decoration: underline; }
+
+/* Label badges in issue list — clickable to filter by label. */
+.badge-label {
+  background: var(--bg-3);
+  color: var(--text-dim);
+  text-decoration: none;
+  cursor: pointer;
+}
+.badge-label:hover { background: var(--accent); color: #fff; }
+
+/* Active filter chips shown above tables. */
+.filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0 0 12px;
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 3px;
+  font-size: 11px;
+  background: var(--bg-3);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+.chip-clear {
+  color: var(--text-dim);
+  text-decoration: none;
+  font-size: 12px;
+  line-height: 1;
+}
+.chip-clear:hover { color: var(--bad); }

--- a/internal/ui/templates/issues.html
+++ b/internal/ui/templates/issues.html
@@ -16,15 +16,21 @@
 </nav>
 
 <div class="tab-bar" data-tab-group>
-  <a href="/ui/r/{{.Repo.Name}}/issues?state=open"
-     data-tab-url="/ui/_/r/{{.Repo.Name}}/issues?state=open"
+  <a href="/ui/r/{{.Repo.Name}}/issues?state=open{{if .Label}}&label={{.Label}}{{end}}"
+     data-tab-url="/ui/_/r/{{.Repo.Name}}/issues?state=open{{if .Label}}&label={{.Label}}{{end}}"
      data-tab-target="#issues-table"
      class="tab{{if eq .State "open"}} active{{end}}">Open</a>
-  <a href="/ui/r/{{.Repo.Name}}/issues?state=closed"
-     data-tab-url="/ui/_/r/{{.Repo.Name}}/issues?state=closed"
+  <a href="/ui/r/{{.Repo.Name}}/issues?state=closed{{if .Label}}&label={{.Label}}{{end}}"
+     data-tab-url="/ui/_/r/{{.Repo.Name}}/issues?state=closed{{if .Label}}&label={{.Label}}{{end}}"
      data-tab-target="#issues-table"
      class="tab{{if eq .State "closed"}} active{{end}}">Closed</a>
 </div>
+
+{{if .Label}}
+<div class="filter-chips">
+  <span class="chip">label: {{.Label}} <a href="/ui/r/{{.Repo.Name}}/issues?state={{.State}}" class="chip-clear" aria-label="clear label filter">&#x2715;</a></span>
+</div>
+{{end}}
 
 <div id="issues-table">
   {{template "issues_rows.html" .}}

--- a/internal/ui/templates/issues_rows.html
+++ b/internal/ui/templates/issues_rows.html
@@ -1,13 +1,14 @@
 {{define "issues_rows.html"}}
 <div class="card">
-  {{if not .Issues}}<div class="empty">no {{.State}} issues{{if eq .State "open"}} — <a href="/ui/r/{{.Repo.Name}}/issues/new">open one</a>{{end}}</div>{{else}}
+  {{if not .Issues}}<div class="empty">no {{.State}} issues{{if .Label}} with label "{{.Label}}"{{end}}{{if eq .State "open"}} — <a href="/ui/r/{{.Repo.Name}}/issues/new">open one</a>{{end}}</div>{{else}}
   <table class="grid">
-    <thead><tr><th>#</th><th>title</th><th>author</th><th>state</th><th>opened</th></tr></thead>
+    <thead><tr><th>#</th><th>title</th><th>labels</th><th>author</th><th>state</th><th>opened</th></tr></thead>
     <tbody>
     {{range .Issues}}
     <tr>
       <td><a href="/ui/r/{{$.Repo.Name}}/issues/{{.Number}}">#{{.Number}}</a></td>
       <td><a href="/ui/r/{{$.Repo.Name}}/issues/{{.Number}}">{{.Title}}</a></td>
+      <td>{{range .Labels}}<a href="/ui/r/{{$.Repo.Name}}/issues?state={{$.State}}&label={{.}}" class="badge badge-label">{{.}}</a> {{end}}</td>
       <td>{{.Author}}</td>
       <td><span class="badge {{statusClass (printf "%s" .State)}}">{{.State}}</span></td>
       <td class="meta">{{relTime .CreatedAt}}</td>

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -41,7 +41,7 @@ type WriteStoreLite interface {
 	ListRoles(ctx context.Context, repo string) ([]model.Role, error)
 	ListRolesByIdentity(ctx context.Context, identity string) ([]model.RepoRole, error)
 	ListCheckRuns(ctx context.Context, repo, branch string, atSeq *int64, history bool) ([]model.CheckRun, error)
-	ListIssues(ctx context.Context, repo, stateFilter, authorFilter string) ([]model.Issue, error)
+	ListIssues(ctx context.Context, repo, stateFilter, authorFilter, labelFilter string) ([]model.Issue, error)
 	GetIssue(ctx context.Context, repo string, number int64) (*model.Issue, error)
 	ListIssueComments(ctx context.Context, repo string, number int64) ([]model.IssueComment, error)
 	GetInviteByToken(ctx context.Context, org, token string) (*model.OrgInvite, error)

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -87,7 +87,7 @@ func (f *fakeWrite) ListRolesByIdentity(_ context.Context, _ string) ([]model.Re
 func (f *fakeWrite) ListCheckRuns(_ context.Context, _, _ string, _ *int64, _ bool) ([]model.CheckRun, error) {
 	return nil, nil
 }
-func (f *fakeWrite) ListIssues(_ context.Context, _, _, _ string) ([]model.Issue, error) {
+func (f *fakeWrite) ListIssues(_ context.Context, _, _, _, _ string) ([]model.Issue, error) {
 	return f.issues, nil
 }
 func (f *fakeWrite) GetIssue(_ context.Context, _ string, number int64) (*model.Issue, error) {


### PR DESCRIPTION
## Summary

- Adds `?label=<name>` query parameter filtering to the issues list in the web UI
- Each label badge in the issue rows is now a clickable link that sets `?label=<name>` to filter the list
- An active label filter shows as a dismissible chip (with ✕ to clear) above the issues table
- Open/closed tab switching preserves the active label filter
- The HTMX partial (`/ui/_/r/{owner}/{name}/issues`) also respects the `?label=` param
- `db.Store.ListIssues` gains a `labelFilter string` parameter using `$N = ANY(labels)` for PostgreSQL array containment
- All interfaces, mocks, and fakes updated to match the new signature
- Also fixes pre-existing build errors in `renderRepoSettingsPage` (missing `r *http.Request` args introduced in #335)

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` passes (all packages)
- [ ] Manual: visit `/ui/r/{owner}/{name}/issues`, click a label badge → list filters
- [ ] Manual: verify ✕ chip clears the label filter
- [ ] Manual: switching Open/Closed tabs preserves the label filter

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)