### PR TITLE
feat(testutil): share postgres container across test packages via WithReuseByName

### DIFF
--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -35,6 +35,10 @@ func StartSharedPostgres() (adminDSN string, cleanup func(), err error) {
 
 	ctx := context.Background()
 
+	// WithReuseByName makes all test packages share a single persistent
+	// container. The first run starts it; subsequent runs reattach to the
+	// existing one. Ryuk automatically excludes reusable containers from its
+	// cleanup sweep, so the container stays up between test runs.
 	ctr, err := postgres.Run(ctx,
 		"postgres:16-alpine",
 		postgres.WithDatabase("postgres"),
@@ -47,6 +51,7 @@ func StartSharedPostgres() (adminDSN string, cleanup func(), err error) {
 				WithOccurrence(2).
 				WithStartupTimeout(30*time.Second),
 		),
+		testcontainers.WithReuseByName("docstore-test-postgres"),
 	)
 	if err != nil {
 		return "", func() {}, fmt.Errorf("start postgres container: %w", err)
@@ -54,15 +59,12 @@ func StartSharedPostgres() (adminDSN string, cleanup func(), err error) {
 
 	connStr, err := ctr.ConnectionString(ctx, "sslmode=disable")
 	if err != nil {
-		_ = ctr.Terminate(ctx)
 		return "", func() {}, fmt.Errorf("get connection string: %w", err)
 	}
 
-	return connStr, func() {
-		if termErr := ctr.Terminate(ctx); termErr != nil {
-			fmt.Fprintf(os.Stderr, "terminate postgres container: %v\n", termErr)
-		}
-	}, nil
+	// No-op cleanup: the container is persistent and shared across packages.
+	// Ryuk excludes reusable containers from automatic cleanup.
+	return connStr, func() {}, nil
 }
 
 // TestDBFromShared creates an isolated database from a shared admin DSN,


### PR DESCRIPTION
## Summary

- Add `testcontainers.WithReuseByName("docstore-test-postgres")` to `StartSharedPostgres()` so all 6 test packages that call it share a single persistent container instead of each spinning up a separate `postgres:16-alpine` testcontainer.
- Change the cleanup func to a no-op (`func() {}`) — reusable containers persist between runs; Ryuk automatically excludes them from cleanup sweeps.
- Add a comment explaining the lifecycle: first run starts the container, subsequent runs reattach.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All non-smoke tests pass: `go test ./... -count=1`
- `TestDockerSmoke` in `internal/server` is a pre-existing flake: it builds a Docker image and passes when run in isolation (65s) but can time out under heavy parallel load. This failure is not caused by this change — my change reduces Docker resource pressure by halving the number of postgres containers from 6 to 1.

## Notes

The `docstore-test-postgres` container remains running after the test suite completes. It can be removed manually with `docker rm -f docstore-test-postgres` if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)