### PR TITLE
fix(ui): auto-grant creator roles after CreateOrg and CreateRepo

### DIFF
--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -1712,6 +1712,10 @@ func (h *Handler) handleCreateOrg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := h.write.AddOrgMember(ctx, name, identity, model.OrgRoleOwner, identity); err != nil {
+		slog.Error("ui create org: add owner", "name", name, "identity", identity, "error", err)
+	}
+
 	http.Redirect(w, r, "/ui/o/"+name, http.StatusSeeOther)
 }
 
@@ -1768,6 +1772,10 @@ func (h *Handler) handleCreateRepo(w http.ResponseWriter, r *http.Request) {
 			renderPage(owner, name, "Could not create repository: "+err.Error())
 		}
 		return
+	}
+
+	if err := h.write.SetRole(ctx, owner+"/"+name, identity, model.RoleAdmin); err != nil {
+		slog.Error("ui create repo: set admin role", "repo", owner+"/"+name, "identity", identity, "error", err)
 	}
 
 	http.Redirect(w, r, "/ui/r/"+owner+"/"+name, http.StatusSeeOther)


### PR DESCRIPTION
## Summary

Fixes #345.

The UI `handleCreateOrg` and `handleCreateRepo` handlers were missing the auto-grant calls that the API handlers (`internal/server/handlers_orgs.go` and `internal/server/handlers_repos.go`) already had:

- **handleCreateOrg**: after a successful `CreateOrg`, now calls `AddOrgMember` to grant the creator `owner` role — matching `server.handleCreateOrg` line 50.
- **handleCreateRepo**: after a successful `CreateRepo`, now calls `SetRole` to grant the creator `admin` role — matching `server.handleCreateRepo` line 57.

Both methods (`AddOrgMember`, `SetRole`) are already part of the `WriteStoreLite` interface so no interface changes were needed.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)