### PR TITLE
feat(ci-oidc): phase 3 — KMSSigner, RecordOIDCToken, and ci-oidc service

### DIFF
--- a/Dockerfile.ci-oidc
+++ b/Dockerfile.ci-oidc
@@ -1,0 +1,10 @@
+FROM golang:1.26-bookworm AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /ci-oidc ./cmd/ci-oidc
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=builder /ci-oidc /ci-oidc
+ENTRYPOINT ["/ci-oidc"]

--- a/cmd/ci-oidc/main.go
+++ b/cmd/ci-oidc/main.go
@@ -1,0 +1,330 @@
+// Package main implements the ci-oidc binary.
+//
+// ci-oidc is a standalone Cloud Run service that issues OIDC identity tokens
+// for CI jobs. It provides:
+//   - GET  /.well-known/openid-configuration  — OIDC discovery document
+//   - GET  /.well-known/jwks.json             — JSON Web Key Set
+//   - POST /ci/token                          — issue a signed JWT for a CI job
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	"github.com/dlorenc/docstore/internal/citoken"
+	"github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/lestrrat-go/jwx/v3/jwt"
+)
+
+// ---------------------------------------------------------------------------
+// Store interface — minimal subset of db.Store needed by ci-oidc.
+// ---------------------------------------------------------------------------
+
+type tokenStore interface {
+	LookupRequestToken(ctx context.Context, hashedToken string) (*model.CIJob, error)
+	RecordOIDCToken(ctx context.Context, jti, jobID, audience string, exp time.Time) error
+}
+
+// ---------------------------------------------------------------------------
+// server holds handler dependencies.
+// ---------------------------------------------------------------------------
+
+type server struct {
+	store     tokenStore
+	signer    citoken.Signer
+	issuerURL string
+}
+
+// ---------------------------------------------------------------------------
+// GET /.well-known/openid-configuration
+// ---------------------------------------------------------------------------
+
+func (s *server) handleDiscovery(w http.ResponseWriter, r *http.Request) {
+	doc := map[string]any{
+		"issuer":                                s.issuerURL,
+		"jwks_uri":                              s.issuerURL + "/.well-known/jwks.json",
+		"response_types_supported":              []string{"id_token"},
+		"subject_types_supported":               []string{"public"},
+		"id_token_signing_alg_values_supported": []string{"RS256"},
+	}
+	data, err := json.Marshal(doc)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.WriteHeader(http.StatusOK)
+	w.Write(data) //nolint:errcheck
+}
+
+// ---------------------------------------------------------------------------
+// GET /.well-known/jwks.json
+// ---------------------------------------------------------------------------
+
+func (s *server) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	data, err := s.signer.PublicKeys(r.Context())
+	if err != nil {
+		slog.Error("failed to get public keys", "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	w.WriteHeader(http.StatusOK)
+	w.Write(data) //nolint:errcheck
+}
+
+// ---------------------------------------------------------------------------
+// POST /ci/token
+// ---------------------------------------------------------------------------
+
+type tokenRequest struct {
+	Audience  string `json:"audience"`
+	CheckName string `json:"check_name"`
+}
+
+func (s *server) handleToken(w http.ResponseWriter, r *http.Request) {
+	// 1. Extract Bearer token.
+	authHdr := r.Header.Get("Authorization")
+	plaintext := strings.TrimPrefix(authHdr, "Bearer ")
+	if plaintext == "" || plaintext == authHdr {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// 2. Validate request token → look up job.
+	hashed := citoken.HashRequestToken(plaintext)
+	job, err := s.store.LookupRequestToken(r.Context(), hashed)
+	if err == db.ErrTokenInvalid {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if err != nil {
+		slog.Error("lookup request token failed", "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// 3. Decode request body.
+	body, err := io.ReadAll(io.LimitReader(r.Body, 64*1024))
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+	var req tokenRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.Audience == "" {
+		http.Error(w, "audience is required", http.StatusBadRequest)
+		return
+	}
+
+	// 4. Derive ref_type from trigger type.
+	refType := triggerToRefType(job.TriggerType)
+
+	// 5. Extract org as first path segment of repo (e.g. "acme" from "acme/myrepo").
+	org := job.Repo
+	if idx := strings.Index(job.Repo, "/"); idx >= 0 {
+		org = job.Repo[:idx]
+	}
+
+	// 6. Build claims.
+	checkName := req.CheckName
+	claims := citoken.JobClaims{
+		Issuer:      s.issuerURL,
+		Subject:     fmt.Sprintf("repo:%s:branch:%s:check:%s", job.Repo, job.Branch, checkName),
+		Audience:    req.Audience,
+		Repo:        job.Repo,
+		Org:         org,
+		Branch:      job.Branch,
+		CheckName:   checkName,
+		RefType:     refType,
+		TriggeredBy: "",
+		JobID:       job.ID,
+		Sequence:    job.Sequence,
+	}
+
+	// 7. Issue JWT.
+	tokenStr, err := citoken.IssueJWT(r.Context(), s.signer, claims)
+	if err != nil {
+		slog.Error("issue jwt failed", "job_id", job.ID, "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// 8. Extract jti from the issued token (parse without verification since we just issued it).
+	parsed, err := jwt.ParseInsecure([]byte(tokenStr))
+	if err != nil {
+		slog.Error("parse issued jwt failed", "job_id", job.ID, "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	jti, ok := parsed.JwtID()
+	if !ok || jti == "" {
+		slog.Error("issued jwt missing jti", "job_id", job.ID)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	exp := time.Now().Add(time.Hour)
+
+	// 9. Record audit log entry.
+	if err := s.store.RecordOIDCToken(r.Context(), jti, job.ID, req.Audience, exp); err != nil {
+		slog.Error("record oidc token failed", "job_id", job.ID, "jti", jti, "error", err)
+		// Non-fatal: token was issued; log and continue.
+	}
+
+	// 10. Return token.
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{"token": tokenStr}) //nolint:errcheck
+}
+
+// triggerToRefType maps a CI job trigger_type to an OIDC ref_type claim.
+func triggerToRefType(triggerType string) string {
+	switch triggerType {
+	case "push":
+		return "post-submit"
+	case "proposal", "proposal_synchronized":
+		return "pre-submit"
+	case "schedule":
+		return "schedule"
+	case "manual":
+		return "manual"
+	default:
+		return "unknown"
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTP mux
+// ---------------------------------------------------------------------------
+
+func newMux(s *server) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /.well-known/openid-configuration", s.handleDiscovery)
+	mux.HandleFunc("GET /.well-known/jwks.json", s.handleJWKS)
+	mux.HandleFunc("POST /ci/token", s.handleToken)
+	return mux
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+func main() {
+	port := flag.String("port", "8080", "HTTP listen port")
+	issuerURL := flag.String("issuer-url", "https://oidc.docstore.dev", "OIDC issuer URL")
+	kmsKeyVersion := flag.String("kms-key-version", "", "KMS key version resource name (empty = use LocalSigner)")
+	flag.Parse()
+
+	if v := os.Getenv("PORT"); v != "" && *port == "8080" {
+		*port = v
+	}
+	if v := os.Getenv("ISSUER_URL"); v != "" {
+		*issuerURL = v
+	}
+	if v := os.Getenv("KMS_KEY_VERSION"); v != "" {
+		*kmsKeyVersion = v
+	}
+
+	// Set up structured logging.
+	var logLevel slog.LevelVar
+	if lvlStr := os.Getenv("LOG_LEVEL"); lvlStr != "" {
+		if err := logLevel.UnmarshalText([]byte(lvlStr)); err != nil {
+			logLevel.Set(slog.LevelInfo)
+		}
+	}
+	var handler slog.Handler
+	if os.Getenv("LOG_FORMAT") == "text" {
+		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: &logLevel})
+	} else {
+		handler = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: &logLevel})
+	}
+	slog.SetDefault(slog.New(handler))
+
+	// Connect to Postgres.
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		slog.Error("DATABASE_URL environment variable is required")
+		os.Exit(1)
+	}
+	database, err := db.Open(dsn)
+	if err != nil {
+		slog.Error("failed to connect to database", "error", err)
+		os.Exit(1)
+	}
+	defer database.Close()
+
+	store := db.NewStore(database)
+
+	// Build signer.
+	ctx := context.Background()
+	var signer citoken.Signer
+	if *kmsKeyVersion != "" {
+		kmsSigner, err := citoken.NewKMSSigner(ctx, *kmsKeyVersion)
+		if err != nil {
+			slog.Error("failed to create KMS signer", "error", err)
+			os.Exit(1)
+		}
+		signer = kmsSigner
+		slog.Info("using KMS signer", "key_version", *kmsKeyVersion)
+	} else {
+		slog.Warn("KMS_KEY_VERSION not set — using LocalSigner (dev mode only)")
+		localSigner, err := citoken.NewLocalSigner()
+		if err != nil {
+			slog.Error("failed to create local signer", "error", err)
+			os.Exit(1)
+		}
+		signer = localSigner
+	}
+
+	srv := &server{
+		store:     store,
+		signer:    signer,
+		issuerURL: strings.TrimRight(*issuerURL, "/"),
+	}
+
+	httpSrv := &http.Server{
+		Addr:        ":" + *port,
+		Handler:     newMux(srv),
+		ReadTimeout: 10 * time.Second,
+		IdleTimeout: 60 * time.Second,
+	}
+
+	go func() {
+		slog.Info("starting ci-oidc", "port", *port, "issuer", *issuerURL)
+		if err := httpSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("server error", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+	slog.Info("shutting down")
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
+	if err := httpSrv.Shutdown(shutdownCtx); err != nil {
+		slog.Error("shutdown error", "error", err)
+		os.Exit(1)
+	}
+	slog.Info("stopped")
+}

--- a/cmd/ci-oidc/main_test.go
+++ b/cmd/ci-oidc/main_test.go
@@ -1,0 +1,373 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dlorenc/docstore/internal/citoken"
+	"github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/model"
+	"github.com/lestrrat-go/jwx/v3/jwt"
+)
+
+// ---------------------------------------------------------------------------
+// stubStore satisfies the tokenStore interface for tests.
+// ---------------------------------------------------------------------------
+
+type stubStore struct {
+	job      *model.CIJob
+	lookupFn func(ctx context.Context, hashedToken string) (*model.CIJob, error)
+
+	recordedJTI      string
+	recordedJobID    string
+	recordedAudience string
+}
+
+func (s *stubStore) LookupRequestToken(ctx context.Context, hashedToken string) (*model.CIJob, error) {
+	if s.lookupFn != nil {
+		return s.lookupFn(ctx, hashedToken)
+	}
+	if s.job == nil {
+		return nil, db.ErrTokenInvalid
+	}
+	return s.job, nil
+}
+
+func (s *stubStore) RecordOIDCToken(ctx context.Context, jti, jobID, audience string, exp time.Time) error {
+	s.recordedJTI = jti
+	s.recordedJobID = jobID
+	s.recordedAudience = audience
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func newTestServer(t *testing.T, store tokenStore) (*server, citoken.Signer) {
+	t.Helper()
+	signer, err := citoken.NewLocalSigner()
+	if err != nil {
+		t.Fatalf("NewLocalSigner: %v", err)
+	}
+	s := &server{
+		store:     store,
+		signer:    signer,
+		issuerURL: "https://oidc.example.test",
+	}
+	return s, signer
+}
+
+func newRequest(t *testing.T, method, path string, body []byte) *http.Request {
+	t.Helper()
+	var bodyReader *bytes.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	} else {
+		bodyReader = bytes.NewReader(nil)
+	}
+	r, err := http.NewRequest(method, path, bodyReader)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	return r
+}
+
+func defaultJob() *model.CIJob {
+	return &model.CIJob{
+		ID:          "job-uuid-1234",
+		Repo:        "org/repo",
+		Branch:      "main",
+		Sequence:    10,
+		Status:      "claimed",
+		TriggerType: "push",
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestHandleDiscovery(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestServer(t, &stubStore{})
+
+	r := newRequest(t, http.MethodGet, "/.well-known/openid-configuration", nil)
+	w := httptest.NewRecorder()
+	s.handleDiscovery(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("decode discovery doc: %v", err)
+	}
+	if doc["issuer"] != s.issuerURL {
+		t.Errorf("issuer = %v, want %q", doc["issuer"], s.issuerURL)
+	}
+	wantJWKSURI := s.issuerURL + "/.well-known/jwks.json"
+	if doc["jwks_uri"] != wantJWKSURI {
+		t.Errorf("jwks_uri = %v, want %q", doc["jwks_uri"], wantJWKSURI)
+	}
+	if cc := w.Header().Get("Cache-Control"); cc == "" {
+		t.Error("Cache-Control header missing")
+	}
+}
+
+func TestHandleJWKS(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestServer(t, &stubStore{})
+
+	r := newRequest(t, http.MethodGet, "/.well-known/jwks.json", nil)
+	w := httptest.NewRecorder()
+	s.handleJWKS(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var jwks struct {
+		Keys []map[string]any `json:"keys"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &jwks); err != nil {
+		t.Fatalf("decode jwks: %v", err)
+	}
+	if len(jwks.Keys) == 0 {
+		t.Fatal("expected at least one key in JWKS")
+	}
+	key := jwks.Keys[0]
+	if key["kid"] == "" || key["kid"] == nil {
+		t.Error("expected non-empty kid in JWKS key")
+	}
+	if key["alg"] != "RS256" {
+		t.Errorf("alg = %v, want RS256", key["alg"])
+	}
+}
+
+func TestHandleToken_ValidRequest(t *testing.T) {
+	t.Parallel()
+	store := &stubStore{job: defaultJob()}
+	s, _ := newTestServer(t, store)
+
+	body, _ := json.Marshal(map[string]string{"audience": "https://example.com"})
+	r := newRequest(t, http.MethodPost, "/ci/token", body)
+	r.Header.Set("Authorization", "Bearer validtoken")
+	w := httptest.NewRecorder()
+	s.handleToken(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	tokenStr := resp["token"]
+	if tokenStr == "" {
+		t.Fatal("expected non-empty token field")
+	}
+
+	// Parse without verification to check claims.
+	tok, err := jwt.ParseInsecure([]byte(tokenStr))
+	if err != nil {
+		t.Fatalf("ParseInsecure: %v", err)
+	}
+	iss, ok := tok.Issuer()
+	if !ok || iss != s.issuerURL {
+		t.Errorf("iss = %q, want %q", iss, s.issuerURL)
+	}
+	sub, ok := tok.Subject()
+	if !ok || sub == "" {
+		t.Error("expected non-empty sub")
+	}
+	aud, ok := tok.Audience()
+	if !ok || len(aud) == 0 || aud[0] != "https://example.com" {
+		t.Errorf("aud = %v, want [https://example.com]", aud)
+	}
+	jti, ok := tok.JwtID()
+	if !ok || jti == "" {
+		t.Error("expected non-empty jti")
+	}
+	var repo string
+	if err := tok.Get("repo", &repo); err != nil || repo != defaultJob().Repo {
+		t.Errorf("repo = %q, want %q", repo, defaultJob().Repo)
+	}
+	var org string
+	if err := tok.Get("org", &org); err != nil || org != "org" {
+		t.Errorf("org = %q, want %q", org, "org")
+	}
+	var branch string
+	if err := tok.Get("branch", &branch); err != nil || branch != "main" {
+		t.Errorf("branch = %q, want %q", branch, "main")
+	}
+
+	// RecordOIDCToken should have been called with matching jti.
+	if store.recordedJTI != jti {
+		t.Errorf("recorded jti = %q, want %q", store.recordedJTI, jti)
+	}
+	if store.recordedJobID != defaultJob().ID {
+		t.Errorf("recorded job_id = %q, want %q", store.recordedJobID, defaultJob().ID)
+	}
+}
+
+func TestHandleToken_InvalidToken(t *testing.T) {
+	t.Parallel()
+	store := &stubStore{
+		lookupFn: func(_ context.Context, _ string) (*model.CIJob, error) {
+			return nil, db.ErrTokenInvalid
+		},
+	}
+	s, _ := newTestServer(t, store)
+
+	body, _ := json.Marshal(map[string]string{"audience": "https://example.com"})
+	r := newRequest(t, http.MethodPost, "/ci/token", body)
+	r.Header.Set("Authorization", "Bearer badtoken")
+	w := httptest.NewRecorder()
+	s.handleToken(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleToken_MissingAudience(t *testing.T) {
+	t.Parallel()
+	store := &stubStore{job: defaultJob()}
+	s, _ := newTestServer(t, store)
+
+	body, _ := json.Marshal(map[string]string{"audience": ""})
+	r := newRequest(t, http.MethodPost, "/ci/token", body)
+	r.Header.Set("Authorization", "Bearer validtoken")
+	w := httptest.NewRecorder()
+	s.handleToken(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleToken_MissingAuthHeader(t *testing.T) {
+	t.Parallel()
+	store := &stubStore{job: defaultJob()}
+	s, _ := newTestServer(t, store)
+
+	body, _ := json.Marshal(map[string]string{"audience": "https://example.com"})
+	r := newRequest(t, http.MethodPost, "/ci/token", body)
+	// No Authorization header.
+	w := httptest.NewRecorder()
+	s.handleToken(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleToken_CheckNameInSubject(t *testing.T) {
+	t.Parallel()
+	store := &stubStore{job: defaultJob()}
+	s, _ := newTestServer(t, store)
+
+	body, _ := json.Marshal(map[string]string{
+		"audience":   "https://example.com",
+		"check_name": "ci/deploy",
+	})
+	r := newRequest(t, http.MethodPost, "/ci/token", body)
+	r.Header.Set("Authorization", "Bearer validtoken")
+	w := httptest.NewRecorder()
+	s.handleToken(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp) //nolint:errcheck
+	tok, err := jwt.ParseInsecure([]byte(resp["token"]))
+	if err != nil {
+		t.Fatalf("ParseInsecure: %v", err)
+	}
+	sub, _ := tok.Subject()
+	wantSub := "repo:org/repo:branch:main:check:ci/deploy"
+	if sub != wantSub {
+		t.Errorf("sub = %q, want %q", sub, wantSub)
+	}
+}
+
+func TestHandleToken_RefTypeMapping(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		triggerType string
+		wantRefType string
+	}{
+		{"push", "post-submit"},
+		{"proposal", "pre-submit"},
+		{"proposal_synchronized", "pre-submit"},
+		{"schedule", "schedule"},
+		{"manual", "manual"},
+		{"unknown-type", "unknown"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.triggerType, func(t *testing.T) {
+			t.Parallel()
+			job := defaultJob()
+			job.TriggerType = tc.triggerType
+			store := &stubStore{job: job}
+			s, _ := newTestServer(t, store)
+
+			body, _ := json.Marshal(map[string]string{"audience": "https://example.com"})
+			r := newRequest(t, http.MethodPost, "/ci/token", body)
+			r.Header.Set("Authorization", "Bearer validtoken")
+			w := httptest.NewRecorder()
+			s.handleToken(w, r)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+			}
+
+			var resp map[string]string
+			json.Unmarshal(w.Body.Bytes(), &resp) //nolint:errcheck
+			tok, err := jwt.ParseInsecure([]byte(resp["token"]))
+			if err != nil {
+				t.Fatalf("ParseInsecure: %v", err)
+			}
+			var refType string
+			if err := tok.Get("ref_type", &refType); err != nil {
+				t.Fatalf("get ref_type: %v", err)
+			}
+			if refType != tc.wantRefType {
+				t.Errorf("ref_type = %q, want %q", refType, tc.wantRefType)
+			}
+		})
+	}
+}
+
+// Verify that triggerToRefType is exercised (also tested indirectly above).
+func TestTriggerToRefType(t *testing.T) {
+	t.Parallel()
+	tests := []struct{ in, out string }{
+		{"push", "post-submit"},
+		{"proposal", "pre-submit"},
+		{"proposal_synchronized", "pre-submit"},
+		{"schedule", "schedule"},
+		{"manual", "manual"},
+		{"", "unknown"},
+		{"other", "unknown"},
+	}
+	for _, tt := range tests {
+		got := triggerToRefType(tt.in)
+		if got != tt.out {
+			t.Errorf("triggerToRefType(%q) = %q, want %q", tt.in, got, tt.out)
+		}
+	}
+}
+

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,8 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.7.0 // indirect
+	cloud.google.com/go/kms v1.29.0 // indirect
+	cloud.google.com/go/longrunning v0.9.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/iam v1.7.0 h1:JD3zh0C6LHl16aCn5Akff0+GELdp1+4hmh6ndoFLl8U=
 cloud.google.com/go/iam v1.7.0/go.mod h1:tetWZW1PD/m6vcuY2Zj/aU0eCHNPuxedbnbRTyKXvdY=
+cloud.google.com/go/kms v1.29.0 h1:bAW1C5FQf+6GhPkywQzPlsULALCG7c16qpXLFGV9ivY=
+cloud.google.com/go/kms v1.29.0/go.mod h1:YIyXZym11R5uovJJt4oN5eUL3oPmirF3yKeIh6QAf4U=
 cloud.google.com/go/logging v1.13.2 h1:qqlHCBvieJT9Cdq4QqYx1KPadCQ2noD4FK02eNqHAjA=
 cloud.google.com/go/logging v1.13.2/go.mod h1:zaybliM3yun1J8mU2dVQ1/qDzjbOqEijZCn6hSBtKak=
 cloud.google.com/go/longrunning v0.9.0 h1:0EzbDEGsAvOZNbqXopgniY0w0a1phvu5IdUFq8grmqY=

--- a/internal/citoken/citoken.go
+++ b/internal/citoken/citoken.go
@@ -8,11 +8,16 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"sync"
 	"time"
 
+	kms "cloud.google.com/go/kms/apiv1"
+	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
 	"github.com/google/uuid"
 	"github.com/lestrrat-go/jwx/v3/jwa"
 	"github.com/lestrrat-go/jwx/v3/jwk"
@@ -157,6 +162,12 @@ func (s *LocalSigner) PublicKeys(_ context.Context) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get public key: %w", err)
 	}
+	if err := pubKey.Set(jwk.AlgorithmKey, jwa.RS256()); err != nil {
+		return nil, fmt.Errorf("set alg on public key: %w", err)
+	}
+	if err := pubKey.Set(jwk.KeyUsageKey, "sig"); err != nil {
+		return nil, fmt.Errorf("set use on public key: %w", err)
+	}
 
 	set := jwk.NewSet()
 	if err := set.AddKey(pubKey); err != nil {
@@ -171,24 +182,140 @@ func (s *LocalSigner) PublicKeys(_ context.Context) ([]byte, error) {
 }
 
 // KMSSigner uses Google Cloud KMS for production JWT signing.
-// TODO: implement full KMS signing once the KMS client is wired in.
+// The key must be an asymmetric RSA-2048 or RSA-4096 signing key with
+// purpose ASYMMETRIC_SIGN and algorithm RSA_SIGN_PKCS1_*_SHA256.
 type KMSSigner struct {
-	// keyName is the full KMS resource name, e.g.
-	// "projects/my-project/locations/global/keyRings/my-ring/cryptoKeys/my-key/cryptoKeyVersions/1"
-	keyName string
+	keyVersionName string
+	client         *kms.KeyManagementClient
+	// cached public key (fetched once; KMS keys rotate infrequently)
+	once   sync.Once
+	pubKey *rsa.PublicKey
+	kid    string
+	pubErr error
 }
 
-// NewKMSSigner creates a KMSSigner for the given KMS key resource name.
-func NewKMSSigner(keyName string) *KMSSigner {
-	return &KMSSigner{keyName: keyName}
+// NewKMSSigner creates a KMSSigner backed by the given KMS key version resource name.
+// The format is:
+//
+//	projects/{project}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{key}/cryptoKeyVersions/{version}
+func NewKMSSigner(ctx context.Context, keyVersionName string) (*KMSSigner, error) {
+	c, err := kms.NewKeyManagementClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create kms client: %w", err)
+	}
+	return &KMSSigner{keyVersionName: keyVersionName, client: c}, nil
 }
 
-// Sign is not yet implemented for KMSSigner.
-func (s *KMSSigner) Sign(_ context.Context, _ map[string]any) (string, error) {
-	return "", fmt.Errorf("KMSSigner.Sign: not yet implemented (key: %s)", s.keyName)
+// fetchPublicKey retrieves and caches the RSA public key from KMS (called once via sync.Once).
+func (s *KMSSigner) fetchPublicKey(ctx context.Context) {
+	resp, err := s.client.GetPublicKey(ctx, &kmspb.GetPublicKeyRequest{Name: s.keyVersionName})
+	if err != nil {
+		s.pubErr = fmt.Errorf("kms get public key: %w", err)
+		return
+	}
+	block, _ := pem.Decode([]byte(resp.Pem))
+	if block == nil {
+		s.pubErr = fmt.Errorf("kms public key: failed to PEM-decode response")
+		return
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		s.pubErr = fmt.Errorf("kms public key: parse PKIX: %w", err)
+		return
+	}
+	rsaKey, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		s.pubErr = fmt.Errorf("kms public key: expected *rsa.PublicKey, got %T", pub)
+		return
+	}
+	jwkKey, err := jwk.Import(rsaKey)
+	if err != nil {
+		s.pubErr = fmt.Errorf("kms public key: import to jwk: %w", err)
+		return
+	}
+	if err := jwk.AssignKeyID(jwkKey); err != nil {
+		s.pubErr = fmt.Errorf("kms public key: assign kid: %w", err)
+		return
+	}
+	kid, ok := jwkKey.KeyID()
+	if !ok {
+		s.pubErr = fmt.Errorf("kms public key: kid not set after AssignKeyID")
+		return
+	}
+	s.pubKey = rsaKey
+	s.kid = kid
 }
 
-// PublicKeys is not yet implemented for KMSSigner.
-func (s *KMSSigner) PublicKeys(_ context.Context) ([]byte, error) {
-	return nil, fmt.Errorf("KMSSigner.PublicKeys: not yet implemented (key: %s)", s.keyName)
+// PublicKeys returns the JWKS JSON containing the KMS RSA public key.
+func (s *KMSSigner) PublicKeys(ctx context.Context) ([]byte, error) {
+	s.once.Do(func() { s.fetchPublicKey(ctx) })
+	if s.pubErr != nil {
+		return nil, s.pubErr
+	}
+
+	jwkKey, err := jwk.Import(s.pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("kms jwks: import public key: %w", err)
+	}
+	if err := jwk.AssignKeyID(jwkKey); err != nil {
+		return nil, fmt.Errorf("kms jwks: assign kid: %w", err)
+	}
+	if err := jwkKey.Set(jwk.AlgorithmKey, jwa.RS256()); err != nil {
+		return nil, fmt.Errorf("kms jwks: set alg: %w", err)
+	}
+	if err := jwkKey.Set(jwk.KeyUsageKey, "sig"); err != nil {
+		return nil, fmt.Errorf("kms jwks: set use: %w", err)
+	}
+
+	set := jwk.NewSet()
+	if err := set.AddKey(jwkKey); err != nil {
+		return nil, fmt.Errorf("kms jwks: add key: %w", err)
+	}
+	data, err := json.Marshal(set)
+	if err != nil {
+		return nil, fmt.Errorf("kms jwks: marshal: %w", err)
+	}
+	return data, nil
+}
+
+// Sign builds a JWT with the given claims and signs it via KMS AsymmetricSign.
+// The JWT is assembled manually so that only the digest is sent to KMS
+// (the private key never leaves KMS).
+func (s *KMSSigner) Sign(ctx context.Context, claims map[string]any) (string, error) {
+	s.once.Do(func() { s.fetchPublicKey(ctx) })
+	if s.pubErr != nil {
+		return "", s.pubErr
+	}
+
+	headerJSON, err := json.Marshal(map[string]string{
+		"alg": "RS256",
+		"kid": s.kid,
+		"typ": "JWT",
+	})
+	if err != nil {
+		return "", fmt.Errorf("kms sign: marshal header: %w", err)
+	}
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+
+	payloadJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("kms sign: marshal payload: %w", err)
+	}
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+	signingInput := headerB64 + "." + payloadB64
+	digest := sha256.Sum256([]byte(signingInput))
+
+	signResp, err := s.client.AsymmetricSign(ctx, &kmspb.AsymmetricSignRequest{
+		Name: s.keyVersionName,
+		Digest: &kmspb.Digest{
+			Digest: &kmspb.Digest_Sha256{Sha256: digest[:]},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("kms sign: asymmetric sign: %w", err)
+	}
+
+	sigB64 := base64.RawURLEncoding.EncodeToString(signResp.Signature)
+	return signingInput + "." + sigB64, nil
 }

--- a/internal/citoken/citoken_test.go
+++ b/internal/citoken/citoken_test.go
@@ -12,6 +12,14 @@ import (
 	"github.com/lestrrat-go/jwx/v3/jwt"
 )
 
+// TestNewKMSSigner_Compile verifies that *KMSSigner satisfies the Signer interface
+// at compile time. No network calls are made; the constructor would fail at runtime
+// without real KMS credentials.
+func TestNewKMSSigner_Compile(t *testing.T) {
+	t.Parallel()
+	var _ citoken.Signer = (*citoken.KMSSigner)(nil)
+}
+
 func TestIssueJWT(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/db/ci_oidc_tokens.go
+++ b/internal/db/ci_oidc_tokens.go
@@ -1,0 +1,22 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// RecordOIDCToken inserts an audit record for an issued OIDC JWT.
+// jti is the JWT ID (UUID), jobID is the ci_jobs.id, audience is the requested
+// audience, and exp is the token expiry time.
+func (s *Store) RecordOIDCToken(ctx context.Context, jti, jobID, audience string, exp time.Time) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO ci_oidc_tokens (jti, job_id, audience, expires_at)
+		 VALUES ($1, $2, $3, $4)`,
+		jti, jobID, audience, exp,
+	)
+	if err != nil {
+		return fmt.Errorf("record oidc token: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Phase 3 of issue #283: implements the public-facing OIDC service (`oidc.docstore.dev`) and fills in the KMS signing implementation.

- **KMSSigner** (`internal/citoken/citoken.go`): Replaces the stub with a full implementation. Uses `cloud.google.com/go/kms/apiv1` — `GetPublicKey` to fetch/cache the RSA public key (via `sync.Once`), and `AsymmetricSign` to sign with only the digest leaving the process. JWT header+payload are assembled locally so the private key never leaves KMS.
- **LocalSigner.PublicKeys** now sets `alg: RS256` and `use: sig` on the exported JWK for standards compliance.
- **RecordOIDCToken** (`internal/db/ci_oidc_tokens.go`): Inserts an audit row into `ci_oidc_tokens` for every issued JWT.
- **cmd/ci-oidc/main.go**: Standalone Cloud Run service with three endpoints:
  - `GET /.well-known/openid-configuration` — OIDC discovery document
  - `GET /.well-known/jwks.json` — JWKS (rotates safely with 5-min cache)
  - `POST /ci/token` — validates the worker's request token, issues a signed JWT with CI job claims, and records the audit entry
  - Wires up KMS or LocalSigner based on `KMS_KEY_VERSION` env var
  - Graceful shutdown on SIGTERM/SIGINT
- **cmd/ci-oidc/main_test.go**: Full handler test suite using a stub store and LocalSigner — covers discovery, JWKS, valid token issuance (claims verified), invalid token, missing auth header, missing audience, `check_name` in subject, and all `ref_type` mappings.
- **Dockerfile.ci-oidc**: Multi-stage distroless build following existing Dockerfile patterns.

## Test plan

- [x] `go build ./...` — clean build
- [x] `go vet ./...` — no issues
- [x] `go test ./internal/citoken/... -count=1` — existing tests + compile-time KMSSigner interface check
- [x] `go test ./cmd/ci-oidc/... -count=1` — all new service tests pass
- [x] `go test ./... -count=1` — full suite passes (22 packages)

## Notes for future phases

- Phase 4 (presign endpoint) and Phase 5 (worker API auth with OIDC tokens) are not implemented here.
- KMSSigner unit tests require a real KMS key; the compile-time interface check in `TestNewKMSSigner_Compile` is the only automated test for that type.
- Cloud Run deployment config and GitHub Actions changes are deferred (separate concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)