### PR TITLE
feat(ui): add inline role-change form to org member rows

### DIFF
--- a/internal/ui/templates/org.html
+++ b/internal/ui/templates/org.html
@@ -35,7 +35,17 @@
     {{range .Members}}
     <tr>
       <td>{{.Identity}}</td>
-      <td><span class="badge {{statusClass .Role}}">{{.Role}}</span></td>
+      <td>
+        <form method="POST" action="/ui/o/{{$org}}/members" style="display:flex;gap:4px;align-items:center">
+          {{csrfField}}
+          <input type="hidden" name="identity" value="{{.Identity}}">
+          <select name="role" class="form-input" style="width:auto;padding:2px 6px;font-size:12px">
+            <option value="member"{{if eq (print .Role) "member"}} selected{{end}}>member</option>
+            <option value="owner"{{if eq (print .Role) "owner"}} selected{{end}}>owner</option>
+          </select>
+          <button type="submit" class="btn" style="padding:2px 8px;font-size:12px">Change</button>
+        </form>
+      </td>
       <td>{{.InvitedBy}}</td>
       <td>{{relTime .CreatedAt}}</td>
       <td>


### PR DESCRIPTION
## Summary

- Each member row on `/ui/o/{org}` now has an inline role select dropdown + 'Change' button
- POSTs to the existing `/ui/o/{org}/members` endpoint — no new handler or route needed
- `AddOrgMember` in the store is already an upsert (`ON CONFLICT DO UPDATE SET role`), so the existing handler transparently handles both add and role-change

## Test plan

- [ ] Navigate to an org page with members
- [ ] Change a member's role via the inline select and 'Change' button — verify role updates
- [ ] Confirm existing add-member and remove-member flows still work
- [ ] `go test ./... && go build ./... && go vet ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)