### PR TITLE
fix(ui): fix template type errors and add templatecheck regression test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/google/safehtml v0.0.2 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
 	github.com/googleapis/gax-go/v2 v2.21.0 // indirect
@@ -88,6 +89,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/in-toto/attestation v1.1.2 // indirect
 	github.com/in-toto/in-toto-golang v0.10.0 // indirect
+	github.com/jba/templatecheck v0.7.1 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.4 // indirect
 	github.com/lestrrat-go/dsig v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,8 @@ github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9
 github.com/google/martian/v3 v3.3.3/go.mod h1:iEPrYcgCF7jA9OtScMFQyAlZZ4YXTKEtJ1E6RWzmBA0=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
+github.com/google/safehtml v0.0.2 h1:ZOt2VXg4x24bW0m2jtzAOkhoXV0iM8vNKc0paByCZqM=
+github.com/google/safehtml v0.0.2/go.mod h1:L4KWwDsUJdECRAEpZoBn3O64bQaywRscowZjJAzjHnU=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -230,6 +232,8 @@ github.com/jackc/pgx/v5 v5.5.4 h1:Xp2aQS8uXButQdnCMWNmvx6UysWQQC+u1EoizjguY+8=
 github.com/jackc/pgx/v5 v5.5.4/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiwgm1A=
 github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
 github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
+github.com/jba/templatecheck v0.7.1 h1:yOEIFazBEwzdTPYHZF3Pm81NF1ksxx1+vJncSEwvjKc=
+github.com/jba/templatecheck v0.7.1/go.mod h1:n1Etw+Rrw1mDDD8dDRsEKTwMZsJ98EkktgNJC6wLUGo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -417,7 +417,10 @@ func shortHash(s string) string {
 // "ok" is reserved for genuine success states (passed, approved); lifecycle
 // states like "active" and "merged" map to "neutral" so they don't compete
 // visually with the mergeable verdict on the branch detail page.
-func statusClass(s string) string {
+// Accepts any value so templates can pass named string types (e.g. OrgRole)
+// without an explicit fmt.Sprint conversion.
+func statusClass(v any) string {
+	s := fmt.Sprint(v)
 	switch strings.ToLower(s) {
 	case "passed", "approved", "open":
 		return "ok"

--- a/internal/ui/templatecheck_test.go
+++ b/internal/ui/templatecheck_test.go
@@ -1,0 +1,151 @@
+package ui
+
+import (
+	"html/template"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/store"
+	"github.com/jba/templatecheck"
+)
+
+// TestTemplateTypes runs templatecheck against every parsed template to catch
+// type errors—missing fields, wrong argument types, invalid slice/index ops—at
+// test time rather than at runtime.  The subtests mirror the templateSet fields
+// so that a single failing template is easy to identify.
+//
+// Keep this file alongside the templates as a permanent regression guard:
+// template changes that introduce type errors will be caught here first.
+func TestTemplateTypes(t *testing.T) {
+	tmpl, err := parseTemplates(templatesFS)
+	if err != nil {
+		t.Fatalf("parseTemplates: %v", err)
+	}
+
+	check := func(t *testing.T, tmpl *template.Template, data any) {
+		t.Helper()
+		if err := templatecheck.CheckHTML(tmpl, data); err != nil {
+			t.Error(err)
+		}
+	}
+
+	// Helper to build a pageData wrapper around a concrete body type.
+	// The Body field is `any`, so passing the concrete value lets templatecheck
+	// follow types through {{with .Body}} blocks.
+	page := func(body any) pageData { return pageData{Body: body} }
+
+	t.Run("repos", func(t *testing.T) {
+		check(t, tmpl.repos, page(reposPage{}))
+	})
+	t.Run("branches", func(t *testing.T) {
+		check(t, tmpl.branches, page(branchesPage{}))
+	})
+	t.Run("branch_detail", func(t *testing.T) {
+		check(t, tmpl.branchDetail, page(branchDetailPage{
+			Ctx: &model.AgentContextResponse{},
+		}))
+	})
+	t.Run("branch_checks", func(t *testing.T) {
+		check(t, tmpl.branchChecks, &model.AgentContextResponse{
+			CheckRuns: []model.CheckRun{},
+		})
+	})
+	t.Run("check_history", func(t *testing.T) {
+		check(t, tmpl.checkHistory, []model.CheckRun{})
+	})
+	t.Run("review_comments", func(t *testing.T) {
+		check(t, tmpl.reviewComments, reviewCommentsData{})
+	})
+	t.Run("file", func(t *testing.T) {
+		check(t, tmpl.fileView, page(filePage{}))
+	})
+	t.Run("error", func(t *testing.T) {
+		check(t, tmpl.errorPage, pageData{})
+	})
+	t.Run("commit_log", func(t *testing.T) {
+		check(t, tmpl.commitLog, page(logPage{
+			Repo: model.Repo{},
+		}))
+	})
+	t.Run("log_rows", func(t *testing.T) {
+		check(t, tmpl.logRows, logRowsData{})
+	})
+	t.Run("commit_detail", func(t *testing.T) {
+		check(t, tmpl.commitDetail, page(commitDetailPage{
+			Commit: &store.CommitDetail{},
+		}))
+	})
+	t.Run("issues", func(t *testing.T) {
+		check(t, tmpl.issues, page(issuesPage{}))
+	})
+	t.Run("issues_rows", func(t *testing.T) {
+		check(t, tmpl.issuesRows, issuesPage{})
+	})
+	t.Run("issue_detail", func(t *testing.T) {
+		check(t, tmpl.issueDetail, page(issueDetailPage{
+			Issue: &model.Issue{},
+		}))
+	})
+	t.Run("new_issue", func(t *testing.T) {
+		check(t, tmpl.newIssue, page(newIssuePage{}))
+	})
+	t.Run("accept_invite", func(t *testing.T) {
+		check(t, tmpl.acceptInvite, page(acceptInvitePage{}))
+	})
+	t.Run("org", func(t *testing.T) {
+		// org.html passes model.OrgRole to statusClass — fixed by accepting any.
+		check(t, tmpl.org, page(orgPage{
+			Members: []model.OrgMember{{Role: model.OrgRoleMember}},
+			Invites: []model.OrgInvite{{Role: model.OrgRoleMember}},
+		}))
+	})
+	t.Run("proposals", func(t *testing.T) {
+		check(t, tmpl.proposals, page(proposalsPage{}))
+	})
+	t.Run("proposals_rows", func(t *testing.T) {
+		check(t, tmpl.proposalsRows, []*model.Proposal{})
+	})
+	t.Run("proposal_detail", func(t *testing.T) {
+		check(t, tmpl.proposalDetail, page(proposalDetailPage{
+			Proposal: &model.Proposal{},
+		}))
+	})
+	t.Run("releases", func(t *testing.T) {
+		check(t, tmpl.releases, page(releasesPage{}))
+	})
+	t.Run("release_detail", func(t *testing.T) {
+		check(t, tmpl.releaseDetail, page(releaseDetailPage{
+			Release: &model.Release{},
+		}))
+	})
+	t.Run("ci_jobs", func(t *testing.T) {
+		check(t, tmpl.ciJobs, page(ciJobsPage{
+			Jobs: []model.CIJob{},
+		}))
+	})
+	t.Run("ci_job_detail", func(t *testing.T) {
+		// ci_job_detail uses {{printf "%.8s" .Job.ID}} — fixed from {{slice .Job.ID 0 8}}
+		// which templatecheck couldn't resolve through the CIJob type alias pointer.
+		check(t, tmpl.ciJobDetail, page(ciJobDetailPage{
+			Job: &model.CIJob{ID: "abcdefgh-1234"},
+		}))
+	})
+	t.Run("create_org", func(t *testing.T) {
+		check(t, tmpl.createOrg, page(createOrgPage{}))
+	})
+	t.Run("create_repo", func(t *testing.T) {
+		check(t, tmpl.createRepo, page(createRepoPage{}))
+	})
+	t.Run("new_commit", func(t *testing.T) {
+		check(t, tmpl.newCommit, page(commitFormPage{}))
+	})
+	t.Run("repo_settings", func(t *testing.T) {
+		check(t, tmpl.repoSettings, page(repoSettingsPage{}))
+	})
+	t.Run("user_profile", func(t *testing.T) {
+		// user.html passes model.OrgRole to statusClass — fixed by accepting any.
+		check(t, tmpl.userProfile, page(userProfilePage{
+			Memberships: []model.OrgMember{{Role: model.OrgRoleMember}},
+		}))
+	})
+}

--- a/internal/ui/templates/branch_checks.html
+++ b/internal/ui/templates/branch_checks.html
@@ -20,7 +20,7 @@
 </div>
 {{end}}
 {{end}}
-{{if gt $passed 0}}
+{{if $passed}}
 <div class="checks-collapsed">
   <span class="badge ok">{{$passed}} passed</span>
   <span style="margin-left:8px">

--- a/internal/ui/templates/ci_job_detail.html
+++ b/internal/ui/templates/ci_job_detail.html
@@ -11,7 +11,7 @@
 </nav>
 
 <div class="headline">
-  <h1>CI Job {{slice .Job.ID 0 8}}</h1>
+  <h1>CI Job {{printf "%.8s" .Job.ID}}</h1>
   <span class="badge {{statusClass .Job.Status}}">{{.Job.Status}}</span>
 </div>
 


### PR DESCRIPTION
## Summary

- **statusClass type mismatch**: `statusClass(s string)` was called with `model.OrgRole` (a named type `type OrgRole string`, not `string`) in `org.html` and `user.html`. This caused a `reflect.Value.Call` type mismatch at runtime on `/ui/o/<org>` and `/ui/u/<identity>`. Fixed by changing to `statusClass(v any)` with `fmt.Sprint` internally.

- **branch_checks.html false positive**: `{{if gt $passed 0}}` after `$passed = add $passed 1` — templatecheck loses track of the type returned by the custom `add` function. Fixed by replacing with `{{if $passed}}` (integer 0 is falsy in Go templates, no typed comparison needed).

- **ci_job_detail.html false positive**: `{{slice .Job.ID 0 8}}` — templatecheck cannot resolve fields through the `CIJob` type alias pointer (`type CIJob = api.CIJob`). Fixed by replacing with `{{printf "%.8s" .Job.ID}}`.

Adds `internal/ui/templatecheck_test.go` with `TestTemplateTypes` (29 subtests, one per template) using `github.com/jba/templatecheck` as a permanent regression guard.

## Test plan

- [x] `go test ./internal/ui/ -run TestTemplateTypes` — all 29 subtests green
- [x] `go test ./... -count=1` — all tests pass
- [x] `go build ./... && go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)