### PR TITLE
fix(ui): fix org.html production crash and strengthen templatecheck coverage

### DIFF
--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -271,10 +271,15 @@ func (h *Handler) render(w http.ResponseWriter, r *http.Request, t *template.Tem
 // renderError renders the error page with the given status.
 func (h *Handler) renderError(w http.ResponseWriter, r *http.Request, status int, message string) {
 	var buf bytes.Buffer
+	title := fmt.Sprintf("%d %s", status, http.StatusText(status))
 	data := pageData{
-		Title: fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Title: title,
 		Err: errorInfo{
 			Status:  status,
+			Message: message,
+		},
+		Body: errorBody{
+			Title:   title,
 			Message: message,
 		},
 	}
@@ -309,6 +314,12 @@ type crumb struct {
 
 type errorInfo struct {
 	Status  int
+	Message string
+}
+
+// errorBody is the concrete body type passed to the error page content template.
+type errorBody struct {
+	Title   string
 	Message string
 }
 

--- a/internal/ui/templatecheck_test.go
+++ b/internal/ui/templatecheck_test.go
@@ -14,6 +14,11 @@ import (
 // test time rather than at runtime.  The subtests mirror the templateSet fields
 // so that a single failing template is easy to identify.
 //
+// Each page template's "content" sub-template is checked directly with its
+// concrete page type so that templatecheck can follow types through the full
+// template body. Fragment templates that don't use the layout are checked with
+// their own data type directly.
+//
 // Keep this file alongside the templates as a permanent regression guard:
 // template changes that introduce type errors will be caught here first.
 func TestTemplateTypes(t *testing.T) {
@@ -29,21 +34,23 @@ func TestTemplateTypes(t *testing.T) {
 		}
 	}
 
-	// Helper to build a pageData wrapper around a concrete body type.
-	// The Body field is `any`, so passing the concrete value lets templatecheck
-	// follow types through {{with .Body}} blocks.
-	page := func(body any) pageData { return pageData{Body: body} }
+	// layout checks the layout-level fields (.Title, .Breadcrumbs, .Identity)
+	// with an empty pageData. The body is nil/unknown so content is unchecked
+	// here; each page's content is checked separately below.
+	t.Run("layout", func(t *testing.T) {
+		check(t, tmpl.repos, pageData{})
+	})
 
 	t.Run("repos", func(t *testing.T) {
-		check(t, tmpl.repos, page(reposPage{}))
+		check(t, tmpl.repos.Lookup("content"), reposPage{})
 	})
 	t.Run("branches", func(t *testing.T) {
-		check(t, tmpl.branches, page(branchesPage{}))
+		check(t, tmpl.branches.Lookup("content"), branchesPage{})
 	})
 	t.Run("branch_detail", func(t *testing.T) {
-		check(t, tmpl.branchDetail, page(branchDetailPage{
+		check(t, tmpl.branchDetail.Lookup("content"), branchDetailPage{
 			Ctx: &model.AgentContextResponse{},
-		}))
+		})
 	})
 	t.Run("branch_checks", func(t *testing.T) {
 		check(t, tmpl.branchChecks, &model.AgentContextResponse{
@@ -57,95 +64,91 @@ func TestTemplateTypes(t *testing.T) {
 		check(t, tmpl.reviewComments, reviewCommentsData{})
 	})
 	t.Run("file", func(t *testing.T) {
-		check(t, tmpl.fileView, page(filePage{}))
+		check(t, tmpl.fileView.Lookup("content"), filePage{})
 	})
 	t.Run("error", func(t *testing.T) {
-		check(t, tmpl.errorPage, pageData{})
+		check(t, tmpl.errorPage.Lookup("content"), errorBody{})
 	})
 	t.Run("commit_log", func(t *testing.T) {
-		check(t, tmpl.commitLog, page(logPage{
+		check(t, tmpl.commitLog.Lookup("content"), logPage{
 			Repo: model.Repo{},
-		}))
+		})
 	})
 	t.Run("log_rows", func(t *testing.T) {
 		check(t, tmpl.logRows, logRowsData{})
 	})
 	t.Run("commit_detail", func(t *testing.T) {
-		check(t, tmpl.commitDetail, page(commitDetailPage{
+		check(t, tmpl.commitDetail.Lookup("content"), commitDetailPage{
 			Commit: &store.CommitDetail{},
-		}))
+		})
 	})
 	t.Run("issues", func(t *testing.T) {
-		check(t, tmpl.issues, page(issuesPage{}))
+		check(t, tmpl.issues.Lookup("content"), issuesPage{})
 	})
 	t.Run("issues_rows", func(t *testing.T) {
 		check(t, tmpl.issuesRows, issuesPage{})
 	})
 	t.Run("issue_detail", func(t *testing.T) {
-		check(t, tmpl.issueDetail, page(issueDetailPage{
+		check(t, tmpl.issueDetail.Lookup("content"), issueDetailPage{
 			Issue: &model.Issue{},
-		}))
+		})
 	})
 	t.Run("new_issue", func(t *testing.T) {
-		check(t, tmpl.newIssue, page(newIssuePage{}))
+		check(t, tmpl.newIssue.Lookup("content"), newIssuePage{})
 	})
 	t.Run("accept_invite", func(t *testing.T) {
-		check(t, tmpl.acceptInvite, page(acceptInvitePage{}))
+		check(t, tmpl.acceptInvite.Lookup("content"), acceptInvitePage{})
 	})
 	t.Run("org", func(t *testing.T) {
-		// org.html passes model.OrgRole to statusClass — fixed by accepting any.
-		check(t, tmpl.org, page(orgPage{
+		check(t, tmpl.org.Lookup("content"), orgPage{
 			Members: []model.OrgMember{{Role: model.OrgRoleMember}},
 			Invites: []model.OrgInvite{{Role: model.OrgRoleMember}},
-		}))
+		})
 	})
 	t.Run("proposals", func(t *testing.T) {
-		check(t, tmpl.proposals, page(proposalsPage{}))
+		check(t, tmpl.proposals.Lookup("content"), proposalsPage{})
 	})
 	t.Run("proposals_rows", func(t *testing.T) {
 		check(t, tmpl.proposalsRows, []*model.Proposal{})
 	})
 	t.Run("proposal_detail", func(t *testing.T) {
-		check(t, tmpl.proposalDetail, page(proposalDetailPage{
+		check(t, tmpl.proposalDetail.Lookup("content"), proposalDetailPage{
 			Proposal: &model.Proposal{},
-		}))
+		})
 	})
 	t.Run("releases", func(t *testing.T) {
-		check(t, tmpl.releases, page(releasesPage{}))
+		check(t, tmpl.releases.Lookup("content"), releasesPage{})
 	})
 	t.Run("release_detail", func(t *testing.T) {
-		check(t, tmpl.releaseDetail, page(releaseDetailPage{
+		check(t, tmpl.releaseDetail.Lookup("content"), releaseDetailPage{
 			Release: &model.Release{},
-		}))
+		})
 	})
 	t.Run("ci_jobs", func(t *testing.T) {
-		check(t, tmpl.ciJobs, page(ciJobsPage{
+		check(t, tmpl.ciJobs.Lookup("content"), ciJobsPage{
 			Jobs: []model.CIJob{},
-		}))
+		})
 	})
 	t.Run("ci_job_detail", func(t *testing.T) {
-		// ci_job_detail uses {{printf "%.8s" .Job.ID}} — fixed from {{slice .Job.ID 0 8}}
-		// which templatecheck couldn't resolve through the CIJob type alias pointer.
-		check(t, tmpl.ciJobDetail, page(ciJobDetailPage{
+		check(t, tmpl.ciJobDetail.Lookup("content"), ciJobDetailPage{
 			Job: &model.CIJob{ID: "abcdefgh-1234"},
-		}))
+		})
 	})
 	t.Run("create_org", func(t *testing.T) {
-		check(t, tmpl.createOrg, page(createOrgPage{}))
+		check(t, tmpl.createOrg.Lookup("content"), createOrgPage{})
 	})
 	t.Run("create_repo", func(t *testing.T) {
-		check(t, tmpl.createRepo, page(createRepoPage{}))
+		check(t, tmpl.createRepo.Lookup("content"), createRepoPage{})
 	})
 	t.Run("new_commit", func(t *testing.T) {
-		check(t, tmpl.newCommit, page(commitFormPage{}))
+		check(t, tmpl.newCommit.Lookup("content"), commitFormPage{})
 	})
 	t.Run("repo_settings", func(t *testing.T) {
-		check(t, tmpl.repoSettings, page(repoSettingsPage{}))
+		check(t, tmpl.repoSettings.Lookup("content"), repoSettingsPage{})
 	})
 	t.Run("user_profile", func(t *testing.T) {
-		// user.html passes model.OrgRole to statusClass — fixed by accepting any.
-		check(t, tmpl.userProfile, page(userProfilePage{
+		check(t, tmpl.userProfile.Lookup("content"), userProfilePage{
 			Memberships: []model.OrgMember{{Role: model.OrgRoleMember}},
-		}))
+		})
 	})
 }

--- a/internal/ui/templates/accept_invite.html
+++ b/internal/ui/templates/accept_invite.html
@@ -1,6 +1,5 @@
 {{define "content"}}
 <h1>Accept invitation</h1>
-{{with .Body}}
 <div class="card">
   <div class="row"><strong>Organisation</strong> {{.Org}}</div>
   <div class="row"><strong>Role</strong> <span class="badge neutral">{{.Role}}</span></div>
@@ -13,5 +12,4 @@
   </form>
   {{end}}
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/branch_detail.html
+++ b/internal/ui/templates/branch_detail.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 {{$ctx := .Ctx}}
 {{$page := .}}
 <div class="headline">
@@ -267,5 +266,4 @@
   </table>
   {{end}}
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/branches.html
+++ b/internal/ui/templates/branches.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 <div class="headline"><h1>{{.Repo.Name}}</h1><span class="meta">owner {{.Repo.Owner}} · {{relTime .Repo.CreatedAt}} · <a href="/repos/{{.Repo.Name}}/-/archive">download archive</a></span></div>
 
 <nav class="repo-tabs">
@@ -56,8 +55,6 @@
   {{end}}
 </div>
 {{end}}
-{{end}}
-
 {{define "branchSection"}}
 <h2>{{.Title}} ({{len .Rows}})</h2>
 <div class="card">

--- a/internal/ui/templates/ci_job_detail.html
+++ b/internal/ui/templates/ci_job_detail.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 <nav class="repo-tabs">
   <a href="/ui/r/{{.Repo.Name}}">branches</a>
   <a href="/ui/r/{{.Repo.Name}}/issues">issues</a>
@@ -94,5 +93,4 @@
   </div>
   {{end}}
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/ci_jobs.html
+++ b/internal/ui/templates/ci_jobs.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 <div class="headline">
   <h1>{{.Repo.Name}} / ci-jobs</h1>
   <span class="meta">owner {{.Repo.Owner}}</span>
@@ -51,5 +50,4 @@
 </table>
 {{end}}
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/commit.html
+++ b/internal/ui/templates/commit.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 {{$page := .}}
 <div class="headline">
   <h1>commit {{.Commit.Sequence}}</h1>
@@ -33,5 +32,4 @@
   </table>
   {{end}}
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/create_org.html
+++ b/internal/ui/templates/create_org.html
@@ -1,6 +1,5 @@
 {{define "content"}}
 <h1>New organisation</h1>
-{{with .Body}}
 <div class="card">
   {{if .Err}}
   <div class="row"><span class="badge bad">{{.Err}}</span></div>
@@ -16,5 +15,4 @@
     </div>
   </form>
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/create_repo.html
+++ b/internal/ui/templates/create_repo.html
@@ -1,6 +1,5 @@
 {{define "content"}}
 <h1>New repository</h1>
-{{with .Body}}
 <div class="card">
   {{if .Err}}
   <div class="row"><span class="badge bad">{{.Err}}</span></div>
@@ -13,7 +12,7 @@
       <select id="owner" name="owner" style="margin-left:8px" required>
         <option value="">— select —</option>
         {{range .Orgs}}
-        <option value="{{.Name}}"{{if eq $.Body.Owner .Name}} selected{{end}}>{{.Name}}</option>
+        <option value="{{.Name}}"{{if eq $.Owner .Name}} selected{{end}}>{{.Name}}</option>
         {{end}}
       </select>
       {{else}}
@@ -29,5 +28,4 @@
     </div>
   </form>
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/error.html
+++ b/internal/ui/templates/error.html
@@ -1,7 +1,9 @@
 {{define "content"}}
+{{if .}}
 <div class="err-box">
   <h1>{{.Title}}</h1>
-  <p>{{.Err.Message}}</p>
+  <p>{{.Message}}</p>
   <p><a href="/ui/">back to repos</a></p>
 </div>
+{{end}}
 {{end}}

--- a/internal/ui/templates/file.html
+++ b/internal/ui/templates/file.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 {{$page := .}}
 <div class="headline">
   <h1>{{$page.Repo.Name}} <span class="meta">{{$page.Branch}}:{{$page.Path}}</span></h1>
@@ -56,5 +55,4 @@
     {{end}}
   </div>
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/issue_detail.html
+++ b/internal/ui/templates/issue_detail.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 {{$d := .}}
 <nav class="repo-tabs">
   <a href="/ui/r/{{.Repo.Name}}">branches</a>
@@ -152,5 +151,4 @@
   </div>
 </details>
 
-{{end}}
 {{end}}

--- a/internal/ui/templates/issues.html
+++ b/internal/ui/templates/issues.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 <div class="headline">
   <h1>{{.Repo.Name}} / issues</h1>
   <a href="/ui/r/{{.Repo.Name}}/issues/new" class="btn">New Issue</a>
@@ -35,5 +34,4 @@
 <div id="issues-table">
   {{template "issues_rows.html" .}}
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/layout.html
+++ b/internal/ui/templates/layout.html
@@ -19,7 +19,7 @@
   <button class="theme-toggle" data-theme-toggle type="button" aria-label="Toggle theme" title="Toggle theme"><span data-theme-icon-dark>☾</span><span data-theme-icon-light>☀</span></button>
 </nav>
 <main>
-{{block "content" .}}{{end}}
+{{block "content" .Body}}{{end}}
 </main>
 </body>
 </html>{{end}}

--- a/internal/ui/templates/log.html
+++ b/internal/ui/templates/log.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 <div class="headline">
   <h1>{{.Repo.Name}} / {{.Branch}} / log</h1>
 </div>
@@ -16,5 +15,4 @@
   </table>
   {{end}}
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/new_commit.html
+++ b/internal/ui/templates/new_commit.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 <div class="headline">
   <h1>New commit — {{.Branch}}</h1>
   <span class="meta">{{.Repo.Name}}</span>
@@ -34,5 +33,4 @@
     <a href="/ui/r/{{.Repo.Name}}/b/{{urlPathEscape .Branch}}" style="margin-left:12px;font-size:12px">cancel</a>
   </form>
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/new_issue.html
+++ b/internal/ui/templates/new_issue.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 <nav class="repo-tabs">
   <a href="/ui/r/{{.Repo.Name}}">branches</a>
   <a href="/ui/r/{{.Repo.Name}}/issues" class="active">issues</a>
@@ -37,5 +36,4 @@
     <a href="/ui/r/{{.Repo.Name}}/issues" style="margin-left:12px;font-size:12px">cancel</a>
   </form>
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/org.html
+++ b/internal/ui/templates/org.html
@@ -1,5 +1,5 @@
 {{define "content"}}
-{{with .Body}}
+{{- $org := .Org -}}
 <div class="headline"><h1>{{.Org}}</h1></div>
 
 {{if .Err}}
@@ -39,7 +39,7 @@
       <td>{{.InvitedBy}}</td>
       <td>{{relTime .CreatedAt}}</td>
       <td>
-        <form method="POST" action="/ui/o/{{$.Org}}/members/{{.Identity}}/remove" style="display:inline">
+        <form method="POST" action="/ui/o/{{$org}}/members/{{.Identity}}/remove" style="display:inline">
           {{csrfField}}
           <button type="submit" class="btn-danger-small">remove</button>
         </form>
@@ -78,7 +78,7 @@
       <td>{{.InvitedBy}}</td>
       <td>{{relTime .ExpiresAt}}</td>
       <td>
-        <form method="POST" action="/ui/o/{{$.Org}}/invites/{{.ID}}/revoke" style="display:inline">
+        <form method="POST" action="/ui/o/{{$org}}/invites/{{.ID}}/revoke" style="display:inline">
           {{csrfField}}
           <button type="submit" class="btn-danger-small">revoke</button>
         </form>
@@ -117,5 +117,4 @@
     </form>
   </details>
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/proposal_detail.html
+++ b/internal/ui/templates/proposal_detail.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 <nav class="repo-tabs">
   <a href="/ui/r/{{.Repo.Name}}">branches</a>
   <a href="/ui/r/{{.Repo.Name}}/issues">issues</a>
@@ -73,6 +72,5 @@
     <button type="submit" class="btn">Close proposal</button>
   </form>
 </div>
-{{end}}
 {{end}}
 {{end}}

--- a/internal/ui/templates/proposals.html
+++ b/internal/ui/templates/proposals.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 <div class="headline">
   <h1>{{.Repo.Name}} / proposals</h1>
   <span class="meta">owner {{.Repo.Owner}}</span>
@@ -63,5 +62,4 @@
     <button type="submit" class="btn">Create proposal</button>
   </form>
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/release_detail.html
+++ b/internal/ui/templates/release_detail.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 <nav class="repo-tabs">
   <a href="/ui/r/{{.Repo.Name}}">branches</a>
   <a href="/ui/r/{{.Repo.Name}}/issues">issues</a>
@@ -50,5 +49,4 @@
     <button type="submit" class="btn-danger">Delete release</button>
   </form>
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/releases.html
+++ b/internal/ui/templates/releases.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 <div class="headline">
   <h1>{{.Repo.Name}} / releases</h1>
   <span class="meta">owner {{.Repo.Owner}}</span>
@@ -59,5 +58,4 @@
     <button type="submit" class="btn">Create release</button>
   </form>
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/repos.html
+++ b/internal/ui/templates/repos.html
@@ -1,6 +1,5 @@
 {{define "content"}}
 <h1>Repos</h1>
-{{with .Body}}
 <div style="margin-bottom:12px">
   <a href="/ui/orgs/new"><button>New org</button></a>
   <a href="/ui/repos/new" style="margin-left:8px"><button>New repo</button></a>
@@ -42,6 +41,5 @@
 {{end}}
 {{else}}
 <div class="card empty">No repos yet.</div>
-{{end}}
 {{end}}
 {{end}}

--- a/internal/ui/templates/settings.html
+++ b/internal/ui/templates/settings.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 <div class="headline"><h1>{{.Repo.Name}}</h1><span class="meta">owner {{.Repo.Owner}} · {{relTime .Repo.CreatedAt}}</span></div>
 
 <nav class="repo-tabs">
@@ -71,5 +70,4 @@
     </form>
   </details>
 </div>
-{{end}}
 {{end}}

--- a/internal/ui/templates/user.html
+++ b/internal/ui/templates/user.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{with .Body}}
 <div class="headline"><h1>{{.Identity}}</h1></div>
 
 <h2>Org memberships ({{len .Memberships}})</h2>
@@ -41,5 +40,4 @@
   </table>
   {{end}}
 </div>
-{{end}}
 {{end}}


### PR DESCRIPTION
## Summary

- **Issue 1 (production crash)**: `org.html` used `{{$.Org}}` inside `{{range .Members}}` and `{{range .Invites}}`. Inside those range loops, `$` was `pageData` (the root data passed to `Execute`), which has no `Org` field — causing a template execution panic on `/ui/o/*` in production.
- **Issue 2 (test coverage gap)**: `templatecheck_test.go` passed page data as `pageData{Body: <concrete>}`, but since `Body` is `any`, templatecheck stopped checking at the `{{with .Body}}` boundary. The entire content block was unchecked, which is why the `$.Org` crash was never caught by tests.

## Changes

**Root fix — restructure template/layout boundary:**
- `layout.html`: `{{block "content" .}}` → `{{block "content" .Body}}` — the layout now passes the concrete body value directly to content blocks
- All 22 page templates: removed `{{with .Body}}` wrapper — content blocks now receive the concrete page type as dot, so templatecheck can fully type-check them
- `org.html`: added `{{$org := .Org}}` at the top and replaced `{{$.Org}}` with `{{$org}}` in range loops (explicit capture, clear intent)
- `create_repo.html`: `{{$.Body.Owner}}` → `{{$.Owner}}` (`$` is now `createRepoPage`)
- `error.html`: updated to use `errorBody.Title` / `errorBody.Message` (new concrete body type)
- `render.go`: added `errorBody` struct; `renderError` now populates `Body: errorBody{...}`

**Test improvement:**
- `templatecheck_test.go`: each page template now checked via `tmpl.xxx.Lookup("content")` with the concrete page type — templatecheck has full type visibility into the content block
- Fragment templates (branchChecks, checkHistory, logRows, etc.) remain checked with their own data types as before
- New `layout` sub-test uses `pageData{}` on the full template to catch layout-level field errors (Title, Breadcrumbs, Identity)

## Test plan

- [x] `go test ./internal/ui/ -run TestTemplateTypes -v` — all 31 sub-tests pass
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — passes; `TestDockerSmoke` failure in `internal/server` is a pre-existing Docker infrastructure issue unrelated to this change

## Notes / future opportunities

- The `{{with .Body}}` wrapper was a pattern that made content blocks opaque to static analysis. This PR removes it; going forward, new page templates should receive the concrete page type directly (no wrapper needed).
- `$.Body.Owner` in `create_repo.html` was another latent bug of the same class (accessing `any` via `$`); fixed here as a side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)