### PR TITLE
fix(ui): remove duplicate Members section from branches.html

### DIFF
--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -56,7 +56,6 @@ type branchesPage struct {
 	Active    []branchRow
 	Merged    []branchRow
 	Abandoned []branchRow
-	Members   []model.OrgMember
 	Roles     []model.Role
 	Err       string
 }
@@ -1428,12 +1427,6 @@ func (h *Handler) renderBranchesPage(w http.ResponseWriter, r *http.Request, own
 		return
 	}
 
-	members, err := h.write.ListOrgMembers(ctx, repo.Owner)
-	if err != nil {
-		slog.Error("ui list org members", "org", repo.Owner, "error", err)
-		members = nil
-	}
-
 	roles, err := h.write.ListRoles(ctx, repoName)
 	if err != nil {
 		slog.Error("ui list roles", "repo", repoName, "error", err)
@@ -1452,7 +1445,7 @@ func (h *Handler) renderBranchesPage(w http.ResponseWriter, r *http.Request, own
 		}
 	}
 
-	page := branchesPage{Repo: *repo, Members: members, Roles: roles, Err: errMsg}
+	page := branchesPage{Repo: *repo, Roles: roles, Err: errMsg}
 	for _, b := range branches {
 		row := branchRow{
 			Name:         b.Name,

--- a/internal/ui/templates/branches.html
+++ b/internal/ui/templates/branches.html
@@ -36,24 +36,6 @@
 {{template "branchSection" (dict "Title" "Merged" "EmptyMsg" "no merged branches" "Rows" .Merged "Repo" .Repo.Name)}}
 {{template "branchSection" (dict "Title" "Abandoned" "EmptyMsg" "no abandoned branches" "Rows" .Abandoned "Repo" .Repo.Name)}}
 
-<h2>Members ({{len .Members}})</h2>
-<div class="card">
-  {{if not .Members}}<div class="empty">no members</div>{{else}}
-  <table class="grid">
-    <thead><tr><th>identity</th><th>role</th><th>invited by</th><th>joined</th></tr></thead>
-    <tbody>
-    {{range .Members}}
-    <tr>
-      <td>{{.Identity}}</td>
-      <td><span class="badge neutral">{{.Role}}</span></td>
-      <td>{{.InvitedBy}}</td>
-      <td class="meta">{{relTime .CreatedAt}}</td>
-    </tr>
-    {{end}}
-    </tbody>
-  </table>
-  {{end}}
-</div>
 {{end}}
 {{define "branchSection"}}
 <h2>{{.Title}} ({{len .Rows}})</h2>


### PR DESCRIPTION
## Summary

- Removes the read-only Members table from the bottom of the branches page (`branches.html`), which duplicated info already shown on the org page and managed via the Settings page (added in #332).
- Removes the `Members []model.OrgMember` field from `branchesPage` struct.
- Removes the `ListOrgMembers` DB call from `renderBranchesPage` since it was only fetching data for the now-removed section.

Closes #332 (follow-up cleanup).

## Test plan

- [x] `go test ./... -count=1` — all tests pass
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `TestHandleBranches_NoRolesOrDangerZone` and templatecheck tests in `internal/ui` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)