### PR TITLE
feat(ui): show linked issues on proposal and commit detail pages

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -246,6 +246,9 @@ func (fakeWrite) GetRelease(_ context.Context, _, name string) (*model.Release, 
 func (fakeWrite) ListIssueRefs(_ context.Context, _ string, _ int64) ([]model.IssueRef, error) {
 	return nil, nil
 }
+func (fakeWrite) ListIssuesByRef(_ context.Context, _ string, _ model.IssueRefType, _ string) ([]model.Issue, error) {
+	return nil, nil
+}
 func (fakeWrite) CreateIssue(_ context.Context, _, _, _, _ string, _ []string) (*model.Issue, error) {
 	return &model.Issue{ID: "new-id", Number: 99, Title: "new", Author: "test", State: "open"}, nil
 }

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -151,6 +151,7 @@ type commitDetailPage struct {
 	Repo   model.Repo
 	Branch string
 	Commit *store.CommitDetail
+	Issues []model.Issue
 }
 
 type issuesPage struct {
@@ -193,6 +194,7 @@ type proposalsPage struct {
 type proposalDetailPage struct {
 	Repo     model.Repo
 	Proposal *model.Proposal
+	Issues   []model.Issue
 	Err      string
 }
 
@@ -937,6 +939,13 @@ func (h *Handler) handleProposalDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	linkedIssues, err := h.write.ListIssuesByRef(ctx, repoName, model.IssueRefTypeProposal, id)
+	if err != nil {
+		slog.Error("ui list proposal issues", "repo", repoName, "id", id, "error", err)
+		h.renderError(w, r, http.StatusInternalServerError, "could not load linked issues")
+		return
+	}
+
 	h.render(w, r, h.tmpl.proposalDetail, "layout.html", pageData{
 		Title: repoName + " / proposals / " + id,
 		Breadcrumbs: []crumb{
@@ -945,7 +954,7 @@ func (h *Handler) handleProposalDetail(w http.ResponseWriter, r *http.Request) {
 			{Label: "proposals", Href: "/ui/r/" + repoName + "/proposals"},
 			{Label: proposal.Title, Href: ""},
 		},
-		Body: proposalDetailPage{Repo: *repo, Proposal: proposal},
+		Body: proposalDetailPage{Repo: *repo, Proposal: proposal, Issues: linkedIssues},
 	})
 }
 
@@ -1289,6 +1298,13 @@ func (h *Handler) handleCommitDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	linkedIssues, err := h.write.ListIssuesByRef(r.Context(), repoName, model.IssueRefTypeCommit, seqStr)
+	if err != nil {
+		slog.Error("ui list commit issues", "repo", repoName, "seq", seq, "error", err)
+		h.renderError(w, r, http.StatusInternalServerError, "could not load linked issues")
+		return
+	}
+
 	h.render(w, r, h.tmpl.commitDetail, "layout.html", pageData{
 		Title: fmt.Sprintf("%s / %s / commit %d", repoName, branch, seq),
 		Breadcrumbs: []crumb{
@@ -1302,6 +1318,7 @@ func (h *Handler) handleCommitDetail(w http.ResponseWriter, r *http.Request) {
 			Repo:   *repo,
 			Branch: branch,
 			Commit: commit,
+			Issues: linkedIssues,
 		},
 	})
 }

--- a/internal/ui/templates/commit.html
+++ b/internal/ui/templates/commit.html
@@ -24,6 +24,22 @@
   </div>
 </div>
 
+<h2>Linked issues</h2>
+<div class="card">
+  {{if not .Issues}}
+  <div class="empty">no linked issues</div>
+  {{else}}
+  {{range .Issues}}
+  <div class="row">
+    <div>
+      <a href="/ui/r/{{$page.Repo.Name}}/issues/{{.Number}}">#{{.Number}} {{.Title}}</a>
+    </div>
+    <span class="badge {{statusClass (printf "%s" .State)}}">{{.State}}</span>
+  </div>
+  {{end}}
+  {{end}}
+</div>
+
 <h2>files changed ({{len .Commit.Files}})</h2>
 {{if not .Commit.Files}}
 <div class="card"><div class="empty">no files changed</div></div>

--- a/internal/ui/templates/proposal_detail.html
+++ b/internal/ui/templates/proposal_detail.html
@@ -47,6 +47,22 @@
 </div>
 {{end}}
 
+<h2>Linked issues</h2>
+<div class="card">
+  {{if not .Issues}}
+  <div class="empty">no linked issues</div>
+  {{else}}
+  {{range .Issues}}
+  <div class="row">
+    <div>
+      <a href="/ui/r/{{$.Repo.Name}}/issues/{{.Number}}">#{{.Number}} {{.Title}}</a>
+    </div>
+    <span class="badge {{statusClass (printf "%s" .State)}}">{{.State}}</span>
+  </div>
+  {{end}}
+  {{end}}
+</div>
+
 <h2>Edit proposal</h2>
 <div class="card">
   <form method="POST" action="/ui/r/{{.Repo.Name}}/proposals/{{.Proposal.ID}}/edit" style="padding:8px 4px 4px">

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -55,6 +55,7 @@ type WriteStoreLite interface {
 	ListReleases(ctx context.Context, repo string, limit int, afterID string) ([]model.Release, error)
 	GetRelease(ctx context.Context, repo, name string) (*model.Release, error)
 	ListIssueRefs(ctx context.Context, repo string, number int64) ([]model.IssueRef, error)
+	ListIssuesByRef(ctx context.Context, repo string, refType model.IssueRefType, refID string) ([]model.Issue, error)
 	ListCIJobs(ctx context.Context, repo string, branch, status *string, limit int) ([]model.CIJob, error)
 	GetCIJob(ctx context.Context, id string) (*model.CIJob, error)
 	CreateOrg(ctx context.Context, name, createdBy string) (*model.Org, error)

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -156,6 +156,9 @@ func (f *fakeWrite) GetRelease(_ context.Context, _, name string) (*model.Releas
 func (f *fakeWrite) ListIssueRefs(_ context.Context, _ string, _ int64) ([]model.IssueRef, error) {
 	return nil, nil
 }
+func (f *fakeWrite) ListIssuesByRef(_ context.Context, _ string, _ model.IssueRefType, _ string) ([]model.Issue, error) {
+	return nil, nil
+}
 func (f *fakeWrite) CreateIssue(_ context.Context, _, _, _, _ string, _ []string) (*model.Issue, error) {
 	iss := &model.Issue{ID: "new-id", Number: 99, Title: "new", Author: "test", State: "open"}
 	return iss, nil


### PR DESCRIPTION
## Summary

- Added `ListIssuesByRef` to the `WriteStoreLite` interface in `internal/ui/ui.go` so the UI handler layer can look up issues linked to a proposal or commit
- Updated `handleProposalDetail` to call `ListIssuesByRef` (refType=proposal, refID=proposal ID) and pass the result into `proposalDetailPage.Issues`
- Updated `handleCommitDetail` to call `ListIssuesByRef` (refType=commit, refID=sequence string) and pass the result into `commitDetailPage.Issues`
- Added a "Linked issues" section to `proposal_detail.html` showing issue number, title, state badge, and a link to the issue detail page; shows "no linked issues" when empty
- Added the same "Linked issues" section to `commit.html` above the files-changed list
- Added `ListIssuesByRef` stub to both `fakeWrite` implementations (`internal/ui/ui_test.go` and `cmd/ui-preview/main.go`) to satisfy the interface

## Test plan

- [x] `go test ./... -count=1` — all tests pass
- [x] `go build ./...` — clean build
- [x] `go vet ./...` — no issues

## Notes

The `ListIssuesByRef` DB function already existed in `internal/db/issues.go` and the server endpoints (`GET /repos/{name}/-/proposals/{id}/issues`, `GET /repos/{name}/-/commit/{seq}/issues`) were already wired up — this change purely surfaces the data in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)