### PR TITLE
fix(deploy): resolve ci-oidc race condition and unauthenticated access

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,14 @@ jobs:
             --vpc-egress=private-ranges-only \
             --args=--bootstrap-admin=dlorenc@chainguard.dev,--iap-client-id=320310132788-md94jtp0d9fdcdlq2quma4mcpr0ul1qr.apps.googleusercontent.com
 
+      - name: Grant CI workers access to docstore internal URL
+        run: |
+          gcloud run services add-iam-policy-binding docstore \
+            --region=us-central1 \
+            --project=dlorenc-chainguard \
+            --member=allUsers \
+            --role=roles/run.invoker
+
   build-and-deploy-ci-scheduler:
     runs-on: ubuntu-latest
     needs: [deploy]
@@ -176,7 +184,7 @@ jobs:
 
   build-and-deploy-ci-oidc:
     runs-on: ubuntu-latest
-    needs: [deploy]
+    needs: [deploy, build-and-deploy-ci-scheduler]
     steps:
       - uses: actions/checkout@v4
 
@@ -220,6 +228,7 @@ jobs:
             --add-cloudsql-instances=dlorenc-chainguard:us-central1:docstore-mvp \
             --update-secrets=DATABASE_URL=docstore-db-url:latest,KMS_KEY_VERSION=ci-oidc-kms-key-version:latest \
             --ingress=internal \
+            --allow-unauthenticated \
             --min-instances=1 \
             --max-instances=3 \
             --no-cpu-throttling \


### PR DESCRIPTION
## Summary

- **Race condition fix**: `build-and-deploy-ci-oidc` now depends on `build-and-deploy-ci-scheduler`. Previously both jobs ran concurrently after `deploy`, so `ci-scheduler`'s `kubectl apply -f` (which resets `OIDC_TOKEN_URL` to `''`) could overwrite the env var set by `ci-oidc`'s `kubectl set env` step.
- **ci-oidc `--allow-unauthenticated`**: CI worker pods authenticate with a `Bearer <request_token>` header that is not a Google identity token. Cloud Run's IAM layer was rejecting these requests with 401 before they reached the Go application. Added `--allow-unauthenticated`; network-level restriction is enforced by `--ingress=internal` (VPC only).
- **docstore `allUsers` invoker binding**: CI worker pods call docstore's `fetchConfig` and `postCheckRun` APIs via the internal `*.run.app` URL. Added `gcloud run services add-iam-policy-binding` with `--member=allUsers`. External traffic still goes through the IAP-protected LB at `docstore.dev`; the `*.run.app` URL is only reachable from within the VPC.

## Deploy order after fix

1. `deploy` (docstore) — grants `allUsers` invoker binding
2. `build-and-deploy-ci-scheduler` — deploys ci-scheduler (resets `OIDC_TOKEN_URL` to `''`)
3. `build-and-deploy-ci-oidc` — waits for ci-scheduler, then sets `OIDC_TOKEN_URL` correctly
4. `build-and-deploy-ci-worker` — unchanged, already depends on ci-scheduler

## Test plan

- [ ] Verify `go build ./...` passes (no Go code changed)
- [ ] Confirm deploy workflow runs in correct order in GitHub Actions
- [ ] Confirm CI workers can reach ci-oidc internal URL with Bearer token
- [ ] Confirm CI workers can call docstore `fetchConfig` / `postCheckRun`

🤖 Generated with [Claude Code](https://claude.com/claude-code)