### PR TITLE
feat(ui): support branch names with forward slashes in URL routing

### DIFF
--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -339,6 +339,134 @@ func (h *Handler) handleBranches(w http.ResponseWriter, r *http.Request) {
 	h.renderBranchesPage(w, r, r.PathValue("owner"), r.PathValue("name"), "")
 }
 
+// branchURLPath builds a URL path segment for a branch name that preserves
+// forward slashes (which are structural in multi-segment branch names like
+// "feature/auth") while still percent-encoding other special characters.
+func branchURLPath(branch string) string {
+	parts := strings.Split(branch, "/")
+	for i, p := range parts {
+		parts[i] = url.PathEscape(p)
+	}
+	return strings.Join(parts, "/")
+}
+
+// handleBranchGetDispatch routes GET requests under /b/{branch...} to the
+// appropriate handler by inspecting the trailing suffix of the branch path
+// value. This allows branch names that contain forward slashes (e.g.
+// "feature/auth") to appear literally in URLs while still supporting the
+// existing sub-page routes (/log, /c/{seq}, /commit).
+//
+// Disambiguation: suffixes are checked from most-specific to least-specific.
+// The /c/{seq} case requires the trailing segment to parse as a positive
+// integer, so accidental matches against branch names are unlikely.
+func (h *Handler) handleBranchGetDispatch(w http.ResponseWriter, r *http.Request) {
+	raw := strings.TrimSuffix(r.PathValue("branch"), "/")
+
+	// /b/{branch}/commit → commit form (GET)
+	if strings.HasSuffix(raw, "/commit") {
+		r.SetPathValue("branch", strings.TrimSuffix(raw, "/commit"))
+		h.handleNewCommit(w, r)
+		return
+	}
+
+	// /b/{branch}/log → commit log
+	if strings.HasSuffix(raw, "/log") {
+		r.SetPathValue("branch", strings.TrimSuffix(raw, "/log"))
+		h.handleCommitLog(w, r)
+		return
+	}
+
+	// /b/{branch}/c/{seq} → commit detail; only matches when trailing segment
+	// is a valid positive integer so branch names containing "/c/" are safe.
+	if idx := strings.LastIndex(raw, "/c/"); idx >= 0 {
+		seqStr := raw[idx+3:]
+		if seq, err := strconv.ParseInt(seqStr, 10, 64); err == nil && seq > 0 {
+			r.SetPathValue("branch", raw[:idx])
+			r.SetPathValue("seq", seqStr)
+			h.handleCommitDetail(w, r)
+			return
+		}
+	}
+
+	// Default: branch detail page.
+	r.SetPathValue("branch", raw)
+	h.handleBranchDetail(w, r)
+}
+
+// handleBranchPartialGetDispatch routes GET requests under /_/…/b/{branch...}
+// to the appropriate HTMX partial handler by inspecting the trailing suffix.
+func (h *Handler) handleBranchPartialGetDispatch(w http.ResponseWriter, r *http.Request) {
+	raw := strings.TrimSuffix(r.PathValue("branch"), "/")
+
+	if strings.HasSuffix(raw, "/checks") {
+		r.SetPathValue("branch", strings.TrimSuffix(raw, "/checks"))
+		h.handleChecksPartial(w, r)
+		return
+	}
+	if strings.HasSuffix(raw, "/comments") {
+		r.SetPathValue("branch", strings.TrimSuffix(raw, "/comments"))
+		h.handleReviewCommentsPartial(w, r)
+		return
+	}
+	if strings.HasSuffix(raw, "/log") {
+		r.SetPathValue("branch", strings.TrimSuffix(raw, "/log"))
+		h.handleLogRowsPartial(w, r)
+		return
+	}
+	if strings.HasSuffix(raw, "/check-history") {
+		r.SetPathValue("branch", strings.TrimSuffix(raw, "/check-history"))
+		h.handleCheckHistoryPartial(w, r)
+		return
+	}
+
+	http.NotFound(w, r)
+}
+
+// handleBranchPostDispatch routes POST requests under /b/{branch...} to the
+// appropriate write handler by inspecting the trailing suffix.
+func (h *Handler) handleBranchPostDispatch(w http.ResponseWriter, r *http.Request) {
+	raw := strings.TrimSuffix(r.PathValue("branch"), "/")
+
+	// /b/{branch}/review
+	if strings.HasSuffix(raw, "/review") {
+		r.SetPathValue("branch", strings.TrimSuffix(raw, "/review"))
+		h.handleSubmitReview(w, r)
+		return
+	}
+
+	// /b/{branch}/comment/{id}/delete — checked before /comment to avoid
+	// ambiguity: strip /delete, extract id, confirm segment before id is "comment".
+	if strings.HasSuffix(raw, "/delete") {
+		trimmed := strings.TrimSuffix(raw, "/delete")
+		if slash := strings.LastIndex(trimmed, "/"); slash >= 0 {
+			id := trimmed[slash+1:]
+			rest := trimmed[:slash]
+			if strings.HasSuffix(rest, "/comment") {
+				r.SetPathValue("branch", strings.TrimSuffix(rest, "/comment"))
+				r.SetPathValue("id", id)
+				h.handleDeleteComment(w, r)
+				return
+			}
+		}
+	}
+
+	// /b/{branch}/comment
+	if strings.HasSuffix(raw, "/comment") {
+		r.SetPathValue("branch", strings.TrimSuffix(raw, "/comment"))
+		h.handlePostComment(w, r)
+		return
+	}
+
+	// /b/{branch}/commit → commit form (POST)
+	if strings.HasSuffix(raw, "/commit") {
+		r.SetPathValue("branch", strings.TrimSuffix(raw, "/commit"))
+		h.handleNewCommit(w, r)
+		return
+	}
+
+	http.NotFound(w, r)
+}
+
 // handleBranchDetail renders the diff + reviews + checks + policy view.
 func (h *Handler) handleBranchDetail(w http.ResponseWriter, r *http.Request) {
 	owner := r.PathValue("owner")
@@ -2464,7 +2592,7 @@ func (h *Handler) handleSubmitReview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+url.PathEscape(branch), http.StatusSeeOther)
+	http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+branchURLPath(branch), http.StatusSeeOther)
 }
 
 // handlePostComment processes a POST form to add an inline review comment.
@@ -2499,7 +2627,7 @@ func (h *Handler) handlePostComment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+url.PathEscape(branch), http.StatusSeeOther)
+	http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+branchURLPath(branch), http.StatusSeeOther)
 }
 
 // handleDeleteComment processes a POST form to delete an inline review comment.
@@ -2517,7 +2645,7 @@ func (h *Handler) handleDeleteComment(w http.ResponseWriter, r *http.Request) {
 	role := h.svc.GetRole(r.Context(), repoName, identity)
 	if err := h.svc.DeleteReviewComment(r.Context(), identity, role, repoName, id); err != nil {
 		if errors.Is(err, service.ErrForbidden) {
-			http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+url.PathEscape(branch)+"?err=forbidden", http.StatusSeeOther)
+			http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+branchURLPath(branch)+"?err=forbidden", http.StatusSeeOther)
 			return
 		}
 		slog.Error("ui delete review comment", "repo", repoName, "id", id, "error", err)
@@ -2525,7 +2653,7 @@ func (h *Handler) handleDeleteComment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+url.PathEscape(branch), http.StatusSeeOther)
+	http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+branchURLPath(branch), http.StatusSeeOther)
 }
 
 // handleCreateProposalUI processes a POST form to create a new proposal.
@@ -2819,7 +2947,7 @@ func (h *Handler) handleNewCommit(w http.ResponseWriter, r *http.Request) {
 			Breadcrumbs: []crumb{
 				{Label: "repos", Href: "/ui/"},
 				{Label: repoName, Href: "/ui/r/" + repoName},
-				{Label: branch, Href: "/ui/r/" + repoName + "/b/" + url.PathEscape(branch)},
+				{Label: branch, Href: "/ui/r/" + repoName + "/b/" + branchURLPath(branch)},
 				{Label: "commit", Href: ""},
 			},
 			Body: commitFormPage{
@@ -2876,7 +3004,7 @@ func (h *Handler) handleNewCommit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+url.PathEscape(branch), http.StatusSeeOther)
+	http.Redirect(w, r, "/ui/r/"+repoName+"/b/"+branchURLPath(branch), http.StatusSeeOther)
 }
 
 // Only entries for the named branch are included.

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -209,14 +209,12 @@ func (h *Handler) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ui/o/{org}", h.handleOrg)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}", h.handleBranches)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/settings", h.handleRepoSettings)
-	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}", h.handleBranchDetail)
-	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/checks", h.handleChecksPartial)
-	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/comments", h.handleReviewCommentsPartial)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/log", h.handleRepoLog)
-	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}/log", h.handleCommitLog)
-	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/log", h.handleLogRowsPartial)
-	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}/c/{seq}", h.handleCommitDetail)
-	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch}/check-history", h.handleCheckHistoryPartial)
+	// Branch routes use {branch...} to support multi-segment branch names like
+	// "feature/auth". The dispatch handlers parse the trailing suffix to route
+	// to the appropriate sub-handler.
+	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch...}", h.handleBranchGetDispatch)
+	mux.HandleFunc("GET /ui/_/r/{owner}/{name}/b/{branch...}", h.handleBranchPartialGetDispatch)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/f/{path...}", h.handleFile)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/issues", h.handleIssues)
 	mux.HandleFunc("GET /ui/r/{owner}/{name}/issues/new", h.handleNewIssue)
@@ -251,9 +249,7 @@ func (h *Handler) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /ui/r/{owner}/{name}/-/set-auto-merge", h.handleUISetAutoMerge)
 
 	// Write operations — POST forms from branch detail and proposals pages.
-	mux.HandleFunc("POST /ui/r/{owner}/{name}/b/{branch}/review", h.handleSubmitReview)
-	mux.HandleFunc("POST /ui/r/{owner}/{name}/b/{branch}/comment", h.handlePostComment)
-	mux.HandleFunc("POST /ui/r/{owner}/{name}/b/{branch}/comment/{id}/delete", h.handleDeleteComment)
+	mux.HandleFunc("POST /ui/r/{owner}/{name}/b/{branch...}", h.handleBranchPostDispatch)
 	mux.HandleFunc("POST /ui/r/{owner}/{name}/proposals", h.handleCreateProposalUI)
 	mux.HandleFunc("POST /ui/r/{owner}/{name}/proposals/{id}/edit", h.handleEditProposal)
 	mux.HandleFunc("POST /ui/r/{owner}/{name}/proposals/{id}/close", h.handleCloseProposalUI)
@@ -272,9 +268,7 @@ func (h *Handler) registerRoutes(mux *http.ServeMux) {
 	// Write operations: delete org/repo.
 	mux.HandleFunc("POST /ui/o/{org}/delete", h.handleUIDeleteOrg)
 	mux.HandleFunc("POST /ui/r/{owner}/{name}/-/delete-repo", h.handleUIDeleteRepo)
-	// Commit form.
-	mux.HandleFunc("GET /ui/r/{owner}/{name}/b/{branch}/commit", h.handleNewCommit)
-	mux.HandleFunc("POST /ui/r/{owner}/{name}/b/{branch}/commit", h.handleNewCommit)
+	// (commit form is handled by handleBranchGetDispatch / handleBranchPostDispatch above)
 
 	mux.Handle("GET /ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(h.staticSub))))
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1153,6 +1153,88 @@ func TestHandleBranches_NoRolesOrDangerZone(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Multi-segment branch name routing tests
+// ---------------------------------------------------------------------------
+
+// TestBranchRoutingSlashes verifies that branch names containing forward
+// slashes (e.g. "feature/auth") work with literal slashes in the URL.
+func TestBranchRoutingSlashes_BranchDetail(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, newFakeAssembler("feature/auth"))
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/b/feature/auth")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	if !strings.Contains(body, "feature/auth") {
+		t.Errorf("body missing branch name %q", "feature/auth")
+	}
+}
+
+func TestBranchRoutingSlashes_CommitLog(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	// /b/feature/auth/log should route to the commit log for branch "feature/auth".
+	// fakeRead.GetBranch returns nil (branch not found) so we expect 404, not 405.
+	code, _ := getStatusAndBody(t, h, "/ui/r/acme/a/b/feature/auth/log")
+	// 404 means the handler ran and did not find the branch — correct routing.
+	if code == http.StatusMethodNotAllowed || code == http.StatusMovedPermanently {
+		t.Fatalf("routing failed: status = %d", code)
+	}
+}
+
+func TestBranchRoutingSlashes_ChecksPartial(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme"}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, newFakeAssembler("feature/auth"))
+
+	code, body := getStatusAndBody(t, h, "/ui/_/r/acme/a/b/feature/auth/checks")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if strings.Contains(body, "<!doctype html>") {
+		t.Errorf("expected fragment, got full layout")
+	}
+}
+
+func TestBranchRoutingSlashes_CommitForm(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now(), CreatedBy: "me"}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, nil)
+
+	code, body := getStatusAndBody(t, h, "/ui/r/acme/a/b/feature/auth/commit")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", code, body)
+	}
+	// The rendered form should mention the branch name.
+	if !strings.Contains(body, "feature/auth") {
+		t.Errorf("body missing branch name %q", "feature/auth")
+	}
+}
+
+func TestBranchRoutingSlashes_PostReview(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, newFakeAssembler("feature/auth"))
+
+	code, _, _ := postForm(t, h, "/ui/r/acme/a/b/feature/auth/review", url.Values{
+		"status": {"approved"},
+		"body":   {"looks good"},
+	})
+	if code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (redirect)", code)
+	}
+}
+
+func TestBranchRoutingSlashes_DeleteComment(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedAt: time.Now()}}
+	h := newTestHandler(t, &fakeRead{}, &fakeWrite{repos: repos}, newFakeAssembler("feature/auth"))
+
+	code, _, _ := postForm(t, h, "/ui/r/acme/a/b/feature/auth/comment/cmt-1/delete", nil)
+	if code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (redirect)", code)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // CSRF middleware tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Root cause**: Go's `net/http` ServeMux requires `{name...}` wildcards at the end of URL patterns, so patterns like `/b/{branch}/log` could not be changed to `/b/{branch...}/log`. Branch names containing `/` (e.g. `feature/auth`) therefore 404'd.
- **Fix**: Replace all 12 individual `/b/{branch}/…` route registrations with three catch-all routes using `{branch...}`, plus dispatch handlers that parse the trailing suffix to route to the correct sub-handler.
- **Redirect URLs**: Added `branchURLPath()` helper that escapes each path segment but preserves `/` separators, replacing `url.PathEscape(branch)` which would double-encode slashes in redirects.
- **New tests**: Six tests covering multi-segment branch routing for detail page, commit log, checks partial, commit form, review POST, and delete-comment POST.

## Implementation notes

`{branch...}` captures the entire remaining path. To differentiate `/b/feature/auth` (branch detail) from `/b/feature/auth/log` (commit log), the dispatch handlers strip known fixed suffixes from the captured value. Suffixes checked in priority order:
1. `/commit` — commit form (GET and POST)
2. `/log` — commit log
3. `/c/{seq}` — commit detail (only matched when the last segment is a valid positive integer)
4. `/checks`, `/comments`, `/check-history` — HTMX partials
5. `/review`, `/comment/{id}/delete`, `/comment` — write operations

**Known limitation**: branch names that end with a reserved suffix word (e.g. a branch literally named `feature/log`) will be misrouted. This mirrors the unavoidable ambiguity in GitHub-style multi-segment branch URLs and is acceptable for common branch naming conventions (`type/description`).

## Test plan

- [x] `go test ./internal/ui/... -count=1` — all tests pass (including 6 new slash-routing tests)
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- Pre-existing Postgres failures in `internal/automerge` and integration tests are unrelated to this change (notified supervisor via msg-15afb56e-cec0)

## Opportunities (not implemented)

- Templates that build branch links currently use raw `branch` string concatenation. For branch names with special characters (not `/`), these links could be incorrect. A future PR could add a `branchURLPath` template function.
- The disambiguation heuristic could be made explicit with a `/-/` separator (GitLab style) to remove any theoretical ambiguity, at the cost of changing the URL structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)