### PR TITLE
feat(ci): phase 5 — worker API authentication with job OIDC tokens

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -251,13 +251,58 @@ func getPresignedArchiveURL(ctx context.Context, docstoreURL, repo, requestToken
 	return body.URL, nil
 }
 
-func fetchConfig(ctx context.Context, client *http.Client, docstoreURL, repo, branch string, headSeq int64) (*executor.Config, error) {
+// getDocstoreOIDCToken exchanges the request_token for a short-lived OIDC JWT
+// with aud=docstore. This token is used to authenticate API calls to docstore.
+// Returns empty string if oidcTokenURL is empty (local dev / OIDC not configured).
+func getDocstoreOIDCToken(ctx context.Context, oidcTokenURL, requestToken string) (string, error) {
+	if oidcTokenURL == "" {
+		return "", nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	body, err := json.Marshal(map[string]string{"audience": "docstore"})
+	if err != nil {
+		return "", fmt.Errorf("marshal token request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, oidcTokenURL, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+requestToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token request: unexpected status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decode token response: %w", err)
+	}
+	if result.Token == "" {
+		return "", fmt.Errorf("token response missing token field")
+	}
+	return result.Token, nil
+}
+
+func fetchConfig(ctx context.Context, client *http.Client, docstoreURL, repo, branch string, headSeq int64, jwt string) (*executor.Config, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	fileURL := fmt.Sprintf("%s/repos/%s/-/file/.docstore/ci.yaml?branch=%s&at=%d", docstoreURL, repo, url.QueryEscape(branch), headSeq)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create config request: %w", err)
+	}
+	if jwt != "" {
+		req.Header.Set("Authorization", "Bearer "+jwt)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -281,7 +326,7 @@ func fetchConfig(ctx context.Context, client *http.Client, docstoreURL, repo, br
 	return &cfg, nil
 }
 
-func postCheckRun(ctx context.Context, client *http.Client, docstoreURL, repo string, req model.CreateCheckRunRequest) error {
+func postCheckRun(ctx context.Context, client *http.Client, docstoreURL, repo string, jwt string, req model.CreateCheckRunRequest) error {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return fmt.Errorf("marshal check run: %w", err)
@@ -292,6 +337,9 @@ func postCheckRun(ctx context.Context, client *http.Client, docstoreURL, repo st
 		return fmt.Errorf("create check run request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	if jwt != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+jwt)
+	}
 	resp, err := client.Do(httpReq)
 	if err != nil {
 		return fmt.Errorf("post check run: %w", err)
@@ -353,6 +401,8 @@ func (s *checkLogServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // runJob fetches CI config, pulls source, executes checks, uploads logs, and
 // posts check run results. Returns (overallStatus, firstLogURL, errorMessage).
+// jwt is the OIDC job token for authenticating requests to docstore; may be
+// empty when OIDC is not configured (local dev mode).
 func runJob(
 	ctx context.Context,
 	httpClient *http.Client,
@@ -361,6 +411,7 @@ func runJob(
 	docstoreURL string,
 	job *model.CIJob,
 	requestToken string,
+	jwt string,
 	logDir string,
 	triggerCtx ciconfig.TriggerContext,
 	extraEnv []string,
@@ -371,9 +422,9 @@ func runJob(
 	}
 
 	// 1. Fetch CI config from the branch under test at its head sequence.
-	cfg, err := fetchConfig(ctx, httpClient, docstoreURL, job.Repo, job.Branch, job.Sequence)
+	cfg, err := fetchConfig(ctx, httpClient, docstoreURL, job.Repo, job.Branch, job.Sequence, jwt)
 	if err != nil {
-		_ = postCheckRun(ctx, httpClient, docstoreURL, job.Repo, model.CreateCheckRunRequest{
+		_ = postCheckRun(ctx, httpClient, docstoreURL, job.Repo, jwt, model.CreateCheckRunRequest{
 			Branch:    job.Branch,
 			CheckName: "ci/config",
 			Status:    model.CheckRunFailed,
@@ -398,7 +449,7 @@ func runJob(
 		pendingWg.Add(1)
 		go func(checkName string) {
 			defer pendingWg.Done()
-			if err := postCheckRun(ctx, httpClient, docstoreURL, job.Repo, model.CreateCheckRunRequest{
+			if err := postCheckRun(ctx, httpClient, docstoreURL, job.Repo, jwt, model.CreateCheckRunRequest{
 				Branch:    job.Branch,
 				CheckName: checkName,
 				Status:    model.CheckRunPending,
@@ -436,7 +487,7 @@ func runJob(
 			}
 		}
 
-		if err := postCheckRun(ctx, httpClient, docstoreURL, job.Repo, model.CreateCheckRunRequest{
+		if err := postCheckRun(ctx, httpClient, docstoreURL, job.Repo, jwt, model.CreateCheckRunRequest{
 			Branch:    job.Branch,
 			CheckName: result.Name,
 			Status:    model.CheckRunStatus(result.Status),
@@ -540,6 +591,19 @@ func main() {
 
 		slog.Info("claimed job", "job_id", job.ID, "repo", job.Repo, "branch", job.Branch, "sequence", job.Sequence)
 
+		// Exchange the request_token for a short-lived OIDC JWT (aud=docstore)
+		// to authenticate API calls to docstore. If the OIDC token URL is empty
+		// (local dev / presign not configured), jwt remains empty and calls are
+		// made without authentication (relying on DEV_IDENTITY bypass).
+		jwt, err := getDocstoreOIDCToken(ctx, cr.OIDCTokenURL, requestToken)
+		if err != nil {
+			slog.Error("get docstore OIDC token failed", "job_id", job.ID, "error", err)
+			msg := err.Error()
+			_ = completeJob(ctx, schedulerURL, job.ID, requestToken, "failed", nil, &msg)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
 		// Start heartbeat goroutine.
 		hbDone := make(chan struct{})
 		go heartbeat(ctx, schedulerURL, job.ID, requestToken, hbDone)
@@ -573,7 +637,7 @@ func main() {
 		}
 
 		// Execute the job.
-		jobStatus, jobLogURL, jobErrMsg := runJob(ctx, httpClient, exec, ls, docstoreURL, job, requestToken, logDir, triggerCtx, extraEnv)
+		jobStatus, jobLogURL, jobErrMsg := runJob(ctx, httpClient, exec, ls, docstoreURL, job, requestToken, jwt, logDir, triggerCtx, extraEnv)
 
 		// Stop heartbeat and clear log dir.
 		close(hbDone)

--- a/cmd/ci-worker/main_test.go
+++ b/cmd/ci-worker/main_test.go
@@ -229,7 +229,7 @@ func TestFetchConfig_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cfg, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "main", 1)
+	cfg, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "main", 1, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -247,7 +247,7 @@ func TestFetchConfig_NotFound_ReturnsNil(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cfg, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "main", 1)
+	cfg, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "main", 1, "")
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
@@ -262,7 +262,7 @@ func TestFetchConfig_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "main", 1)
+	_, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "main", 1, "")
 	if err == nil {
 		t.Fatal("expected error for 500, got nil")
 	}
@@ -274,7 +274,7 @@ func TestFetchConfig_InvalidJSON(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "main", 1)
+	_, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "main", 1, "")
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
 	}
@@ -289,7 +289,7 @@ func TestFetchConfig_URLContainsBranchAndSeq(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, _ = fetchConfig(context.Background(), srv.Client(), srv.URL, "myrepo", "feat/x", 99)
+	_, _ = fetchConfig(context.Background(), srv.Client(), srv.URL, "myrepo", "feat/x", 99, "")
 	if !strings.Contains(gotURL, "feat%2Fx") {
 		t.Errorf("branch not URL-encoded in request: %s", gotURL)
 	}
@@ -319,7 +319,7 @@ func TestPostCheckRun_Success(t *testing.T) {
 		Status:    model.CheckRunPassed,
 		Sequence:  &seq,
 	}
-	if err := postCheckRun(context.Background(), srv.Client(), srv.URL, "myrepo", req); err != nil {
+	if err := postCheckRun(context.Background(), srv.Client(), srv.URL, "myrepo", "", req); err != nil {
 		t.Fatal(err)
 	}
 	if received.CheckName != "lint" {
@@ -337,7 +337,7 @@ func TestPostCheckRun_UnexpectedStatus(t *testing.T) {
 	defer srv.Close()
 
 	seq := int64(1)
-	err := postCheckRun(context.Background(), srv.Client(), srv.URL, "myrepo", model.CreateCheckRunRequest{
+	err := postCheckRun(context.Background(), srv.Client(), srv.URL, "myrepo", "", model.CreateCheckRunRequest{
 		Branch:    "b",
 		CheckName: "c",
 		Status:    model.CheckRunFailed,
@@ -361,7 +361,7 @@ func TestPostCheckRun_WithLogURL(t *testing.T) {
 
 	logURL := "file:///tmp/test.log"
 	seq := int64(3)
-	_ = postCheckRun(context.Background(), srv.Client(), srv.URL, "r", model.CreateCheckRunRequest{
+	_ = postCheckRun(context.Background(), srv.Client(), srv.URL, "r", "", model.CreateCheckRunRequest{
 		Branch:    "b",
 		CheckName: "c",
 		Status:    model.CheckRunPassed,
@@ -508,7 +508,7 @@ func TestRunJob_NoCIYAML_ReturnsPassed(t *testing.T) {
 
 	status, logURL, errMsg := runJob(
 		context.Background(), srv.Client(), &mockRunner{}, nil,
-		srv.URL, testJob(), "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, nil,
+		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, nil,
 	)
 	if status != "passed" {
 		t.Errorf("expected passed, got %q", status)
@@ -531,7 +531,7 @@ func TestRunJob_FetchConfigError_ReturnsFailed(t *testing.T) {
 
 	status, _, errMsg := runJob(
 		context.Background(), srv.Client(), &mockRunner{}, nil,
-		srv.URL, testJob(), "", t.TempDir(), ciconfig.TriggerContext{}, nil,
+		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, nil,
 	)
 	if status != "failed" {
 		t.Errorf("expected failed, got %q", status)
@@ -551,7 +551,7 @@ func TestRunJob_ExecutorError_ReturnsFailed(t *testing.T) {
 	mockExec := &mockRunner{err: fmt.Errorf("buildkit unavailable")}
 	status, _, errMsg := runJob(
 		context.Background(), srv.Client(), mockExec, nil,
-		srv.URL, testJob(), "", t.TempDir(), ciconfig.TriggerContext{}, nil,
+		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, nil,
 	)
 	if status != "failed" {
 		t.Errorf("expected failed, got %q", status)
@@ -582,7 +582,7 @@ func TestRunJob_AllChecksPassed(t *testing.T) {
 
 	status, logURL, errMsg := runJob(
 		context.Background(), srv.Client(), mockExec, ls,
-		srv.URL, testJob(), "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, nil,
+		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, nil,
 	)
 	if status != "passed" {
 		t.Errorf("expected passed, got %q", status)
@@ -618,7 +618,7 @@ func TestRunJob_OneCheckFailed_OverallFailed(t *testing.T) {
 
 	status, _, errMsg := runJob(
 		context.Background(), srv.Client(), mockExec, nil,
-		srv.URL, testJob(), "", t.TempDir(), ciconfig.TriggerContext{}, nil,
+		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, nil,
 	)
 	if status != "failed" {
 		t.Errorf("expected failed, got %q", status)
@@ -657,7 +657,7 @@ func TestRunJob_NilLogStore_StillPosts(t *testing.T) {
 
 	status, logURL, _ := runJob(
 		context.Background(), srv.Client(), mockExec, nil, // nil log store
-		srv.URL, testJob(), "", t.TempDir(), ciconfig.TriggerContext{}, nil,
+		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, nil,
 	)
 	if status != "passed" {
 		t.Errorf("expected passed, got %q", status)
@@ -683,7 +683,7 @@ func TestRunJob_LogsWrittenToDir(t *testing.T) {
 	}}
 
 	logDir := t.TempDir()
-	runJob(context.Background(), srv.Client(), mockExec, nil, srv.URL, testJob(), "", logDir, ciconfig.TriggerContext{}, nil) //nolint:errcheck
+	runJob(context.Background(), srv.Client(), mockExec, nil, srv.URL, testJob(), "", "", logDir, ciconfig.TriggerContext{}, nil) //nolint:errcheck
 
 	data, err := os.ReadFile(filepath.Join(logDir, "test.log"))
 	if err != nil {
@@ -691,5 +691,133 @@ func TestRunJob_LogsWrittenToDir(t *testing.T) {
 	}
 	if string(data) != logOutput {
 		t.Errorf("unexpected log content: %q", string(data))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getDocstoreOIDCToken
+// ---------------------------------------------------------------------------
+
+func TestGetDocstoreOIDCToken_Success(t *testing.T) {
+	const fakeToken = "eyJhbGciOiJSUzI1NiJ9.fake.token"
+	var gotAuth, gotContentType string
+	var gotBody map[string]string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"token": fakeToken}) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	tok, err := getDocstoreOIDCToken(context.Background(), srv.URL, "my-request-token")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if tok != fakeToken {
+		t.Errorf("expected token %q, got %q", fakeToken, tok)
+	}
+	if gotAuth != "Bearer my-request-token" {
+		t.Errorf("expected Authorization header %q, got %q", "Bearer my-request-token", gotAuth)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", gotContentType)
+	}
+	if gotBody["audience"] != "docstore" {
+		t.Errorf("expected audience=docstore in body, got %q", gotBody["audience"])
+	}
+}
+
+func TestGetDocstoreOIDCToken_EmptyURL_ReturnsEmpty(t *testing.T) {
+	tok, err := getDocstoreOIDCToken(context.Background(), "", "my-request-token")
+	if err != nil {
+		t.Fatalf("expected no error for empty URL, got %v", err)
+	}
+	if tok != "" {
+		t.Errorf("expected empty token for empty URL, got %q", tok)
+	}
+}
+
+func TestGetDocstoreOIDCToken_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := getDocstoreOIDCToken(context.Background(), srv.URL, "bad-token")
+	if err == nil {
+		t.Fatal("expected error for 401, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected 401 in error, got: %v", err)
+	}
+}
+
+func TestGetDocstoreOIDCToken_MissingTokenField(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	_, err := getDocstoreOIDCToken(context.Background(), srv.URL, "tok")
+	if err == nil {
+		t.Fatal("expected error for missing token field, got nil")
+	}
+}
+
+func TestFetchConfig_SendsAuthHeader(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(fileResponseJSON(t, "checks: []")) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	_, _ = fetchConfig(context.Background(), srv.Client(), srv.URL, "myrepo", "main", 1, "my-jwt")
+	if gotAuth != "Bearer my-jwt" {
+		t.Errorf("expected Authorization: Bearer my-jwt, got %q", gotAuth)
+	}
+}
+
+func TestFetchConfig_NoAuthHeaderWhenJWTEmpty(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(fileResponseJSON(t, "checks: []")) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	_, _ = fetchConfig(context.Background(), srv.Client(), srv.URL, "myrepo", "main", 1, "")
+	if gotAuth != "" {
+		t.Errorf("expected no Authorization header for empty JWT, got %q", gotAuth)
+	}
+}
+
+func TestPostCheckRun_SendsAuthHeader(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	seq := int64(1)
+	_ = postCheckRun(context.Background(), srv.Client(), srv.URL, "r", "my-jwt", model.CreateCheckRunRequest{
+		Branch:    "b",
+		CheckName: "c",
+		Status:    model.CheckRunPassed,
+		Sequence:  &seq,
+	})
+	if gotAuth != "Bearer my-jwt" {
+		t.Errorf("expected Authorization: Bearer my-jwt, got %q", gotAuth)
 	}
 }

--- a/cmd/docstore/main.go
+++ b/cmd/docstore/main.go
@@ -160,10 +160,22 @@ func main() {
 		logger.Warn("ARCHIVE_HMAC_SECRET not set — presigned archive URLs disabled")
 	}
 
+	// Configure OIDC job token authentication (optional).
+	// OIDC_JWKS_URL: JWKS endpoint of the OIDC issuer.
+	// OIDC_AUDIENCE: expected audience claim (default: "docstore").
+	// OIDC_ISSUER: expected issuer claim (default: "https://oidc.docstore.dev").
+	oidcJWKSURL := os.Getenv("OIDC_JWKS_URL")
+	oidcAudience := cmp.Or(os.Getenv("OIDC_AUDIENCE"), "docstore")
+	oidcIssuer := cmp.Or(os.Getenv("OIDC_ISSUER"), "https://oidc.docstore.dev")
+	if oidcJWKSURL == "" {
+		logger.Warn("OIDC_JWKS_URL not set — job OIDC token authentication disabled")
+	}
+
 	jobStore := db.NewStore(database)
-	srv := server.NewWithPresign(commitStore, database, bs, broker,
+	srv := server.NewWithOIDC(commitStore, database, bs, broker,
 		*devIdentity, *bootstrapAdmin, *iapClientID, *iapClientSecret,
-		jobStore, archiveHMACSecret, archiveBaseURL)
+		jobStore, archiveHMACSecret, archiveBaseURL,
+		oidcJWKSURL, oidcAudience, oidcIssuer)
 
 	// Start the auto-merge worker. It subscribes to check.reported and
 	// review.submitted events and merges branches with auto_merge=true.

--- a/internal/server/handlers_proposals.go
+++ b/internal/server/handlers_proposals.go
@@ -63,6 +63,11 @@ func (s *server) handleReview(w http.ResponseWriter, r *http.Request) {
 func (s *server) handleCheck(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
 	reporter := IdentityFromContext(r.Context())
+	// If the request was authenticated via a job OIDC token, prefer the job
+	// subject as the reporter so check runs record the precise job identity.
+	if jobID := JobIdentityFromContext(r.Context()); jobID != nil {
+		reporter = jobID.Subject
+	}
 
 	var req model.CreateCheckRunRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -360,6 +360,173 @@ func commitTargetsMain(r *http.Request) bool {
 	return req.Branch == "main"
 }
 
+// --- Job OIDC token middleware ---
+
+const jobIdentityKey contextKey = "jobIdentity"
+
+// JobIdentity holds the identity of a CI job extracted from a validated OIDC token.
+type JobIdentity struct {
+	JobID   string
+	Repo    string
+	Branch  string
+	Subject string
+}
+
+// JobIdentityFromContext returns the job identity stored in the context by
+// JobTokenMiddleware. Returns nil if the request was not authenticated via
+// a job OIDC token.
+func JobIdentityFromContext(ctx context.Context) *JobIdentity {
+	v, _ := ctx.Value(jobIdentityKey).(*JobIdentity)
+	return v
+}
+
+// JobTokenMiddleware validates a CI job OIDC JWT (issued by oidc.docstore.dev)
+// and extracts the job context. If the token is valid, it sets the identity
+// in context so the request proceeds. If invalid, returns 401.
+// If no Authorization header is present, falls through (allows IAP to handle it).
+func JobTokenMiddleware(jwksURL, audience, issuer string) func(http.Handler) http.Handler {
+	cache := newKeyCacheForURL(jwksURL)
+	return newJobTokenMiddlewareWithKeyFetcher(cache.get, audience, issuer)
+}
+
+// newJobTokenMiddlewareWithKeyFetcher is the testable core of JobTokenMiddleware.
+func newJobTokenMiddlewareWithKeyFetcher(fetchKey func(kid string) (crypto.PublicKey, error), audience, issuer string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+			tokenStr := strings.TrimPrefix(auth, "Bearer ")
+			if tokenStr == "" || tokenStr == auth {
+				// No Bearer token — fall through to next handler.
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			jobID, err := validateJobOIDCToken(tokenStr, fetchKey, audience, issuer)
+			if err != nil {
+				slog.Warn("job token auth failed", "reason", err, "path", r.URL.Path)
+				writeAPIError(w, ErrCodeUnauthorized, http.StatusUnauthorized, "unauthenticated")
+				return
+			}
+
+			identity := "ci-job:" + jobID.JobID
+			if rl := requestLogFromContext(r.Context()); rl != nil {
+				rl.identity = identity
+			}
+			ctx := context.WithValue(r.Context(), jobIdentityKey, jobID)
+			ctx = context.WithValue(ctx, identityKey, identity)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// validateJobOIDCToken parses and validates an RS256 job OIDC JWT, returning the JobIdentity.
+func validateJobOIDCToken(tokenString string, fetchKey func(kid string) (crypto.PublicKey, error), audience, issuer string) (*JobIdentity, error) {
+	parts := strings.SplitN(tokenString, ".", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid JWT format")
+	}
+
+	// Parse header to get algorithm and key ID.
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("decode header: %w", err)
+	}
+	var header struct {
+		Alg string `json:"alg"`
+		Kid string `json:"kid"`
+	}
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		return nil, fmt.Errorf("parse header: %w", err)
+	}
+	if header.Alg != "RS256" {
+		return nil, fmt.Errorf("unsupported algorithm: %s", header.Alg)
+	}
+	if header.Kid == "" {
+		return nil, fmt.Errorf("missing kid")
+	}
+
+	// Fetch the public key for this key ID.
+	key, err := fetchKey(header.Kid)
+	if err != nil {
+		return nil, fmt.Errorf("fetch key: %w", err)
+	}
+	rsaKey, ok := key.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("expected RSA key for RS256")
+	}
+
+	// Verify the signature over header.payload.
+	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("decode signature: %w", err)
+	}
+	signingInput := parts[0] + "." + parts[1]
+	digest := sha256.Sum256([]byte(signingInput))
+	if err := rsa.VerifyPKCS1v15(rsaKey, crypto.SHA256, digest[:], sigBytes); err != nil {
+		return nil, fmt.Errorf("invalid signature: %w", err)
+	}
+
+	// Parse payload claims.
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode payload: %w", err)
+	}
+	var claims struct {
+		Iss    string  `json:"iss"`
+		Sub    string  `json:"sub"`
+		Aud    any     `json:"aud"` // string or []interface{}
+		Exp    float64 `json:"exp"`
+		JobID  string  `json:"job_id"`
+		Repo   string  `json:"repo"`
+		Branch string  `json:"branch"`
+	}
+	if err := json.Unmarshal(payloadJSON, &claims); err != nil {
+		return nil, fmt.Errorf("parse payload: %w", err)
+	}
+
+	// Check expiry.
+	if time.Now().Unix() > int64(claims.Exp) {
+		return nil, fmt.Errorf("token expired")
+	}
+
+	// Check issuer.
+	if claims.Iss != issuer {
+		return nil, fmt.Errorf("invalid issuer: %q", claims.Iss)
+	}
+
+	// Check audience.
+	if !jwtAudienceContains(claims.Aud, audience) {
+		return nil, fmt.Errorf("invalid audience")
+	}
+
+	if claims.JobID == "" {
+		return nil, fmt.Errorf("missing job_id claim")
+	}
+
+	return &JobIdentity{
+		JobID:   claims.JobID,
+		Repo:    claims.Repo,
+		Branch:  claims.Branch,
+		Subject: claims.Sub,
+	}, nil
+}
+
+// jwtAudienceContains checks whether target is present in the JWT aud claim,
+// which may be a single string or a JSON array.
+func jwtAudienceContains(aud any, target string) bool {
+	switch v := aud.(type) {
+	case string:
+		return v == target
+	case []any:
+		for _, a := range v {
+			if s, ok := a.(string); ok && s == target {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // IAPMiddleware returns an HTTP middleware that validates GCP IAP JWTs from the
 // X-Goog-IAP-JWT-Assertion header. If devIdentity is non-empty, JWT validation is
 // skipped and devIdentity is used directly (for local dev/testing).
@@ -500,6 +667,7 @@ func validateIAPJWT(tokenString string, fetchKey func(kid string) (crypto.Public
 const iapJWKURL = "https://www.gstatic.com/iap/verify/public_key-jwk"
 
 type keyCache struct {
+	url       string // JWKS URL to fetch; defaults to iapJWKURL if empty
 	mu        sync.RWMutex
 	keys      map[string]crypto.PublicKey
 	fetchedAt time.Time
@@ -508,6 +676,15 @@ type keyCache struct {
 
 func newKeyCache() *keyCache {
 	return &keyCache{
+		url: iapJWKURL,
+		ttl: time.Hour,
+	}
+}
+
+// newKeyCacheForURL returns a keyCache that fetches JWKS from the given URL.
+func newKeyCacheForURL(url string) *keyCache {
+	return &keyCache{
+		url: url,
 		ttl: time.Hour,
 	}
 }
@@ -545,7 +722,11 @@ func (c *keyCache) get(kid string) (crypto.PublicKey, error) {
 }
 
 func (c *keyCache) refresh() error {
-	resp, err := http.Get(iapJWKURL) //nolint:noctx
+	url := c.url
+	if url == "" {
+		url = iapJWKURL
+	}
+	resp, err := http.Get(url) //nolint:noctx
 	if err != nil {
 		return err
 	}

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -631,6 +631,188 @@ func TestIAPMiddleware_FutureIatIsAccepted(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// JobTokenMiddleware tests
+// ---------------------------------------------------------------------------
+
+// makeJobJWT returns a signed RS256 JWT with the given job claims.
+func makeJobJWT(t *testing.T, key *rsa.PrivateKey, kid, issuer, audience, jobID string, exp time.Time) string {
+	t.Helper()
+	headerJSON, _ := json.Marshal(map[string]string{"alg": "RS256", "kid": kid, "typ": "JWT"})
+	payloadJSON, _ := json.Marshal(map[string]any{
+		"iss":    issuer,
+		"sub":    "repo:testrepo:branch:main:check:",
+		"aud":    audience,
+		"exp":    exp.Unix(),
+		"iat":    time.Now().Unix(),
+		"job_id": jobID,
+		"repo":   "testrepo",
+		"branch": "main",
+	})
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	signingInput := headerB64 + "." + payloadB64
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+	if err != nil {
+		t.Fatalf("sign job JWT: %v", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+func TestJobTokenMiddleware_ValidToken(t *testing.T) {
+	key := generateTestKey(t)
+	kid := "job-key-1"
+	const issuer = "https://oidc.docstore.dev"
+	const audience = "docstore"
+	const jobID = "job-abc-123"
+
+	fetcher := staticKeyFetcher(kid, &key.PublicKey)
+	mw := newJobTokenMiddlewareWithKeyFetcher(fetcher, audience, issuer)
+
+	var capturedJobID *JobIdentity
+	var capturedIdentity string
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedJobID = JobIdentityFromContext(r.Context())
+		capturedIdentity = IdentityFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token := makeJobJWT(t, key, kid, issuer, audience, jobID, time.Now().Add(time.Hour))
+	req := httptest.NewRequest(http.MethodPost, "/repos/testrepo/-/check", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	if capturedJobID == nil {
+		t.Fatal("expected JobIdentity in context, got nil")
+	}
+	if capturedJobID.JobID != jobID {
+		t.Errorf("expected job_id %q, got %q", jobID, capturedJobID.JobID)
+	}
+	if capturedIdentity != "ci-job:"+jobID {
+		t.Errorf("expected identity %q, got %q", "ci-job:"+jobID, capturedIdentity)
+	}
+}
+
+func TestJobTokenMiddleware_InvalidToken(t *testing.T) {
+	signingKey := generateTestKey(t)
+	verifyKey := generateTestKey(t) // different key
+	kid := "job-key-1"
+	const issuer = "https://oidc.docstore.dev"
+
+	fetcher := staticKeyFetcher(kid, &verifyKey.PublicKey) // verifyKey ≠ signingKey
+	mw := newJobTokenMiddlewareWithKeyFetcher(fetcher, "docstore", issuer)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token := makeJobJWT(t, signingKey, kid, issuer, "docstore", "job-1", time.Now().Add(time.Hour))
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for tampered token, got %d", rec.Code)
+	}
+}
+
+func TestJobTokenMiddleware_NoToken(t *testing.T) {
+	// No Authorization header → middleware must fall through (call next).
+	mw := newJobTokenMiddlewareWithKeyFetcher(func(kid string) (crypto.PublicKey, error) {
+		t.Error("fetchKey should not be called with no token")
+		return nil, fmt.Errorf("should not be called")
+	}, "docstore", "https://oidc.docstore.dev")
+
+	called := false
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/testrepo/-/file/ci.yaml", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (fall through), got %d", rec.Code)
+	}
+	if !called {
+		t.Error("expected next handler to be called when no Authorization header")
+	}
+}
+
+func TestJobTokenMiddleware_WrongAudience(t *testing.T) {
+	key := generateTestKey(t)
+	kid := "job-key-1"
+	const issuer = "https://oidc.docstore.dev"
+
+	fetcher := staticKeyFetcher(kid, &key.PublicKey)
+	mw := newJobTokenMiddlewareWithKeyFetcher(fetcher, "docstore", issuer)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Token issued for wrong audience.
+	token := makeJobJWT(t, key, kid, issuer, "wrong-audience", "job-1", time.Now().Add(time.Hour))
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for wrong audience, got %d", rec.Code)
+	}
+}
+
+func TestJobTokenMiddleware_ExpiredToken(t *testing.T) {
+	key := generateTestKey(t)
+	kid := "job-key-1"
+	const issuer = "https://oidc.docstore.dev"
+
+	fetcher := staticKeyFetcher(kid, &key.PublicKey)
+	mw := newJobTokenMiddlewareWithKeyFetcher(fetcher, "docstore", issuer)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token := makeJobJWT(t, key, kid, issuer, "docstore", "job-1", time.Now().Add(-time.Hour))
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for expired token, got %d", rec.Code)
+	}
+}
+
+func TestJobTokenMiddleware_WrongIssuer(t *testing.T) {
+	key := generateTestKey(t)
+	kid := "job-key-1"
+	const issuer = "https://oidc.docstore.dev"
+
+	fetcher := staticKeyFetcher(kid, &key.PublicKey)
+	mw := newJobTokenMiddlewareWithKeyFetcher(fetcher, "docstore", issuer)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token := makeJobJWT(t, key, kid, "https://evil.example.com", "docstore", "job-1", time.Now().Add(time.Hour))
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for wrong issuer, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // commitTargetsMain tests
 // ---------------------------------------------------------------------------
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/dlorenc/docstore/internal/blob"
@@ -207,6 +208,24 @@ func NewWithBroker(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, b
 func NewWithPresign(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker,
 	devIdentity, bootstrapAdmin, iapClientID, iapClientSecret string,
 	jobStore jobTokenStore, archiveHMACSecret []byte, archiveBaseURL string) http.Handler {
+	return NewWithOIDC(writeStore, database, bs, broker,
+		devIdentity, bootstrapAdmin, iapClientID, iapClientSecret,
+		jobStore, archiveHMACSecret, archiveBaseURL,
+		"", "", "")
+}
+
+// NewWithOIDC is like NewWithPresign but also enables OIDC job token authentication
+// for worker-facing endpoints. Workers presenting a valid job OIDC JWT bypass IAP
+// and RBAC and are routed directly to the inner handler with their job identity.
+//
+// oidcJWKSURL is the JWKS endpoint of the OIDC issuer (e.g. https://oidc.docstore.dev/.well-known/jwks.json).
+// oidcAudience is the expected audience claim (e.g. "docstore").
+// oidcIssuer is the expected issuer claim (e.g. "https://oidc.docstore.dev").
+// If oidcJWKSURL is empty, OIDC job token auth is disabled.
+func NewWithOIDC(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker,
+	devIdentity, bootstrapAdmin, iapClientID, iapClientSecret string,
+	jobStore jobTokenStore, archiveHMACSecret []byte, archiveBaseURL string,
+	oidcJWKSURL, oidcAudience, oidcIssuer string) http.Handler {
 	pc := policy.NewCache()
 	s := &server{
 		commitStore:       writeStore,
@@ -218,6 +237,12 @@ func NewWithPresign(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, 
 		archiveHMACSecret: archiveHMACSecret,
 		archiveBaseURL:    archiveBaseURL,
 		jobTokenStore:     jobStore,
+		oidcJWKSURL:       oidcJWKSURL,
+		oidcAudience:      oidcAudience,
+		oidcIssuer:        oidcIssuer,
+	}
+	if oidcJWKSURL != "" {
+		s.oidcKeyCache = newKeyCacheForURL(oidcJWKSURL)
 	}
 	if writeStore != nil {
 		var emitter service.EventEmitter
@@ -346,8 +371,9 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 	}
 	iapHandler := IAPMiddleware(devIdentity)(routed)
 
-	// Wrap the IAP handler: intercept presign and HMAC-signed archive requests
-	// before IAP validation. Everything else falls through to iapHandler.
+	// Wrap the IAP handler: intercept presign, HMAC-signed archive, and job
+	// OIDC token requests before IAP validation. Everything else falls through
+	// to iapHandler.
 	// Using "/" (not "/repos/") avoids the Go mux trailing-slash redirect that
 	// would turn POST /repos into a 307 → POST /repos/.
 	outer.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -366,6 +392,31 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 				return
 			}
 		}
+
+		// Job OIDC token auth: if a Bearer token is present and OIDC is configured,
+		// validate it as a job OIDC JWT. On success, inject job identity into context
+		// and route directly to the inner mux (bypassing IAP and RBAC).
+		// On failure, return 401. If no Bearer token, fall through to iapHandler.
+		if s.oidcKeyCache != nil {
+			auth := r.Header.Get("Authorization")
+			if tok := strings.TrimPrefix(auth, "Bearer "); tok != "" && tok != auth {
+				jobID, err := validateJobOIDCToken(tok, s.oidcKeyCache.get, s.oidcAudience, s.oidcIssuer)
+				if err != nil {
+					slog.Warn("job token auth failed", "reason", err, "path", r.URL.Path)
+					writeAPIError(w, ErrCodeUnauthorized, http.StatusUnauthorized, "unauthenticated")
+					return
+				}
+				identity := "ci-job:" + jobID.JobID
+				if rl := requestLogFromContext(r.Context()); rl != nil {
+					rl.identity = identity
+				}
+				ctx := context.WithValue(r.Context(), jobIdentityKey, jobID)
+				ctx = context.WithValue(ctx, identityKey, identity)
+				inner.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+		}
+
 		iapHandler.ServeHTTP(w, r)
 	}))
 	return RequestLogger(outer)
@@ -396,6 +447,12 @@ type server struct {
 	archiveBaseURL string
 	// jobTokenStore validates request_tokens for presigned archive URL issuance.
 	jobTokenStore jobTokenStore
+	// OIDC job token authentication fields.
+	// oidcJWKSURL is the JWKS endpoint; empty disables OIDC auth.
+	oidcJWKSURL  string
+	oidcAudience string
+	oidcIssuer   string
+	oidcKeyCache *keyCache
 }
 
 // handleDSConfig serves GET /.well-known/ds-config — unauthenticated.


### PR DESCRIPTION
## Summary

Implements phase 5 of issue #283: workers now authenticate docstore API calls using short-lived OIDC JWTs instead of calling unauthenticated.

- **Worker**: exchanges `request_token` for a job OIDC JWT (aud=docstore) via ci-oidc, then sends `Authorization: Bearer <jwt>` on `fetchConfig` and `postCheckRun` calls. Empty `DOCSTORE_OIDC_REQUEST_URL` (local dev) skips exchange and preserves existing unauthenticated behavior.
- **Server**: new `JobTokenMiddleware` validates RS256 JWTs from oidc.docstore.dev. Valid job tokens bypass IAP and RBAC and are routed directly to the inner mux with `JobIdentity` in context. Human browser requests (IAP header) are completely unaffected.
- **Check runs**: `handleCheck` records `JobIdentity.Subject` (e.g. `repo:acme/myrepo:branch:feature:check:lint`) as the reporter when authenticated via OIDC job token.
- **Config**: three new env vars on docstore server: `OIDC_JWKS_URL`, `OIDC_AUDIENCE` (default: `docstore`), `OIDC_ISSUER` (default: `https://oidc.docstore.dev`). If `OIDC_JWKS_URL` is empty, OIDC auth is disabled.

## Architecture

The outer handler in `buildHandler` intercepts `Authorization: Bearer` requests when OIDC is configured. On valid token: injects job identity into context, routes to `inner` mux (bypassing IAP and RBAC). On invalid token: 401. No token: falls through to `iapHandler`.

`NewWithOIDC` is the new constructor (accepts OIDC params). `NewWithPresign` now delegates to it with empty OIDC params for backwards compat.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/server/... -count=1` — all pass
- [x] `go test ./cmd/ci-worker/... -count=1` — all pass
- [x] `go test ./... -count=1` — all pass
- [x] `TestJobTokenMiddleware_{ValidToken,InvalidToken,NoToken,WrongAudience,ExpiredToken,WrongIssuer}`
- [x] `TestGetDocstoreOIDCToken_{Success,EmptyURL,ServerError,MissingTokenField}`
- [x] `TestFetchConfig_SendsAuthHeader`, `TestPostCheckRun_SendsAuthHeader`

## Opportunities (not implemented)

- Worker could refresh the OIDC token mid-job if jobs exceed 1 hour
- Server could log the full `JobIdentity` (repo, branch, sequence) in access logs alongside the identity string

Closes part of #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)