### PR TITLE
feat(ci-oidc): deploy ci-oidc with split public/internal Cloud Run services

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,8 @@ jobs:
             --region=us-central1 \
             --service-account=docstore-server@dlorenc-chainguard.iam.gserviceaccount.com \
             --add-cloudsql-instances=dlorenc-chainguard:us-central1:docstore-mvp \
-            --update-secrets=DATABASE_URL=docstore-db-url:latest,IAP_CLIENT_SECRET=iap-oauth-client-secret:latest \
+            --update-secrets=DATABASE_URL=docstore-db-url:latest,IAP_CLIENT_SECRET=iap-oauth-client-secret:latest,ARCHIVE_HMAC_SECRET=archive-hmac-secret:latest \
+            --set-env-vars=ARCHIVE_BASE_URL=https://docstore.dev,OIDC_JWKS_URL=https://oidc.docstore.dev/.well-known/jwks.json,OIDC_AUDIENCE=docstore,OIDC_ISSUER=https://oidc.docstore.dev \
             --ingress=internal-and-cloud-load-balancing \
             --min-instances=1 \
             --max-instances=1 \
@@ -101,6 +102,10 @@ jobs:
             ci-scheduler=us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-scheduler@${{ steps.build.outputs.digest }} \
             -n docstore-ci
           kubectl rollout status deployment/ci-scheduler -n docstore-ci --timeout=300s
+
+      - name: Apply ci-scheduler RBAC
+        run: |
+          kubectl apply -f deploy/k8s/ci-scheduler-rbac.yaml
 
       - name: Update ci-runner-url secret
         run: |
@@ -168,3 +173,102 @@ jobs:
           kubectl patch scaledjob ci-worker -n docstore-ci \
             --type='json' \
             -p='[{"op":"replace","path":"/spec/jobTargetRef/template/spec/containers/0/image","value":"us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-worker@${{ steps.build.outputs.digest }}"}]'
+
+  build-and-deploy-ci-oidc:
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/320310132788/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: docstore-deployer@dlorenc-chainguard.iam.gserviceaccount.com
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: docstore-ci
+          location: us-central1
+          project_id: dlorenc-chainguard
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - name: Build and push ci-oidc image
+        id: build
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          docker buildx build --platform linux/amd64 \
+            -f Dockerfile.ci-oidc \
+            -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-oidc:latest \
+            -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-oidc:${SHA} \
+            --push \
+            --metadata-file /tmp/ci-oidc-metadata.json \
+            .
+          DIGEST=$(jq -r '."containerimage.digest"' /tmp/ci-oidc-metadata.json)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+
+      - name: Deploy ci-oidc (internal)
+        run: |
+          gcloud run deploy ci-oidc \
+            --image=us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-oidc@${{ steps.build.outputs.digest }} \
+            --project=dlorenc-chainguard \
+            --region=us-central1 \
+            --service-account=ci-oidc@dlorenc-chainguard.iam.gserviceaccount.com \
+            --add-cloudsql-instances=dlorenc-chainguard:us-central1:docstore-mvp \
+            --update-secrets=DATABASE_URL=docstore-db-url:latest,KMS_KEY_VERSION=ci-oidc-kms-key-version:latest \
+            --ingress=internal \
+            --min-instances=1 \
+            --max-instances=3 \
+            --no-cpu-throttling \
+            --port=8081 \
+            --network=default \
+            --subnet=default \
+            --vpc-egress=private-ranges-only
+
+      - name: Store internal token URL in Secret Manager
+        run: |
+          OIDC_INTERNAL_URL=$(gcloud run services describe ci-oidc \
+            --region=us-central1 \
+            --project=dlorenc-chainguard \
+            --format='value(status.url)')
+          printf '%s' "${OIDC_INTERNAL_URL}/ci/token" | \
+            gcloud secrets versions add ci-oidc-token-url \
+              --data-file=- --project=dlorenc-chainguard \
+            || printf '%s' "${OIDC_INTERNAL_URL}/ci/token" | \
+            gcloud secrets create ci-oidc-token-url \
+              --data-file=- --project=dlorenc-chainguard \
+              --replication-policy=automatic
+          echo "oidc_internal_url=${OIDC_INTERNAL_URL}" >> $GITHUB_ENV
+
+      - name: Deploy ci-oidc-public (public)
+        run: |
+          gcloud run deploy ci-oidc-public \
+            --image=us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-oidc@${{ steps.build.outputs.digest }} \
+            --project=dlorenc-chainguard \
+            --region=us-central1 \
+            --service-account=ci-oidc-public@dlorenc-chainguard.iam.gserviceaccount.com \
+            --update-secrets=KMS_KEY_VERSION=ci-oidc-kms-key-version:latest \
+            --set-env-vars=PUBLIC_ONLY=true \
+            --ingress=all \
+            --allow-unauthenticated \
+            --min-instances=1 \
+            --max-instances=10 \
+            --port=8081
+
+      - name: Create domain mapping for ci-oidc-public (idempotent)
+        run: |
+          gcloud run domain-mappings create \
+            --service=ci-oidc-public \
+            --domain=oidc.docstore.dev \
+            --region=us-central1 \
+            --project=dlorenc-chainguard \
+            2>/dev/null || echo 'domain mapping already exists'
+
+      - name: Update ci-scheduler OIDC_TOKEN_URL in GKE
+        run: |
+          kubectl set env deployment/ci-scheduler \
+            OIDC_TOKEN_URL="${{ env.oidc_internal_url }}/ci/token" \
+            -n docstore-ci

--- a/cmd/ci-oidc/main.go
+++ b/cmd/ci-oidc/main.go
@@ -225,6 +225,17 @@ func handleHealth(w http.ResponseWriter, r *http.Request) {
 // HTTP mux
 // ---------------------------------------------------------------------------
 
+// newPublicMux returns a mux that serves only the public OIDC discovery
+// endpoints: /healthz, /.well-known/openid-configuration, /.well-known/jwks.json.
+// It does NOT register POST /ci/token. Used when PUBLIC_ONLY=true.
+func newPublicMux(s *server) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", handleHealth)
+	mux.HandleFunc("GET /.well-known/openid-configuration", s.handleDiscovery)
+	mux.HandleFunc("GET /.well-known/jwks.json", s.handleJWKS)
+	return mux
+}
+
 func newMux(s *server) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", handleHealth)
@@ -242,6 +253,7 @@ func main() {
 	port := flag.String("port", "8080", "HTTP listen port")
 	issuerURL := flag.String("issuer-url", "https://oidc.docstore.dev", "OIDC issuer URL")
 	kmsKeyVersion := flag.String("kms-key-version", "", "KMS key version resource name (empty = use LocalSigner)")
+	publicOnly := flag.Bool("public-only", false, "Only serve public endpoints (/.well-known/*, /healthz); skip DATABASE_URL")
 	flag.Parse()
 
 	if v := os.Getenv("PORT"); v != "" && *port == "8080" {
@@ -252,6 +264,9 @@ func main() {
 	}
 	if v := os.Getenv("KMS_KEY_VERSION"); v != "" {
 		*kmsKeyVersion = v
+	}
+	if v := os.Getenv("PUBLIC_ONLY"); v == "true" || v == "1" {
+		*publicOnly = true
 	}
 
 	// Set up structured logging.
@@ -269,22 +284,7 @@ func main() {
 	}
 	slog.SetDefault(slog.New(handler))
 
-	// Connect to Postgres.
-	dsn := os.Getenv("DATABASE_URL")
-	if dsn == "" {
-		slog.Error("DATABASE_URL environment variable is required")
-		os.Exit(1)
-	}
-	database, err := db.Open(dsn)
-	if err != nil {
-		slog.Error("failed to connect to database", "error", err)
-		os.Exit(1)
-	}
-	defer database.Close()
-
-	store := db.NewStore(database)
-
-	// Build signer.
+	// Build signer (needed in all modes for PublicKeys()).
 	ctx := context.Background()
 	var signer citoken.Signer
 	if *kmsKeyVersion != "" {
@@ -306,14 +306,35 @@ func main() {
 	}
 
 	srv := &server{
-		store:     store,
 		signer:    signer,
 		issuerURL: strings.TrimRight(*issuerURL, "/"),
 	}
 
+	var mux *http.ServeMux
+	if *publicOnly {
+		slog.Info("starting ci-oidc in public-only mode")
+		mux = newPublicMux(srv)
+	} else {
+		// Connect to Postgres.
+		dsn := os.Getenv("DATABASE_URL")
+		if dsn == "" {
+			slog.Error("DATABASE_URL environment variable is required")
+			os.Exit(1)
+		}
+		database, err := db.Open(dsn)
+		if err != nil {
+			slog.Error("failed to connect to database", "error", err)
+			os.Exit(1)
+		}
+		defer database.Close()
+
+		srv.store = db.NewStore(database)
+		mux = newMux(srv)
+	}
+
 	httpSrv := &http.Server{
 		Addr:        ":" + *port,
-		Handler:     newMux(srv),
+		Handler:     mux,
 		ReadTimeout: 10 * time.Second,
 		IdleTimeout: 60 * time.Second,
 	}

--- a/cmd/ci-oidc/main_test.go
+++ b/cmd/ci-oidc/main_test.go
@@ -368,6 +368,25 @@ func TestHandleHealth(t *testing.T) {
 	}
 }
 
+// TestHandleToken_PublicOnlyMode_Returns404 verifies that POST /ci/token is
+// not registered when the server is built with newPublicMux (PUBLIC_ONLY mode).
+func TestHandleToken_PublicOnlyMode_Returns404(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestServer(t, &stubStore{})
+
+	mux := newPublicMux(s)
+
+	body, _ := json.Marshal(map[string]string{"audience": "https://example.com"})
+	r := newRequest(t, http.MethodPost, "/ci/token", body)
+	r.Header.Set("Authorization", "Bearer validtoken")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (public-only mode must not serve /ci/token)", w.Code)
+	}
+}
+
 // Verify that triggerToRefType is exercised (also tested indirectly above).
 func TestTriggerToRefType(t *testing.T) {
 	t.Parallel()

--- a/deploy/k8s/ci-scheduler.yaml
+++ b/deploy/k8s/ci-scheduler.yaml
@@ -59,6 +59,8 @@ spec:
               name: ci-runner
               key: runner-url
               optional: true
+        - name: OIDC_TOKEN_URL
+          value: ''  # set at deploy time by workflow via kubectl set env
         ports:
         - containerPort: 8080
         resources:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -191,6 +191,118 @@ gcloud dns record-sets create docstore.dev \
 
 The domain `docstore.dev` is registered via Cloud Domains in project `dlorenc-chainguard` with its nameservers pointed at the Cloud DNS zone above.
 
+## One-time OIDC setup prerequisites
+
+The ci-oidc service requires several GCP resources that must be created once before first deployment.
+
+### 1. Create the KMS keyring and signing key
+
+```bash
+# Create the keyring
+gcloud kms keyrings create docstore-oidc \
+  --location=us-central1 \
+  --project=dlorenc-chainguard
+
+# Create the RSA signing key
+gcloud kms keys create ci-oidc-signing-key \
+  --keyring=docstore-oidc \
+  --location=us-central1 \
+  --purpose=asymmetric-signing \
+  --default-algorithm=rsa-sign-pkcs1-2048-sha256 \
+  --project=dlorenc-chainguard
+```
+
+### 2. Store the key version name in Secret Manager
+
+```bash
+KEY_VERSION=$(gcloud kms keys versions list \
+  --key=ci-oidc-signing-key \
+  --keyring=docstore-oidc \
+  --location=us-central1 \
+  --project=dlorenc-chainguard \
+  --format='value(name)' | head -1)
+
+printf '%s' "${KEY_VERSION}" | \
+  gcloud secrets create ci-oidc-kms-key-version \
+    --data-file=- \
+    --project=dlorenc-chainguard \
+    --replication-policy=automatic
+```
+
+### 3. Create the archive HMAC secret
+
+```bash
+openssl rand -base64 32 | \
+  gcloud secrets create archive-hmac-secret \
+    --data-file=- \
+    --project=dlorenc-chainguard \
+    --replication-policy=automatic
+```
+
+### 4. Create service accounts
+
+```bash
+# Internal service (DB + KMS sign)
+gcloud iam service-accounts create ci-oidc \
+  --display-name="ci-oidc service account" \
+  --project=dlorenc-chainguard
+
+# Public service (KMS verify only)
+gcloud iam service-accounts create ci-oidc-public \
+  --display-name="ci-oidc-public service account" \
+  --project=dlorenc-chainguard
+```
+
+### 5. Grant KMS roles
+
+```bash
+# ci-oidc SA: can sign and verify (needed to issue JWTs)
+gcloud kms keys add-iam-policy-binding ci-oidc-signing-key \
+  --keyring=docstore-oidc \
+  --location=us-central1 \
+  --member=serviceAccount:ci-oidc@dlorenc-chainguard.iam.gserviceaccount.com \
+  --role=roles/cloudkms.signerVerifier \
+  --project=dlorenc-chainguard
+
+# ci-oidc-public SA: can only verify (needed to serve JWKS)
+gcloud kms keys add-iam-policy-binding ci-oidc-signing-key \
+  --keyring=docstore-oidc \
+  --location=us-central1 \
+  --member=serviceAccount:ci-oidc-public@dlorenc-chainguard.iam.gserviceaccount.com \
+  --role=roles/cloudkms.verifier \
+  --project=dlorenc-chainguard
+```
+
+### 6. Grant archive HMAC secret access to the docstore server SA
+
+```bash
+gcloud secrets add-iam-policy-binding archive-hmac-secret \
+  --member=serviceAccount:docstore-server@dlorenc-chainguard.iam.gserviceaccount.com \
+  --role=roles/secretmanager.secretAccessor \
+  --project=dlorenc-chainguard
+```
+
+### 7. DNS setup for oidc.docstore.dev
+
+After the Cloud Run domain mapping is created by the deploy workflow, add a CNAME record:
+
+```
+oidc.docstore.dev. CNAME ghs.googlehosted.com.
+```
+
+With Cloud DNS:
+
+```bash
+gcloud dns record-sets create oidc.docstore.dev. \
+  --zone=docstore-dev \
+  --type=CNAME \
+  --ttl=300 \
+  --rrdatas=ghs.googlehosted.com. \
+  --project=dlorenc-chainguard
+```
+
+The domain mapping is created idempotently by the `build-and-deploy-ci-oidc` workflow job on each deploy. Wait for the mapping to become active before the CNAME resolves correctly (can take a few minutes on first creation).
+
 ## GKE deployment (CI system)
 
 The CI system runs in GKE cluster `docstore-ci` in region `us-central1`, project `dlorenc-chainguard`.


### PR DESCRIPTION
## Summary

- **`--public-only` flag** (`PUBLIC_ONLY` env var) added to `cmd/ci-oidc/main.go`. When set, only `GET /healthz`, `GET /.well-known/openid-configuration`, and `GET /.well-known/jwks.json` are registered; `DATABASE_URL` is skipped; the KMS signer is still built for `PublicKeys()`. Logs `starting ci-oidc in public-only mode`.
- **Test**: `TestHandleToken_PublicOnlyMode_Returns404` verifies `POST /ci/token` returns 404 when the public-only mux is used.
- **New `build-and-deploy-ci-oidc` job** in `deploy.yml` (runs after `[deploy]`): builds from `Dockerfile.ci-oidc`, deploys two Cloud Run services from the same image:
  - `ci-oidc`: internal ingress, Cloud SQL + KMS secrets, min 1 / max 3 instances.
  - `ci-oidc-public`: all ingress, `--allow-unauthenticated`, `PUBLIC_ONLY=true`, KMS only, min 1 / max 10 instances.
  - Stores the internal token URL as `ci-oidc-token-url` Secret Manager secret (create-or-add-version).
  - Creates `oidc.docstore.dev` domain mapping (idempotent `2>/dev/null || echo`).
  - Patches `ci-scheduler` deployment with `OIDC_TOKEN_URL` via `kubectl set env`.
- **Updated `deploy` job**: adds `ARCHIVE_HMAC_SECRET` to `--update-secrets` and sets `ARCHIVE_BASE_URL`, `OIDC_JWKS_URL`, `OIDC_AUDIENCE`, `OIDC_ISSUER` env vars on the docstore Cloud Run service.
- **Updated `build-and-deploy-ci-scheduler`**: applies `deploy/k8s/ci-scheduler-rbac.yaml` after the image rollout.
- **`deploy/k8s/ci-scheduler.yaml`**: adds `OIDC_TOKEN_URL` env var (empty placeholder; patched at deploy time by the workflow).
- **`docs/deployment.md`**: new "One-time OIDC setup prerequisites" section with exact `gcloud` commands for KMS keyring/key, Secret Manager secrets, service accounts, IAM bindings, and DNS CNAME.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./cmd/ci-oidc/... -count=1` passes (including new `TestHandleToken_PublicOnlyMode_Returns404`)
- [x] `go test ./... -count=1` passes (all packages)
- [x] `deploy.yml` is valid YAML (verified with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] On next push to main: verify both `ci-oidc` and `ci-oidc-public` Cloud Run services deploy and `oidc.docstore.dev` resolves (requires one-time DNS CNAME setup per docs)

## Opportunities noted (not implemented)

- The ci-oidc internal service port is set to 8081 per the task spec; the existing ci-worker also uses 8081 for live log access — these are separate services so no conflict, but worth noting.
- `ISSUER_URL` default is `https://oidc.docstore.dev` already hardcoded in main.go; the public service doesn't need it overridden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)