### PR TITLE
feat(cli): rename ds metadata directory from .docstore to .ds

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -53,7 +53,10 @@ type fileHistEntry struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
-const configDir = ".docstore"
+// configDir is the local metadata directory for the ds CLI.
+// Note: previously this was ".docstore"; existing users must rename .docstore/ to .ds/.
+// Note: .docstore/ci.yaml is the CI config path (separate concern) and is NOT affected.
+const configDir = ".ds"
 const configFile = "config.json"
 const stateFile = "state.json"
 
@@ -88,7 +91,7 @@ func (a *App) fetchChain(cfg *Config, from, to int64) ([]chainEntry, error) {
 	return entries, nil
 }
 
-// Config is the persistent CLI configuration stored in .docstore/config.json.
+// Config is the persistent CLI configuration stored in .ds/config.json.
 type Config struct {
 	Remote string `json:"remote"`
 	Repo   string `json:"repo"`
@@ -133,7 +136,7 @@ func (a *App) loadConfig() (*Config, error) {
 }
 
 // loadRemote returns the server remote URL. It first tries to read
-// .docstore/config.json; if absent it falls back to App.DefaultRemote.
+// .ds/config.json; if absent it falls back to App.DefaultRemote.
 func (a *App) loadRemote() (string, error) {
 	data, err := os.ReadFile(a.configPath())
 	if err == nil {
@@ -180,7 +183,7 @@ func (a *App) saveState(st *State) error {
 }
 
 // scanLocalFiles walks the working directory and returns a map of path -> content_hash.
-// It skips the .docstore directory.
+// It skips the .ds directory.
 func (a *App) scanLocalFiles() (map[string]string, error) {
 	localFiles := make(map[string]string)
 	err := filepath.Walk(a.Dir, func(path string, info os.FileInfo, err error) error {
@@ -2016,7 +2019,7 @@ func (a *App) RetryChecks(branch string, checks []string) error {
 	return nil
 }
 
-// TUI launches the terminal UI reading config from .docstore/config.json.
+// TUI launches the terminal UI reading config from .ds/config.json.
 func (a *App) TUI() error {
 	cfg, err := a.loadConfig()
 	if err != nil {

--- a/internal/cli/ci.go
+++ b/internal/cli/ci.go
@@ -27,7 +27,8 @@ var ErrChecksFailed = errors.New("checks failed")
 // connects to buildkitd, and streams results to a.Out.
 func (a *App) CIRun(checkFilter, trigger, baseBranch, buildkitAddr string) error {
 	// 1. Read and parse .docstore/ci.yaml from working directory.
-	ciYAMLPath := filepath.Join(a.Dir, configDir, "ci.yaml")
+	// Note: .docstore/ci.yaml is the CI config path (not the ds metadata dir .ds/).
+	ciYAMLPath := filepath.Join(a.Dir, ".docstore", "ci.yaml")
 	data, err := os.ReadFile(ciYAMLPath)
 	if err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
## Summary

- Changes `configDir` constant from `".docstore"` to `".ds"` in `internal/cli/app.go`
- Fixes a collision where `.docstore/ci.yaml` (the CI config file) was being silently skipped by the commit/scan logic
- In `internal/cli/ci.go`, replaces the `configDir` reference with a hardcoded `".docstore"` literal so the CI config path stays as `.docstore/ci.yaml`
- Updates all comments mentioning `.docstore/config.json` or `.docstore directory` (in the metadata context) to reference `.ds`

## Why

The `scanLocalFiles` skip logic filters out anything with a path prefix matching `configDir`. When `configDir` was `".docstore"`, this also silently dropped `.docstore/ci.yaml` from commits — making it impossible to manage the CI config through `ds`. After this change, the metadata lives in `.ds/` and `.docstore/ci.yaml` commits normally.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/cli/... -count=1` — passes

## Migration note

Existing users must rename `.docstore/` to `.ds/` in their workspaces. No automatic migration is provided (small user base).

## Out of scope / opportunities noted

- No automatic migration helper; could be added if the user base grows
- Server-side paths and `docs/ci.md` references to `.docstore/ci.yaml` are intentionally unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)