### PR TITLE
test(ci-scheduler): add tests for /claim, /heartbeat, /complete endpoints

### DIFF
--- a/cmd/ci-scheduler/main.go
+++ b/cmd/ci-scheduler/main.go
@@ -148,6 +148,12 @@ func registerWebhookSubscription(ctx context.Context, client *http.Client, docst
 	}
 }
 
+// claimValidator validates a worker pod's Kubernetes service account token.
+// *k8sproof.PodClaimer satisfies this interface.
+type claimValidator interface {
+	ValidateToken(ctx context.Context, token string) (podName, podIP string, err error)
+}
+
 // ---------------------------------------------------------------------------
 // scheduler holds handler dependencies
 // ---------------------------------------------------------------------------
@@ -157,7 +163,7 @@ type scheduler struct {
 	webhookSecret string
 	docstoreURL   string
 	httpClient    *http.Client
-	claimer       *k8sproof.PodClaimer // nil in local dev (no in-cluster K8s)
+	claimer       claimValidator // nil in local dev (no in-cluster K8s)
 	oidcTokenURL  string
 }
 
@@ -612,6 +618,10 @@ func (s *scheduler) handleComplete(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Status == "" {
 		http.Error(w, "status is required", http.StatusBadRequest)
+		return
+	}
+	if req.Status != "passed" && req.Status != "failed" {
+		http.Error(w, "status must be 'passed' or 'failed'", http.StatusBadRequest)
 		return
 	}
 

--- a/cmd/ci-scheduler/main_test.go
+++ b/cmd/ci-scheduler/main_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/model"
 )
 
@@ -23,12 +25,18 @@ import (
 // ---------------------------------------------------------------------------
 
 type stubStore struct {
-	insertedJobs []*model.CIJob
-	getJob       *model.CIJob
-	getErr       error
-	reapJobs     []model.CIJob
-	reapErr      error
-	queueDepth   int64
+	insertedJobs  []*model.CIJob
+	getJob        *model.CIJob
+	getErr        error
+	reapJobs      []model.CIJob
+	reapErr       error
+	queueDepth    int64
+	claimJob      *model.CIJob
+	claimErr      error
+	lookupJob     *model.CIJob
+	lookupErr     error
+	tokenStored   bool
+	storeTokenErr error
 }
 
 func (s *stubStore) InsertCIJob(_ context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerBaseBranch, triggerProposalID string) (*model.CIJob, error) {
@@ -54,15 +62,16 @@ func (s *stubStore) GetCIJob(_ context.Context, id string) (*model.CIJob, error)
 }
 
 func (s *stubStore) ClaimCIJob(_ context.Context, podName, podIP string) (*model.CIJob, error) {
-	return nil, nil
+	return s.claimJob, s.claimErr
 }
 
 func (s *stubStore) StoreRequestToken(_ context.Context, jobID string, hashedToken string, exp time.Time) error {
-	return nil
+	s.tokenStored = true
+	return s.storeTokenErr
 }
 
 func (s *stubStore) LookupRequestToken(_ context.Context, hashedToken string) (*model.CIJob, error) {
-	return nil, nil
+	return s.lookupJob, s.lookupErr
 }
 
 func (s *stubStore) HeartbeatCIJob(_ context.Context, id string) error {
@@ -1313,5 +1322,283 @@ func TestHandleQueueDepth_ZeroDepth(t *testing.T) {
 	want := `{"queue_depth":0}`
 	if got := strings.TrimSpace(w.Body.String()); got != want {
 		t.Errorf("body = %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// stubClaimer — test double for claimValidator
+// ---------------------------------------------------------------------------
+
+type stubClaimer struct {
+	podName string
+	podIP   string
+	err     error
+}
+
+func (s *stubClaimer) ValidateToken(_ context.Context, _ string) (string, string, error) {
+	return s.podName, s.podIP, s.err
+}
+
+// ---------------------------------------------------------------------------
+// Tests: POST /claim
+// ---------------------------------------------------------------------------
+
+func TestHandleClaim_NoClaimer_NoJobs(t *testing.T) {
+	stub := &stubStore{claimJob: nil, claimErr: nil}
+	sched := &scheduler{store: stub}
+
+	req := httptest.NewRequest(http.MethodPost, "/claim", nil)
+	w := httptest.NewRecorder()
+
+	sched.handleClaim(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+}
+
+func TestHandleClaim_NoClaimer_ClaimsJob(t *testing.T) {
+	job := &model.CIJob{ID: "job-1", Repo: "org/repo", Branch: "main", Status: "claimed"}
+	stub := &stubStore{claimJob: job}
+	sched := &scheduler{store: stub, oidcTokenURL: "https://example.com/oidc"}
+
+	req := httptest.NewRequest(http.MethodPost, "/claim", nil)
+	w := httptest.NewRecorder()
+
+	sched.handleClaim(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp claimResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.RequestToken == "" {
+		t.Error("expected non-empty RequestToken")
+	}
+	if resp.OIDCTokenURL == "" {
+		t.Error("expected non-empty OIDCTokenURL")
+	}
+	if !stub.tokenStored {
+		t.Error("expected StoreRequestToken to have been called")
+	}
+}
+
+func TestHandleClaim_NoClaimer_StoreError(t *testing.T) {
+	job := &model.CIJob{ID: "job-1", Status: "claimed"}
+	stub := &stubStore{claimJob: job, storeTokenErr: errors.New("db error")}
+	sched := &scheduler{store: stub}
+
+	req := httptest.NewRequest(http.MethodPost, "/claim", nil)
+	w := httptest.NewRecorder()
+
+	sched.handleClaim(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandleClaim_WithClaimer_ValidToken(t *testing.T) {
+	job := &model.CIJob{ID: "job-2", Status: "claimed"}
+	stub := &stubStore{claimJob: job}
+	claimer := &stubClaimer{podName: "pod-1", podIP: "10.0.0.1"}
+	sched := &scheduler{store: stub, claimer: claimer, oidcTokenURL: "https://example.com/oidc"}
+
+	req := httptest.NewRequest(http.MethodPost, "/claim", nil)
+	req.Header.Set("Authorization", "Bearer some-sa-token")
+	w := httptest.NewRecorder()
+
+	sched.handleClaim(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp claimResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.RequestToken == "" {
+		t.Error("expected non-empty RequestToken")
+	}
+}
+
+func TestHandleClaim_WithClaimer_InvalidToken(t *testing.T) {
+	stub := &stubStore{}
+	claimer := &stubClaimer{err: errors.New("token rejected")}
+	sched := &scheduler{store: stub, claimer: claimer}
+
+	req := httptest.NewRequest(http.MethodPost, "/claim", nil)
+	req.Header.Set("Authorization", "Bearer bad-token")
+	w := httptest.NewRecorder()
+
+	sched.handleClaim(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: POST /jobs/{id}/heartbeat
+// ---------------------------------------------------------------------------
+
+func TestHandleHeartbeat_ValidToken(t *testing.T) {
+	job := &model.CIJob{ID: "job-hb", Status: "claimed"}
+	stub := &stubStore{lookupJob: job}
+	sched := &scheduler{store: stub}
+
+	req := httptest.NewRequest(http.MethodPost, "/jobs/job-hb/heartbeat", nil)
+	req.SetPathValue("id", "job-hb")
+	req.Header.Set("Authorization", "Bearer valid-token")
+	w := httptest.NewRecorder()
+
+	sched.handleHeartbeat(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleHeartbeat_InvalidToken(t *testing.T) {
+	stub := &stubStore{lookupErr: db.ErrTokenInvalid}
+	sched := &scheduler{store: stub}
+
+	req := httptest.NewRequest(http.MethodPost, "/jobs/job-hb/heartbeat", nil)
+	req.SetPathValue("id", "job-hb")
+	req.Header.Set("Authorization", "Bearer expired-token")
+	w := httptest.NewRecorder()
+
+	sched.handleHeartbeat(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestHandleHeartbeat_TokenJobMismatch(t *testing.T) {
+	// Token is valid but belongs to a different job.
+	job := &model.CIJob{ID: "other-job", Status: "claimed"}
+	stub := &stubStore{lookupJob: job}
+	sched := &scheduler{store: stub}
+
+	req := httptest.NewRequest(http.MethodPost, "/jobs/job-hb/heartbeat", nil)
+	req.SetPathValue("id", "job-hb")
+	req.Header.Set("Authorization", "Bearer valid-token")
+	w := httptest.NewRecorder()
+
+	sched.handleHeartbeat(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestHandleHeartbeat_MissingToken(t *testing.T) {
+	stub := &stubStore{}
+	sched := &scheduler{store: stub}
+
+	req := httptest.NewRequest(http.MethodPost, "/jobs/job-hb/heartbeat", nil)
+	req.SetPathValue("id", "job-hb")
+	// No Authorization header.
+	w := httptest.NewRecorder()
+
+	sched.handleHeartbeat(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: POST /jobs/{id}/complete
+// ---------------------------------------------------------------------------
+
+func TestHandleComplete_ValidToken(t *testing.T) {
+	job := &model.CIJob{ID: "job-c", Status: "claimed"}
+	stub := &stubStore{lookupJob: job}
+	sched := &scheduler{store: stub}
+
+	body, _ := json.Marshal(map[string]string{"status": "passed"})
+	req := httptest.NewRequest(http.MethodPost, "/jobs/job-c/complete", bytes.NewReader(body))
+	req.SetPathValue("id", "job-c")
+	req.Header.Set("Authorization", "Bearer valid-token")
+	w := httptest.NewRecorder()
+
+	sched.handleComplete(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleComplete_InvalidToken(t *testing.T) {
+	stub := &stubStore{lookupErr: db.ErrTokenInvalid}
+	sched := &scheduler{store: stub}
+
+	body, _ := json.Marshal(map[string]string{"status": "passed"})
+	req := httptest.NewRequest(http.MethodPost, "/jobs/job-c/complete", bytes.NewReader(body))
+	req.SetPathValue("id", "job-c")
+	req.Header.Set("Authorization", "Bearer bad-token")
+	w := httptest.NewRecorder()
+
+	sched.handleComplete(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestHandleComplete_TokenJobMismatch(t *testing.T) {
+	job := &model.CIJob{ID: "other-job", Status: "claimed"}
+	stub := &stubStore{lookupJob: job}
+	sched := &scheduler{store: stub}
+
+	body, _ := json.Marshal(map[string]string{"status": "passed"})
+	req := httptest.NewRequest(http.MethodPost, "/jobs/job-c/complete", bytes.NewReader(body))
+	req.SetPathValue("id", "job-c")
+	req.Header.Set("Authorization", "Bearer valid-token")
+	w := httptest.NewRecorder()
+
+	sched.handleComplete(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestHandleComplete_InvalidStatus(t *testing.T) {
+	job := &model.CIJob{ID: "job-c", Status: "claimed"}
+	stub := &stubStore{lookupJob: job}
+	sched := &scheduler{store: stub}
+
+	body, _ := json.Marshal(map[string]string{"status": "unknown"})
+	req := httptest.NewRequest(http.MethodPost, "/jobs/job-c/complete", bytes.NewReader(body))
+	req.SetPathValue("id", "job-c")
+	req.Header.Set("Authorization", "Bearer valid-token")
+	w := httptest.NewRecorder()
+
+	sched.handleComplete(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleComplete_MissingToken(t *testing.T) {
+	stub := &stubStore{}
+	sched := &scheduler{store: stub}
+
+	body, _ := json.Marshal(map[string]string{"status": "passed"})
+	req := httptest.NewRequest(http.MethodPost, "/jobs/job-c/complete", bytes.NewReader(body))
+	req.SetPathValue("id", "job-c")
+	// No Authorization header.
+	w := httptest.NewRecorder()
+
+	sched.handleComplete(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
 	}
 }


### PR DESCRIPTION
## Summary

- Add 14 unit tests for the three Phase 2 OIDC endpoints introduced in #283 (POST /claim, POST /jobs/{id}/heartbeat, POST /jobs/{id}/complete)
- Introduce `claimValidator` interface in `main.go` to decouple the scheduler from `*k8sproof.PodClaimer` — enables stub injection in tests without a real K8s client
- Add status validation to `handleComplete` (rejects values other than `passed`/`failed` with 400) to support `TestHandleComplete_InvalidStatus`
- Extend `stubStore` with controllable `claimJob`, `claimErr`, `lookupJob`, `lookupErr`, `tokenStored`, `storeTokenErr` fields (previous stubs always returned `nil, nil`)

## Test coverage added

**POST /claim** (5 cases):
- `TestHandleClaim_NoClaimer_NoJobs` — nil claimer, no job available → 204
- `TestHandleClaim_NoClaimer_ClaimsJob` — nil claimer, job claimed → 200 with claimResponse, StoreRequestToken called
- `TestHandleClaim_NoClaimer_StoreError` — StoreRequestToken returns error → 500
- `TestHandleClaim_WithClaimer_ValidToken` — claimer succeeds → 200
- `TestHandleClaim_WithClaimer_InvalidToken` — claimer rejects token → 401

**POST /jobs/{id}/heartbeat** (4 cases):
- `TestHandleHeartbeat_ValidToken` — matching token+job → 204
- `TestHandleHeartbeat_InvalidToken` — ErrTokenInvalid → 401
- `TestHandleHeartbeat_TokenJobMismatch` — token belongs to different job → 401
- `TestHandleHeartbeat_MissingToken` — no Authorization header → 401

**POST /jobs/{id}/complete** (5 cases):
- `TestHandleComplete_ValidToken` — valid token, status=passed → 204
- `TestHandleComplete_InvalidToken` — ErrTokenInvalid → 401
- `TestHandleComplete_TokenJobMismatch` — token belongs to different job → 401
- `TestHandleComplete_InvalidStatus` — status not in {passed,failed} → 400
- `TestHandleComplete_MissingToken` — no Authorization header → 401

## Test plan

- [x] `go test ./cmd/ci-scheduler/... -count=1 -run TestHandleClaim` passes
- [x] `go test ./cmd/ci-scheduler/... -count=1 -run TestHandleHeartbeat` passes
- [x] `go test ./cmd/ci-scheduler/... -count=1 -run TestHandleComplete` passes
- [x] `go test ./... -count=1` passes (all packages green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)