### PR TITLE
feat(ui): add inline file diffs to commit detail page

### DIFF
--- a/internal/ui/diff.go
+++ b/internal/ui/diff.go
@@ -1,0 +1,171 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// commitDiffLine is one rendered line in an inline file diff.
+type commitDiffLine struct {
+	Kind    string // "add", "del", "ctx", "hunk"
+	Content string // display content including +/- prefix
+}
+
+// commitFileDiffData is the template data for the commit file diff partial.
+type commitFileDiffData struct {
+	Lines  []commitDiffLine
+	Binary bool
+}
+
+// computeFileDiff builds an inline diff between old and new file content.
+// Returns a binary indicator if either side is not plain text.
+// A size cap of 512 KB per side prevents O(n²) memory use on huge files.
+func computeFileDiff(oldContent, newContent []byte, _ string) commitFileDiffData {
+	const sizeLimit = 512 * 1024
+	if !isProbablyText(oldContent) || !isProbablyText(newContent) {
+		return commitFileDiffData{Binary: true}
+	}
+	if len(oldContent) > sizeLimit || len(newContent) > sizeLimit {
+		return commitFileDiffData{Binary: true}
+	}
+
+	oldLines := splitIntoLines(oldContent)
+	newLines := splitIntoLines(newContent)
+
+	ops := lcsEditScript(oldLines, newLines)
+	lines := opsToHunks(ops, 3)
+	return commitFileDiffData{Lines: lines}
+}
+
+// splitIntoLines splits content into lines without trailing newlines.
+func splitIntoLines(b []byte) []string {
+	if len(b) == 0 {
+		return nil
+	}
+	s := strings.TrimRight(string(b), "\n")
+	return strings.Split(s, "\n")
+}
+
+type editOp struct {
+	kind    string // "ctx", "add", "del"
+	content string
+}
+
+// lcsEditScript produces the shortest edit script transforming a into b using
+// an O(m·n) LCS dynamic-programming approach.
+func lcsEditScript(a, b []string) []editOp {
+	m, n := len(a), len(b)
+
+	// dp[i][j] = length of LCS of a[:i] and b[:j]
+	dp := make([][]int, m+1)
+	for i := range dp {
+		dp[i] = make([]int, n+1)
+	}
+	for i := 1; i <= m; i++ {
+		for j := 1; j <= n; j++ {
+			if a[i-1] == b[j-1] {
+				dp[i][j] = dp[i-1][j-1] + 1
+			} else if dp[i-1][j] >= dp[i][j-1] {
+				dp[i][j] = dp[i-1][j]
+			} else {
+				dp[i][j] = dp[i][j-1]
+			}
+		}
+	}
+
+	// Backtrack
+	ops := make([]editOp, 0, m+n)
+	i, j := m, n
+	for i > 0 || j > 0 {
+		switch {
+		case i > 0 && j > 0 && a[i-1] == b[j-1]:
+			ops = append(ops, editOp{"ctx", a[i-1]})
+			i--
+			j--
+		case j > 0 && (i == 0 || dp[i][j-1] >= dp[i-1][j]):
+			ops = append(ops, editOp{"add", b[j-1]})
+			j--
+		default:
+			ops = append(ops, editOp{"del", a[i-1]})
+			i--
+		}
+	}
+
+	// Reverse to get forward order
+	for l, r := 0, len(ops)-1; l < r; l, r = l+1, r-1 {
+		ops[l], ops[r] = ops[r], ops[l]
+	}
+	return ops
+}
+
+// opsToHunks groups edit ops into unified-diff hunks with ctx context lines.
+func opsToHunks(ops []editOp, ctx int) []commitDiffLine {
+	n := len(ops)
+	if n == 0 {
+		return nil
+	}
+
+	// Mark lines that should appear in output (within ctx of a change).
+	include := make([]bool, n)
+	for i, op := range ops {
+		if op.kind != "ctx" {
+			for j := max(0, i-ctx); j <= min(n-1, i+ctx); j++ {
+				include[j] = true
+			}
+		}
+	}
+
+	var result []commitDiffLine
+	i := 0
+	for i < n {
+		if !include[i] {
+			i++
+			continue
+		}
+
+		// Find end of this hunk.
+		end := i
+		for end < n && include[end] {
+			end++
+		}
+
+		// Compute hunk header line numbers.
+		oldStart, newStart := 1, 1
+		for k := 0; k < i; k++ {
+			if ops[k].kind != "add" {
+				oldStart++
+			}
+			if ops[k].kind != "del" {
+				newStart++
+			}
+		}
+		oldCount, newCount := 0, 0
+		for k := i; k < end; k++ {
+			if ops[k].kind != "add" {
+				oldCount++
+			}
+			if ops[k].kind != "del" {
+				newCount++
+			}
+		}
+
+		result = append(result, commitDiffLine{
+			Kind:    "hunk",
+			Content: fmt.Sprintf("@@ -%d,%d +%d,%d @@", oldStart, oldCount, newStart, newCount),
+		})
+
+		for k := i; k < end; k++ {
+			op := ops[k]
+			prefix := " "
+			if op.kind == "add" {
+				prefix = "+"
+			} else if op.kind == "del" {
+				prefix = "-"
+			}
+			result = append(result, commitDiffLine{Kind: op.kind, Content: prefix + op.content})
+		}
+
+		i = end
+	}
+	return result
+}

--- a/internal/ui/diff_test.go
+++ b/internal/ui/diff_test.go
@@ -1,0 +1,95 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComputeFileDiff(t *testing.T) {
+	t.Run("identical files produce no diff lines", func(t *testing.T) {
+		content := []byte("line1\nline2\nline3\n")
+		d := computeFileDiff(content, content, "file.txt")
+		if d.Binary {
+			t.Fatal("expected non-binary")
+		}
+		if len(d.Lines) != 0 {
+			t.Fatalf("expected empty diff, got %d lines", len(d.Lines))
+		}
+	})
+
+	t.Run("new file shows all additions", func(t *testing.T) {
+		d := computeFileDiff(nil, []byte("a\nb\n"), "file.txt")
+		if d.Binary {
+			t.Fatal("expected non-binary")
+		}
+		adds := countKind(d.Lines, "add")
+		if adds != 2 {
+			t.Fatalf("expected 2 add lines, got %d", adds)
+		}
+	})
+
+	t.Run("deleted file shows all deletions", func(t *testing.T) {
+		d := computeFileDiff([]byte("a\nb\n"), nil, "file.txt")
+		if d.Binary {
+			t.Fatal("expected non-binary")
+		}
+		dels := countKind(d.Lines, "del")
+		if dels != 2 {
+			t.Fatalf("expected 2 del lines, got %d", dels)
+		}
+	})
+
+	t.Run("modified line shows add and del", func(t *testing.T) {
+		old := []byte("line1\nline2\nline3\n")
+		new := []byte("line1\nLINE2\nline3\n")
+		d := computeFileDiff(old, new, "file.txt")
+		if d.Binary {
+			t.Fatal("expected non-binary")
+		}
+		if countKind(d.Lines, "add") != 1 {
+			t.Fatalf("expected 1 add line, got %d", countKind(d.Lines, "add"))
+		}
+		if countKind(d.Lines, "del") != 1 {
+			t.Fatalf("expected 1 del line, got %d", countKind(d.Lines, "del"))
+		}
+		if countKind(d.Lines, "hunk") == 0 {
+			t.Fatal("expected at least one hunk header")
+		}
+	})
+
+	t.Run("binary content flagged as binary", func(t *testing.T) {
+		bin := []byte{0x00, 0x01, 0x02}
+		d := computeFileDiff(bin, bin, "file.bin")
+		if !d.Binary {
+			t.Fatal("expected binary")
+		}
+	})
+
+	t.Run("add line starts with +", func(t *testing.T) {
+		d := computeFileDiff(nil, []byte("hello\n"), "file.txt")
+		for _, l := range d.Lines {
+			if l.Kind == "add" && !strings.HasPrefix(l.Content, "+") {
+				t.Errorf("add line missing + prefix: %q", l.Content)
+			}
+		}
+	})
+
+	t.Run("del line starts with -", func(t *testing.T) {
+		d := computeFileDiff([]byte("hello\n"), nil, "file.txt")
+		for _, l := range d.Lines {
+			if l.Kind == "del" && !strings.HasPrefix(l.Content, "-") {
+				t.Errorf("del line missing - prefix: %q", l.Content)
+			}
+		}
+	})
+}
+
+func countKind(lines []commitDiffLine, kind string) int {
+	n := 0
+	for _, l := range lines {
+		if l.Kind == kind {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -428,6 +428,19 @@ func (h *Handler) handleBranchPartialGetDispatch(w http.ResponseWriter, r *http.
 		h.handleCheckHistoryPartial(w, r)
 		return
 	}
+	// /b/{branch}/c/{seq}/diff/{path...} — inline file diff partial
+	if idx := strings.Index(raw, "/c/"); idx >= 0 {
+		after := raw[idx+3:] // seq/diff/path...
+		if diffIdx := strings.Index(after, "/diff/"); diffIdx >= 0 {
+			seqStr := after[:diffIdx]
+			filePath := after[diffIdx+6:]
+			r.SetPathValue("branch", raw[:idx])
+			r.SetPathValue("seq", seqStr)
+			r.SetPathValue("path", filePath)
+			h.handleCommitFileDiffPartial(w, r)
+			return
+		}
+	}
 
 	http.NotFound(w, r)
 }
@@ -1291,6 +1304,64 @@ func (h *Handler) handleCommitDetail(w http.ResponseWriter, r *http.Request) {
 			Commit: commit,
 		},
 	})
+}
+
+// handleCommitFileDiffPartial returns an HTML fragment with the inline diff
+// for a single file in a commit. The diff compares the file at sequence seq
+// against seq-1 (the previous commit that touched any file on the branch).
+// Route: GET /ui/_/r/{owner}/{name}/b/{branch}/c/{seq}/diff/{path...}
+func (h *Handler) handleCommitFileDiffPartial(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	branch := r.PathValue("branch")
+	seqStr := r.PathValue("seq")
+	path := r.PathValue("path")
+	repoName := owner + "/" + name
+
+	seq, err := strconv.ParseInt(seqStr, 10, 64)
+	if err != nil || seq < 1 {
+		h.renderError(w, r, http.StatusBadRequest, "invalid seq")
+		return
+	}
+
+	_, err = h.write.GetRepo(r.Context(), repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, r, http.StatusNotFound, "repo not found")
+			return
+		}
+		slog.Error("ui commit diff get repo", "repo", repoName, "error", err)
+		h.renderError(w, r, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	current, err := h.read.GetFile(r.Context(), repoName, branch, path, &seq)
+	if err != nil {
+		slog.Error("ui commit diff get current", "repo", repoName, "path", path, "seq", seq, "error", err)
+		h.renderError(w, r, http.StatusInternalServerError, "could not load file")
+		return
+	}
+
+	var previous *store.FileContent
+	if prevSeq := seq - 1; prevSeq >= 1 {
+		previous, err = h.read.GetFile(r.Context(), repoName, branch, path, &prevSeq)
+		if err != nil {
+			slog.Error("ui commit diff get previous", "repo", repoName, "path", path, "seq", prevSeq, "error", err)
+			h.renderError(w, r, http.StatusInternalServerError, "could not load file")
+			return
+		}
+	}
+
+	var oldContent, newContent []byte
+	if previous != nil {
+		oldContent = previous.Content
+	}
+	if current != nil {
+		newContent = current.Content
+	}
+
+	data := computeFileDiff(oldContent, newContent, path)
+	h.render(w, r, h.tmpl.commitFileDiff, "_commit_file_diff.html", data)
 }
 
 // handleAcceptInvite renders the invite acceptance confirmation page (GET) and

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -46,6 +46,7 @@ type templateSet struct {
 	newCommit       *template.Template
 	repoSettings    *template.Template
 	userProfile     *template.Template
+	commitFileDiff  *template.Template
 }
 
 func parseTemplates(root fs.FS) (*templateSet, error) {
@@ -203,6 +204,10 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse user: %w", err)
 	}
+	commitFileDiff, err := loadFragment("_commit_file_diff.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse commit_file_diff: %w", err)
+	}
 	return &templateSet{
 		repos:          repos,
 		branches:       branches,
@@ -233,6 +238,7 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		newCommit:       newCommit,
 		repoSettings:    repoSettings,
 		userProfile:     userProfile,
+		commitFileDiff:  commitFileDiff,
 	}, nil
 }
 

--- a/internal/ui/static/poll.js
+++ b/internal/ui/static/poll.js
@@ -93,6 +93,22 @@
     }).catch(function () {});
   });
 
+  // Lazy-load file diffs inside <details data-diff-url> blocks.
+  // The toggle event fires on the <details> element and does not bubble, so we
+  // use capture-phase (true) to intercept it from the document root.
+  document.addEventListener('toggle', function (e) {
+    var details = e.target;
+    if (!details || details.tagName !== 'DETAILS' || !details.open) return;
+    var body = details.querySelector('[data-diff-url]');
+    if (!body || body.getAttribute('data-diff-loaded')) return;
+    body.setAttribute('data-diff-loaded', '1');
+    var url = body.getAttribute('data-diff-url');
+    fetch(url, { credentials: 'same-origin' }).then(function (r) {
+      if (!r.ok) return;
+      return r.text().then(function (html) { body.innerHTML = html; });
+    }).catch(function () {});
+  }, true);
+
   // Branch-list filter. Hides tbody rows whose first cell text doesn't match.
   document.addEventListener('DOMContentLoaded', function () {
     var inputs = document.querySelectorAll('[data-branch-filter]');

--- a/internal/ui/static/styles.css
+++ b/internal/ui/static/styles.css
@@ -495,3 +495,34 @@ details.form-section > summary::-webkit-details-marker { display: none; }
   line-height: 1;
 }
 .chip-clear:hover { color: var(--bad); }
+
+/* Commit detail: expandable per-file diff blocks. */
+details.file-diff { padding: 0; margin-bottom: 8px; }
+details.file-diff summary.file-diff-summary {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+details.file-diff summary.file-diff-summary::-webkit-details-marker { display: none; }
+details.file-diff summary.file-diff-summary::before {
+  content: "▸";
+  color: var(--text-dim);
+  font-size: 10px;
+  flex-shrink: 0;
+}
+details.file-diff[open] summary.file-diff-summary::before { content: "▾"; }
+details.file-diff summary.file-diff-summary:hover { background: var(--bg-3); border-radius: 4px 4px 0 0; }
+.file-diff-path { flex: 1; }
+.file-diff-body { border-top: 1px solid var(--border); overflow-x: auto; }
+
+/* Inline code diff rendered by the commit file diff partial. */
+.cdiff { font-family: var(--mono); font-size: 12px; }
+.cdiff-line { padding: 1px 8px; white-space: pre; line-height: 1.5; }
+.cdiff-add { background: var(--ok-bg); color: var(--ok); }
+.cdiff-del { background: var(--bad-bg); color: var(--bad); }
+.cdiff-hunk { background: var(--bg-2); color: var(--text-dim); border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); margin: 2px 0; }
+.cdiff-ctx { color: var(--text); }

--- a/internal/ui/templatecheck_test.go
+++ b/internal/ui/templatecheck_test.go
@@ -151,4 +151,7 @@ func TestTemplateTypes(t *testing.T) {
 			Memberships: []model.OrgMember{{Role: model.OrgRoleMember}},
 		})
 	})
+	t.Run("commit_file_diff", func(t *testing.T) {
+		check(t, tmpl.commitFileDiff, commitFileDiffData{})
+	})
 }

--- a/internal/ui/templates/_commit_file_diff.html
+++ b/internal/ui/templates/_commit_file_diff.html
@@ -1,0 +1,10 @@
+{{define "_commit_file_diff.html"}}
+{{if .Binary}}<div class="empty">binary file — diff not shown</div>
+{{else if not .Lines}}<div class="empty">no textual changes</div>
+{{else}}<div class="cdiff">
+{{- range .Lines}}
+<div class="cdiff-line cdiff-{{.Kind}}"><span class="cdiff-text">{{.Content}}</span></div>
+{{- end}}
+</div>
+{{end}}
+{{end}}

--- a/internal/ui/templates/commit.html
+++ b/internal/ui/templates/commit.html
@@ -25,21 +25,20 @@
 </div>
 
 <h2>files changed ({{len .Commit.Files}})</h2>
-<div class="card">
-  {{if not .Commit.Files}}
-    <div class="empty">no files changed</div>
-  {{else}}
-  <table class="grid">
-    <thead><tr><th>path</th><th>change</th></tr></thead>
-    <tbody>
-    {{range .Commit.Files}}
-    <tr>
-      <td><a href="/ui/r/{{$page.Repo.Name}}/f/{{.Path}}?branch={{$page.Branch}}&at={{$page.Commit.Sequence}}">{{.Path}}</a></td>
-      <td><span class="badge {{diffClass .VersionID}}">{{if .VersionID}}modified{{else}}deleted{{end}}</span></td>
-    </tr>
-    {{end}}
-    </tbody>
-  </table>
-  {{end}}
-</div>
+{{if not .Commit.Files}}
+<div class="card"><div class="empty">no files changed</div></div>
+{{else}}
+{{range .Commit.Files}}
+<details class="card file-diff">
+  <summary class="file-diff-summary">
+    <span class="file-diff-path"><a href="/ui/r/{{$page.Repo.Name}}/f/{{.Path}}?branch={{$page.Branch}}&at={{$page.Commit.Sequence}}" onclick="event.stopPropagation()">{{.Path}}</a></span>
+    <span class="badge {{diffClass .VersionID}}">{{if .VersionID}}modified{{else}}deleted{{end}}</span>
+  </summary>
+  <div class="file-diff-body"
+       data-diff-url="/ui/_/r/{{$page.Repo.Name}}/b/{{urlPathEscape $page.Branch}}/c/{{$page.Commit.Sequence}}/diff/{{.Path}}">
+    <div class="empty">Loading diff…</div>
+  </div>
+</details>
+{{end}}
+{{end}}
 {{end}}


### PR DESCRIPTION
## Summary

- Replaces the flat files-changed table on the commit detail page with collapsible `<details>` blocks — one per file — that lazy-load an inline unified diff when the user expands them.
- New partial endpoint `GET /ui/_/r/{owner}/{name}/b/{branch}/c/{seq}/diff/{path...}` serves the diff fragment. The handler fetches the file at sequence N (current) and N-1 (previous via `GetFile` with `atSequence`), computes the diff, and renders the `_commit_file_diff.html` fragment.
- Pure-Go LCS diff algorithm in `diff.go` (no new dependencies). 512 KB per-side cap prevents O(n²) memory use on large files.
- `poll.js` gains a capture-phase `toggle` listener that fires the lazy fetch on first open of each `<details>` block (toggle events don't bubble, so capture=true is required).
- CSS in `styles.css` styles the collapsible blocks and the `+`/`-`/context/hunk lines.
- `diff_test.go` covers the diff algorithm; `templatecheck_test.go` covers the new template.

## Pre-existing failures

Packages `internal/db`, `store`, `server`, `automerge`, `cli`, `events` fail with a Docker/Postgres container error (`container is marked for removal and cannot be started`). These are infrastructure failures unrelated to this PR; `internal/ui` passes.

## Test plan

- [ ] `go test ./internal/ui/... -count=1` — passes
- [ ] `go build ./...` — passes
- [ ] `go vet ./...` — passes
- [ ] Manually navigate to a commit detail page, expand a file, verify diff renders with color-coded lines
- [ ] Verify that collapsing and re-expanding does not re-fetch (once flag on `data-diff-loaded`)
- [ ] Verify binary files show "binary file — diff not shown"
- [ ] Verify new files show all-addition diff, deleted files show all-deletion diff

## Opportunities noted (out of scope)

- Could add syntax highlighting to diff lines in a future pass
- Could pre-expand the first file (or all files for small commits) server-side
- Could surface the diff at the branch detail level per commit as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)