### PR TITLE
feat(ui): identity link, favicon, and clickable author names

### DIFF
--- a/internal/ui/templates/branch_detail.html
+++ b/internal/ui/templates/branch_detail.html
@@ -258,7 +258,7 @@
     <tr>
       <td><a href="/ui/r/{{$page.Repo.Name}}/b/{{urlPathEscape $ctx.Branch.Name}}/c/{{.Sequence}}">{{.Sequence}}</a></td>
       <td>{{.Message}}</td>
-      <td>{{.Author}}</td>
+      <td><a href="/ui/u/{{.Author}}">{{.Author}}</a></td>
       <td class="meta">{{relTime .CreatedAt}}</td>
     </tr>
     {{end}}

--- a/internal/ui/templates/commit.html
+++ b/internal/ui/templates/commit.html
@@ -8,7 +8,7 @@
 <div class="card">
   <div class="commit-meta">
     <div><strong>message</strong> {{.Commit.Message}}</div>
-    <div><strong>author</strong> {{.Commit.Author}}</div>
+    <div><strong>author</strong> <a href="/ui/u/{{.Commit.Author}}">{{.Commit.Author}}</a></div>
     <div><strong>branch</strong> {{.Commit.Branch}}</div>
     <div><strong>when</strong> {{relTime .Commit.CreatedAt}}</div>
   </div>

--- a/internal/ui/templates/issue_detail.html
+++ b/internal/ui/templates/issue_detail.html
@@ -40,7 +40,7 @@
 </div>
 
 <div class="meta" style="margin-bottom:14px">
-  by {{.Issue.Author}} · opened {{relTime .Issue.CreatedAt}}{{if .Issue.ClosedAt}} · closed {{relTimep .Issue.ClosedAt}}{{end}}
+  by <a href="/ui/u/{{.Issue.Author}}">{{.Issue.Author}}</a> · opened {{relTime .Issue.CreatedAt}}{{if .Issue.ClosedAt}} · closed {{relTimep .Issue.ClosedAt}}{{end}}
 </div>
 
 {{if .Issue.Labels}}
@@ -83,7 +83,7 @@
   {{range .Comments}}
   <div class="row">
     <div>
-      <strong>{{.Author}}</strong>
+      <strong><a href="/ui/u/{{.Author}}">{{.Author}}</a></strong>
       <span class="meta">{{relTime .CreatedAt}}{{if .EditedAt}} · edited{{end}}</span>
     </div>
     <form method="POST" action="/ui/r/{{$d.Repo.Name}}/issues/{{$d.Issue.Number}}/comments/{{.ID}}/delete">

--- a/internal/ui/templates/layout.html
+++ b/internal/ui/templates/layout.html
@@ -6,6 +6,7 @@
 <title>{{.Title}} · docstore</title>
 <script>(function(){try{var t=localStorage.getItem("ds-theme");if(t==="light"||t==="dark")document.documentElement.setAttribute("data-theme",t);}catch(e){}})();</script>
 <link rel="stylesheet" href="/ui/static/styles.css">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' rx='2' fill='%234f6ef7'/%3E%3Ctext x='8' y='12' font-family='monospace' font-size='11' font-weight='bold' text-anchor='middle' fill='white'%3Ed%3C/text%3E%3C/svg%3E">
 <script defer src="/ui/static/poll.js"></script>
 </head>
 <body>
@@ -15,7 +16,7 @@
   {{range $i, $c := .Breadcrumbs}}{{if $i}}<span class="sep">›</span>{{end}}{{if $c.Href}}<a href="{{$c.Href}}">{{$c.Label}}</a>{{else}}{{$c.Label}}{{end}}{{end}}
   </span>
   <span class="spacer"></span>
-  {{if .Identity}}<span class="nav-identity" title="Signed in as {{.Identity}}">{{.Identity}}</span>{{end}}
+  {{if .Identity}}<a href="/ui/u/{{.Identity}}" class="nav-identity" title="Signed in as {{.Identity}}">{{.Identity}}</a>{{end}}
   <button class="theme-toggle" data-theme-toggle type="button" aria-label="Toggle theme" title="Toggle theme"><span data-theme-icon-dark>☾</span><span data-theme-icon-light>☀</span></button>
 </nav>
 <main>

--- a/internal/ui/templates/log_rows.html
+++ b/internal/ui/templates/log_rows.html
@@ -3,7 +3,7 @@
 <tr>
   <td><a href="/ui/r/{{$.Repo.Name}}/b/{{urlPathEscape $.Branch}}/c/{{.Seq}}">{{.Seq}}</a></td>
   <td>{{.Message}}</td>
-  <td>{{.Author}}</td>
+  <td><a href="/ui/u/{{.Author}}">{{.Author}}</a></td>
   <td>{{relTime .Time}}</td>
 </tr>
 {{end}}

--- a/internal/ui/templates/proposal_detail.html
+++ b/internal/ui/templates/proposal_detail.html
@@ -15,7 +15,7 @@
 </div>
 
 <div class="meta" style="margin-bottom:14px">
-  by {{.Proposal.Author}} · opened {{relTime .Proposal.CreatedAt}} · updated {{relTime .Proposal.UpdatedAt}}
+  by <a href="/ui/u/{{.Proposal.Author}}">{{.Proposal.Author}}</a> · opened {{relTime .Proposal.CreatedAt}} · updated {{relTime .Proposal.UpdatedAt}}
 </div>
 
 {{if .Err}}


### PR DESCRIPTION
## Summary

- **Identity link in nav**: `layout.html` — nav identity `<span>` replaced with `<a href="/ui/u/{{.Identity}}">`, letting signed-in users navigate to their profile from any page
- **Favicon**: `layout.html` — added `<link rel="icon">` with inline SVG data URI (blue tile, white "d"), fixes 404 on every page load for `/favicon.ico`
- **Clickable author names**: wrapped author name plain text in `<a href="/ui/u/...">` links across five templates:
  - `issue_detail.html`: issue author meta line + comment author `<strong>` tags
  - `proposal_detail.html`: proposal author meta line
  - `log_rows.html`: author column in commit log rows
  - `commit.html`: author field in commit detail card
  - `branch_detail.html`: author column in recent-commits table

## Test plan

- [ ] `go test ./internal/ui/...` — passes (templatecheck covers all modified templates)
- [ ] `go build ./...` and `go vet ./...` — clean

**Note on pre-existing test failures**: `internal/db`, `internal/automerge`, and `internal/server` have failures caused by Postgres/Docker connection resets (`read tcp ... connection reset by peer`). These require `TEST_DATABASE_URL` or Docker to be available and are not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)