### PR TITLE
feat(ci): add CI job log viewer to web UI

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -403,6 +403,21 @@ func (s *server) handleReposPrefix(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		}
 
+	case strings.HasPrefix(endpoint, "ci-jobs/") && strings.Contains(endpoint, "/logs/"):
+		// endpoint format: ci-jobs/{id}/logs/{check}
+		rest := strings.TrimPrefix(endpoint, "ci-jobs/")
+		if idx := strings.Index(rest, "/logs/"); idx >= 0 {
+			r.SetPathValue("id", rest[:idx])
+			r.SetPathValue("check", rest[idx+len("/logs/"):])
+			if r.Method == http.MethodGet {
+				s.handleCIJobLogs(w, r)
+			} else {
+				writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			}
+		} else {
+			writeError(w, http.StatusNotFound, "not found")
+		}
+
 	default:
 		writeError(w, http.StatusNotFound, "not found")
 	}

--- a/internal/server/handlers_ci.go
+++ b/internal/server/handlers_ci.go
@@ -1,12 +1,39 @@
 package server
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
+
+	"cloud.google.com/go/storage"
 
 	"github.com/dlorenc/docstore/internal/model"
 )
+
+// logFetcher abstracts reading a log object from a remote store.
+// The real implementation reads from GCS; tests inject a mock.
+type logFetcher interface {
+	Fetch(ctx context.Context, bucket, key string) ([]byte, error)
+}
+
+// gcsLogFetcher implements logFetcher using the GCS storage client.
+type gcsLogFetcher struct {
+	client *storage.Client
+}
+
+func (f *gcsLogFetcher) Fetch(ctx context.Context, bucket, key string) ([]byte, error) {
+	rc, err := f.client.Bucket(bucket).Object(key).NewReader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	return io.ReadAll(rc)
+}
 
 // ---------------------------------------------------------------------------
 // CI job handlers (read-only)
@@ -86,4 +113,80 @@ func (s *server) handleGetCIJob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, job)
+}
+
+// handleCIJobLogs implements GET /repos/:repo/-/ci-jobs/:id/logs/:check
+// Streams the stored log for the named check as text/plain.
+func (s *server) handleCIJobLogs(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	id := r.PathValue("id")
+	check := r.PathValue("check")
+
+	job, err := s.commitStore.GetCIJob(r.Context(), id)
+	if err != nil {
+		slog.Error("internal error", "op", "ci_job_logs", "id", id, "error", err)
+		writeAPIError(w, ErrCodeInternalError, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if job == nil {
+		writeError(w, http.StatusNotFound, "ci job not found")
+		return
+	}
+	if job.Repo != repo {
+		writeError(w, http.StatusNotFound, "ci job not found")
+		return
+	}
+	if job.LogURL == nil || *job.LogURL == "" {
+		writeError(w, http.StatusNotFound, "no logs for this job")
+		return
+	}
+
+	// Extract bucket from gs:// URL.
+	const gsPrefix = "gs://"
+	if !strings.HasPrefix(*job.LogURL, gsPrefix) {
+		writeError(w, http.StatusNotFound, "log not available")
+		return
+	}
+	rest := strings.TrimPrefix(*job.LogURL, gsPrefix)
+	bucket, _, found := strings.Cut(rest, "/")
+	if !found || bucket == "" {
+		writeError(w, http.StatusInternalServerError, "invalid log URL")
+		return
+	}
+
+	// Construct the object key for the requested check.
+	safeName := strings.ReplaceAll(check, "/", "_")
+	objectKey := fmt.Sprintf("%s/%s/%d/%s.log", job.Repo, job.Branch, job.Sequence, safeName)
+
+	lf := s.logFetcher
+	if lf == nil {
+		// Production: create a GCS client using Application Default Credentials.
+		client, err := storage.NewClient(r.Context())
+		if err != nil {
+			slog.Error("create gcs client for log fetch", "error", err)
+			writeError(w, http.StatusInternalServerError, "could not connect to log storage")
+			return
+		}
+		defer client.Close()
+		lf = &gcsLogFetcher{client: client}
+	}
+
+	data, err := lf.Fetch(r.Context(), bucket, objectKey)
+	if err != nil {
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			writeError(w, http.StatusNotFound, "log not found")
+			return
+		}
+		slog.Error("fetch log", "bucket", bucket, "key", objectKey, "error", err)
+		writeError(w, http.StatusInternalServerError, "could not read log")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	w.Write(data) //nolint:errcheck
 }

--- a/internal/server/handlers_ci_logs_test.go
+++ b/internal/server/handlers_ci_logs_test.go
@@ -1,0 +1,168 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"cloud.google.com/go/storage"
+
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// mockLogFetcher implements logFetcher for tests.
+type mockLogFetcher struct {
+	data []byte
+	err  error
+}
+
+func (m *mockLogFetcher) Fetch(_ context.Context, _, _ string) ([]byte, error) {
+	return m.data, m.err
+}
+
+// newCILogServer constructs a server with an injected logFetcher for testing.
+func newCILogServer(ms *mockStore, lf logFetcher) http.Handler {
+	s := &server{
+		commitStore: ms,
+		logFetcher:  lf,
+	}
+	return s.buildHandler(devID, devID, ms)
+}
+
+// ---------------------------------------------------------------------------
+// handleCIJobLogs tests
+// ---------------------------------------------------------------------------
+
+func TestHandleCIJobLogs_JobNotFound(t *testing.T) {
+	// getCIJobFn returns nil → 404
+	ms := &mockStore{} // GetCIJob returns nil, nil by default
+	srv := newCILogServer(ms, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/org/repo/-/ci-jobs/no-such-id/logs/ci_build", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCIJobLogs_NoLogURL(t *testing.T) {
+	// Job exists but has no log_url → 404
+	ms := &mockStore{
+		getCIJobFn: func(_ context.Context, id string) (*model.CIJob, error) {
+			return &model.CIJob{
+				ID:     id,
+				Repo:   "org/repo",
+				Branch: "main",
+			}, nil
+		},
+	}
+	srv := newCILogServer(ms, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/org/repo/-/ci-jobs/some-id/logs/ci_build", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCIJobLogs_Found(t *testing.T) {
+	// Job exists with log_url, GCS returns content → 200 text/plain
+	logURL := "gs://my-bucket/org/repo/main/42/ci_build.log"
+	wantContent := "=== build output ===\nok\n"
+	ms := &mockStore{
+		getCIJobFn: func(_ context.Context, id string) (*model.CIJob, error) {
+			return &model.CIJob{
+				ID:       id,
+				Repo:     "org/repo",
+				Branch:   "main",
+				Sequence: 42,
+				LogURL:   &logURL,
+			}, nil
+		},
+	}
+	lf := &mockLogFetcher{data: []byte(wantContent)}
+	srv := newCILogServer(ms, lf)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/org/repo/-/ci-jobs/some-id/logs/ci_build", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	ct := rec.Header().Get("Content-Type")
+	if ct != "text/plain; charset=utf-8" {
+		t.Errorf("expected text/plain; charset=utf-8, got %q", ct)
+	}
+	if got := rec.Body.String(); got != wantContent {
+		t.Errorf("expected body %q, got %q", wantContent, got)
+	}
+}
+
+func TestHandleCIJobLogs_GCSNotFound(t *testing.T) {
+	// GCS returns ErrObjectNotExist → 404
+	logURL := "gs://my-bucket/org/repo/main/42/ci_build.log"
+	ms := &mockStore{
+		getCIJobFn: func(_ context.Context, id string) (*model.CIJob, error) {
+			return &model.CIJob{
+				ID:       id,
+				Repo:     "org/repo",
+				Branch:   "main",
+				Sequence: 42,
+				LogURL:   &logURL,
+			}, nil
+		},
+	}
+	lf := &mockLogFetcher{err: storage.ErrObjectNotExist}
+	srv := newCILogServer(ms, lf)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/org/repo/-/ci-jobs/some-id/logs/ci_build", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing GCS object, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCIJobLogs_WrongRepo(t *testing.T) {
+	// Job exists but for a different repo → 404
+	logURL := "gs://my-bucket/other/repo/main/42/ci_build.log"
+	ms := &mockStore{
+		getCIJobFn: func(_ context.Context, id string) (*model.CIJob, error) {
+			return &model.CIJob{
+				ID:     id,
+				Repo:   "other/repo", // different from URL repo
+				Branch: "main",
+				LogURL: &logURL,
+			}, nil
+		},
+	}
+	srv := newCILogServer(ms, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/org/repo/-/ci-jobs/some-id/logs/ci_build", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for wrong repo, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCIJobLogs_MethodNotAllowed(t *testing.T) {
+	ms := &mockStore{}
+	srv := newCILogServer(ms, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/repo/-/ci-jobs/some-id/logs/ci_build", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -433,6 +433,9 @@ type server struct {
 	policyCache policyCache
 	broker      *events.Broker
 	svc         *service.Service
+	// logFetcher reads CI log objects. Nil in production (uses real GCS);
+	// injected in tests to avoid real GCS calls.
+	logFetcher logFetcher
 	// globalAdmin is the identity that may manage global resources like
 	// event subscriptions. Corresponds to the --bootstrap-admin flag.
 	globalAdmin string

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -80,6 +80,9 @@ type mockStore struct {
 	updateProposalFn  func(ctx context.Context, repo, proposalID string, title, description *string) (*model.Proposal, error)
 	closeProposalFn   func(ctx context.Context, repo, proposalID string) error
 	listIssuesByRefFn func(ctx context.Context, repo string, refType model.IssueRefType, refID string) ([]model.Issue, error)
+
+	getCIJobFn   func(ctx context.Context, id string) (*model.CIJob, error)
+	listCIJobsFn func(ctx context.Context, repo string, branch, status *string, limit int) ([]model.CIJob, error)
 }
 
 func (m *mockStore) Commit(ctx context.Context, req model.CommitRequest) (*model.CommitResponse, error) {
@@ -526,11 +529,17 @@ func (m *mockStore) ListIssuesByRef(ctx context.Context, repo string, refType mo
 	return []model.Issue{}, nil
 }
 
-func (m *mockStore) GetCIJob(_ context.Context, _ string) (*model.CIJob, error) {
+func (m *mockStore) GetCIJob(ctx context.Context, id string) (*model.CIJob, error) {
+	if m.getCIJobFn != nil {
+		return m.getCIJobFn(ctx, id)
+	}
 	return nil, nil
 }
 
-func (m *mockStore) ListCIJobs(_ context.Context, _ string, _, _ *string, _ int) ([]model.CIJob, error) {
+func (m *mockStore) ListCIJobs(ctx context.Context, repo string, branch, status *string, limit int) ([]model.CIJob, error) {
+	if m.listCIJobsFn != nil {
+		return m.listCIJobsFn(ctx, repo, branch, status, limit)
+	}
 	return []model.CIJob{}, nil
 }
 

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -216,8 +216,9 @@ type ciJobsPage struct {
 }
 
 type ciJobDetailPage struct {
-	Repo model.Repo
-	Job  *model.CIJob
+	Repo      model.Repo
+	Job       *model.CIJob
+	CheckName string // basename of log_url without .log, used for the inline log viewer
 }
 
 type createOrgPage struct {
@@ -1078,6 +1079,16 @@ func (h *Handler) handleCIJobDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Derive check name from the log URL for the inline log viewer.
+	// log_url is gs://{bucket}/{repo}/{branch}/{seq}/{safe_name}.log
+	var checkName string
+	if job.LogURL != nil {
+		u := *job.LogURL
+		if idx := strings.LastIndex(u, "/"); idx >= 0 {
+			checkName = strings.TrimSuffix(u[idx+1:], ".log")
+		}
+	}
+
 	h.render(w, r, h.tmpl.ciJobDetail, "layout.html", pageData{
 		Title: repoName + " / ci-jobs / " + id,
 		Breadcrumbs: []crumb{
@@ -1086,7 +1097,7 @@ func (h *Handler) handleCIJobDetail(w http.ResponseWriter, r *http.Request) {
 			{Label: "ci-jobs", Href: "/ui/r/" + repoName + "/ci-jobs"},
 			{Label: id[:8], Href: ""},
 		},
-		Body: ciJobDetailPage{Repo: *repo, Job: job},
+		Body: ciJobDetailPage{Repo: *repo, Job: job, CheckName: checkName},
 	})
 }
 

--- a/internal/ui/static/styles.css
+++ b/internal/ui/static/styles.css
@@ -526,3 +526,19 @@ details.file-diff summary.file-diff-summary:hover { background: var(--bg-3); bor
 .cdiff-del { background: var(--bad-bg); color: var(--bad); }
 .cdiff-hunk { background: var(--bg-2); color: var(--text-dim); border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); margin: 2px 0; }
 .cdiff-ctx { color: var(--text); }
+
+.log-output {
+  background: #0d1117;
+  color: #e6edf3;
+  padding: 16px;
+  border-radius: 6px;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 600px;
+  overflow-y: auto;
+  margin: 0;
+}

--- a/internal/ui/templates/ci_job_detail.html
+++ b/internal/ui/templates/ci_job_detail.html
@@ -80,12 +80,6 @@
     <div class="meta">{{relTimep .Job.LastHeartbeatAt}}</div>
   </div>
   {{end}}
-  {{if .Job.LogURL}}
-  <div class="row">
-    <div><strong>log</strong></div>
-    <div><a href="{{.Job.LogURL}}" target="_blank" rel="noopener">view logs →</a></div>
-  </div>
-  {{end}}
   {{if .Job.ErrorMessage}}
   <div class="row">
     <div><strong>error</strong></div>
@@ -93,4 +87,20 @@
   </div>
   {{end}}
 </div>
+
+{{if .Job.LogURL}}
+<h2>Logs</h2>
+<div class="card">
+  <div style="margin-bottom:8px">
+    <strong>{{.CheckName}}</strong>
+  </div>
+  <pre class="log-output" id="log-output">Loading...</pre>
+</div>
+<script>
+fetch('/repos/{{.Repo.Name}}/-/ci-jobs/{{.Job.ID}}/logs/{{.CheckName}}')
+  .then(r => r.ok ? r.text() : Promise.reject(r.status))
+  .then(t => { document.getElementById('log-output').textContent = t })
+  .catch(e => { document.getElementById('log-output').textContent = 'could not load logs: ' + e })
+</script>
+{{end}}
 {{end}}


### PR DESCRIPTION
## Summary

- **New API endpoint** `GET /repos/:repo/-/ci-jobs/:id/logs/:check` — validates the repo and job, extracts the GCS bucket from the job's `gs://` log URL, constructs the object key from job metadata + check name, and streams log content as `text/plain`
- **Inline log viewer** on the CI job detail page — replaces the raw "view logs →" link with a `<pre class="log-output">` block that fetches content via the new API endpoint on page load
- **`.log-output` CSS** — dark monospace block, max-height 600px with scroll

## Architecture notes

- `logFetcher` interface added to `internal/server` so the real GCS client can be swapped out in tests (no GCS needed for unit tests)
- Bucket extracted from the job's existing `log_url` field — no new env var required
- `ciJobDetailPage.CheckName` derived from the `log_url` basename (strip `.log`) and used in the fetch URL; server-side converts `/` → `_` when constructing the storage key

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/server/... -count=1 -short` — all pass
- [x] `go test ./internal/ui/... -count=1` — all pass
- New tests in `handlers_ci_logs_test.go`: job not found → 404, no log_url → 404, GCS found → 200, GCS not found → 404, wrong repo → 404, wrong method → 405

## Opportunities (out of scope)

- Support multiple checks per job (currently the page shows only the first check from `log_url`; each check run also has its own `log_url` that could be listed)
- Add a "raw" link alongside the inline viewer
- Support streaming/tailing for in-progress jobs (currently only completed job logs from GCS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)