### PR TITLE
feat(auth): implement IAP authentication for ds CLI (closes #351)

### DIFF
--- a/cmd/docstore/main.go
+++ b/cmd/docstore/main.go
@@ -26,6 +26,8 @@ import (
 func main() {
 	devIdentity := flag.String("dev-identity", "", "bypass IAP JWT validation and use this identity (local dev/testing only)")
 	bootstrapAdmin := flag.String("bootstrap-admin", "", "identity granted admin access to repos with no admin assigned yet")
+	iapClientID := flag.String("iap-client-id", "", "IAP OAuth client ID advertised via /.well-known/ds-config (overrides IAP_CLIENT_ID env var)")
+	iapClientSecret := flag.String("iap-client-secret", "", "IAP OAuth client secret advertised via /.well-known/ds-config (overrides IAP_CLIENT_SECRET env var)")
 	flag.Parse()
 
 	// Set up structured logger based on LOG_FORMAT and LOG_LEVEL env vars.
@@ -53,6 +55,12 @@ func main() {
 	}
 	if *bootstrapAdmin == "" {
 		*bootstrapAdmin = os.Getenv("BOOTSTRAP_ADMIN")
+	}
+	if *iapClientID == "" {
+		*iapClientID = os.Getenv("IAP_CLIENT_ID")
+	}
+	if *iapClientSecret == "" {
+		*iapClientSecret = os.Getenv("IAP_CLIENT_SECRET")
 	}
 
 	if *devIdentity != "" {
@@ -135,7 +143,7 @@ func main() {
 	dispatchCtx, dispatchCancel := context.WithCancel(context.Background())
 	events.StartDispatcher(dispatchCtx, database, dsn, broker)
 
-	srv := server.NewWithBroker(commitStore, database, bs, broker, *devIdentity, *bootstrapAdmin)
+	srv := server.NewWithBroker(commitStore, database, bs, broker, *devIdentity, *bootstrapAdmin, *iapClientID, *iapClientSecret)
 
 	// Start the auto-merge worker. It subscribes to check.reported and
 	// review.submitted events and merges branches with auto_merge=true.

--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -105,7 +105,10 @@ commands:
   issues comment edit <number> <comment-id> --body <markdown>  Edit an issue comment
   issues refs <number>                                       List cross-refs for an issue
   issues tie <number> --proposal <uuid>                      Tie a proposal to an issue
-  issues tie <number> --commit <seq>                         Tie a commit to an issue`
+  issues tie <number> --commit <seq>                         Tie a commit to an issue
+
+  login [server-url]                                         Authenticate with the server (defaults to compiled-in remote)
+  logout [server-url]                                        Remove stored credentials for the server`
 
 func main() {
 	if len(os.Args) < 2 {
@@ -122,7 +125,7 @@ func main() {
 	app := &cli.App{
 		Dir:           dir,
 		Out:           os.Stdout,
-		HTTP:          http.DefaultClient,
+		HTTP:          &http.Client{Transport: cli.NewAuthTransport()},
 		DefaultRemote: defaultRemote,
 	}
 
@@ -1216,6 +1219,30 @@ func main() {
 				os.Exit(1)
 			}
 		}
+
+	case "login":
+		serverURL := defaultRemote
+		if len(args) >= 2 && !strings.HasPrefix(args[1], "--") {
+			serverURL = args[1]
+		}
+		if serverURL == "" {
+			fmt.Fprintln(os.Stderr, "usage: ds login [server-url]")
+			fmt.Fprintln(os.Stderr, "error: no server URL provided and no default compiled in")
+			os.Exit(1)
+		}
+		err = app.Login(serverURL)
+
+	case "logout":
+		serverURL := defaultRemote
+		if len(args) >= 2 && !strings.HasPrefix(args[1], "--") {
+			serverURL = args[1]
+		}
+		if serverURL == "" {
+			fmt.Fprintln(os.Stderr, "usage: ds logout [server-url]")
+			fmt.Fprintln(os.Stderr, "error: no server URL provided and no default compiled in")
+			os.Exit(1)
+		}
+		err = app.Logout(serverURL)
 
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", cmd)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
+	github.com/jba/templatecheck v0.7.1
 	github.com/lib/pq v1.12.3
 	github.com/moby/buildkit v0.29.0
 	github.com/moby/moby/api v1.54.1
@@ -20,6 +21,8 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
+	github.com/yuin/goldmark v1.8.2
+	golang.org/x/oauth2 v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -89,7 +92,6 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/in-toto/attestation v1.1.2 // indirect
 	github.com/in-toto/in-toto-golang v0.10.0 // indirect
-	github.com/jba/templatecheck v0.7.1 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.4 // indirect
 	github.com/lestrrat-go/dsig v1.0.0 // indirect
@@ -145,7 +147,6 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
-	github.com/yuin/goldmark v1.8.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.39.0 // indirect
@@ -163,7 +164,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -1,0 +1,365 @@
+package cli
+
+import (
+	cryptorand "crypto/rand"
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// Token holds OAuth2 credentials cached for a server URL.
+type Token struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	Expiry       time.Time `json:"expiry"`
+	ClientID     string    `json:"client_id"`
+	ClientSecret string    `json:"client_secret"`
+}
+
+type credStore map[string]*Token
+
+func credentialsFilePath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("get config dir: %w", err)
+	}
+	return filepath.Join(dir, "ds", "credentials.json"), nil
+}
+
+func readCredStore() (credStore, error) {
+	path, err := credentialsFilePath()
+	if err != nil {
+		return credStore{}, err
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return credStore{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read credentials: %w", err)
+	}
+	var cs credStore
+	if err := json.Unmarshal(data, &cs); err != nil {
+		return nil, fmt.Errorf("parse credentials: %w", err)
+	}
+	return cs, nil
+}
+
+func writeCredStore(cs credStore) error {
+	path, err := credentialsFilePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("create credentials directory: %w", err)
+	}
+	data, err := json.MarshalIndent(cs, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+// loadCreds returns cached credentials for serverURL, or nil if none.
+func loadCreds(serverURL string) (*Token, error) {
+	cs, err := readCredStore()
+	if err != nil {
+		return nil, err
+	}
+	return cs[serverURL], nil
+}
+
+// saveCreds stores credentials for serverURL.
+func saveCreds(serverURL string, tok *Token) error {
+	cs, err := readCredStore()
+	if err != nil {
+		cs = credStore{}
+	}
+	cs[serverURL] = tok
+	return writeCredStore(cs)
+}
+
+// deleteCreds removes credentials for serverURL.
+func deleteCreds(serverURL string) error {
+	cs, err := readCredStore()
+	if err != nil {
+		cs = credStore{}
+	}
+	delete(cs, serverURL)
+	return writeCredStore(cs)
+}
+
+// authTransport is an http.RoundTripper that injects Authorization: Bearer
+// headers for servers that have cached credentials. It refreshes expired tokens
+// automatically using the stored refresh token.
+type authTransport struct {
+	base http.RoundTripper
+	mu   sync.Mutex
+}
+
+// NewAuthTransport returns an http.RoundTripper that injects Bearer tokens
+// from the credential store when available. All existing CLI commands get auth
+// headers automatically when credentials are cached — no per-command changes needed.
+func NewAuthTransport() http.RoundTripper {
+	return &authTransport{base: http.DefaultTransport}
+}
+
+func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	serverURL := req.URL.Scheme + "://" + req.URL.Host
+
+	tok, err := loadCreds(serverURL)
+	if err != nil || tok == nil {
+		// No credentials — pass through without auth header.
+		return t.base.RoundTrip(req)
+	}
+
+	// Refresh token if expired or expiring within 30 seconds.
+	if !tok.Expiry.IsZero() && time.Now().After(tok.Expiry.Add(-30*time.Second)) && tok.RefreshToken != "" {
+		t.mu.Lock()
+		// Re-read under lock to avoid redundant refreshes from concurrent requests.
+		if tok2, loadErr := loadCreds(serverURL); loadErr == nil && tok2 != nil {
+			tok = tok2
+		}
+		if !tok.Expiry.IsZero() && time.Now().After(tok.Expiry.Add(-30*time.Second)) {
+			if refreshed, refreshErr := refreshOAuthToken(tok); refreshErr == nil {
+				tok = refreshed
+				_ = saveCreds(serverURL, tok) // best effort; failure is non-fatal
+			}
+		}
+		t.mu.Unlock()
+	}
+
+	reqCopy := req.Clone(req.Context())
+	reqCopy.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	return t.base.RoundTrip(reqCopy)
+}
+
+// refreshOAuthToken uses the stored refresh token to obtain a new access token.
+func refreshOAuthToken(tok *Token) (*Token, error) {
+	conf := &oauth2.Config{
+		ClientID:     tok.ClientID,
+		ClientSecret: tok.ClientSecret,
+		Endpoint:     google.Endpoint,
+	}
+	src := conf.TokenSource(context.Background(), &oauth2.Token{
+		AccessToken:  tok.AccessToken,
+		RefreshToken: tok.RefreshToken,
+		Expiry:       tok.Expiry,
+	})
+	newTok, err := src.Token()
+	if err != nil {
+		return nil, err
+	}
+	return &Token{
+		AccessToken:  newTok.AccessToken,
+		RefreshToken: newTok.RefreshToken,
+		Expiry:       newTok.Expiry,
+		ClientID:     tok.ClientID,
+		ClientSecret: tok.ClientSecret,
+	}, nil
+}
+
+// dsAuthConfig is the auth section of the /.well-known/ds-config response.
+type dsAuthConfig struct {
+	Type         string `json:"type"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+// dsServerConfig is the full /.well-known/ds-config response.
+type dsServerConfig struct {
+	Auth dsAuthConfig `json:"auth"`
+}
+
+// Login authenticates with the given server using the OAuth flow advertised
+// by the server's /.well-known/ds-config endpoint and stores the credentials.
+func (a *App) Login(serverURL string) error {
+	serverURL = strings.TrimRight(serverURL, "/")
+
+	resp, err := a.HTTP.Get(serverURL + "/.well-known/ds-config")
+	if err != nil {
+		return fmt.Errorf("fetch server config: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("server returned status %d for /.well-known/ds-config", resp.StatusCode)
+	}
+
+	var cfg dsServerConfig
+	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
+		return fmt.Errorf("parse server config: %w", err)
+	}
+
+	if cfg.Auth.Type == "none" || cfg.Auth.Type == "" {
+		fmt.Fprintln(a.Out, "Server does not require authentication")
+		return nil
+	}
+	if cfg.Auth.Type != "iap" {
+		return fmt.Errorf("unsupported auth type: %s", cfg.Auth.Type)
+	}
+	if cfg.Auth.ClientID == "" {
+		return fmt.Errorf("server did not provide client_id in auth config")
+	}
+
+	oauthTok, err := runOAuthDesktopFlow(cfg.Auth.ClientID, cfg.Auth.ClientSecret)
+	if err != nil {
+		return fmt.Errorf("oauth flow: %w", err)
+	}
+
+	// Extract email from ID token JWT (Google always returns one for openid scope).
+	email := ""
+	if idToken, ok := oauthTok.Extra("id_token").(string); ok && idToken != "" {
+		email, _ = jwtEmail(idToken)
+	}
+
+	tok := &Token{
+		AccessToken:  oauthTok.AccessToken,
+		RefreshToken: oauthTok.RefreshToken,
+		Expiry:       oauthTok.Expiry,
+		ClientID:     cfg.Auth.ClientID,
+		ClientSecret: cfg.Auth.ClientSecret,
+	}
+	if err := saveCreds(serverURL, tok); err != nil {
+		return fmt.Errorf("save credentials: %w", err)
+	}
+
+	if email != "" {
+		fmt.Fprintf(a.Out, "Logged in as %s\n", email)
+	} else {
+		fmt.Fprintln(a.Out, "Logged in successfully")
+	}
+	return nil
+}
+
+// Logout removes stored credentials for the given server.
+func (a *App) Logout(serverURL string) error {
+	serverURL = strings.TrimRight(serverURL, "/")
+	if err := deleteCreds(serverURL); err != nil {
+		return fmt.Errorf("delete credentials: %w", err)
+	}
+	fmt.Fprintf(a.Out, "Logged out from %s\n", serverURL)
+	return nil
+}
+
+// runOAuthDesktopFlow performs a browser-based OAuth 2.0 authorization code
+// flow and returns the resulting token.
+func runOAuthDesktopFlow(clientID, clientSecret string) (*oauth2.Token, error) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return nil, fmt.Errorf("listen for OAuth callback: %w", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	conf := &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  fmt.Sprintf("http://localhost:%d/callback", port),
+		Scopes:       []string{"openid", "email"},
+		Endpoint:     google.Endpoint,
+	}
+
+	stateBytes := make([]byte, 16)
+	if _, err := cryptorand.Read(stateBytes); err != nil {
+		return nil, fmt.Errorf("generate state: %w", err)
+	}
+	state := hex.EncodeToString(stateBytes)
+
+	authURL := conf.AuthCodeURL(state, oauth2.AccessTypeOffline)
+	fmt.Printf("Opening browser for authentication...\n")
+	fmt.Printf("If the browser does not open, visit:\n  %s\n", authURL)
+	openBrowser(authURL)
+
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("state"); got != state {
+			errCh <- fmt.Errorf("state mismatch in OAuth callback")
+			http.Error(w, "state mismatch", http.StatusBadRequest)
+			return
+		}
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			errCh <- fmt.Errorf("no authorization code in OAuth callback")
+			http.Error(w, "missing code", http.StatusBadRequest)
+			return
+		}
+		fmt.Fprintln(w, "Authentication successful! You can close this tab.")
+		codeCh <- code
+	})
+
+	cbSrv := &http.Server{Handler: mux}
+	go cbSrv.Serve(ln) //nolint:errcheck
+
+	var code string
+	select {
+	case code = <-codeCh:
+	case err = <-errCh:
+		cbSrv.Close()
+		return nil, err
+	case <-time.After(5 * time.Minute):
+		cbSrv.Close()
+		return nil, fmt.Errorf("timed out waiting for browser authentication")
+	}
+	cbSrv.Close()
+
+	tok, err := conf.Exchange(context.Background(), code)
+	if err != nil {
+		return nil, fmt.Errorf("exchange authorization code: %w", err)
+	}
+	return tok, nil
+}
+
+// openBrowser opens url in the user's default browser.
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", url)
+	default:
+		return
+	}
+	_ = cmd.Start()
+}
+
+// jwtEmail decodes a JWT payload (without verifying the signature) and
+// returns the "email" claim.
+func jwtEmail(token string) (string, error) {
+	parts := strings.SplitN(token, ".", 3)
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid JWT format")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decode JWT payload: %w", err)
+	}
+	var claims struct {
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("parse JWT claims: %w", err)
+	}
+	if claims.Email == "" {
+		return "", fmt.Errorf("no email claim in token")
+	}
+	return claims.Email, nil
+}

--- a/internal/server/dsconfig_test.go
+++ b/internal/server/dsconfig_test.go
@@ -1,0 +1,101 @@
+package server_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/server"
+)
+
+func TestDSConfigEndpoint_NoIAP(t *testing.T) {
+	// Server without IAP client ID configured.
+	h := server.NewWithReadStore(nil, nil, "dev@example.com", "")
+	req := httptest.NewRequest("GET", "/.well-known/ds-config", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	auth, ok := got["auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected auth object, got %T", got["auth"])
+	}
+	if auth["type"] != "none" {
+		t.Errorf("expected type=none, got %v", auth["type"])
+	}
+}
+
+func TestDSConfigEndpoint_WithIAP(t *testing.T) {
+	// Server with IAP client ID configured.
+	h := server.NewWithBroker(nil, nil, nil, nil, "dev@example.com", "", "test-client-id", "test-secret")
+	req := httptest.NewRequest("GET", "/.well-known/ds-config", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	auth, ok := got["auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected auth object, got %T", got["auth"])
+	}
+	if auth["type"] != "iap" {
+		t.Errorf("expected type=iap, got %v", auth["type"])
+	}
+	if auth["client_id"] != "test-client-id" {
+		t.Errorf("expected client_id=test-client-id, got %v", auth["client_id"])
+	}
+	if auth["client_secret"] != "test-secret" {
+		t.Errorf("expected client_secret=test-secret, got %v", auth["client_secret"])
+	}
+}
+
+func TestDSConfigEndpoint_WithIAPNoSecret(t *testing.T) {
+	// Server with IAP client ID but no client secret.
+	h := server.NewWithBroker(nil, nil, nil, nil, "dev@example.com", "", "test-client-id", "")
+	req := httptest.NewRequest("GET", "/.well-known/ds-config", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	auth, ok := got["auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected auth object, got %T", got["auth"])
+	}
+	if auth["type"] != "iap" {
+		t.Errorf("expected type=iap, got %v", auth["type"])
+	}
+	if _, has := auth["client_secret"]; has {
+		t.Errorf("expected no client_secret field when secret is empty")
+	}
+}
+
+func TestDSConfigEndpoint_Unauthenticated(t *testing.T) {
+	// Endpoint must be accessible without auth (no IAP token required).
+	// Use a server without dev identity — real IAP mode — and verify 200 (not 401).
+	h := server.NewWithBroker(nil, nil, nil, nil, "", "", "some-client-id", "")
+	req := httptest.NewRequest("GET", "/.well-known/ds-config", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (unauthenticated access allowed), got %d", w.Code)
+	}
+}

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -30,7 +30,7 @@ func newEventTestServer(t *testing.T, db *sql.DB) (*httptest.Server, *events.Bro
 	t.Helper()
 	store := dbpkg.NewStore(db)
 	broker := events.NewBroker(db)
-	handler := server.NewWithBroker(store, db, nil, broker, "test@example.com", "test@example.com")
+	handler := server.NewWithBroker(store, db, nil, broker, "test@example.com", "test@example.com", "", "")
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 	return srv, broker
@@ -425,7 +425,7 @@ func TestSSE_CurrentSeqFailure_Returns503(t *testing.T) {
 
 	st := dbpkg.NewStore(db)
 	broker := events.NewBroker(brokenDB)
-	handler := server.NewWithBroker(st, db, nil, broker, "test@example.com", "test@example.com")
+	handler := server.NewWithBroker(st, db, nil, broker, "test@example.com", "test@example.com", "", "")
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
@@ -448,7 +448,7 @@ func TestSubscription_AdminOnly(t *testing.T) {
 	// Create server with no global admin (empty bootstrapAdmin).
 	store := dbpkg.NewStore(db)
 	broker := events.NewBroker(db)
-	handler := server.NewWithBroker(store, db, nil, broker, "test@example.com", "")
+	handler := server.NewWithBroker(store, db, nil, broker, "test@example.com", "", "", "")
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -176,34 +176,39 @@ func NewWithReadStore(ws WriteStore, rs ReadStore, devIdentity, bootstrapAdmin s
 	return s.buildHandler(devIdentity, bootstrapAdmin, ws)
 }
 
+
 // New returns an http.Handler with all routes registered.
 // devIdentity, if non-empty, bypasses IAP JWT validation (for local dev/testing).
 // bootstrapAdmin, if non-empty, has admin access to any repo with no existing admin.
 // writeStore provides write operations; pass nil if only read/health endpoints are needed.
 // database provides read operations; pass nil if only write/health endpoints are needed.
 func New(writeStore WriteStore, database *sql.DB, devIdentity, bootstrapAdmin string) http.Handler {
-	return newServer(writeStore, database, nil, nil, devIdentity, bootstrapAdmin)
+	return newServer(writeStore, database, nil, nil, devIdentity, bootstrapAdmin, "", "")
 }
 
 // NewWithBlobStore is like New but also wires a BlobStore into the read store
 // so that files stored externally can be fetched by the file endpoint.
 func NewWithBlobStore(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, devIdentity, bootstrapAdmin string) http.Handler {
-	return newServer(writeStore, database, bs, nil, devIdentity, bootstrapAdmin)
+	return newServer(writeStore, database, bs, nil, devIdentity, bootstrapAdmin, "", "")
 }
 
 // NewWithBroker is like NewWithBlobStore but also wires an event Broker.
 // Use this in production so mutation handlers can emit events.
-func NewWithBroker(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker, devIdentity, bootstrapAdmin string) http.Handler {
-	return newServer(writeStore, database, bs, broker, devIdentity, bootstrapAdmin)
+// iapClientID and iapClientSecret are optional; when set they are advertised
+// via the /.well-known/ds-config endpoint so the CLI can perform the OAuth flow.
+func NewWithBroker(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker, devIdentity, bootstrapAdmin, iapClientID, iapClientSecret string) http.Handler {
+	return newServer(writeStore, database, bs, broker, devIdentity, bootstrapAdmin, iapClientID, iapClientSecret)
 }
 
-func newServer(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker, devIdentity, bootstrapAdmin string) http.Handler {
+func newServer(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker, devIdentity, bootstrapAdmin, iapClientID, iapClientSecret string) http.Handler {
 	pc := policy.NewCache()
 	s := &server{
-		commitStore: writeStore,
-		policyCache: pc,
-		broker:      broker,
-		globalAdmin: bootstrapAdmin,
+		commitStore:     writeStore,
+		policyCache:     pc,
+		broker:          broker,
+		globalAdmin:     bootstrapAdmin,
+		iapClientID:     iapClientID,
+		iapClientSecret: iapClientSecret,
 	}
 	if writeStore != nil {
 		var emitter service.EventEmitter
@@ -226,9 +231,10 @@ func newServer(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broke
 // Extracted so tests can construct a server with injected dependencies and still
 // get the full middleware stack.
 func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore WriteStore) http.Handler {
-	// Health check is exempt from auth — load balancers and probes call it.
+	// Health check and well-known config are exempt from auth.
 	outer := http.NewServeMux()
 	outer.HandleFunc("GET /healthz", handleHealth)
+	outer.HandleFunc("GET /.well-known/ds-config", s.handleDSConfig)
 
 	// All other routes require IAP authentication.
 	inner := http.NewServeMux()
@@ -315,6 +321,28 @@ type server struct {
 	// globalAdmin is the identity that may manage global resources like
 	// event subscriptions. Corresponds to the --bootstrap-admin flag.
 	globalAdmin string
+	// iapClientID and iapClientSecret are advertised via /.well-known/ds-config
+	// so CLI tools can perform the IAP OAuth flow.
+	iapClientID     string
+	iapClientSecret string
+}
+
+// handleDSConfig serves GET /.well-known/ds-config — unauthenticated.
+// It advertises the server's authentication configuration so CLI tools can
+// perform the appropriate OAuth flow.
+func (s *server) handleDSConfig(w http.ResponseWriter, r *http.Request) {
+	if s.iapClientID == "" {
+		writeJSON(w, http.StatusOK, map[string]any{"auth": map[string]string{"type": "none"}})
+		return
+	}
+	auth := map[string]any{
+		"type":      "iap",
+		"client_id": s.iapClientID,
+	}
+	if s.iapClientSecret != "" {
+		auth["client_secret"] = s.iapClientSecret
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"auth": auth})
 }
 
 func (s *server) handleCommit(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- **Server**: Adds `GET /.well-known/ds-config` endpoint (served unauthenticated, registered on the outer mux before `IAPMiddleware`) that returns `{"auth":{"type":"iap","client_id":"..."}}` when `--iap-client-id`/`IAP_CLIENT_ID` is set, or `{"auth":{"type":"none"}}` otherwise. Optional `client_secret` field included when `--iap-client-secret`/`IAP_CLIENT_SECRET` is set.
- **CLI credential store** (`internal/cli/auth.go`): `Token` struct, `~/.config/ds/credentials.json` keyed by server URL, `loadCreds`/`saveCreds`/`deleteCreds` helpers, `authTransport` that auto-refreshes expired tokens via `golang.org/x/oauth2` and injects `Authorization: Bearer`.
- **`ds login [server-url]`**: Fetches well-known config, runs OAuth 2.0 desktop flow (browser redirect to localhost callback), saves token, prints `Logged in as <email>`.
- **`ds logout [server-url]`**: Deletes cached credentials.
- **Auth wired automatically**: `authTransport` is set as the HTTP transport on `App` — all existing commands get auth headers when credentials are cached, no per-command changes.

## Test plan

- [ ] `go test ./... -count=1 -short` passes (all 17 packages)
- [ ] New `TestDSConfigEndpoint_*` tests in `internal/server/dsconfig_test.go` cover: no IAP, with IAP+secret, with IAP+no secret, unauthenticated access
- [ ] `NewWithBroker` signature updated; 3 test callers in `events_test.go` updated with empty string args

## Notes for continuation

- The well-known endpoint is completely unauthenticated (no IAP token needed), matching production requirements
- `golang.org/x/oauth2` promoted from indirect to direct dependency (was already in go.sum)
- `NewWithBroker` gains two new trailing parameters `iapClientID, iapClientSecret string`; other constructors (`New`, `NewWithBlobStore`, `NewWithReadStore`) pass `"", ""` internally and are unchanged in signature

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)