### PR TITLE
feat(ci): phase 4 — presigned archive URLs for CI workers (#283)

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -219,6 +219,38 @@ func heartbeat(ctx context.Context, schedulerURL, jobID, requestToken string, do
 // Docstore API helpers
 // ---------------------------------------------------------------------------
 
+// getPresignedArchiveURL calls POST /repos/{repo}/-/archive/presign with the
+// request_token and returns the presigned URL for BuildKit to fetch the archive.
+// This endpoint bypasses IAP and uses the request_token for authentication.
+func getPresignedArchiveURL(ctx context.Context, docstoreURL, repo, requestToken string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	u := fmt.Sprintf("%s/repos/%s/-/archive/presign", docstoreURL, url.PathEscape(repo))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
+	if err != nil {
+		return "", fmt.Errorf("build presign request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+requestToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("presign request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("presign: unexpected status %d", resp.StatusCode)
+	}
+	var body struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("decode presign response: %w", err)
+	}
+	if body.URL == "" {
+		return "", fmt.Errorf("presign: empty URL in response")
+	}
+	return body.URL, nil
+}
+
 func fetchConfig(ctx context.Context, client *http.Client, docstoreURL, repo, branch string, headSeq int64) (*executor.Config, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -328,6 +360,7 @@ func runJob(
 	ls logstore.LogStore,
 	docstoreURL string,
 	job *model.CIJob,
+	requestToken string,
 	logDir string,
 	triggerCtx ciconfig.TriggerContext,
 	extraEnv []string,
@@ -353,9 +386,11 @@ func runJob(
 		return "passed", nil, nil
 	}
 
-	// 2. Construct the archive URL.
-	archiveURL := fmt.Sprintf("%s/repos/%s/-/archive?branch=%s&at=%d",
-		docstoreURL, job.Repo, url.QueryEscape(job.Branch), job.Sequence)
+	// 2. Obtain a presigned archive URL for BuildKit to fetch the source.
+	archiveURL, err := getPresignedArchiveURL(ctx, docstoreURL, job.Repo, requestToken)
+	if err != nil {
+		return fail(fmt.Sprintf("get presigned archive URL: %v", err))
+	}
 
 	// 3. Mark each check as pending (in parallel).
 	var pendingWg sync.WaitGroup
@@ -538,7 +573,7 @@ func main() {
 		}
 
 		// Execute the job.
-		jobStatus, jobLogURL, jobErrMsg := runJob(ctx, httpClient, exec, ls, docstoreURL, job, logDir, triggerCtx, extraEnv)
+		jobStatus, jobLogURL, jobErrMsg := runJob(ctx, httpClient, exec, ls, docstoreURL, job, requestToken, logDir, triggerCtx, extraEnv)
 
 		// Stop heartbeat and clear log dir.
 		close(hbDone)

--- a/cmd/ci-worker/main_test.go
+++ b/cmd/ci-worker/main_test.go
@@ -484,6 +484,10 @@ func docstoreHandler(t *testing.T, ciYAML string, tarData []byte, checkStatus in
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.Write(fileResponseJSON(t, ciYAML)) //nolint:errcheck
+		case r.Method == http.MethodPost && strings.Contains(path, "/-/archive/presign"):
+			// Return a fake presigned URL; the mock executor does not fetch it.
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"url":"http://test-archive.example.com/archive.tar"}`)) //nolint:errcheck
 		case strings.Contains(path, "/-/archive"):
 			w.Header().Set("Content-Type", "application/x-tar")
 			w.Write(tarData) //nolint:errcheck
@@ -504,7 +508,7 @@ func TestRunJob_NoCIYAML_ReturnsPassed(t *testing.T) {
 
 	status, logURL, errMsg := runJob(
 		context.Background(), srv.Client(), &mockRunner{}, nil,
-		srv.URL, testJob(), t.TempDir(), ciconfig.TriggerContext{Type: "push"}, nil,
+		srv.URL, testJob(), "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, nil,
 	)
 	if status != "passed" {
 		t.Errorf("expected passed, got %q", status)
@@ -527,7 +531,7 @@ func TestRunJob_FetchConfigError_ReturnsFailed(t *testing.T) {
 
 	status, _, errMsg := runJob(
 		context.Background(), srv.Client(), &mockRunner{}, nil,
-		srv.URL, testJob(), t.TempDir(), ciconfig.TriggerContext{}, nil,
+		srv.URL, testJob(), "", t.TempDir(), ciconfig.TriggerContext{}, nil,
 	)
 	if status != "failed" {
 		t.Errorf("expected failed, got %q", status)
@@ -547,7 +551,7 @@ func TestRunJob_ExecutorError_ReturnsFailed(t *testing.T) {
 	mockExec := &mockRunner{err: fmt.Errorf("buildkit unavailable")}
 	status, _, errMsg := runJob(
 		context.Background(), srv.Client(), mockExec, nil,
-		srv.URL, testJob(), t.TempDir(), ciconfig.TriggerContext{}, nil,
+		srv.URL, testJob(), "", t.TempDir(), ciconfig.TriggerContext{}, nil,
 	)
 	if status != "failed" {
 		t.Errorf("expected failed, got %q", status)
@@ -578,7 +582,7 @@ func TestRunJob_AllChecksPassed(t *testing.T) {
 
 	status, logURL, errMsg := runJob(
 		context.Background(), srv.Client(), mockExec, ls,
-		srv.URL, testJob(), t.TempDir(), ciconfig.TriggerContext{Type: "push"}, nil,
+		srv.URL, testJob(), "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, nil,
 	)
 	if status != "passed" {
 		t.Errorf("expected passed, got %q", status)
@@ -614,7 +618,7 @@ func TestRunJob_OneCheckFailed_OverallFailed(t *testing.T) {
 
 	status, _, errMsg := runJob(
 		context.Background(), srv.Client(), mockExec, nil,
-		srv.URL, testJob(), t.TempDir(), ciconfig.TriggerContext{}, nil,
+		srv.URL, testJob(), "", t.TempDir(), ciconfig.TriggerContext{}, nil,
 	)
 	if status != "failed" {
 		t.Errorf("expected failed, got %q", status)
@@ -630,13 +634,17 @@ func TestRunJob_NilLogStore_StillPosts(t *testing.T) {
 
 	var checkPostCount int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
 		switch {
-		case strings.Contains(r.URL.Path, "/-/file/"):
+		case strings.Contains(path, "/-/file/"):
 			w.Header().Set("Content-Type", "application/json")
 			w.Write(fileResponseJSON(t, ciYAML)) //nolint:errcheck
-		case strings.Contains(r.URL.Path, "/-/archive"):
+		case r.Method == http.MethodPost && strings.Contains(path, "/-/archive/presign"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"url":"http://test-archive.example.com/archive.tar"}`)) //nolint:errcheck
+		case strings.Contains(path, "/-/archive"):
 			w.Write(tarData) //nolint:errcheck
-		case strings.Contains(r.URL.Path, "/-/check"):
+		case strings.Contains(path, "/-/check"):
 			checkPostCount++
 			w.WriteHeader(http.StatusCreated)
 		}
@@ -649,7 +657,7 @@ func TestRunJob_NilLogStore_StillPosts(t *testing.T) {
 
 	status, logURL, _ := runJob(
 		context.Background(), srv.Client(), mockExec, nil, // nil log store
-		srv.URL, testJob(), t.TempDir(), ciconfig.TriggerContext{}, nil,
+		srv.URL, testJob(), "", t.TempDir(), ciconfig.TriggerContext{}, nil,
 	)
 	if status != "passed" {
 		t.Errorf("expected passed, got %q", status)
@@ -675,7 +683,7 @@ func TestRunJob_LogsWrittenToDir(t *testing.T) {
 	}}
 
 	logDir := t.TempDir()
-	runJob(context.Background(), srv.Client(), mockExec, nil, srv.URL, testJob(), logDir, ciconfig.TriggerContext{}, nil) //nolint:errcheck
+	runJob(context.Background(), srv.Client(), mockExec, nil, srv.URL, testJob(), "", logDir, ciconfig.TriggerContext{}, nil) //nolint:errcheck
 
 	data, err := os.ReadFile(filepath.Join(logDir, "test.log"))
 	if err != nil {

--- a/cmd/docstore/main.go
+++ b/cmd/docstore/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"cmp"
 	"context"
+	"encoding/base64"
 	"flag"
 	"log/slog"
 	"net/http"
@@ -143,7 +144,26 @@ func main() {
 	dispatchCtx, dispatchCancel := context.WithCancel(context.Background())
 	events.StartDispatcher(dispatchCtx, database, dsn, broker)
 
-	srv := server.NewWithBroker(commitStore, database, bs, broker, *devIdentity, *bootstrapAdmin, *iapClientID, *iapClientSecret)
+	// Configure presigned archive URLs (optional).
+	// ARCHIVE_HMAC_SECRET: base64-encoded raw HMAC secret bytes.
+	// ARCHIVE_BASE_URL: public server base URL, e.g. "https://docstore.dev".
+	archiveHMACSecretB64 := os.Getenv("ARCHIVE_HMAC_SECRET")
+	archiveBaseURL := os.Getenv("ARCHIVE_BASE_URL")
+	var archiveHMACSecret []byte
+	if archiveHMACSecretB64 != "" {
+		archiveHMACSecret, err = base64.StdEncoding.DecodeString(archiveHMACSecretB64)
+		if err != nil {
+			logger.Error("invalid ARCHIVE_HMAC_SECRET", "error", err)
+			os.Exit(1)
+		}
+	} else {
+		logger.Warn("ARCHIVE_HMAC_SECRET not set — presigned archive URLs disabled")
+	}
+
+	jobStore := db.NewStore(database)
+	srv := server.NewWithPresign(commitStore, database, bs, broker,
+		*devIdentity, *bootstrapAdmin, *iapClientID, *iapClientSecret,
+		jobStore, archiveHMACSecret, archiveBaseURL)
 
 	// Start the auto-merge worker. It subscribes to check.reported and
 	// review.submitted events and merges branches with auto_merge=true.

--- a/internal/archivesign/archivesign.go
+++ b/internal/archivesign/archivesign.go
@@ -1,0 +1,38 @@
+package archivesign
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+)
+
+// Sign returns a hex-encoded HMAC-SHA256 signature over the canonical message
+// "repo\nbranch\nsequence\nexpires" (newline-separated to prevent ambiguity).
+func Sign(secret []byte, repo, branch string, sequence, expiresUnix int64) string {
+	msg := canonicalMessage(repo, branch, sequence, expiresUnix)
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(msg))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Verify reports whether sig is a valid HMAC for the given parameters.
+// Uses hmac.Equal for constant-time comparison.
+func Verify(secret []byte, repo, branch string, sequence, expiresUnix int64, sig string) bool {
+	expected := Sign(secret, repo, branch, sequence, expiresUnix)
+	got, err := hex.DecodeString(sig)
+	if err != nil {
+		return false
+	}
+	exp, _ := hex.DecodeString(expected)
+	return hmac.Equal(exp, got)
+}
+
+func canonicalMessage(repo, branch string, sequence, expiresUnix int64) string {
+	return fmt.Sprintf("%s\n%s\n%s\n%s",
+		repo, branch,
+		strconv.FormatInt(sequence, 10),
+		strconv.FormatInt(expiresUnix, 10),
+	)
+}

--- a/internal/archivesign/archivesign_test.go
+++ b/internal/archivesign/archivesign_test.go
@@ -1,0 +1,70 @@
+package archivesign
+
+import (
+	"testing"
+)
+
+func TestSign_Deterministic(t *testing.T) {
+	secret := []byte("test-secret")
+	repo := "org/repo"
+	branch := "main"
+	var sequence int64 = 42
+	var expiresUnix int64 = 1700000000
+
+	sig1 := Sign(secret, repo, branch, sequence, expiresUnix)
+	sig2 := Sign(secret, repo, branch, sequence, expiresUnix)
+	if sig1 != sig2 {
+		t.Errorf("Sign not deterministic: %q != %q", sig1, sig2)
+	}
+	if sig1 == "" {
+		t.Error("Sign returned empty string")
+	}
+}
+
+func TestVerify_Valid(t *testing.T) {
+	secret := []byte("test-secret")
+	repo := "org/repo"
+	branch := "feature"
+	var sequence int64 = 7
+	var expiresUnix int64 = 1800000000
+
+	sig := Sign(secret, repo, branch, sequence, expiresUnix)
+	if !Verify(secret, repo, branch, sequence, expiresUnix, sig) {
+		t.Error("Verify returned false for a valid signature")
+	}
+}
+
+func TestVerify_WrongSecret(t *testing.T) {
+	secret := []byte("correct-secret")
+	wrongSecret := []byte("wrong-secret")
+	repo := "org/repo"
+	branch := "main"
+	var sequence int64 = 1
+	var expiresUnix int64 = 1700000000
+
+	sig := Sign(secret, repo, branch, sequence, expiresUnix)
+	if Verify(wrongSecret, repo, branch, sequence, expiresUnix, sig) {
+		t.Error("Verify returned true for wrong secret")
+	}
+}
+
+func TestVerify_Tampered(t *testing.T) {
+	secret := []byte("test-secret")
+	repo := "org/repo"
+	branch := "main"
+	var sequence int64 = 42
+	var expiresUnix int64 = 1700000000
+
+	sig := Sign(secret, repo, branch, sequence, expiresUnix)
+	// Verify with altered repo.
+	if Verify(secret, "other/repo", branch, sequence, expiresUnix, sig) {
+		t.Error("Verify returned true for tampered repo")
+	}
+}
+
+func TestVerify_InvalidHex(t *testing.T) {
+	secret := []byte("test-secret")
+	if Verify(secret, "r", "b", 1, 1, "not-valid-hex!!!") {
+		t.Error("Verify returned true for invalid hex signature")
+	}
+}

--- a/internal/server/handlers_archive.go
+++ b/internal/server/handlers_archive.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dlorenc/docstore/internal/archivesign"
+	"github.com/dlorenc/docstore/internal/citoken"
+	"github.com/dlorenc/docstore/internal/db"
+)
+
+// handleArchivePresign implements POST /repos/{repo}/-/archive/presign.
+// Authenticated via request_token (Authorization: Bearer <plaintext>).
+// Returns a presigned URL for BuildKit to fetch the archive.
+func (s *server) handleArchivePresign(w http.ResponseWriter, r *http.Request) {
+	if s.archiveHMACSecret == nil || s.jobTokenStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "presigned archives not configured")
+		return
+	}
+
+	// 1. Extract and validate request_token from Authorization header.
+	authHdr := r.Header.Get("Authorization")
+	plaintext := strings.TrimPrefix(authHdr, "Bearer ")
+	if plaintext == "" || plaintext == authHdr {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	hashed := citoken.HashRequestToken(plaintext)
+	job, err := s.jobTokenStore.LookupRequestToken(r.Context(), hashed)
+	if errors.Is(err, db.ErrTokenInvalid) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// 2. Verify repo in token matches the request path.
+	repoName := r.PathValue("name")
+	if job.Repo != repoName {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// 3. Generate presigned URL with 1-hour expiry.
+	expiresUnix := time.Now().Add(time.Hour).Unix()
+	sig := archivesign.Sign(s.archiveHMACSecret, job.Repo, job.Branch, job.Sequence, expiresUnix)
+
+	presignedURL := fmt.Sprintf("%s/repos/%s/-/archive?branch=%s&at=%d&expires=%d&sig=%s",
+		s.archiveBaseURL,
+		url.PathEscape(job.Repo),
+		url.QueryEscape(job.Branch),
+		job.Sequence,
+		expiresUnix,
+		sig,
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"url": presignedURL}) //nolint:errcheck
+}
+
+// handlePresignedArchive serves GET /repos/{repo}/-/archive when the sig and expires
+// query params are present. Validates the HMAC signature and expiry before serving.
+func (s *server) handlePresignedArchive(w http.ResponseWriter, r *http.Request) {
+	if s.archiveHMACSecret == nil {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	repo := r.PathValue("name")
+	branch := r.URL.Query().Get("branch")
+	atStr := r.URL.Query().Get("at")
+	expiresStr := r.URL.Query().Get("expires")
+	sig := r.URL.Query().Get("sig")
+
+	if branch == "" || atStr == "" || expiresStr == "" || sig == "" {
+		writeError(w, http.StatusBadRequest, "missing required query parameters")
+		return
+	}
+
+	sequence, err := strconv.ParseInt(atStr, 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid at parameter")
+		return
+	}
+	expiresUnix, err := strconv.ParseInt(expiresStr, 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid expires parameter")
+		return
+	}
+
+	// Check expiry.
+	if time.Now().Unix() > expiresUnix {
+		http.Error(w, "expired", http.StatusForbidden)
+		return
+	}
+
+	// Verify HMAC using constant-time comparison.
+	if !archivesign.Verify(s.archiveHMACSecret, repo, branch, sequence, expiresUnix, sig) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	// Serve the archive by delegating to the existing archive handler.
+	// The "at", "branch" params are already in the query string, and
+	// "name" path value is already set on the request.
+	s.handleArchive(w, r)
+}

--- a/internal/server/handlers_archive_test.go
+++ b/internal/server/handlers_archive_test.go
@@ -1,0 +1,250 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dlorenc/docstore/internal/archivesign"
+	"github.com/dlorenc/docstore/internal/citoken"
+	"github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// stubJobTokenStore is a minimal jobTokenStore implementation for tests.
+type stubJobTokenStore struct {
+	lookupFn func(ctx context.Context, hashedToken string) (*model.CIJob, error)
+}
+
+func (s *stubJobTokenStore) LookupRequestToken(ctx context.Context, hashedToken string) (*model.CIJob, error) {
+	return s.lookupFn(ctx, hashedToken)
+}
+
+// buildPresignServer creates a server with archiveHMACSecret and optional jobTokenStore
+// for testing the presigned archive handlers.
+func buildPresignServer(secret []byte, jobStore jobTokenStore) *server {
+	return &server{
+		commitStore:       &mockStore{},
+		archiveHMACSecret: secret,
+		archiveBaseURL:    "https://example.com",
+		jobTokenStore:     jobStore,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleArchivePresign tests
+// ---------------------------------------------------------------------------
+
+func TestHandleArchivePresign_NotConfigured(t *testing.T) {
+	// archiveHMACSecret is nil → 503
+	s := buildPresignServer(nil, nil)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/archive/presign", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleArchivePresign_MissingAuth(t *testing.T) {
+	secret := []byte("test-secret")
+	store := &stubJobTokenStore{
+		lookupFn: func(_ context.Context, _ string) (*model.CIJob, error) {
+			return nil, db.ErrTokenInvalid
+		},
+	}
+	s := buildPresignServer(secret, store)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+	// No Authorization header.
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/archive/presign", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleArchivePresign_InvalidToken(t *testing.T) {
+	secret := []byte("test-secret")
+	store := &stubJobTokenStore{
+		lookupFn: func(_ context.Context, _ string) (*model.CIJob, error) {
+			return nil, db.ErrTokenInvalid
+		},
+	}
+	s := buildPresignServer(secret, store)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/archive/presign", nil)
+	req.Header.Set("Authorization", "Bearer invalid-token")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleArchivePresign_RepoMismatch(t *testing.T) {
+	secret := []byte("test-secret")
+	// Token is valid but job.Repo doesn't match the URL repo.
+	store := &stubJobTokenStore{
+		lookupFn: func(_ context.Context, _ string) (*model.CIJob, error) {
+			return &model.CIJob{
+				ID:       "job-1",
+				Repo:     "org/other-repo", // different repo
+				Branch:   "main",
+				Sequence: 10,
+			}, nil
+		},
+	}
+	s := buildPresignServer(secret, store)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+	plaintext, _, _ := citoken.GenerateRequestToken()
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/archive/presign", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for repo mismatch, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleArchivePresign_ValidToken(t *testing.T) {
+	secret := []byte("test-secret")
+	plaintext, hashed, err := citoken.GenerateRequestToken()
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	store := &stubJobTokenStore{
+		lookupFn: func(_ context.Context, h string) (*model.CIJob, error) {
+			if h != hashed {
+				return nil, db.ErrTokenInvalid
+			}
+			return &model.CIJob{
+				ID:       "job-1",
+				Repo:     "org/myrepo",
+				Branch:   "feature",
+				Sequence: 42,
+			}, nil
+		},
+	}
+	s := buildPresignServer(secret, store)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/archive/presign", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	u, ok := resp["url"]
+	if !ok || u == "" {
+		t.Fatal("expected non-empty url in response")
+	}
+	// URL should contain branch, at, expires, sig params.
+	for _, param := range []string{"branch=", "at=42", "expires=", "sig="} {
+		if !containsStr(u, param) {
+			t.Errorf("expected URL to contain %q; got %q", param, u)
+		}
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsAt(s, substr))
+}
+
+func containsAt(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// handlePresignedArchive tests
+// ---------------------------------------------------------------------------
+
+func TestHandlePresignedArchive_MissingSig(t *testing.T) {
+	// Without sig param, the request is passed through to IAP and the inner mux.
+	// In the inner mux, "archive" with GET goes to handleArchive, which needs
+	// a read store. Without one configured, it returns 503.
+	// The key test: no sig → does NOT call handlePresignedArchive directly.
+	s := buildPresignServer([]byte("secret"), nil)
+	s.readStore = nil // ensure readStore is nil
+	handler := s.buildHandler(devID, devID, s.commitStore)
+	req := httptest.NewRequest(http.MethodGet, "/repos/org/myrepo/-/archive?branch=main", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	// Without sig, goes through IAP → inner mux → handleArchive → 503 (no read store)
+	// or 404 (repo not found via validateRepo with mockStore returning ErrRepoNotFound).
+	// Either way, it's not 403 (which would come from handlePresignedArchive's HMAC check).
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("expected non-403 (not from presigned handler) when sig is absent, got %d", rec.Code)
+	}
+}
+
+func TestHandlePresignedArchive_ExpiredURL(t *testing.T) {
+	secret := []byte("test-secret")
+	s := buildPresignServer(secret, nil)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+
+	// Sign with past expiry.
+	expiresUnix := time.Now().Add(-time.Hour).Unix()
+	sig := archivesign.Sign(secret, "org/myrepo", "main", 1, expiresUnix)
+	url := fmt.Sprintf("/repos/org/myrepo/-/archive?branch=main&at=1&expires=%d&sig=%s", expiresUnix, sig)
+
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for expired URL, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandlePresignedArchive_InvalidSig(t *testing.T) {
+	secret := []byte("test-secret")
+	s := buildPresignServer(secret, nil)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+
+	expiresUnix := time.Now().Add(time.Hour).Unix()
+	// Use a wrong secret to generate the sig.
+	badSig := archivesign.Sign([]byte("wrong-secret"), "org/myrepo", "main", 1, expiresUnix)
+	url := fmt.Sprintf("/repos/org/myrepo/-/archive?branch=main&at=1&expires=%d&sig=%s", expiresUnix, badSig)
+
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for invalid sig, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandlePresignedArchive_ValidSig_PassesHMACCheck(t *testing.T) {
+	secret := []byte("test-secret")
+	s := buildPresignServer(secret, nil)
+	// mockStore.getRepoFn returns ErrRepoNotFound by default (nil fn → ErrRepoNotFound).
+	// So after HMAC passes, handleArchive will call validateRepo → 404.
+	// This proves the request passes the HMAC check (doesn't return 403).
+	handler := s.buildHandler(devID, devID, s.commitStore)
+
+	expiresUnix := time.Now().Add(time.Hour).Unix()
+	sig := archivesign.Sign(secret, "org/myrepo", "main", 1, expiresUnix)
+	url := fmt.Sprintf("/repos/org/myrepo/-/archive?branch=main&at=1&expires=%d&sig=%s", expiresUnix, sig)
+
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	// 403 would indicate HMAC failure; any other code means HMAC check passed.
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("HMAC check should have passed, got 403; body: %s", rec.Body.String())
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -346,9 +346,11 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 	}
 	iapHandler := IAPMiddleware(devIdentity)(routed)
 
-	// /repos/ prefix handler on outer: intercepts presign requests and
-	// HMAC-verified archive downloads; everything else passes through IAP.
-	outer.Handle("/repos/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Wrap the IAP handler: intercept presign and HMAC-signed archive requests
+	// before IAP validation. Everything else falls through to iapHandler.
+	// Using "/" (not "/repos/") avoids the Go mux trailing-slash redirect that
+	// would turn POST /repos into a 307 → POST /repos/.
+	outer.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		repoName, endpoint, ok := parseRepoPath(r.URL.Path)
 		if ok && repoName != "" {
 			// Presign request (worker → get presigned URL): auth via request_token.
@@ -366,7 +368,6 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 		}
 		iapHandler.ServeHTTP(w, r)
 	}))
-	outer.Handle("/", iapHandler)
 	return RequestLogger(outer)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -200,6 +200,42 @@ func NewWithBroker(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, b
 	return newServer(writeStore, database, bs, broker, devIdentity, bootstrapAdmin, iapClientID, iapClientSecret)
 }
 
+// NewWithPresign is like NewWithBroker but also enables presigned archive URLs.
+// archiveHMACSecret is the raw HMAC secret (not base64); archiveBaseURL is the
+// public server base URL used when constructing presigned URLs.
+// If archiveHMACSecret is nil, presigned archive URLs are disabled.
+func NewWithPresign(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker,
+	devIdentity, bootstrapAdmin, iapClientID, iapClientSecret string,
+	jobStore jobTokenStore, archiveHMACSecret []byte, archiveBaseURL string) http.Handler {
+	pc := policy.NewCache()
+	s := &server{
+		commitStore:       writeStore,
+		policyCache:       pc,
+		broker:            broker,
+		globalAdmin:       bootstrapAdmin,
+		iapClientID:       iapClientID,
+		iapClientSecret:   iapClientSecret,
+		archiveHMACSecret: archiveHMACSecret,
+		archiveBaseURL:    archiveBaseURL,
+		jobTokenStore:     jobStore,
+	}
+	if writeStore != nil {
+		var emitter service.EventEmitter
+		if broker != nil {
+			emitter = broker
+		}
+		s.svc = service.New(writeStore, emitter, pc)
+	}
+	if database != nil {
+		rs := store.New(database)
+		if bs != nil {
+			rs.SetBlobStore(bs)
+		}
+		s.readStore = rs
+	}
+	return s.buildHandler(devIdentity, bootstrapAdmin, writeStore)
+}
+
 func newServer(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker, devIdentity, bootstrapAdmin, iapClientID, iapClientSecret string) http.Handler {
 	pc := policy.NewCache()
 	s := &server{
@@ -308,8 +344,35 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 	if writeStore != nil {
 		routed = RBACMiddleware(writeStore, bootstrapAdmin)(inner)
 	}
-	outer.Handle("/", IAPMiddleware(devIdentity)(routed))
+	iapHandler := IAPMiddleware(devIdentity)(routed)
+
+	// /repos/ prefix handler on outer: intercepts presign requests and
+	// HMAC-verified archive downloads; everything else passes through IAP.
+	outer.Handle("/repos/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		repoName, endpoint, ok := parseRepoPath(r.URL.Path)
+		if ok && repoName != "" {
+			// Presign request (worker → get presigned URL): auth via request_token.
+			if endpoint == "archive/presign" && r.Method == http.MethodPost {
+				r.SetPathValue("name", repoName)
+				s.handleArchivePresign(w, r)
+				return
+			}
+			// HMAC-verified archive download (BuildKit → fetch source): auth via sig.
+			if endpoint == "archive" && r.Method == http.MethodGet && r.URL.Query().Get("sig") != "" {
+				r.SetPathValue("name", repoName)
+				s.handlePresignedArchive(w, r)
+				return
+			}
+		}
+		iapHandler.ServeHTTP(w, r)
+	}))
+	outer.Handle("/", iapHandler)
 	return RequestLogger(outer)
+}
+
+// jobTokenStore is the subset of db.Store needed for request_token validation.
+type jobTokenStore interface {
+	LookupRequestToken(ctx context.Context, hashedToken string) (*model.CIJob, error)
 }
 
 type server struct {
@@ -325,6 +388,13 @@ type server struct {
 	// so CLI tools can perform the IAP OAuth flow.
 	iapClientID     string
 	iapClientSecret string
+	// archiveHMACSecret is the raw HMAC key for presigned archive URLs.
+	// nil means the feature is disabled.
+	archiveHMACSecret []byte
+	// archiveBaseURL is the public server base URL used when constructing presigned URLs.
+	archiveBaseURL string
+	// jobTokenStore validates request_tokens for presigned archive URL issuance.
+	jobTokenStore jobTokenStore
 }
 
 // handleDSConfig serves GET /.well-known/ds-config — unauthenticated.


### PR DESCRIPTION
## Summary

- **New package `internal/archivesign`**: HMAC-SHA256 signing/verification over `"repo\nbranch\nsequence\nexpires"` canonical message; constant-time comparison via `hmac.Equal`
- **New server endpoints** (bypass IAP, authenticated differently):
  - `POST /repos/{repo}/-/archive/presign` — auth via `request_token` Bearer token; returns 1-hour presigned URL for BuildKit
  - `GET /repos/{repo}/-/archive?sig=...&expires=...&at=...&branch=...` — HMAC + expiry validation before delegating to existing `handleArchive`
- **`NewWithPresign` constructor** with `jobTokenStore`, `archiveHMACSecret`, `archiveBaseURL` fields; outer-mux bypass handler intercepts presign/HMAC requests before IAP middleware
- **`cmd/docstore/main.go`**: reads `ARCHIVE_HMAC_SECRET` (base64 raw bytes) and `ARCHIVE_BASE_URL` env vars; uses `NewWithPresign`
- **`cmd/ci-worker/main.go`**: `runJob` now calls `getPresignedArchiveURL` (POST to presign endpoint with `request_token`) and passes the resulting URL to the executor; `requestToken` added to `runJob` signature

## Routing fix (regression from initial PR)

The original implementation registered the bypass handler on `outer.Handle("/repos/", ...)`. Go's `http.ServeMux` treats `/repos/` as a subtree pattern and auto-emits a 307 redirect from `POST /repos` → `POST /repos/`, breaking existing repo creation. Fixed by registering on `outer.Handle("/", ...)` instead — the exact-match routes (`GET /healthz`, `GET /.well-known/ds-config`) still take priority, so they continue to work. Tests verified with `go test ./internal/server/... -count=1 -p 1` (all pass).

## Security properties

- HMAC uses constant-time comparison (`hmac.Equal`)
- Presign endpoint validates `request_token` (SHA-256 hashed, stored in DB) scoped to job's repo
- Presigned URLs are time-limited (1-hour expiry checked server-side before HMAC)
- Both new bypass endpoints are unauthenticated at IAP layer but use their own auth mechanisms

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/archivesign/... -count=1` — pass
- [x] `go test ./internal/server/... -count=1 -p 1` — all pass (including new presign tests and all existing tests)
- [x] `go test ./cmd/ci-worker/... -count=1` — all pass
- [x] Routing regression fixed: `POST /repos` → 201 (not 307), `POST /repos/` routes correctly, `GET /repos/*/diff` → 200

## Opportunities for future work (not implemented)

- Secret Manager integration for `ARCHIVE_HMAC_SECRET` (currently env var)
- URL signing could include IP/user-agent binding for extra security
- Could add `HEAD` support on the presigned archive endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)