### PR TITLE
fix(ui): add repo-tabs nav to log/commit pages, fix hardcoded /b/main/log links

### DIFF
--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -972,6 +972,13 @@ func siblingTreeRows(entries []store.TreeEntry, dir string) []treeRow {
 	return rows
 }
 
+// handleRepoLog redirects /ui/r/{owner}/{name}/log to the main branch log.
+func (h *Handler) handleRepoLog(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	http.Redirect(w, r, "/ui/r/"+owner+"/"+name+"/b/main/log", http.StatusFound)
+}
+
 // handleCommitLog renders the paginated commit log for a branch.
 func (h *Handler) handleCommitLog(w http.ResponseWriter, r *http.Request) {
 	owner := r.PathValue("owner")

--- a/internal/ui/templates/branches.html
+++ b/internal/ui/templates/branches.html
@@ -7,7 +7,7 @@
   <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
-  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/log">log</a>
   <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/ci_job_detail.html
+++ b/internal/ui/templates/ci_job_detail.html
@@ -5,7 +5,7 @@
   <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs" class="active">ci-jobs</a>
-  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/log">log</a>
   <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/ci_jobs.html
+++ b/internal/ui/templates/ci_jobs.html
@@ -10,7 +10,7 @@
   <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs" class="active">ci-jobs</a>
-  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/log">log</a>
   <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/commit.html
+++ b/internal/ui/templates/commit.html
@@ -5,6 +5,16 @@
   <span class="meta">{{.Repo.Name}} · {{.Branch}}</span>
 </div>
 
+<nav class="repo-tabs">
+  <a href="/ui/r/{{.Repo.Name}}">branches</a>
+  <a href="/ui/r/{{.Repo.Name}}/issues">issues</a>
+  <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
+  <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
+  <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
+  <a href="/ui/r/{{.Repo.Name}}/log" class="active">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
+</nav>
+
 <div class="card">
   <div class="commit-meta">
     <div><strong>message</strong> {{.Commit.Message}}</div>

--- a/internal/ui/templates/issue_detail.html
+++ b/internal/ui/templates/issue_detail.html
@@ -6,7 +6,7 @@
   <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
-  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/log">log</a>
   <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/issues.html
+++ b/internal/ui/templates/issues.html
@@ -10,7 +10,7 @@
   <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
-  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/log">log</a>
   <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/log.html
+++ b/internal/ui/templates/log.html
@@ -3,6 +3,16 @@
   <h1>{{.Repo.Name}} / {{.Branch}} / log</h1>
 </div>
 
+<nav class="repo-tabs">
+  <a href="/ui/r/{{.Repo.Name}}">branches</a>
+  <a href="/ui/r/{{.Repo.Name}}/issues">issues</a>
+  <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
+  <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
+  <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
+  <a href="/ui/r/{{.Repo.Name}}/log" class="active">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
+</nav>
+
 <div class="card">
   {{if not .Rows}}
     <div class="empty">no commits yet</div>

--- a/internal/ui/templates/new_issue.html
+++ b/internal/ui/templates/new_issue.html
@@ -5,7 +5,7 @@
   <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
-  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/log">log</a>
   <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/proposal_detail.html
+++ b/internal/ui/templates/proposal_detail.html
@@ -5,7 +5,7 @@
   <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
   <a href="/ui/r/{{.Repo.Name}}/proposals" class="active">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
-  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/log">log</a>
   <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/proposals.html
+++ b/internal/ui/templates/proposals.html
@@ -10,7 +10,7 @@
   <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
   <a href="/ui/r/{{.Repo.Name}}/proposals" class="active">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
-  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/log">log</a>
   <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/release_detail.html
+++ b/internal/ui/templates/release_detail.html
@@ -5,7 +5,7 @@
   <a href="/ui/r/{{.Repo.Name}}/releases" class="active">releases</a>
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
-  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/log">log</a>
   <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/releases.html
+++ b/internal/ui/templates/releases.html
@@ -10,7 +10,7 @@
   <a href="/ui/r/{{.Repo.Name}}/releases" class="active">releases</a>
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
-  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/log">log</a>
   <a href="/ui/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/settings.html
+++ b/internal/ui/templates/settings.html
@@ -7,7 +7,7 @@
   <a href="/ui/r/{{.Repo.Name}}/releases">releases</a>
   <a href="/ui/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/ui/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
-  <a href="/ui/r/{{.Repo.Name}}/b/main/log">log</a>
+  <a href="/ui/r/{{.Repo.Name}}/log">log</a>
   <a href="/ui/r/{{.Repo.Name}}/settings" class="active">settings</a>
 </nav>
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -212,6 +212,7 @@ func (h *Handler) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}", h.handleBranchDetail)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/checks", h.handleChecksPartial)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/comments", h.handleReviewCommentsPartial)
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/log", h.handleRepoLog)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}/log", h.handleCommitLog)
 	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/log", h.handleLogRowsPartial)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}/c/{seq}", h.handleCommitDetail)


### PR DESCRIPTION
## Summary

- **Add `<nav class=\"repo-tabs\">` to `log.html` and `commit.html`** — with \"log\" as the active tab. Users previously lost tab navigation when entering the commit log or viewing a commit detail page.
- **Add `handleRepoLog` redirect handler** at `GET /ui/r/{owner}/{name}/log` that forwards to `/b/main/log`, providing a branch-agnostic entry point for the log tab.
- **Fix hardcoded `/b/main/log` in 11 templates** — all repo-tabs navs now link to `/ui/r/{repo}/log` (the new branch-agnostic URL) instead of `/ui/r/{repo}/b/main/log`.

## Test plan

- [x] `go test ./internal/ui/... -count=1` passes (templatecheck validates log.html and commit.html with their concrete page types)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` — all packages pass; `TestDockerSmoke` in `internal/server` timed out after 9+ min (pre-existing Docker build test, unrelated to this change)

## Notes for continuers

- The redirect still hardcodes `main` as the branch name in `handleRepoLog`. If a future task adds a `DefaultBranch` field to `model.Repo`, this redirect can be made truly dynamic by looking up the repo's default branch instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)