### PR TITLE
feat(ui): file history collapsible panel and raw file download

### DIFF
--- a/internal/server/handlers_files.go
+++ b/internal/server/handlers_files.go
@@ -120,6 +120,17 @@ func (s *server) handleFileContent(w http.ResponseWriter, r *http.Request, repo,
 		return
 	}
 
+	if r.URL.Query().Get("format") == "raw" {
+		ct := fc.ContentType
+		if ct == "" {
+			ct = "application/octet-stream"
+		}
+		w.Header().Set("Content-Type", ct)
+		w.WriteHeader(http.StatusOK)
+		w.Write(fc.Content) //nolint:errcheck
+		return
+	}
+
 	writeJSON(w, http.StatusOK, fc)
 }
 

--- a/internal/ui/templates/file.html
+++ b/internal/ui/templates/file.html
@@ -4,7 +4,7 @@
   <h1>{{$page.Repo.Name}} <span class="meta">{{$page.Branch}}:{{$page.Path}}</span></h1>
   <span class="meta">
     {{if $page.File}}{{shortHash $page.File.ContentHash}}{{if $page.File.ContentType}} · {{$page.File.ContentType}}{{end}}<span class="dot">·</span>
-    <a href="/repos/{{$page.Repo.Name}}/-/file/{{$page.Path}}?branch={{$page.Branch}}{{if $page.AtSeq}}&at={{$page.AtSeq}}{{end}}" download>download</a><span class="dot">·</span>{{end}}
+    <a href="/repos/{{$page.Repo.Name}}/-/file/{{$page.Path}}?branch={{$page.Branch}}{{if $page.AtSeq}}&at={{$page.AtSeq}}{{end}}&format=raw" download>download</a><span class="dot">·</span>{{end}}
     <select onchange="window.location='/ui/r/{{$page.Repo.Name}}/f/{{$page.Path}}?branch='+this.value">
       {{range $page.Branches}}<option value="{{.}}"{{if eq . $page.Branch}} selected{{end}}>{{.}}</option>{{end}}
     </select>
@@ -36,22 +36,24 @@
     {{end}}
 
     {{if and $page.Path $page.FileHistory}}
-    <h2>File history</h2>
-    <div class="card">
-      <table class="grid">
-        <thead><tr><th>seq</th><th>message</th><th>author</th><th>when</th></tr></thead>
-        <tbody>
-        {{range $page.FileHistory}}
-        <tr>
-          <td><a href="/ui/r/{{$page.Repo.Name}}/b/{{urlPathEscape $page.Branch}}/c/{{.Sequence}}">{{.Sequence}}</a></td>
-          <td>{{.Message}}</td>
-          <td>{{.Author}}</td>
-          <td class="meta">{{relTime .CreatedAt}}</td>
-        </tr>
-        {{end}}
-        </tbody>
-      </table>
-    </div>
+    <details>
+      <summary>file history</summary>
+      <div class="card">
+        <table class="grid">
+          <thead><tr><th>seq</th><th>message</th><th>author</th><th>when</th></tr></thead>
+          <tbody>
+          {{range $page.FileHistory}}
+          <tr>
+            <td><a href="/ui/r/{{$page.Repo.Name}}/b/{{urlPathEscape $page.Branch}}/c/{{.Sequence}}">{{.Sequence}}</a></td>
+            <td>{{.Message}}</td>
+            <td>{{.Author}}</td>
+            <td class="meta">{{relTime .CreatedAt}}</td>
+          </tr>
+          {{end}}
+          </tbody>
+        </table>
+      </div>
+    </details>
     {{end}}
   </div>
 </div>


### PR DESCRIPTION
## Summary

- **File history panel**: Wrapped the file history table in a `<details><summary>file history</summary>` block so it is collapsed by default. No handler changes needed — `handleFile` already fetches history via `GetFileHistory` and passes it as `FileHistory` to the template.

- **Raw download**: Added `?format=raw` query parameter support to `handleFileContent` in `internal/server/handlers_files.go`. When `format=raw` is present, the handler writes raw bytes directly with the file's `ContentType` header (falling back to `application/octet-stream`). Updated the download link URL in `file.html` to append `&format=raw` so the browser downloads actual file content instead of JSON.

## Files changed

- `internal/server/handlers_files.go` — raw format branch in `handleFileContent`
- `internal/ui/templates/file.html` — `<details>` wrapper, `&format=raw` in download URL

## Test plan

- [x] `go test ./internal/ui/... -count=1` passes (includes `TestTemplateTypes` templatecheck)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] `go test ./internal/server/...` — skipped: requires Docker/Postgres testcontainer (pre-existing infra issue: stale container reference unrelated to this change)

## Notes for reviewers

The server integration tests fail due to a stale Docker container reference (`No such container: 6fa6bff8...`). This is a pre-existing environment issue, not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)