### PR TITLE
feat(ci-oidc): phase 1 — DB schema, model fields, and citoken package

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -906,6 +906,8 @@ type CIJob struct {
 	TriggerBranch     string     `json:"trigger_branch,omitempty"`
 	TriggerBaseBranch string     `json:"trigger_base_branch,omitempty"`
 	TriggerProposalID *string    `json:"trigger_proposal_id,omitempty"`
+	RequestToken      *string    `json:"request_token,omitempty"`
+	RequestTokenExp   *time.Time `json:"request_token_exp,omitempty"`
 }
 
 // ListCIJobsResponse is the response for GET .../ci-jobs

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
 	github.com/jba/templatecheck v0.7.1
+	github.com/lestrrat-go/jwx/v3 v3.0.13
 	github.com/lib/pq v1.12.3
 	github.com/moby/buildkit v0.29.0
 	github.com/moby/moby/api v1.54.1
@@ -98,7 +99,6 @@ require (
 	github.com/lestrrat-go/dsig-secp256k1 v1.0.0 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
 	github.com/lestrrat-go/httprc/v3 v3.0.2 // indirect
-	github.com/lestrrat-go/jwx/v3 v3.0.13 // indirect
 	github.com/lestrrat-go/option/v2 v2.0.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect

--- a/internal/citoken/citoken.go
+++ b/internal/citoken/citoken.go
@@ -1,0 +1,194 @@
+// Package citoken implements CI job OIDC identity tokens.
+// It provides JWT issuance backed by either an in-process RSA key (LocalSigner,
+// for dev/test) or Google Cloud KMS (KMSSigner, for production).
+package citoken
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/lestrrat-go/jwx/v3/jwt"
+)
+
+// Signer issues signed JWTs and exposes its public key set.
+type Signer interface {
+	// Sign returns a signed JWT string for the given claims map.
+	Sign(ctx context.Context, claims map[string]any) (string, error)
+	// PublicKeys returns the JWKS set of public keys for verification (JSON-encoded).
+	PublicKeys(ctx context.Context) ([]byte, error)
+}
+
+// JobClaims holds the fields for a CI job OIDC token.
+type JobClaims struct {
+	Issuer      string
+	Subject     string // "repo:{repo}:branch:{branch}:check:{check_name}"
+	Audience    string
+	Repo        string
+	Org         string
+	Branch      string
+	CheckName   string
+	RefType     string // "post-submit", "proposal", etc.
+	TriggeredBy string
+	JobID       string
+	Sequence    int64
+}
+
+// GenerateRequestToken returns a (plaintext, hashedForStorage) pair.
+// plaintext is given to the worker; hashedForStorage is stored in the DB.
+// The hashed value is SHA-256 of the plaintext, base64url-encoded (no padding).
+func GenerateRequestToken() (plaintext string, hashed string, err error) {
+	raw := make([]byte, 32)
+	if _, err = rand.Read(raw); err != nil {
+		return "", "", fmt.Errorf("generate request token: %w", err)
+	}
+	plaintext = base64.RawURLEncoding.EncodeToString(raw)
+	hashed = HashRequestToken(plaintext)
+	return plaintext, hashed, nil
+}
+
+// HashRequestToken returns the storage hash for a given plaintext request token.
+// The hash is SHA-256 of the plaintext, base64url-encoded without padding.
+func HashRequestToken(plaintext string) string {
+	sum := sha256.Sum256([]byte(plaintext))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// IssueJWT builds and signs a JWT for a CI job using the provided Signer.
+// The token includes standard claims (iss, sub, aud, jti, iat, exp) plus
+// all custom CI job claims as top-level fields.
+func IssueJWT(ctx context.Context, signer Signer, claims JobClaims) (string, error) {
+	now := time.Now()
+	jti := uuid.New().String()
+
+	c := map[string]any{
+		"iss":          claims.Issuer,
+		"sub":          claims.Subject,
+		"aud":          claims.Audience,
+		"jti":          jti,
+		"iat":          now.Unix(),
+		"exp":          now.Add(time.Hour).Unix(),
+		"repo":         claims.Repo,
+		"org":          claims.Org,
+		"branch":       claims.Branch,
+		"check_name":   claims.CheckName,
+		"ref_type":     claims.RefType,
+		"triggered_by": claims.TriggeredBy,
+		"job_id":       claims.JobID,
+		"sequence":     claims.Sequence,
+	}
+
+	return signer.Sign(ctx, c)
+}
+
+// LocalSigner uses an in-process RSA-2048 key pair for development and testing.
+type LocalSigner struct {
+	privateKey *rsa.PrivateKey
+	jwkKey     jwk.Key // private JWK with kid set
+	kid        string
+}
+
+// NewLocalSigner generates a fresh RSA-2048 key pair and returns a LocalSigner.
+func NewLocalSigner() (*LocalSigner, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("generate rsa key: %w", err)
+	}
+
+	// Build the JWK from the private key.
+	k, err := jwk.Import(priv)
+	if err != nil {
+		return nil, fmt.Errorf("import rsa key to jwk: %w", err)
+	}
+
+	// Assign a stable kid based on the public key thumbprint (SHA-256).
+	if err := jwk.AssignKeyID(k); err != nil {
+		return nil, fmt.Errorf("assign key id: %w", err)
+	}
+
+	kid, ok := k.KeyID()
+	if !ok {
+		return nil, fmt.Errorf("key id not set after AssignKeyID")
+	}
+
+	return &LocalSigner{
+		privateKey: priv,
+		jwkKey:     k,
+		kid:        kid,
+	}, nil
+}
+
+// KID returns the key ID of the LocalSigner's public key.
+func (s *LocalSigner) KID() string { return s.kid }
+
+// Sign builds and signs a JWT using the in-process RSA key.
+// The claims map must include "iss", "sub", "aud", "jti", "iat", "exp" plus
+// any custom claims; Sign passes them through verbatim.
+// The kid from the JWK is automatically included in the JWS protected header.
+func (s *LocalSigner) Sign(_ context.Context, claims map[string]any) (string, error) {
+	tok := jwt.New()
+
+	for k, v := range claims {
+		if err := tok.Set(k, v); err != nil {
+			return "", fmt.Errorf("set claim %q: %w", k, err)
+		}
+	}
+
+	// Sign with the JWK key (not the raw private key) so the kid is included
+	// in the JWS protected header.
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256(), s.jwkKey))
+	if err != nil {
+		return "", fmt.Errorf("sign jwt: %w", err)
+	}
+	return string(signed), nil
+}
+
+// PublicKeys returns the JWKS JSON containing the RSA public key.
+func (s *LocalSigner) PublicKeys(_ context.Context) ([]byte, error) {
+	pubKey, err := s.jwkKey.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("get public key: %w", err)
+	}
+
+	set := jwk.NewSet()
+	if err := set.AddKey(pubKey); err != nil {
+		return nil, fmt.Errorf("add key to set: %w", err)
+	}
+
+	data, err := json.Marshal(set)
+	if err != nil {
+		return nil, fmt.Errorf("marshal jwks: %w", err)
+	}
+	return data, nil
+}
+
+// KMSSigner uses Google Cloud KMS for production JWT signing.
+// TODO: implement full KMS signing once the KMS client is wired in.
+type KMSSigner struct {
+	// keyName is the full KMS resource name, e.g.
+	// "projects/my-project/locations/global/keyRings/my-ring/cryptoKeys/my-key/cryptoKeyVersions/1"
+	keyName string
+}
+
+// NewKMSSigner creates a KMSSigner for the given KMS key resource name.
+func NewKMSSigner(keyName string) *KMSSigner {
+	return &KMSSigner{keyName: keyName}
+}
+
+// Sign is not yet implemented for KMSSigner.
+func (s *KMSSigner) Sign(_ context.Context, _ map[string]any) (string, error) {
+	return "", fmt.Errorf("KMSSigner.Sign: not yet implemented (key: %s)", s.keyName)
+}
+
+// PublicKeys is not yet implemented for KMSSigner.
+func (s *KMSSigner) PublicKeys(_ context.Context) ([]byte, error) {
+	return nil, fmt.Errorf("KMSSigner.PublicKeys: not yet implemented (key: %s)", s.keyName)
+}

--- a/internal/citoken/citoken_test.go
+++ b/internal/citoken/citoken_test.go
@@ -1,0 +1,251 @@
+package citoken_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/dlorenc/docstore/internal/citoken"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/lestrrat-go/jwx/v3/jws"
+	"github.com/lestrrat-go/jwx/v3/jwt"
+)
+
+func TestIssueJWT(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	signer, err := citoken.NewLocalSigner()
+	if err != nil {
+		t.Fatalf("NewLocalSigner: %v", err)
+	}
+
+	claims := citoken.JobClaims{
+		Issuer:      "https://docstore.dev",
+		Subject:     "repo:acme/myrepo:branch:main:check:lint",
+		Audience:    "https://example.com",
+		Repo:        "acme/myrepo",
+		Org:         "acme",
+		Branch:      "main",
+		CheckName:   "lint",
+		RefType:     "post-submit",
+		TriggeredBy: "user@example.com",
+		JobID:       "job-123",
+		Sequence:    42,
+	}
+
+	tokenStr, err := citoken.IssueJWT(ctx, signer, claims)
+	if err != nil {
+		t.Fatalf("IssueJWT: %v", err)
+	}
+	if tokenStr == "" {
+		t.Fatal("expected non-empty token string")
+	}
+
+	// Fetch the public keys to verify the token.
+	jwksJSON, err := signer.PublicKeys(ctx)
+	if err != nil {
+		t.Fatalf("PublicKeys: %v", err)
+	}
+	keySet, err := jwk.Parse(jwksJSON)
+	if err != nil {
+		t.Fatalf("parse JWKS: %v", err)
+	}
+
+	// Parse and verify the JWT.
+	tok, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(keySet, jws.WithInferAlgorithmFromKey(true)))
+	if err != nil {
+		t.Fatalf("jwt.Parse: %v", err)
+	}
+
+	// Verify standard claims.
+	iss, ok := tok.Issuer()
+	if !ok || iss != claims.Issuer {
+		t.Errorf("iss = %q, want %q", iss, claims.Issuer)
+	}
+	sub, ok := tok.Subject()
+	if !ok || sub != claims.Subject {
+		t.Errorf("sub = %q, want %q", sub, claims.Subject)
+	}
+	aud, ok := tok.Audience()
+	if !ok || len(aud) == 0 || aud[0] != claims.Audience {
+		t.Errorf("aud = %v, want [%q]", aud, claims.Audience)
+	}
+	jti, ok := tok.JwtID()
+	if !ok || jti == "" {
+		t.Error("expected non-empty jti")
+	}
+
+	// Verify custom claims.
+	assertStringClaim(t, tok, "repo", claims.Repo)
+	assertStringClaim(t, tok, "org", claims.Org)
+	assertStringClaim(t, tok, "branch", claims.Branch)
+	assertStringClaim(t, tok, "check_name", claims.CheckName)
+	assertStringClaim(t, tok, "ref_type", claims.RefType)
+	assertStringClaim(t, tok, "triggered_by", claims.TriggeredBy)
+	assertStringClaim(t, tok, "job_id", claims.JobID)
+
+	var seq float64
+	if err := tok.Get("sequence", &seq); err != nil {
+		t.Errorf("get sequence claim: %v", err)
+	} else if int64(seq) != claims.Sequence {
+		t.Errorf("sequence = %v, want %d", seq, claims.Sequence)
+	}
+}
+
+func assertStringClaim(t *testing.T, tok jwt.Token, key, want string) {
+	t.Helper()
+	var got string
+	if err := tok.Get(key, &got); err != nil {
+		t.Errorf("get claim %q: %v", key, err)
+		return
+	}
+	if got != want {
+		t.Errorf("claim %q = %q, want %q", key, got, want)
+	}
+}
+
+func TestJWKS(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	signer, err := citoken.NewLocalSigner()
+	if err != nil {
+		t.Fatalf("NewLocalSigner: %v", err)
+	}
+
+	jwksJSON, err := signer.PublicKeys(ctx)
+	if err != nil {
+		t.Fatalf("PublicKeys: %v", err)
+	}
+
+	// Parse and validate structure.
+	var raw struct {
+		Keys []json.RawMessage `json:"keys"`
+	}
+	if err := json.Unmarshal(jwksJSON, &raw); err != nil {
+		t.Fatalf("unmarshal jwks: %v", err)
+	}
+	if len(raw.Keys) != 1 {
+		t.Fatalf("expected 1 key in JWKS, got %d", len(raw.Keys))
+	}
+
+	// Parse as jwk.Set and check the kid.
+	set, err := jwk.Parse(jwksJSON)
+	if err != nil {
+		t.Fatalf("jwk.Parse: %v", err)
+	}
+	if set.Len() != 1 {
+		t.Fatalf("expected 1 key in set, got %d", set.Len())
+	}
+
+	key, ok := set.Key(0)
+	if !ok {
+		t.Fatal("expected to find key at index 0")
+	}
+
+	kid, ok := key.KeyID()
+	if !ok || kid == "" {
+		t.Error("expected non-empty kid")
+	}
+	if kid != signer.KID() {
+		t.Errorf("JWKS kid = %q, want %q", kid, signer.KID())
+	}
+}
+
+func TestGenerateRequestToken(t *testing.T) {
+	t.Parallel()
+
+	pt, hashed, err := citoken.GenerateRequestToken()
+	if err != nil {
+		t.Fatalf("GenerateRequestToken: %v", err)
+	}
+	if pt == "" {
+		t.Error("expected non-empty plaintext")
+	}
+	if hashed == "" {
+		t.Error("expected non-empty hashed token")
+	}
+	if pt == hashed {
+		t.Error("plaintext and hashed should differ")
+	}
+
+	// Verify determinism: same plaintext → same hash (HashRequestToken is deterministic).
+	rehashed := citoken.HashRequestToken(pt)
+	if rehashed != hashed {
+		t.Errorf("re-hashed = %q, want %q", rehashed, hashed)
+	}
+
+	// Two calls should produce different plaintexts (random).
+	pt2, hashed2, err := citoken.GenerateRequestToken()
+	if err != nil {
+		t.Fatalf("second GenerateRequestToken: %v", err)
+	}
+	if pt == pt2 {
+		t.Error("expected different plaintexts on second call")
+	}
+	if hashed == hashed2 {
+		t.Error("expected different hashes for different plaintexts")
+	}
+}
+
+func TestJWTExpiry(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	signer, err := citoken.NewLocalSigner()
+	if err != nil {
+		t.Fatalf("NewLocalSigner: %v", err)
+	}
+
+	before := time.Now()
+
+	tokenStr, err := citoken.IssueJWT(ctx, signer, citoken.JobClaims{
+		Issuer:    "https://docstore.dev",
+		Subject:   "repo:acme/myrepo:branch:main:check:test",
+		Audience:  "https://example.com",
+		Repo:      "acme/myrepo",
+		Org:       "acme",
+		Branch:    "main",
+		CheckName: "test",
+		JobID:     "job-expiry",
+	})
+	if err != nil {
+		t.Fatalf("IssueJWT: %v", err)
+	}
+
+	jwksJSON, err := signer.PublicKeys(ctx)
+	if err != nil {
+		t.Fatalf("PublicKeys: %v", err)
+	}
+	keySet, err := jwk.Parse(jwksJSON)
+	if err != nil {
+		t.Fatalf("parse JWKS: %v", err)
+	}
+
+	tok, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(keySet, jws.WithInferAlgorithmFromKey(true)))
+	if err != nil {
+		t.Fatalf("jwt.Parse: %v", err)
+	}
+
+	iat, ok := tok.IssuedAt()
+	if !ok {
+		t.Fatal("expected iat claim")
+	}
+	exp, ok := tok.Expiration()
+	if !ok {
+		t.Fatal("expected exp claim")
+	}
+
+	// iat should be very close to before.
+	if iat.Before(before.Add(-2 * time.Second)) {
+		t.Errorf("iat %v too old (before = %v)", iat, before)
+	}
+
+	// exp should be ~1h after iat.
+	ttl := exp.Sub(iat)
+	if ttl < 55*time.Minute || ttl > 65*time.Minute {
+		t.Errorf("token TTL = %v, want ~1h", ttl)
+	}
+}

--- a/internal/db/ci_jobs.go
+++ b/internal/db/ci_jobs.go
@@ -3,14 +3,21 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/dlorenc/docstore/internal/model"
 )
 
+// ErrTokenInvalid is returned by LookupRequestToken when the token is not
+// found, is expired, or the associated job is not in the 'claimed' state.
+var ErrTokenInvalid = errors.New("request token invalid or expired")
+
 // ciJobColumns is the ordered list of columns returned by SELECT * on ci_jobs.
 const ciJobColumns = `id, repo, branch, sequence, status, claimed_at, last_heartbeat_at,
-	worker_pod, worker_pod_ip, log_url, error_message, created_at, trigger_type, trigger_branch, trigger_base_branch, trigger_proposal_id`
+	worker_pod, worker_pod_ip, log_url, error_message, created_at, trigger_type, trigger_branch, trigger_base_branch, trigger_proposal_id,
+	request_token, request_token_exp`
 
 // scanCIJob scans a single ci_jobs row into a model.CIJob.
 func scanCIJob(row interface {
@@ -27,11 +34,14 @@ func scanCIJob(row interface {
 	var triggerBranch sql.NullString
 	var triggerBaseBranch sql.NullString
 	var triggerProposalID sql.NullString
+	var requestToken sql.NullString
+	var requestTokenExp sql.NullTime
 	if err := row.Scan(
 		&j.ID, &j.Repo, &j.Branch, &j.Sequence, &j.Status,
 		&claimedAt, &lastHeartbeatAt, &workerPod, &workerPodIP,
 		&logURL, &errorMessage, &j.CreatedAt,
 		&triggerType, &triggerBranch, &triggerBaseBranch, &triggerProposalID,
+		&requestToken, &requestTokenExp,
 	); err != nil {
 		return nil, err
 	}
@@ -65,7 +75,46 @@ func scanCIJob(row interface {
 	if triggerProposalID.Valid {
 		j.TriggerProposalID = &triggerProposalID.String
 	}
+	if requestToken.Valid {
+		j.RequestToken = &requestToken.String
+	}
+	if requestTokenExp.Valid {
+		j.RequestTokenExp = &requestTokenExp.Time
+	}
 	return &j, nil
+}
+
+// StoreRequestToken sets the hashed request token and its expiry on a ci_job.
+func (s *Store) StoreRequestToken(ctx context.Context, jobID string, hashedToken string, exp time.Time) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE ci_jobs SET request_token = $2, request_token_exp = $3 WHERE id = $1`,
+		jobID, hashedToken, exp,
+	)
+	if err != nil {
+		return fmt.Errorf("store request token: %w", err)
+	}
+	return nil
+}
+
+// LookupRequestToken looks up a ci_job by its hashed request token.
+// It returns the job if the token exists, is not expired, and the job status
+// is 'claimed'. Otherwise it returns ErrTokenInvalid.
+func (s *Store) LookupRequestToken(ctx context.Context, hashedToken string) (*model.CIJob, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+ciJobColumns+` FROM ci_jobs
+		WHERE request_token = $1
+		  AND request_token_exp > now()
+		  AND status = 'claimed'`,
+		hashedToken,
+	)
+	j, err := scanCIJob(row)
+	if err == sql.ErrNoRows {
+		return nil, ErrTokenInvalid
+	}
+	if err != nil {
+		return nil, fmt.Errorf("lookup request token: %w", err)
+	}
+	return j, nil
 }
 
 // InsertCIJob inserts a new ci_job row with status 'queued' and returns it.

--- a/internal/db/ci_oidc_test.go
+++ b/internal/db/ci_oidc_test.go
@@ -1,0 +1,103 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestStoreAndLookupRequestToken(t *testing.T) {
+	t.Parallel()
+	s, _ := newCIJobStore(t)
+	ctx := context.Background()
+
+	// Insert a job and claim it so its status becomes 'claimed'.
+	inserted, err := s.InsertCIJob(ctx, "org/repo", "feat", 5, "push", "feat", "", "")
+	if err != nil {
+		t.Fatalf("InsertCIJob: %v", err)
+	}
+	claimed, err := s.ClaimCIJob(ctx, "pod-a", "1.1.1.1")
+	if err != nil {
+		t.Fatalf("ClaimCIJob: %v", err)
+	}
+	if claimed == nil {
+		t.Fatal("expected job to be claimed")
+	}
+
+	hashedToken := "sha256-abc123"
+	exp := time.Now().Add(10 * time.Minute)
+
+	if err := s.StoreRequestToken(ctx, inserted.ID, hashedToken, exp); err != nil {
+		t.Fatalf("StoreRequestToken: %v", err)
+	}
+
+	// LookupRequestToken should return the job.
+	got, err := s.LookupRequestToken(ctx, hashedToken)
+	if err != nil {
+		t.Fatalf("LookupRequestToken: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil job")
+	}
+	if got.ID != inserted.ID {
+		t.Errorf("job ID = %q, want %q", got.ID, inserted.ID)
+	}
+}
+
+func TestLookupRequestToken_NotFound(t *testing.T) {
+	t.Parallel()
+	s, _ := newCIJobStore(t)
+	ctx := context.Background()
+
+	_, err := s.LookupRequestToken(ctx, "no-such-token")
+	if err != ErrTokenInvalid {
+		t.Errorf("LookupRequestToken error = %v, want ErrTokenInvalid", err)
+	}
+}
+
+func TestLookupRequestToken_Expired(t *testing.T) {
+	t.Parallel()
+	s, _ := newCIJobStore(t)
+	ctx := context.Background()
+
+	inserted, err := s.InsertCIJob(ctx, "org/repo", "feat", 5, "push", "feat", "", "")
+	if err != nil {
+		t.Fatalf("InsertCIJob: %v", err)
+	}
+	if _, err := s.ClaimCIJob(ctx, "pod-a", "1.1.1.1"); err != nil {
+		t.Fatalf("ClaimCIJob: %v", err)
+	}
+
+	// Store a token that has already expired.
+	exp := time.Now().Add(-1 * time.Minute)
+	if err := s.StoreRequestToken(ctx, inserted.ID, "expired-token", exp); err != nil {
+		t.Fatalf("StoreRequestToken: %v", err)
+	}
+
+	_, err = s.LookupRequestToken(ctx, "expired-token")
+	if err != ErrTokenInvalid {
+		t.Errorf("LookupRequestToken error = %v, want ErrTokenInvalid", err)
+	}
+}
+
+func TestLookupRequestToken_WrongStatus(t *testing.T) {
+	t.Parallel()
+	s, _ := newCIJobStore(t)
+	ctx := context.Background()
+
+	// Insert a job but do NOT claim it — it stays 'queued'.
+	inserted, err := s.InsertCIJob(ctx, "org/repo", "feat", 5, "push", "feat", "", "")
+	if err != nil {
+		t.Fatalf("InsertCIJob: %v", err)
+	}
+
+	exp := time.Now().Add(10 * time.Minute)
+	if err := s.StoreRequestToken(ctx, inserted.ID, "queued-job-token", exp); err != nil {
+		t.Fatalf("StoreRequestToken: %v", err)
+	}
+
+	_, err = s.LookupRequestToken(ctx, "queued-job-token")
+	if err != ErrTokenInvalid {
+		t.Errorf("LookupRequestToken on queued job = %v, want ErrTokenInvalid", err)
+	}
+}

--- a/internal/db/migrations/000018_ci_oidc.down.sql
+++ b/internal/db/migrations/000018_ci_oidc.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS ci_oidc_tokens;
+ALTER TABLE ci_jobs
+  DROP COLUMN IF EXISTS request_token,
+  DROP COLUMN IF EXISTS request_token_exp;

--- a/internal/db/migrations/000018_ci_oidc.up.sql
+++ b/internal/db/migrations/000018_ci_oidc.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE ci_jobs
+  ADD COLUMN request_token     TEXT UNIQUE,
+  ADD COLUMN request_token_exp TIMESTAMPTZ;
+
+CREATE TABLE ci_oidc_tokens (
+    jti        UUID PRIMARY KEY,
+    job_id     UUID NOT NULL REFERENCES ci_jobs(id),
+    audience   TEXT NOT NULL,
+    issued_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ NOT NULL
+);


### PR DESCRIPTION
## Summary

- **DB migration 000018**: adds `request_token` + `request_token_exp` columns to `ci_jobs`; creates new `ci_oidc_tokens` table for issued JWT tracking
- **CIJob model update**: two new nullable fields propagated through `api.CIJob`, `ciJobColumns`, and `scanCIJob`
- **New `internal/citoken` package**: `Signer` interface, `LocalSigner` (RSA-2048 + JWK thumbprint kid), `KMSSigner` stub, `GenerateRequestToken`, `HashRequestToken`, `IssueJWT` with full claims

## What's NOT in this PR (per task spec)
- No HTTP handlers
- No `cmd/ci-oidc` binary
- No changes to CI worker or server
- `ClaimCIJob` is unchanged — request_token issuance comes in Phase 2
- `KMSSigner` is a stub (compiles; `Sign`/`PublicKeys` return "not yet implemented")

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/citoken/... -count=1` — 4 tests, all pass (TestIssueJWT, TestJWKS, TestGenerateRequestToken, TestJWTExpiry)
- [x] `go test ./... -count=1` — all packages pass including DB tests (TestStoreAndLookupRequestToken, TestLookupRequestToken_NotFound, TestLookupRequestToken_Expired, TestLookupRequestToken_WrongStatus)

## Opportunities for follow-up
- Phase 2: wire `StoreRequestToken` into `ClaimCIJob` and add the HTTP endpoint for token exchange
- Full `KMSSigner` implementation once KMS key resource naming is decided
- Add `ci_oidc_tokens` insert/lookup functions once the JWT issuance flow is wired

Closes part of #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)