### PR TITLE
fix(auth): ds login fixes — id_token, graceful shutdown, programmatic_clients allowlist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,18 @@
 BINARY := docstore
 BUILD_DIR := bin
 DEFAULT_REMOTE ?= https://docstore.dev
+# IAP OAuth client ID for docstore.dev (public — Desktop app clients are distributed openly).
+IAP_CLIENT_ID ?= 320310132788-md94jtp0d9fdcdlq2quma4mcpr0ul1qr.apps.googleusercontent.com
+# IAP OAuth client secret — do NOT commit. Set via env var or GitHub Actions secret.
+# Local builds: make build-ds IAP_CLIENT_SECRET=<secret>
+# CI builds: injected from the IAP_OAUTH_CLIENT_SECRET Actions secret.
+IAP_CLIENT_SECRET ?=
 
 build:
 	go build -o $(BUILD_DIR)/$(BINARY) ./cmd/docstore
 
 build-ds:
-	go build -ldflags "-X main.defaultRemote=$(DEFAULT_REMOTE)" -o $(BUILD_DIR)/ds ./cmd/ds
+	go build -ldflags "-X main.defaultRemote=$(DEFAULT_REMOTE) -X main.defaultIAPClientID=$(IAP_CLIENT_ID) -X main.defaultIAPClientSecret=$(IAP_CLIENT_SECRET)" -o $(BUILD_DIR)/ds ./cmd/ds
 
 test:
 	go test ./...

--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -16,6 +16,15 @@ import (
 // If empty, ds init requires an explicit remote URL.
 var defaultRemote string
 
+// defaultIAPClientID and defaultIAPClientSecret are the compiled-in OAuth
+// client credentials for the hosted docstore.dev instance, injected via
+// -ldflags. Used as fallback when /.well-known/ds-config is not reachable
+// (e.g. when the server is behind IAP and the endpoint is blocked).
+// Desktop app OAuth secrets are semi-public by nature (shipped in every CLI
+// binary), so embedding them here is intentional and standard practice.
+var defaultIAPClientID string
+var defaultIAPClientSecret string
+
 const usage = `usage: ds <command> [args]
 
 commands:
@@ -1230,7 +1239,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, "error: no server URL provided and no default compiled in")
 			os.Exit(1)
 		}
-		err = app.Login(serverURL)
+		err = app.Login(serverURL, defaultIAPClientID, defaultIAPClientSecret)
 
 	case "logout":
 		serverURL := defaultRemote

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -270,3 +270,23 @@ The deploy workflow (`deploy.yml`) also builds and deploys both CI binaries afte
 ## Horizontal scaling
 
 The event broker persists all events to the `event_log` PostgreSQL table and uses `pg_notify` for real-time wake-ups. SSE streams (`GET /events`, `GET /repos/{name}/-/events`) poll `event_log` directly, so every instance sees every event regardless of which instance processed the original mutation. Multiple Cloud Run instances are fully supported.
+
+### CLI authentication (ds login)
+
+After enabling IAP, add the Desktop app OAuth client to IAP's programmatic access allowlist so `ds login` works:
+
+```bash
+cat > /tmp/iap-settings.yaml << 'YAML'
+access_settings:
+  oauth_settings:
+    programmatic_clients:
+      - <DESKTOP_APP_CLIENT_ID>
+YAML
+
+gcloud iap settings set /tmp/iap-settings.yaml \
+  --project=<PROJECT> \
+  --resource-type=backend-services \
+  --service=<BACKEND_SERVICE_NAME>
+```
+
+This allows ID tokens with the Desktop app client's audience to pass through IAP. Without this step, IAP rejects CLI tokens with "Invalid JWT audience".

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -22,8 +22,10 @@ import (
 )
 
 // Token holds OAuth2 credentials cached for a server URL.
+// IAP requires an OIDC ID token (IDToken), not the OAuth access token.
 type Token struct {
-	AccessToken  string    `json:"access_token"`
+	IDToken      string    `json:"id_token"`      // OIDC JWT — what IAP validates
+	AccessToken  string    `json:"access_token"`  // kept for reference / future use
 	RefreshToken string    `json:"refresh_token"`
 	Expiry       time.Time `json:"expiry"`
 	ClientID     string    `json:"client_id"`
@@ -143,8 +145,13 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		t.mu.Unlock()
 	}
 
+	// IAP requires the OIDC ID token, not the OAuth access token.
+	bearer := tok.IDToken
+	if bearer == "" {
+		bearer = tok.AccessToken // fallback for non-IAP servers
+	}
 	reqCopy := req.Clone(req.Context())
-	reqCopy.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	reqCopy.Header.Set("Authorization", "Bearer "+bearer)
 	return t.base.RoundTrip(reqCopy)
 }
 
@@ -164,7 +171,9 @@ func refreshOAuthToken(tok *Token) (*Token, error) {
 	if err != nil {
 		return nil, err
 	}
+	idToken, _ := newTok.Extra("id_token").(string)
 	return &Token{
+		IDToken:      idToken,
 		AccessToken:  newTok.AccessToken,
 		RefreshToken: newTok.RefreshToken,
 		Expiry:       newTok.Expiry,
@@ -223,13 +232,15 @@ func (a *App) Login(serverURL, fallbackClientID, fallbackClientSecret string) er
 		return fmt.Errorf("oauth flow: %w", err)
 	}
 
-	// Extract email from ID token JWT (Google always returns one for openid scope).
+	// Extract the OIDC ID token — this is what IAP requires as the Bearer token.
 	email := ""
-	if idToken, ok := oauthTok.Extra("id_token").(string); ok && idToken != "" {
+	idToken, _ := oauthTok.Extra("id_token").(string)
+	if idToken != "" {
 		email, _ = jwtEmail(idToken)
 	}
 
 	tok := &Token{
+		IDToken:      idToken,
 		AccessToken:  oauthTok.AccessToken,
 		RefreshToken: oauthTok.RefreshToken,
 		Expiry:       oauthTok.Expiry,

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -185,37 +185,40 @@ type dsServerConfig struct {
 	Auth dsAuthConfig `json:"auth"`
 }
 
-// Login authenticates with the given server using the OAuth flow advertised
-// by the server's /.well-known/ds-config endpoint and stores the credentials.
-func (a *App) Login(serverURL string) error {
+// Login authenticates with the given server and stores the credentials.
+// It first tries to discover OAuth client credentials via /.well-known/ds-config.
+// If that fails (e.g. the endpoint is behind IAP itself), it falls back to the
+// compiled-in fallbackClientID and fallbackClientSecret.
+func (a *App) Login(serverURL, fallbackClientID, fallbackClientSecret string) error {
 	serverURL = strings.TrimRight(serverURL, "/")
 
+	clientID, clientSecret := fallbackClientID, fallbackClientSecret
+
+	// Attempt discovery via well-known endpoint; failure is non-fatal if we
+	// have compiled-in fallback credentials.
 	resp, err := a.HTTP.Get(serverURL + "/.well-known/ds-config")
-	if err != nil {
-		return fmt.Errorf("fetch server config: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("server returned status %d for /.well-known/ds-config", resp.StatusCode)
-	}
-
-	var cfg dsServerConfig
-	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
-		return fmt.Errorf("parse server config: %w", err)
-	}
-
-	if cfg.Auth.Type == "none" || cfg.Auth.Type == "" {
-		fmt.Fprintln(a.Out, "Server does not require authentication")
-		return nil
-	}
-	if cfg.Auth.Type != "iap" {
-		return fmt.Errorf("unsupported auth type: %s", cfg.Auth.Type)
-	}
-	if cfg.Auth.ClientID == "" {
-		return fmt.Errorf("server did not provide client_id in auth config")
+	if err == nil && resp.StatusCode == http.StatusOK {
+		defer resp.Body.Close()
+		var cfg dsServerConfig
+		if jsonErr := json.NewDecoder(resp.Body).Decode(&cfg); jsonErr == nil {
+			if cfg.Auth.Type == "none" || cfg.Auth.Type == "" {
+				fmt.Fprintln(a.Out, "Server does not require authentication")
+				return nil
+			}
+			if cfg.Auth.Type == "iap" && cfg.Auth.ClientID != "" {
+				clientID = cfg.Auth.ClientID
+				clientSecret = cfg.Auth.ClientSecret
+			}
+		}
+	} else if resp != nil {
+		resp.Body.Close()
 	}
 
-	oauthTok, err := runOAuthDesktopFlow(cfg.Auth.ClientID, cfg.Auth.ClientSecret)
+	if clientID == "" {
+		return fmt.Errorf("could not determine OAuth client ID: server did not provide one via /.well-known/ds-config and no default is compiled in")
+	}
+
+	oauthTok, err := runOAuthDesktopFlow(clientID, clientSecret)
 	if err != nil {
 		return fmt.Errorf("oauth flow: %w", err)
 	}
@@ -230,8 +233,8 @@ func (a *App) Login(serverURL string) error {
 		AccessToken:  oauthTok.AccessToken,
 		RefreshToken: oauthTok.RefreshToken,
 		Expiry:       oauthTok.Expiry,
-		ClientID:     cfg.Auth.ClientID,
-		ClientSecret: cfg.Auth.ClientSecret,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
 	}
 	if err := saveCreds(serverURL, tok); err != nil {
 		return fmt.Errorf("save credentials: %w", err)

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -298,6 +298,9 @@ func runOAuthDesktopFlow(clientID, clientSecret string) (*oauth2.Token, error) {
 			return
 		}
 		fmt.Fprintln(w, "Authentication successful! You can close this tab.")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
 		codeCh <- code
 	})
 
@@ -311,17 +314,23 @@ func runOAuthDesktopFlow(clientID, clientSecret string) (*oauth2.Token, error) {
 	fmt.Printf("If the browser does not open, visit:\n  %s\n", authURL)
 	openBrowser(authURL)
 
+	shutdownSrv := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		cbSrv.Shutdown(ctx) //nolint:errcheck
+	}
+
 	var code string
 	select {
 	case code = <-codeCh:
 	case err = <-errCh:
-		cbSrv.Close()
+		shutdownSrv()
 		return nil, err
 	case <-time.After(5 * time.Minute):
-		cbSrv.Close()
+		shutdownSrv()
 		return nil, fmt.Errorf("timed out waiting for browser authentication")
 	}
-	cbSrv.Close()
+	shutdownSrv()
 
 	tok, err := conf.Exchange(context.Background(), code)
 	if err != nil {

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -281,11 +281,6 @@ func runOAuthDesktopFlow(clientID, clientSecret string) (*oauth2.Token, error) {
 	}
 	state := hex.EncodeToString(stateBytes)
 
-	authURL := conf.AuthCodeURL(state, oauth2.AccessTypeOffline)
-	fmt.Printf("Opening browser for authentication...\n")
-	fmt.Printf("If the browser does not open, visit:\n  %s\n", authURL)
-	openBrowser(authURL)
-
 	codeCh := make(chan string, 1)
 	errCh := make(chan error, 1)
 
@@ -306,8 +301,15 @@ func runOAuthDesktopFlow(clientID, clientSecret string) (*oauth2.Token, error) {
 		codeCh <- code
 	})
 
+	// Start the callback server before opening the browser so it is ready
+	// to accept the redirect the moment the user completes sign-in.
 	cbSrv := &http.Server{Handler: mux}
 	go cbSrv.Serve(ln) //nolint:errcheck
+
+	authURL := conf.AuthCodeURL(state, oauth2.AccessTypeOffline)
+	fmt.Printf("Opening browser for authentication...\n")
+	fmt.Printf("If the browser does not open, visit:\n  %s\n", authURL)
+	openBrowser(authURL)
 
 	var code string
 	select {


### PR DESCRIPTION
## Summary

Follow-up fixes to #352 to make \`ds login\` actually work end to end against \`docstore.dev\`.

### Bugs fixed

**1. Wrong token type** — sent \`access_token\` (opaque) instead of \`id_token\` (OIDC JWT). IAP requires the JWT. Embedded OAuth credentials via \`-ldflags\` so the binary carries them compiled-in.

**2. Callback server started after browser** — \`openBrowser()\` was called before \`go cbSrv.Serve(ln)\`. Reordered.

**3. Abrupt server shutdown** — \`cbSrv.Close()\` killed the connection before the browser received the response, causing "This site can't be reached". Fixed with \`Shutdown(ctx)\` + explicit \`Flush()\`.

**4. IAP programmatic_clients allowlist** — IAP rejects tokens from clients not in its allowlist even with valid signatures. Applied to production via \`gcloud iap settings set\`. Documented in \`docs/deployment.md\`.

## Verified working

\`\`\`
$ ds login
Logged in as dlorenc@chainguard.dev

$ ds repos
NAME             OWNER    CREATED BY              CREATED AT
default/default  default  system                  2026-04-17
default/test     default  dlorenc@chainguard.dev  2026-04-28
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)