### PR TITLE
infra: wire IAP OAuth client ID and secret into Cloud Run deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
             --region=us-central1 \
             --service-account=docstore-server@dlorenc-chainguard.iam.gserviceaccount.com \
             --add-cloudsql-instances=dlorenc-chainguard:us-central1:docstore-mvp \
-            --update-secrets=DATABASE_URL=docstore-db-url:latest \
+            --update-secrets=DATABASE_URL=docstore-db-url:latest,IAP_CLIENT_SECRET=iap-oauth-client-secret:latest \
             --ingress=internal-and-cloud-load-balancing \
             --min-instances=1 \
             --max-instances=1 \
@@ -56,7 +56,7 @@ jobs:
             --network=default \
             --subnet=default \
             --vpc-egress=private-ranges-only \
-            --args=--bootstrap-admin=dlorenc@chainguard.dev
+            --args=--bootstrap-admin=dlorenc@chainguard.dev,--iap-client-id=320310132788-md94jtp0d9fdcdlq2quma4mcpr0ul1qr.apps.googleusercontent.com
 
   build-and-deploy-ci-scheduler:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Enables `ds login` by advertising the IAP OAuth credentials via `/.well-known/ds-config`.

- Adds `IAP_CLIENT_SECRET=iap-oauth-client-secret:latest` to `--update-secrets` (secret already created in Secret Manager and IAM binding granted to the Cloud Run service account)
- Adds `--iap-client-id=320310132788-md94jtp0d9fdcdlq2quma4mcpr0ul1qr.apps.googleusercontent.com` to `--args`

After this deploys, `ds login` will:
1. Fetch `https://docstore.dev/.well-known/ds-config`
2. Discover the client ID and secret
3. Open a browser for Google OAuth
4. Cache the token in `~/.config/ds/credentials.json`
5. All subsequent `ds` commands automatically attach `Authorization: Bearer <token>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)