### PR TITLE
fix(k8sproof): raise maxPodAge to 4h for warm pool CI workers

### DIFF
--- a/internal/k8sproof/k8sproof.go
+++ b/internal/k8sproof/k8sproof.go
@@ -22,9 +22,9 @@ const (
 	// that ci-worker pods must run as.
 	expectedServiceAccount = "system:serviceaccount:docstore-ci:ci-worker"
 
-	// maxPodAge is the maximum age of a pod that may claim a job.
-	// This prevents long-lived or recycled pods from claiming jobs.
-	maxPodAge = 10 * time.Minute
+	// DefaultMaxPodAge is the default maximum age for a pod to be eligible to claim a job.
+	// Set to 4 hours to accommodate warm pool workers (KEDA ScaledJob minReplicaCount > 0).
+	DefaultMaxPodAge = 4 * time.Hour
 
 	// expectedScaledJobName is the KEDA ScaledJob that must own the pod.
 	expectedScaledJobName = "ci-worker"
@@ -35,12 +35,17 @@ const (
 type PodClaimer struct {
 	client    kubernetes.Interface
 	namespace string
+	maxAge    time.Duration
 }
 
 // New creates a PodClaimer that validates tokens against the K8s API server.
 // namespace is the Kubernetes namespace where ci-worker pods run.
 func New(client kubernetes.Interface, namespace string) *PodClaimer {
-	return &PodClaimer{client: client, namespace: namespace}
+	return &PodClaimer{
+		client:    client,
+		namespace: namespace,
+		maxAge:    DefaultMaxPodAge,
+	}
 }
 
 // ValidateToken validates a Kubernetes projected service account token and
@@ -79,8 +84,8 @@ func (p *PodClaimer) ValidateToken(ctx context.Context, token string) (podName, 
 		return "", "", fmt.Errorf("fetch pod %q: %w", podName, err)
 	}
 	podAge := time.Since(pod.CreationTimestamp.Time)
-	if podAge > maxPodAge {
-		return "", "", fmt.Errorf("pod %q is too old (%s > %s)", podName, podAge.Round(time.Second), maxPodAge)
+	if podAge > p.maxAge {
+		return "", "", fmt.Errorf("pod %q is too old (%s > %s)", podName, podAge.Round(time.Second), p.maxAge)
 	}
 	podIP = pod.Status.PodIP
 

--- a/internal/k8sproof/k8sproof_test.go
+++ b/internal/k8sproof/k8sproof_test.go
@@ -141,7 +141,7 @@ func TestValidateToken_StalePod(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              podName,
 			Namespace:         ns,
-			CreationTimestamp: metav1.NewTime(time.Now().Add(-20 * time.Minute)),
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-5 * time.Hour)),
 			OwnerReferences: []metav1.OwnerReference{
 				{APIVersion: "batch/v1", Kind: "Job", Name: jobName},
 			},


### PR DESCRIPTION
## Summary

- Replaces the hardcoded 10-minute `maxPodAge` constant with an exported `DefaultMaxPodAge = 4 * time.Hour`
- Adds a `maxAge` field to `PodClaimer` so the threshold flows through the struct rather than being referenced as a bare package-level constant
- Updates the stale-pod unit test to use a pod 5 hours old (> 4h threshold) so the freshness check is still exercised

## Problem

KEDA ScaledJob warm pool pods (`minReplicaCount=3`) sit idle waiting for jobs and are routinely older than 10 minutes. Every claim attempt was being rejected with 401 because the pod freshness check failed.

## Design rationale

4 hours is long enough for any reasonable warm-pool idle period, while still providing defense-in-depth against very stale pods from infrastructure incidents. The ownerReference chain (`Pod → Job → ScaledJob`) and the one-claim-per-pod check remain the primary security guarantees.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/k8sproof/... -count=1` — all 6 tests pass
- [x] `go test ./... -count=1` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)