### PR TITLE
fix(ui): fix false 'Get started' for repo owners; verify auto-grant

### DIFF
--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -286,7 +286,17 @@ func (h *Handler) handleRepos(w http.ResponseWriter, r *http.Request) {
 						RepoCount: len(byOrg[m.Org]),
 					})
 				}
-				showGetStarted = len(myOrgs) == 0
+				if len(myOrgs) == 0 {
+					// Only show the "Get started" card if the user also has no
+					// repo roles. A user who created a repo has an admin role
+					// even without any org membership, so they are not new.
+					roles, rerr := h.write.ListRolesByIdentity(ctx, identity)
+					if rerr != nil {
+						slog.Error("ui list repo roles for get-started check", "error", rerr)
+					} else {
+						showGetStarted = len(roles) == 0
+					}
+				}
 			}
 		}
 	}

--- a/internal/ui/templates/repos.html
+++ b/internal/ui/templates/repos.html
@@ -17,7 +17,7 @@
   </a>
   {{end}}
 </div>
-{{else}}
+{{else if .ShowGetStarted}}
 <div class="card" style="text-align:center; padding:32px; margin-bottom:24px">
   <h2 style="margin-top:0">Get started</h2>
   <p style="color:var(--text-dim)">You don't belong to any orgs yet. Create one to start hosting repos.</p>

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -55,6 +55,8 @@ type fakeWrite struct {
 	miss          bool
 	proposals     []*model.Proposal
 	releases      []model.Release
+	memberships   []model.OrgMember
+	repoRoles     []model.RepoRole
 }
 
 func (f *fakeWrite) ListRepos(_ context.Context) ([]model.Repo, error) { return f.repos, nil }
@@ -77,13 +79,13 @@ func (f *fakeWrite) ListOrgMembers(_ context.Context, _ string) ([]model.OrgMemb
 	return nil, nil
 }
 func (f *fakeWrite) ListOrgMemberships(_ context.Context, _ string) ([]model.OrgMember, error) {
-	return nil, nil
+	return f.memberships, nil
 }
 func (f *fakeWrite) ListRoles(_ context.Context, _ string) ([]model.Role, error) {
 	return nil, nil
 }
 func (f *fakeWrite) ListRolesByIdentity(_ context.Context, _ string) ([]model.RepoRole, error) {
-	return nil, nil
+	return f.repoRoles, nil
 }
 func (f *fakeWrite) ListCheckRuns(_ context.Context, _, _ string, _ *int64, _ bool) ([]model.CheckRun, error) {
 	return nil, nil
@@ -298,6 +300,19 @@ func newTestHandler(t *testing.T, r ReadStore, w *fakeWrite, a AssembleFn) http.
 	t.Helper()
 	svc := service.New(w, nil, nil)
 	h, err := NewHandler(r, w, svc, a, nil)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	mux := http.NewServeMux()
+	h.Register(mux)
+	return mux
+}
+
+func newTestHandlerWithIdentity(t *testing.T, r ReadStore, w *fakeWrite, identity string) http.Handler {
+	t.Helper()
+	svc := service.New(w, nil, nil)
+	identFn := func(_ context.Context) string { return identity }
+	h, err := NewHandler(r, w, svc, nil, identFn)
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}
@@ -856,6 +871,32 @@ func TestHandleRepos_ShowsNewButtons(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing link %q", want)
 		}
+	}
+}
+
+// TestHandleRepos_GetStartedShownForNewUser verifies that the "Get started"
+// card is shown for an authenticated user with no org memberships and no repo
+// roles.
+func TestHandleRepos_GetStartedShownForNewUser(t *testing.T) {
+	w := &fakeWrite{} // no memberships, no repoRoles
+	h := newTestHandlerWithIdentity(t, &fakeRead{}, w, "new@example.com")
+	_, body := getStatusAndBody(t, h, "/ui/")
+	if !strings.Contains(body, "Get started") {
+		t.Errorf("expected 'Get started' card for new user, body: %.300s", body)
+	}
+}
+
+// TestHandleRepos_GetStartedHiddenForUserWithRepoRole verifies that the "Get
+// started" card is NOT shown for a user who has a repo role (e.g. created a
+// repo) even if they have no org memberships.
+func TestHandleRepos_GetStartedHiddenForUserWithRepoRole(t *testing.T) {
+	w := &fakeWrite{
+		repoRoles: []model.RepoRole{{Repo: "acme/myrepo", Role: model.RoleAdmin}},
+	}
+	h := newTestHandlerWithIdentity(t, &fakeRead{}, w, "creator@example.com")
+	_, body := getStatusAndBody(t, h, "/ui/")
+	if strings.Contains(body, "Get started") {
+		t.Errorf("expected no 'Get started' card for user with repo role")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Landing page (handleRepos):** `ShowGetStarted` was always `true` when a user had no org memberships, even if they had created repos and held repo roles. Fixed by also checking `ListRolesByIdentity` before setting the flag; only show the card when the user has neither org memberships nor repo roles.
- **Template (repos.html):** Changed `{{else}}` to `{{else if .ShowGetStarted}}` so the "Get started" card is gated on the flag rather than the bare absence of `.MyOrgs`.
- **Auto-grant:** Verified that `service.CreateOrg` already adds the creator as org owner (`AddOrgMember`) and `service.CreateRepo` already grants the creator the admin role (`SetRole`). No changes needed — existing service tests `TestCreateOrg_AutoGrantOwner` and `TestCreateRepo_AutoGrantAdmin` cover this.

## Test plan

- [ ] `go test ./internal/ui/... ./internal/service/...` — all pass
- [ ] `go build ./... && go vet ./...` — clean
- [ ] New tests added: `TestHandleRepos_GetStartedShownForNewUser` and `TestHandleRepos_GetStartedHiddenForUserWithRepoRole`
- [ ] DB-dependent tests in `internal/server`, `internal/db`, `internal/automerge` fail with "port '5432/tcp' not found" — pre-existing, not caused by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)