### PR TITLE
feat(ui): add merge button to proposal detail page

### DIFF
--- a/internal/ui/templates/proposal_detail.html
+++ b/internal/ui/templates/proposal_detail.html
@@ -64,6 +64,31 @@
 </div>
 
 {{if eq (printf "%s" .Proposal.State) "open"}}
+<h2>Merge branch</h2>
+<div class="card">
+  <div style="padding:8px 4px 4px">
+    <p style="margin:0 0 10px;color:var(--text-dim);font-size:12px">Merge <strong>{{.Proposal.Branch}}</strong> into <strong>{{.Proposal.BaseBranch}}</strong>. The branch must satisfy all policies and checks.</p>
+    <button id="proposal-merge-btn" class="btn" onclick="(function(){
+      var btn = document.getElementById('proposal-merge-btn');
+      var errDiv = document.getElementById('proposal-merge-err');
+      btn.disabled = true; btn.textContent = 'merging…';
+      fetch('/repos/{{.Repo.Name}}/-/merge', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({branch: '{{.Proposal.Branch}}'})
+      }).then(function(r){
+        if(r.ok){ location.reload(); }
+        else { r.json().then(function(j){
+          errDiv.textContent = j.error || JSON.stringify(j);
+          errDiv.style.display = '';
+          btn.disabled = false; btn.textContent = 'Merge branch';
+        }).catch(function(){ errDiv.textContent = 'merge failed (status ' + r.status + ')'; errDiv.style.display = ''; btn.disabled = false; btn.textContent = 'Merge branch'; }); }
+      }).catch(function(e){ errDiv.textContent = String(e); errDiv.style.display = ''; btn.disabled = false; btn.textContent = 'Merge branch'; });
+    })()">Merge branch</button>
+    <div id="proposal-merge-err" style="display:none;color:var(--bad);font-size:12px;margin-top:6px"></div>
+  </div>
+</div>
+
 <h2>Close proposal</h2>
 <div class="card">
   <form method="POST" action="/ui/r/{{.Repo.Name}}/proposals/{{.Proposal.ID}}/close" style="padding:8px 4px 4px">


### PR DESCRIPTION
## Summary

- Adds a **Merge branch** section to `proposal_detail.html`, visible only when the proposal state is `open`
- Uses the same inline `fetch` pattern as `branch_detail.html`: POSTs to `/repos/{repo}/-/merge` with `{branch: proposal.Branch}` as the JSON body
- On success: `location.reload()` to reflect updated state
- On failure: displays the API's `error` field (or raw status) in a styled inline error div
- Styled consistently with the existing **Close proposal** section (same card layout, `var(--text-dim)` description, `class="btn"` button)
- Both "Merge branch" and "Close proposal" sections are guarded by `{{if eq (printf "%s" .Proposal.State) "open"}}`

## Test plan

- [x] `go test ./... -count=1` — all pass
- [x] `go build ./... && go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)