### PR TITLE
refactor(executor): remove CACHE_REF registry cache backend

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -388,8 +388,7 @@ func main() {
 	store := db.NewStore(sqlDB)
 
 	// Build executor.
-	cacheBucket := os.Getenv("CACHE_REF")
-	exec, err := executor.New(buildkitAddr, cacheBucket)
+	exec, err := executor.New(buildkitAddr)
 	if err != nil {
 		slog.Error("connect to buildkitd", "error", err)
 		os.Exit(1)

--- a/deploy/k8s/ci-worker.yaml
+++ b/deploy/k8s/ci-worker.yaml
@@ -67,8 +67,6 @@ spec:
             value: gcs
           - name: LOG_BUCKET
             value: docstore-ci-logs
-          - name: CACHE_REF
-            value: us-central1-docker.pkg.dev/dlorenc-chainguard/images/buildcache
           ports:
           - containerPort: 8081
           resources:

--- a/internal/cli/ci.go
+++ b/internal/cli/ci.go
@@ -90,7 +90,7 @@ func (a *App) CIRun(checkFilter, trigger, baseBranch, buildkitAddr string) error
 	fmt.Fprintln(a.Out)
 
 	// 7. Connect to buildkitd.
-	exec, err := executor.New(buildkitAddr, "")
+	exec, err := executor.New(buildkitAddr)
 	if err != nil {
 		return fmt.Errorf("could not connect to buildkitd at %s — is buildkitd running? (%w)", buildkitAddr, err)
 	}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -50,19 +50,16 @@ type CheckResult struct {
 
 // Executor translates a Config into an LLB DAG and dispatches it to buildkitd.
 type Executor struct {
-	client    *client.Client
-	cacheRef  string // registry image ref for BuildKit cache; empty = no cache
+	client *client.Client
 }
 
 // New creates an Executor connected to the buildkitd at buildkitAddr.
-// cacheRef is an optional registry image reference used for BuildKit registry cache;
-// pass "" to disable. Example: "us-central1-docker.pkg.dev/myproject/images/buildcache".
-func New(buildkitAddr, cacheRef string) (*Executor, error) {
+func New(buildkitAddr string) (*Executor, error) {
 	c, err := client.New(context.Background(), buildkitAddr)
 	if err != nil {
 		return nil, fmt.Errorf("connect to buildkitd at %s: %w", buildkitAddr, err)
 	}
-	return &Executor{client: c, cacheRef: cacheRef}, nil
+	return &Executor{client: c}, nil
 }
 
 // Run executes all checks in cfg in parallel against the given source.
@@ -179,9 +176,6 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check) Che
 	}
 
 	solveOpt := client.SolveOpt{
-		// FrontendAttrs must be non-nil: BuildKit v0.29 calls maps.Clone(opt.FrontendAttrs)
-		// then maps.Copy(result, cacheOpt.frontendAttrs), which panics when CacheImports/
-		// CacheExports are set and FrontendAttrs is nil.
 		FrontendAttrs: map[string]string{},
 		Session: []session.Attachable{
 			authprovider.NewDockerAuthProvider(ap),
@@ -190,19 +184,6 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check) Che
 	if isLocal {
 		solveOpt.LocalDirs = map[string]string{
 			"src": source,
-		}
-	}
-	if e.cacheRef != "" {
-		solveOpt.CacheImports = []client.CacheOptionsEntry{
-			{Type: "registry", Attrs: map[string]string{
-				"ref": e.cacheRef,
-			}},
-		}
-		solveOpt.CacheExports = []client.CacheOptionsEntry{
-			{Type: "registry", Attrs: map[string]string{
-				"ref":  e.cacheRef,
-				"mode": "max",
-			}},
 		}
 	}
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 // newExecutor creates an Executor for tests using the package-level buildkitd address.
 func newExecutor(t *testing.T) *executor.Executor {
 	t.Helper()
-	exec, err := executor.New(pkgBuildkitAddr, "")
+	exec, err := executor.New(pkgBuildkitAddr)
 	if err != nil {
 		t.Fatalf("cannot connect to buildkitd at %s: %v", pkgBuildkitAddr, err)
 	}


### PR DESCRIPTION
## Summary

- Removes the `cacheRef` parameter from `executor.New()` — callers no longer need to pass a cache ref
- Drops `CACHE_REF` env var from the ci-worker pod spec
- Updates `internal/cli/ci.go` (`ds ci run`) to match the simplified signature

The registry cache backend added complexity without measurable benefit given that BuildKit's persistent cache mounts already cover the common cases (go mod, npm, pip, cargo).

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./internal/executor/... -count=1` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)