### PR TITLE
fix(phase4): POST /repos routing test + ARCHIVE_BASE_URL validation

### DIFF
--- a/cmd/docstore/main.go
+++ b/cmd/docstore/main.go
@@ -7,9 +7,11 @@ import (
 	"flag"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -146,9 +148,27 @@ func main() {
 
 	// Configure presigned archive URLs (optional).
 	// ARCHIVE_HMAC_SECRET: base64-encoded raw HMAC secret bytes.
-	// ARCHIVE_BASE_URL: public server base URL, e.g. "https://docstore.dev".
+	// ARCHIVE_BASE_URL: public server base URL used when constructing presigned archive
+	// download URLs returned to CI workers, e.g. "https://docstore.dev". Must use
+	// http or https scheme and include a host. Trailing slash is stripped automatically.
 	archiveHMACSecretB64 := os.Getenv("ARCHIVE_HMAC_SECRET")
 	archiveBaseURL := os.Getenv("ARCHIVE_BASE_URL")
+	if archiveBaseURL != "" {
+		parsedBaseURL, parseErr := url.Parse(archiveBaseURL)
+		if parseErr != nil {
+			logger.Error("invalid ARCHIVE_BASE_URL", "error", parseErr)
+			os.Exit(1)
+		}
+		if parsedBaseURL.Scheme != "http" && parsedBaseURL.Scheme != "https" {
+			logger.Error("ARCHIVE_BASE_URL must use http or https scheme", "url", archiveBaseURL)
+			os.Exit(1)
+		}
+		if parsedBaseURL.Host == "" {
+			logger.Error("ARCHIVE_BASE_URL must include a host", "url", archiveBaseURL)
+			os.Exit(1)
+		}
+		archiveBaseURL = strings.TrimRight(archiveBaseURL, "/")
+	}
 	var archiveHMACSecret []byte
 	if archiveHMACSecretB64 != "" {
 		archiveHMACSecret, err = base64.StdEncoding.DecodeString(archiveHMACSecretB64)

--- a/internal/server/handlers_archive_test.go
+++ b/internal/server/handlers_archive_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +14,8 @@ import (
 	"github.com/dlorenc/docstore/internal/citoken"
 	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/policy"
+	"github.com/dlorenc/docstore/internal/service"
 )
 
 // stubJobTokenStore is a minimal jobTokenStore implementation for tests.
@@ -246,5 +249,42 @@ func TestHandlePresignedArchive_ValidSig_PassesHMACCheck(t *testing.T) {
 	// 403 would indicate HMAC failure; any other code means HMAC check passed.
 	if rec.Code == http.StatusForbidden {
 		t.Fatalf("HMAC check should have passed, got 403; body: %s", rec.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Routing regression: POST /repos must not be redirected
+// ---------------------------------------------------------------------------
+
+// TestCreateRepo_NoTrailingSlashRedirect verifies that POST /repos (without a
+// trailing slash) is served directly and returns 201, not a 307 redirect to
+// POST /repos/. The outer mux previously used "/repos/" as its catch-all which
+// caused Go's ServeMux to redirect bare POST /repos to POST /repos/.
+func TestCreateRepo_NoTrailingSlashRedirect(t *testing.T) {
+	ms := &mockStore{
+		createRepoFn: func(_ context.Context, req model.CreateRepoRequest) (*model.Repo, error) {
+			return &model.Repo{Name: req.Owner + "/" + req.Name, Owner: req.Owner}, nil
+		},
+		setRoleFn: func(_ context.Context, _, _ string, _ model.RoleType) error {
+			return nil
+		},
+	}
+	s := &server{
+		commitStore: ms,
+		svc:         service.New(ms, nil, policy.NewCache()),
+	}
+	handler := s.buildHandler(devID, devID, ms)
+
+	body := strings.NewReader(`{"owner":"default","name":"myrepo"}`)
+	req := httptest.NewRequest(http.MethodPost, "/repos", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusTemporaryRedirect || rec.Code == http.StatusMovedPermanently || rec.Code == http.StatusPermanentRedirect {
+		t.Fatalf("POST /repos was redirected (status %d) — trailing-slash redirect bug; body: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d; body: %s", rec.Code, rec.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

Two small gap fixes for the Phase 4 presigned archive URL implementation (#373):

- **Gap 1** (`internal/server/handlers_archive_test.go`): Add `TestCreateRepo_NoTrailingSlashRedirect` — verifies `POST /repos` (no trailing slash) returns 201, not a 307 redirect. The outer mux catch-all `'/'` fix was already in place but had no automated test coverage.

- **Gap 2** (`cmd/docstore/main.go`): Validate `ARCHIVE_BASE_URL` at startup — parse as URL, require `http`/`https` scheme and non-empty host, strip trailing slash. Server now fails fast with a clear error instead of silently constructing broken presigned URLs.

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go vet ./...` — clean
- [ ] `go test ./internal/server/... -run TestCreateRepo_NoTrailingSlashRedirect -v` — PASS
- [ ] `go test ./internal/server/... -run "TestHandleArchive|TestHandlePresigned" -v` — all PASS
- [ ] Integration test failures are pre-existing (require local Postgres, unrelated to this change)

## Notes

No new opportunities identified — changes are minimal and focused on the two specified gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)