### PR TITLE
feat(ui): get-started empty state for new users (closes #332)

### DIFF
--- a/internal/ui/templates/repos.html
+++ b/internal/ui/templates/repos.html
@@ -18,6 +18,12 @@
   </a>
   {{end}}
 </div>
+{{else}}
+<div class="card" style="text-align:center; padding:32px; margin-bottom:24px">
+  <h2 style="margin-top:0">Get started</h2>
+  <p style="color:var(--text-dim)">You don't belong to any orgs yet. Create one to start hosting repos.</p>
+  <a href="/ui/orgs/new"><button>Create your first org</button></a>
+</div>
 {{end}}
 {{if .Orgs}}
 <h2>All orgs</h2>


### PR DESCRIPTION
## Summary

- When user has no org memberships on `/ui/` landing page, show a prominent **Get started** card linking to `/ui/orgs/new`
- Only `repos.html` template modified (6 line addition)
- Added `{{else}}` branch to the existing `{{if .MyOrgs}}` block

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./... -count=1` passes (except pre-existing `TestDockerSmoke` failure — Docker network cleanup error unrelated to this change)
- [ ] New users with no orgs see the Get started card on landing page
- [ ] Users with orgs continue to see their org list unchanged

## Notes

`TestDockerSmoke` in `internal/server` fails due to a Docker network cleanup error (`network has active endpoints`). This is a pre-existing infrastructure issue, not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)