### PR TITLE
feat(ci-oidc): add GET /healthz health check endpoint

### DIFF
--- a/cmd/ci-oidc/main.go
+++ b/cmd/ci-oidc/main.go
@@ -212,11 +212,22 @@ func triggerToRefType(triggerType string) string {
 }
 
 // ---------------------------------------------------------------------------
+// GET /healthz
+// ---------------------------------------------------------------------------
+
+func handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"status":"ok"}`)) //nolint:errcheck
+}
+
+// ---------------------------------------------------------------------------
 // HTTP mux
 // ---------------------------------------------------------------------------
 
 func newMux(s *server) *http.ServeMux {
 	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", handleHealth)
 	mux.HandleFunc("GET /.well-known/openid-configuration", s.handleDiscovery)
 	mux.HandleFunc("GET /.well-known/jwks.json", s.handleJWKS)
 	mux.HandleFunc("POST /ci/token", s.handleToken)

--- a/cmd/ci-oidc/main_test.go
+++ b/cmd/ci-oidc/main_test.go
@@ -351,6 +351,23 @@ func TestHandleToken_RefTypeMapping(t *testing.T) {
 	}
 }
 
+func TestHandleHealth(t *testing.T) {
+	t.Parallel()
+	r := newRequest(t, http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+	handleHealth(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if body := w.Body.String(); body != `{"status":"ok"}` {
+		t.Errorf("body = %q, want {\"status\":\"ok\"}", body)
+	}
+}
+
 // Verify that triggerToRefType is exercised (also tested indirectly above).
 func TestTriggerToRefType(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- Adds `handleHealth` (package-level function, no server state required) returning `{"status":"ok"}` with HTTP 200 and `Content-Type: application/json`
- Registers `GET /healthz` as the first route in `newMux`, consistent with the main docstore server
- Adds `TestHandleHealth` in `main_test.go` following existing test patterns

## Motivation

Cloud Run requires a health check endpoint to determine service readiness. Without it, Cloud Run cannot confirm the service is healthy after deployment.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./cmd/ci-oidc/... -count=1` passes including `TestHandleHealth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)