### PR TITLE
docs(ci): document OIDC job identity system (phases 1-5 of #283)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -346,6 +346,8 @@ List reviews for a branch.
 
 Report a CI check result.
 
+**Auth:** IAP JWT (human users) or job OIDC JWT (`Authorization: Bearer {jwt}`, issued by `oidc.docstore.dev`).
+
 **Body:**
 ```json
 {
@@ -360,6 +362,8 @@ Report a CI check result.
 `status` is `passed`, `failed`, or `pending`.
 
 **Response 201:** Check run object.
+
+When submitted via a job OIDC JWT, the `reporter` field on the check run is set to `ci-job:{job_id}` (the job UUID from the JWT's `job_id` claim). This identifies which CI job produced the result.
 
 ### `GET /repos/{name}/-/branch/{branch}/checks`
 
@@ -415,6 +419,39 @@ Download the repo tree as a `.tar.gz`.
 **Query parameters:**
 - `branch` — Branch name (default `main`).
 - `at` — Sequence number.
+
+Requires authentication (IAP JWT or job OIDC JWT). For CI workers, use the presigned URL variant instead.
+
+### `GET /repos/{name}/-/archive` (presigned — no auth required)
+
+When the `sig` and `expires` query parameters are present, the server validates the HMAC signature and serves the archive without authentication. This form is intended for BuildKit `llb.HTTP` sources.
+
+**Query parameters:**
+- `branch` — Branch name (required).
+- `at` — Sequence number (required).
+- `expires` — Unix timestamp after which the URL is invalid (required).
+- `sig` — Hex-encoded HMAC-SHA256 over `repo\nbranch\nsequence\nexpires` (required).
+
+**Response 403** if the signature is invalid or the URL has expired.
+
+## CI Job Authentication
+
+### `POST /repos/{name}/-/archive/presign`
+
+Obtain a time-limited presigned URL for a CI job's source archive. The presigned URL can be fetched by BuildKit without any credentials.
+
+**Auth:** `Authorization: Bearer {request_token}` (the one-time token returned by ci-scheduler's `POST /claim`).
+
+The `request_token` is bound to a specific job; the repo in the token must match the `{name}` path parameter.
+
+**Response 200:**
+```json
+{"url": "https://docstore.dev/repos/{repo}/-/archive?branch={branch}&at={seq}&expires={unix}&sig={hex}"}
+```
+
+The URL is valid for 1 hour. Pass it directly to BuildKit as the `llb.HTTP` source — no credentials needed.
+
+**Response 401** if the token is missing, invalid, or expired.
 
 ## Chain
 
@@ -520,3 +557,55 @@ Delete a subscription. Global admin or the subscription creator.
 Resume a suspended subscription. Global admin or the subscription creator. Clears `suspended_at` and resets `failure_count` to 0.
 
 **Response 204.**
+
+## OIDC Identity Endpoints (oidc.docstore.dev)
+
+These endpoints are served by the `ci-oidc-public` Cloud Run service at `oidc.docstore.dev`. They require no authentication.
+
+### `GET /.well-known/openid-configuration`
+
+Returns the OIDC discovery document for the `https://oidc.docstore.dev` issuer.
+
+**Response 200:**
+```json
+{
+  "issuer": "https://oidc.docstore.dev",
+  "jwks_uri": "https://oidc.docstore.dev/.well-known/jwks.json",
+  "response_types_supported": ["id_token"],
+  "subject_types_supported": ["public"],
+  "id_token_signing_alg_values_supported": ["RS256"]
+}
+```
+
+### `GET /.well-known/jwks.json`
+
+Returns the JSON Web Key Set containing the RSA public key used to sign CI job JWTs. Use this to verify job JWT signatures without trusting DocStore's internal state.
+
+External systems (GCP Workload Identity Federation, AWS STS, HashiCorp Vault) can use this endpoint to exchange job JWTs for cloud provider credentials.
+
+## CI OIDC Token Endpoint (internal)
+
+This endpoint is served by the `ci-oidc` Cloud Run service. It is accessible from GKE worker pods via VPC (`--ingress=internal`) but not from the public internet.
+
+### `POST /ci/token`
+
+Exchange a `request_token` for a short-lived job OIDC JWT.
+
+**Auth:** `Authorization: Bearer {request_token}` (the one-time token returned by ci-scheduler's `POST /claim`).
+
+**Body:**
+```json
+{"audience": "docstore", "check_name": "ci/build"}
+```
+
+- `audience` — Required. The JWT `aud` claim. Use `"docstore"` for docstore API access.
+- `check_name` — Optional. Included in the JWT `sub` claim as `repo:{repo}:branch:{branch}:check:{check_name}`.
+
+**Response 200:**
+```json
+{"token": "eyJ..."}
+```
+
+The returned JWT has a 1-hour lifetime and is signed with RS256 via Cloud KMS. Each call produces a unique JWT (unique `jti`) recorded in the `ci_oidc_tokens` audit table.
+
+**Response 401** if the `request_token` is missing, invalid, or expired.

--- a/docs/ci-architecture.md
+++ b/docs/ci-architecture.md
@@ -12,28 +12,36 @@ docstore events (CloudEvents via outbox)
                                                ci-scheduler (standard GKE node, :8080)
                                                ├─ POST /webhook   ← webhook delivery
                                                ├─ POST /run       ← manual trigger
+                                               ├─ POST /claim     ← K8s SA token auth
+                                               ├─ POST /jobs/{id}/heartbeat ← request_token auth
+                                               ├─ POST /jobs/{id}/complete  ← request_token auth
                                                └─ cron runner     ← schedule trigger
                                                          │
                                                INSERT INTO ci_jobs (trigger_type, ...)
                                                          │
-                                               ci-worker pod (Kata CLH microVM) polls ci_jobs
-                                               ├─ claim job (SKIP LOCKED)
-                                               ├─ fetch .docstore/ci.yaml (branch under test)
+                                               ci-worker pod (Kata CLH microVM) calls POST /claim
+                                               ├─ K8s SA token → request_token + oidc_token_url
+                                               ├─ exchange request_token → OIDC JWT
+                                               ├─ GET presigned archive URL
+                                               ├─ fetch .docstore/ci.yaml (JWT auth)
                                                ├─ evaluate if: conditions
                                                ├─ run checks via BuildKit executor
                                                ├─ upload logs → GCS
-                                               └─ POST check_runs → docstore
+                                               └─ POST check_runs → docstore (JWT auth)
 ```
 
 ### Components
 
 | File | Role |
 |---|---|
-| `cmd/ci-scheduler/main.go` | Webhook receiver; inserts `ci_jobs` rows; serves `/run` for manual triggers; reaps stale claimed jobs |
-| `cmd/ci-worker/main.go` | Polls `ci_jobs`, claims one job, runs executor, uploads logs, posts check run results, then exits |
+| `cmd/ci-scheduler/main.go` | Webhook receiver; inserts `ci_jobs` rows; serves `/run` for manual triggers; validates K8s SA tokens; issues request_tokens; reaps stale claimed jobs |
+| `cmd/ci-worker/main.go` | Claims job via POST /claim with K8s SA token; exchanges request_token for OIDC JWT; runs executor; uploads logs; posts check run results; then exits |
+| `cmd/ci-oidc/main.go` | Exchanges request_tokens for signed OIDC JWTs; serves OIDC discovery and JWKS endpoints |
+| `internal/k8sproof/k8sproof.go` | Validates K8s projected SA tokens and pod provenance (owner chain, age, service account) |
 | `internal/executor/executor.go` | Translates `.docstore/ci.yaml` checks into BuildKit LLB DAGs and dispatches them to buildkitd |
+| `internal/archivesign/archivesign.go` | HMAC-SHA256 signing and verification for presigned archive URLs |
 | `entrypoint-worker.sh` | Kata VM startup: GCR auth → loop-ext4 setup → buildkitd → dockerd → ci-worker |
-| `deploy/k8s/ci-worker.yaml` | Kata CLH Deployment (`runtimeClassName: kata-clh`); 3 replicas; each pod handles one job then exits |
+| `deploy/k8s/ci-worker.yaml` | Kata CLH KEDA ScaledJob (`runtimeClassName: kata-clh`); KEDA creates one pod per queued job; each pod handles one job then exits |
 | `deploy/k8s/ci-scheduler.yaml` | Standard GKE Deployment (1 replica) + internal LoadBalancer reachable via VPC Direct Egress |
 | `deploy/k8s/debug-kata.yaml` | Throwaway privileged ubuntu:24.04 pod with `runtimeClassName: kata-clh` for kernel investigation |
 
@@ -46,10 +54,90 @@ Cloud Run (docstore)
                                            └─► PostgreSQL (Cloud SQL proxy sidecar)
 
 ci-worker pods (kata-clh microVM)
+  ├─► ci-scheduler :8080  (claim, heartbeat, complete)
+  ├─► ci-oidc (internal Cloud Run)  (POST /ci/token)
+  ├─► docstore Cloud Run (JWT-authenticated API calls)
   ├─► buildkitd tcp://localhost:1234
   ├─► dockerd   tcp://127.0.0.1:2375
   └─► log HTTP  :8081  (proxied through ci-scheduler for live log streaming)
+
+oidc.docstore.dev (Cloud Run domain mapping → ci-oidc-public)
+  ├─► GET /.well-known/openid-configuration
+  └─► GET /.well-known/jwks.json
 ```
+
+---
+
+## Security Architecture
+
+### Why: the problem with static credentials
+
+The original CI system gave workers direct database access (`DATABASE_URL`). This created a large blast radius: any compromised worker could read or modify any CI job. The new system replaces static shared credentials with cryptographically verifiable, scoped, short-lived job identity.
+
+### How: the authentication chain
+
+```
+Pod starts (Kata CLH microVM)
+    │
+    ├─ K8s projected SA token (auto-mounted at
+    │  /var/run/secrets/kubernetes.io/serviceaccount/token)
+    │
+    ▼
+POST ci-scheduler/claim
+    │  K8s TokenReview + provenance checks (internal/k8sproof):
+    │  • token valid, SA = system:serviceaccount:docstore-ci:ci-worker
+    │  • pod age < 4h (warm pool workers stay valid)
+    │  • owner chain: Pod → batch/v1 Job → keda.sh/v1alpha1 ScaledJob(ci-worker)
+    │
+    ▼
+request_token (32-byte random, base64url, plaintext returned once)
+SHA-256 hash stored in ci_jobs table
+    │
+    ├─ Used for: POST /heartbeat, POST /complete, POST /archive/presign
+    │
+    ▼
+POST ci-oidc/ci/token (internal Cloud Run — GKE only)
+    │  Validates request_token against ci_jobs table
+    │  Signs JWT via Cloud KMS (RS256, private key never leaves KMS)
+    │
+    ▼
+Job OIDC JWT (valid 1 hour)
+    iss: https://oidc.docstore.dev
+    sub: repo:acme/myrepo:branch:main:check:ci/test
+    aud: docstore
+    jti: <uuid> (written to ci_oidc_tokens audit table)
+    job_id, repo, org, branch, check_name, ref_type, sequence
+    │
+    ├─ Authorization: Bearer <jwt> on all docstore API calls
+    │  (fetch config, mark checks pending, post check results)
+    │
+    └─ Can be exchanged with GCP Workload Identity Federation, AWS STS,
+       HashiCorp Vault for cloud provider credentials — no static secrets needed
+```
+
+### Pod provenance chain
+
+The KEDA ScaledJob creates a new Kubernetes Job (and pod) for each item in the queue. ci-scheduler verifies this lineage:
+
+```
+KEDA ScaledJob "ci-worker"
+    └─ creates: batch/v1 Job (per queue item)
+                    └─ creates: Pod (runs Kata CLH microVM)
+                                    └─ mounts: projected SA token
+                                               (bound to the pod's lifetime)
+```
+
+The `internal/k8sproof` package walks this owner reference chain via the Kubernetes API. A token from any pod not owned by the `ci-worker` ScaledJob is rejected, preventing spoofed claims from arbitrary pods.
+
+### OIDC issuer as a trust anchor
+
+`oidc.docstore.dev` acts as a standard OIDC identity provider. The JWKS is publicly accessible so external systems can:
+
+- Verify the JWT signature without trusting DocStore's internal state
+- Use GCP Workload Identity Federation, AWS STS, or HashiCorp Vault to exchange the job JWT for cloud credentials
+- Audit token issuance via the `ci_oidc_tokens` table (jti, job_id, audience, exp)
+
+---
 
 ### Event subscription and routing
 
@@ -82,13 +170,16 @@ The `proposal_synchronized` trigger is synthetic — ci-scheduler detects it by 
 2. ci-scheduler verifies the HMAC signature (webhook path only), parses the CloudEvent, and reads `.docstore/ci.yaml` from the branch under test.
 3. The `on:` block in ci.yaml is evaluated against the event. If no trigger matches, the request is acknowledged and no job is enqueued.
 4. A `ci_jobs` row is inserted with `status='queued'` and trigger metadata (`trigger_type`, `trigger_branch`, `trigger_base_branch`, `trigger_proposal_id`).
-5. A ci-worker pod polls `ClaimCIJob` (atomic `UPDATE … WHERE status='queued' LIMIT 1 … SKIP LOCKED RETURNING *`).
-6. The worker builds a `TriggerContext` from the job row and fetches `.docstore/ci.yaml` from the branch under test at the pinned sequence.
-7. For each check, the worker evaluates the `if:` expression against the `TriggerContext`. Checks that evaluate to false are skipped entirely.
-8. Remaining checks are executed concurrently via BuildKit LLB inside the Kata microVM.
-9. The worker uploads logs to GCS, posts `check_runs` back to docstore, and calls `CompleteCIJob`.
-10. The Deployment controller replaces the exited pod, maintaining the pool size.
-11. ci-scheduler reaps jobs whose `last_heartbeat_at` has gone stale (missed heartbeats from crashed workers) every 30 seconds, resetting them to `queued`.
+5. A ci-worker pod calls `POST /claim` with its Kubernetes projected service account token. ci-scheduler validates the token via the K8s TokenReview API and verifies pod provenance (service account, pod age, owner chain). On success, it atomically claims the oldest queued job and returns the job row plus a one-time `request_token` and `oidc_token_url`.
+6. The worker exchanges the `request_token` for a short-lived OIDC JWT by calling `POST <oidc_token_url>` on the ci-oidc internal service.
+7. The worker calls `POST /repos/{repo}/-/archive/presign` (authenticated with `request_token`) to obtain a presigned, HMAC-signed archive URL. The URL is passed to BuildKit as the source — no credentials are embedded.
+8. The worker fetches `.docstore/ci.yaml` from the branch at the pinned sequence (JWT auth) and builds a `TriggerContext` from the job row.
+9. For each check, the worker evaluates the `if:` expression against the `TriggerContext`. Checks that evaluate to false are skipped entirely.
+10. Remaining checks are executed concurrently via BuildKit LLB inside the Kata microVM.
+11. The worker uploads logs to GCS and posts `check_runs` back to docstore (JWT auth).
+12. The worker calls `POST /jobs/{id}/complete` (authenticated with `request_token`) to record final status.
+13. The pod exits. KEDA sees the queue depth change and creates a new pod for the next job.
+14. ci-scheduler reaps jobs whose `last_heartbeat_at` has gone stale (missed heartbeats from crashed workers) every 30 seconds, resetting them to `queued`.
 
 ### Trigger context
 
@@ -217,6 +308,10 @@ docker push us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-worker:lates
 docker build -f Dockerfile.ci-scheduler \
   -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-scheduler:latest .
 docker push us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-scheduler:latest
+
+docker build -f Dockerfile.ci-oidc \
+  -t us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-oidc:latest .
+docker push us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-oidc:latest
 ```
 
 ### Apply
@@ -225,7 +320,6 @@ docker push us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-scheduler:la
 kubectl apply -f deploy/k8s/ci-scheduler.yaml
 kubectl apply -f deploy/k8s/ci-worker.yaml
 kubectl rollout status deployment/ci-scheduler -n docstore-ci
-kubectl rollout status deployment/ci-worker -n docstore-ci
 ```
 
 Subsequent deploys happen automatically via the `build-and-deploy-ci` CI job on every push to `main`.
@@ -234,13 +328,13 @@ Subsequent deploys happen automatically via the `build-and-deploy-ci` CI job on 
 
 | Variable | Required | Description |
 |---|---|---|
-| `DATABASE_URL` | yes | PostgreSQL connection string (via Cloud SQL proxy) |
 | `DOCSTORE_URL` | yes | Base URL of the docstore server |
-| `POD_NAME` | yes | Injected via Downward API; used to claim jobs |
-| `POD_IP` | yes | Injected via Downward API; used for live log proxying |
+| `CI_SCHEDULER_URL` | yes | URL of the ci-scheduler service |
 | `BUILDKIT_ADDR` | no | buildkitd address; defaults to `tcp://localhost:1234` |
 | `LOG_STORE` | no | `gcs` (production) or `local`; defaults to `local` |
 | `LOG_BUCKET` | if gcs | GCS bucket name for build logs |
+
+The Kubernetes projected service account token is auto-mounted at `/var/run/secrets/kubernetes.io/serviceaccount/token`.
 
 ### Environment variables (ci-scheduler)
 
@@ -248,5 +342,6 @@ Subsequent deploys happen automatically via the `build-and-deploy-ci` CI job on 
 |---|---|---|
 | `DATABASE_URL` | yes | PostgreSQL connection string |
 | `DOCSTORE_URL` | yes | Base URL of the docstore server |
+| `OIDC_TOKEN_URL` | yes | URL of the ci-oidc `/ci/token` endpoint (returned to workers on /claim) |
 | `WEBHOOK_SECRET` | no | HMAC secret for verifying incoming webhook deliveries |
 | `RUNNER_URL` | no | Public URL of this scheduler (used to auto-register with docstore) |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -12,19 +12,21 @@ docstore server
 ci-scheduler (GKE, 1 replica)
     │ INSERT ci_jobs (status=queued)
     │ reap stale claimed jobs every 30s
+    │ POST /claim         ← K8s SA token auth + pod provenance checks
+    │ POST /jobs/{id}/heartbeat ← request_token auth
+    │ POST /jobs/{id}/complete  ← request_token auth
     ▼
-PostgreSQL ci_jobs table
-    │ SELECT FOR UPDATE SKIP LOCKED
-    ▼
-ci-worker pods (GKE, 3 replicas, Kata CLH microVMs)
-    │ claim job (status=claimed)
-    │ heartbeat every 30s
-    │ fetch .docstore/ci.yaml from main
-    │ download branch source tar.gz
-    │ run checks via BuildKit LLB
+ci-worker pods (GKE, KEDA ScaledJob, Kata CLH microVMs)
+    │ POST /claim with K8s SA token
+    │ receive job + request_token + oidc_token_url
+    │ exchange request_token → OIDC JWT
+    │ POST /archive/presign with request_token → presigned URL
+    │ fetch .docstore/ci.yaml (JWT auth)
+    │ run checks via BuildKit LLB (presigned source URL, no credentials)
     │ upload logs to GCS
-    │ POST /repos/{repo}/-/check for each result
-    └─ exit (pod replaced by Deployment controller)
+    │ POST /repos/{repo}/-/check (JWT auth)
+    │ POST /jobs/{id}/complete (request_token)
+    └─ exit (KEDA creates a fresh pod for the next job)
 ```
 
 ## Components
@@ -40,6 +42,10 @@ A lightweight HTTP service that:
 - Proxies live logs at `GET /run/{id}/logs/{check}` — either reverse-proxying to the worker pod (while the job is claimed) or redirecting to the GCS log URL (after completion).
 - Provides a manual trigger at `POST /run`.
 - Runs a stale-job reaper every 30 seconds to reclaim jobs that have missed their heartbeat.
+- Serves `POST /claim` — validates K8s projected SA tokens with pod provenance checks, claims the next queued job, and returns a `request_token`.
+- Serves `POST /jobs/{id}/heartbeat` — request_token authenticated; updates the job heartbeat.
+- Serves `POST /jobs/{id}/complete` — request_token authenticated; marks the job passed or failed.
+- Serves `GET /queue-depth` — returns the count of queued jobs for the KEDA autoscaler.
 
 **Flags / environment variables:**
 
@@ -49,6 +55,7 @@ A lightweight HTTP service that:
 | `-docstore-url` | `DOCSTORE_URL` | Base URL of the docstore server |
 | `-scheduler-url` | `RUNNER_URL` | Public URL of this scheduler (used to auto-register the webhook subscription) |
 | `-webhook-secret` | `WEBHOOK_SECRET` | HMAC secret for webhook signature verification |
+| `-oidc-token-url` | `OIDC_TOKEN_URL` | URL of the CI OIDC token endpoint returned to workers on /claim |
 | — | `DATABASE_URL` | PostgreSQL DSN (required) |
 | — | `LOG_LEVEL` | Log level |
 | — | `LOG_FORMAT` | `json` (default) or `text` |
@@ -57,26 +64,27 @@ On startup, if `DOCSTORE_URL`, `RUNNER_URL`, and `WEBHOOK_SECRET` are all set, t
 
 ### ci-worker (`cmd/ci-worker`)
 
-A long-lived process that:
+A process that:
 
-1. Waits for buildkitd (tcp://localhost:1234) and dockerd (tcp://localhost:2375) to be ready (up to 5 minutes each).
-2. Polls the `ci_jobs` table with `SELECT FOR UPDATE SKIP LOCKED` to claim one job.
-3. Sends a heartbeat to the database every 30 seconds while the job runs.
-4. Executes the job (see below).
-5. Writes the final status and log URL back to `ci_jobs`.
-6. Exits. The Kubernetes Deployment controller creates a fresh pod for the next job.
+1. Waits for buildkitd (`tcp://localhost:1234`) and dockerd (`tcp://localhost:2375`) to be ready (up to 5 minutes each).
+2. Calls `POST /claim` on ci-scheduler with its Kubernetes projected service account token to claim a queued job. Returns 204 (no job) or a JSON body with the job, `request_token`, and `oidc_token_url`.
+3. Exchanges the `request_token` for a short-lived OIDC JWT by calling `oidc_token_url`.
+4. Sends a heartbeat to ci-scheduler via `POST /jobs/{id}/heartbeat` (authenticated with `request_token`) every 30 seconds while the job runs.
+5. Executes the job (see below).
+6. Reports final status to ci-scheduler via `POST /jobs/{id}/complete` (authenticated with `request_token`).
+7. Exits. KEDA creates a fresh pod for the next job.
 
 **Required environment variables:**
 
 | Variable | Description |
 |---|---|
-| `DATABASE_URL` | PostgreSQL DSN |
 | `DOCSTORE_URL` | Base URL of the docstore server |
-| `POD_NAME` | Kubernetes pod name (injected via downward API) |
-| `POD_IP` | Kubernetes pod IP (injected via downward API) |
-| `BUILDKIT_ADDR` | buildkitd address (default `tcp://localhost:1234`) |
+| `CI_SCHEDULER_URL` | URL of the ci-scheduler service |
 | `LOG_STORE` | Log backend: `gcs` or `local` |
 | `LOG_BUCKET` | GCS bucket for logs (required when `LOG_STORE=gcs`) |
+| `BUILDKIT_ADDR` | buildkitd address (default `tcp://localhost:1234`) |
+
+The Kubernetes projected service account token is auto-mounted at `/var/run/secrets/kubernetes.io/serviceaccount/token` and is read automatically by the worker. No explicit env var is required.
 
 The worker serves live logs on port 8081 at `GET /logs/{check}`. The scheduler's log proxy endpoint reverse-proxies to this port while the job is running.
 
@@ -95,21 +103,112 @@ The Dockerfile.ci-worker sets this script as the container entrypoint. It:
 
 ci-worker pods use `runtimeClassName: kata-clh`, which runs each pod inside a Kata Cloud-Hypervisor microVM. This provides a real Linux kernel per pod, so Docker and BuildKit run natively without privileged containers at the host level. The `securityContext.privileged: true` flag in the pod spec applies inside the VM only.
 
+## Authentication and Job Identity
+
+Workers no longer authenticate with a shared database credential. The authentication chain is:
+
+### 1. K8s token validation (POST /claim)
+
+Worker pods present their Kubernetes projected service account token in `Authorization: Bearer <token>` to ci-scheduler's `POST /claim` endpoint. ci-scheduler validates it via the Kubernetes TokenReview API and verifies pod provenance:
+
+- Token is valid and issued for `system:serviceaccount:docstore-ci:ci-worker`
+- Pod was created within the last 4 hours (freshness check)
+- Pod's owner chain: Pod → `batch/v1` Job → `keda.sh/v1alpha1` ScaledJob named `ci-worker`
+- Each pod handles at most one job (enforced by job claiming semantics)
+
+### 2. request_token
+
+On successful claim, ci-scheduler generates a cryptographically random `request_token` (32 bytes, base64url-encoded). The SHA-256 hash is stored in the database; the plaintext is returned once to the worker. The `request_token` is used to:
+
+- Authenticate `POST /jobs/{id}/heartbeat`
+- Authenticate `POST /jobs/{id}/complete`
+- Authenticate `POST /repos/{repo}/-/archive/presign`
+- Exchange for an OIDC JWT
+
+### 3. OIDC JWT exchange
+
+The worker calls `POST <oidc_token_url>` (the ci-oidc Cloud Run internal service) with the `request_token`. The response is a signed JWT with these claims:
+
+| Claim | Value |
+|---|---|
+| `iss` | `https://oidc.docstore.dev` |
+| `sub` | `repo:{repo}:branch:{branch}:check:{check_name}` |
+| `aud` | `docstore` |
+| `jti` | unique UUID (written to `ci_oidc_tokens` audit table) |
+| `job_id` | CI job UUID |
+| `repo` | full repo name (e.g. `acme/myrepo`) |
+| `org` | first path segment of repo |
+| `branch` | branch name |
+| `check_name` | check name (may be empty) |
+| `ref_type` | `post-submit`, `pre-submit`, `schedule`, or `manual` |
+| `sequence` | head sequence number |
+| `exp` | iat + 1 hour |
+
+JWTs are signed with RS256 using a Cloud KMS asymmetric key. The private key never leaves KMS.
+
+### 4. API authentication
+
+Workers include the JWT as `Authorization: Bearer <token>` on all docstore API calls (fetch config, post check results).
+
+### 5. Job identity on check runs
+
+When a worker posts check results via `POST /repos/:repo/-/check`, the docstore server validates the JWT via `JobTokenMiddleware` and records the identity as `ci-job:{job_id}` — the `reporter` on the check run.
+
+## Presigned Archive URLs
+
+BuildKit cannot hold bearer tokens. To fetch the source archive securely without embedding credentials in the build context:
+
+1. Worker calls `POST /repos/{repo}/-/archive/presign` with `Authorization: Bearer {request_token}`.
+2. Server verifies the `request_token` matches the job and the repo in the token matches the request path.
+3. Server generates an HMAC-SHA256 signed URL valid for 1 hour:
+   ```
+   https://docstore.dev/repos/{repo}/-/archive?branch={branch}&at={seq}&expires={unix}&sig={hex}
+   ```
+4. The HMAC covers `repo`, `branch`, `sequence`, and `expires` (newline-separated) with a server-side secret.
+5. Worker passes this URL as the BuildKit source — no credentials are needed to fetch it.
+
 ## Job execution flow
 
 For each job, the ci-worker:
 
-1. **Fetches CI config.** Downloads `.docstore/ci.yaml` from `main` via `GET /repos/{repo}/-/file/.docstore/ci.yaml?branch=main`.
+1. **Fetches CI config.** Downloads `.docstore/ci.yaml` from the branch under test at the job's head sequence via `GET /repos/{repo}/-/file/.docstore/ci.yaml`, authenticated with the OIDC JWT.
 
-2. **Downloads branch source.** Fetches a tar.gz of the branch at the job's head sequence via `GET /repos/{repo}/-/archive?branch={branch}&at={seq}` and extracts it to a temporary directory.
+2. **Gets a presigned archive URL.** Calls `POST /repos/{repo}/-/archive/presign` with the `request_token` to obtain a time-limited, HMAC-signed URL for the source archive. No credentials are embedded in the URL itself.
 
-3. **Marks checks pending.** For each check in `ci.yaml`, posts `POST /repos/{repo}/-/check` with `status=pending`.
+3. **Marks checks pending.** For each check in `ci.yaml`, posts `POST /repos/{repo}/-/check` with `status=pending`, authenticated with the OIDC JWT.
 
-4. **Runs all checks in parallel** via the executor (`internal/executor`).
+4. **Runs all checks in parallel** via the executor (`internal/executor`). The executor fetches the source archive via the presigned URL using BuildKit's `llb.HTTP` source.
 
 5. **Uploads logs.** Writes each check's log to a temp file (served live at `:8081`) and uploads to GCS.
 
-6. **Posts results.** For each check result, posts `POST /repos/{repo}/-/check` with `status=passed` or `status=failed` and the GCS log URL.
+6. **Posts results.** For each check result, posts `POST /repos/{repo}/-/check` with `status=passed` or `status=failed` and the GCS log URL, authenticated with the OIDC JWT.
+
+## OIDC Service
+
+The OIDC identity provider runs as two separate Cloud Run services using the same `ci-oidc` image:
+
+### ci-oidc (internal ingress — GKE only)
+
+Deployed with `--ingress=internal`, reachable from GKE worker pods via VPC. Serves the full endpoint set:
+
+- `POST /ci/token` — accepts `request_token`, issues a signed JWT for the job
+- `GET /.well-known/openid-configuration` — OIDC discovery document
+- `GET /.well-known/jwks.json` — RSA public key for JWT verification
+- `GET /healthz`
+
+**Required env vars:** `DATABASE_URL`, `KMS_KEY_VERSION`
+
+### ci-oidc-public (public — oidc.docstore.dev)
+
+Deployed with `--ingress=all --allow-unauthenticated` and `PUBLIC_ONLY=true`. Serves only the discovery endpoints (no database access, no token issuance):
+
+- `GET /.well-known/openid-configuration`
+- `GET /.well-known/jwks.json`
+- `GET /healthz`
+
+**Required env vars:** `KMS_KEY_VERSION` only (no database access)
+
+The CNAME `oidc.docstore.dev → ghs.googlehosted.com` is configured via Cloud Run domain mapping so that external systems (GCP WIF, AWS STS, HashiCorp Vault) can discover the JWKS and verify job JWTs.
 
 ## Executor (`internal/executor`)
 
@@ -119,7 +218,7 @@ For each check (run in parallel via goroutines):
 
 1. Resolves the image config from the registry to extract environment variables (e.g. `PATH` in `golang:1.25`).
 2. Injects all image ENV variables and `DOCKER_HOST=tcp://localhost:2375` so check steps can use Docker.
-3. Mounts the source directory as a local BuildKit input named `src`.
+3. Fetches the source archive from the presigned URL via BuildKit `llb.HTTP`.
 4. Chains the steps sequentially: each step runs `sh -c <step>` in the image with `/src` mounted. The `/src` mount is passed forward between steps so file mutations persist across steps within the same check.
 5. Marshals the LLB DAG and calls `client.Build`. Log output is collected from the `SolveStatus` channel.
 6. Returns `CheckResult{Name, Status, Logs}`.
@@ -155,10 +254,11 @@ checks:
 
 ### Notes
 
-- The config is always read from `main`, not from the branch being tested. Update `ci.yaml` by merging to `main`.
+- The config is always read from the branch under test at its head sequence, not from `main`. However, `on:` trigger filtering is evaluated against `main` at the time of enqueueing.
 - All checks run in parallel.
 - A check fails if any step exits non-zero.
 - `DOCKER_HOST=tcp://localhost:2375` is injected automatically, so check steps can run `docker build`, `docker push`, etc. The dockerd is running in the same Kata VM.
+- `DOCSTORE_OIDC_REQUEST_TOKEN` and `DOCSTORE_OIDC_REQUEST_URL` are injected into each check's environment so steps can themselves obtain OIDC tokens if needed.
 
 ## ci_jobs table
 
@@ -171,7 +271,9 @@ The scheduler and workers coordinate through a PostgreSQL table (`ci_jobs`). Key
 | `branch` | text | Branch name |
 | `sequence` | int8 | Head sequence at time of event |
 | `status` | text | `queued`, `claimed`, `passed`, `failed` |
+| `worker_pod_name` | text | Pod name of the claiming worker (from K8s token claims) |
 | `worker_pod_ip` | text | IP of the claiming worker (for log proxy) |
+| `request_token_hash` | text | SHA-256 hash of the issued request_token |
 | `last_heartbeat_at` | timestamptz | Updated every 30s by the worker |
 | `log_url` | text | GCS URL for the first check's logs |
 | `error_message` | text | Set if the job itself failed (not a check) |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -193,7 +193,22 @@ The domain `docstore.dev` is registered via Cloud Domains in project `dlorenc-ch
 
 ## One-time OIDC setup prerequisites
 
-The ci-oidc service requires several GCP resources that must be created once before first deployment.
+The CI OIDC identity system deploys as two Cloud Run services from the same `ci-oidc` image:
+
+- **ci-oidc** (`--ingress=internal`): Serves `POST /ci/token` plus the discovery endpoints. Accessible from GKE worker pods via VPC. Requires `DATABASE_URL` and `KMS_KEY_VERSION`. Token issuance happens here.
+- **ci-oidc-public** (`--ingress=all --allow-unauthenticated`, `PUBLIC_ONLY=true`): Serves only `GET /.well-known/openid-configuration` and `GET /.well-known/jwks.json` at `oidc.docstore.dev`. No database access. Allows external systems to verify job JWT signatures.
+
+Additionally, the docstore Cloud Run service must allow unauthenticated invocations so worker pods can call it using the OIDC JWT for application-level auth (rather than needing a Google identity token):
+
+```bash
+gcloud run services add-iam-policy-binding docstore \
+  --member=allUsers \
+  --role=roles/run.invoker \
+  --region=us-central1 \
+  --project=dlorenc-chainguard
+```
+
+The following GCP resources must be created once before first deployment.
 
 ### 1. Create the KMS keyring and signing key
 
@@ -284,7 +299,7 @@ gcloud secrets add-iam-policy-binding archive-hmac-secret \
 
 ### 7. DNS setup for oidc.docstore.dev
 
-After the Cloud Run domain mapping is created by the deploy workflow, add a CNAME record:
+The `build-and-deploy-ci-oidc` workflow job creates the Cloud Run domain mapping for `oidc.docstore.dev → ci-oidc-public` idempotently on each deploy. After the first deploy, add a CNAME record pointing to the Cloud Run hosting:
 
 ```
 oidc.docstore.dev. CNAME ghs.googlehosted.com.
@@ -301,7 +316,11 @@ gcloud dns record-sets create oidc.docstore.dev. \
   --project=dlorenc-chainguard
 ```
 
-The domain mapping is created idempotently by the `build-and-deploy-ci-oidc` workflow job on each deploy. Wait for the mapping to become active before the CNAME resolves correctly (can take a few minutes on first creation).
+Wait for the domain mapping to become active before the CNAME resolves correctly (can take a few minutes on first creation). Verify with:
+
+```bash
+curl https://oidc.docstore.dev/.well-known/jwks.json
+```
 
 ## GKE deployment (CI system)
 
@@ -367,17 +386,33 @@ The deploy workflow (`deploy.yml`) also builds and deploys both CI binaries afte
      --data-file=- --project=dlorenc-chainguard
    ```
 4. Provision the Global HTTPS LB + IAP infrastructure (see "One-time infrastructure" commands in the Authentication section above). This only needs to be done once per project.
-5. Push to `main` to trigger the deploy workflow.
-6. After deploy, verify with `curl https://docstore.dev/healthz`.
-7. Create the first org and repo:
+5. Create the OIDC KMS resources and secrets (see "One-time OIDC setup prerequisites" above):
+   - KMS keyring and signing key
+   - `ci-oidc-kms-key-version` secret in Secret Manager
+   - `archive-hmac-secret` in Secret Manager
+   - `ci-oidc` and `ci-oidc-public` service accounts with KMS roles
+6. Grant allUsers `run.invoker` on the docstore Cloud Run service (allows worker pods to call the internal URL using OIDC JWT auth):
    ```bash
-   ds orgs create myorg
-   ds repos create myorg myrepo
+   gcloud run services add-iam-policy-binding docstore \
+     --member=allUsers --role=roles/run.invoker \
+     --region=us-central1 --project=dlorenc-chainguard
    ```
-8. Assign a bootstrap admin (the `--bootstrap-admin` flag is already set on the Cloud Run service as `dlorenc@chainguard.dev`; update as needed):
+7. Push to `main` to trigger the deploy workflow. The workflow deploys the docstore server, ci-scheduler, ci-worker, and both ci-oidc services in dependency order.
+8. After deploy, add the CNAME for `oidc.docstore.dev` (see step 7 of "One-time OIDC setup prerequisites" above).
+9. Verify OIDC is working:
    ```bash
-   ds roles set you@example.com admin
+   curl https://docstore.dev/healthz
+   curl https://oidc.docstore.dev/.well-known/jwks.json
    ```
+10. Create the first org and repo:
+    ```bash
+    ds orgs create myorg
+    ds repos create myorg myrepo
+    ```
+11. Assign a bootstrap admin (the `--bootstrap-admin` flag is already set on the Cloud Run service as `dlorenc@chainguard.dev`; update as needed):
+    ```bash
+    ds roles set you@example.com admin
+    ```
 
 ## Horizontal scaling
 


### PR DESCRIPTION
## Summary

- **docs/ci.md**: Rewrite to accurately describe the new authentication chain (K8s SA token → request_token → OIDC JWT). Add new sections for Authentication and Job Identity, Presigned Archive URLs, and OIDC Service. Update ci-worker env vars (remove DATABASE_URL, add CI_SCHEDULER_URL), update ci-scheduler endpoint list, update job execution flow.
- **docs/ci-architecture.md**: Add Security Architecture section with full auth chain ASCII flow diagram, pod provenance chain, and OIDC trust anchor explanation. Rewrite job lifecycle steps. Update architecture overview diagram and component table to include ci-oidc, k8sproof, archivesign. Update ci-worker env vars.
- **docs/deployment.md**: Clarify the ci-oidc (internal) vs ci-oidc-public (public, PUBLIC_ONLY) Cloud Run service split. Add allUsers run.invoker note for docstore. Add OIDC prerequisites to first-deployment checklist.
- **docs/api-reference.md**: Document POST /archive/presign, presigned GET /archive, note ci-job:{job_id} reporter on check runs, add OIDC Identity Endpoints section (/.well-known/*), add CI OIDC Token Endpoint section (POST /ci/token).

## Test plan

- [ ] `go build ./...` passes (no code changes — docs only)
- [ ] All sections accurately reflect code in cmd/ci-worker/main.go, cmd/ci-scheduler/main.go, cmd/ci-oidc/main.go, internal/k8sproof/k8sproof.go, internal/archivesign/archivesign.go, internal/server/handlers_archive.go, and deploy/k8s/*.yaml
- [ ] No invented features: triggered_by noted as empty, check_name in sub noted as may be empty

## Notes for reviewers

- The old `DATABASE_URL` env var for ci-worker is removed from all docs (workers never had direct DB access in the new system)
- The `triggered_by` JWT claim is documented as empty — consistent with the code (`TriggeredBy: ""` in ci-oidc/main.go)
- The ci-oidc internal service does not have `--allow-unauthenticated`; worker pods access it using their GCP Workload Identity SA credentials over the internal VPC

🤖 Generated with [Claude Code](https://claude.com/claude-code)