### PR TITLE
fix: correct ARCHIVE_BASE_URL and remove url.PathEscape on repo in archive URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
             --service-account=docstore-server@dlorenc-chainguard.iam.gserviceaccount.com \
             --add-cloudsql-instances=dlorenc-chainguard:us-central1:docstore-mvp \
             --update-secrets=DATABASE_URL=docstore-db-url:latest,IAP_CLIENT_SECRET=iap-oauth-client-secret:latest,ARCHIVE_HMAC_SECRET=archive-hmac-secret:latest \
-            --set-env-vars=ARCHIVE_BASE_URL=https://docstore.dev,OIDC_JWKS_URL=https://oidc.docstore.dev/.well-known/jwks.json,OIDC_AUDIENCE=docstore,OIDC_ISSUER=https://oidc.docstore.dev \
+            --set-env-vars=ARCHIVE_BASE_URL=https://docstore-efuj4cj54a-uc.a.run.app,OIDC_JWKS_URL=https://oidc.docstore.dev/.well-known/jwks.json,OIDC_AUDIENCE=docstore,OIDC_ISSUER=https://oidc.docstore.dev \
             --ingress=internal-and-cloud-load-balancing \
             --min-instances=1 \
             --max-instances=1 \

--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -225,7 +225,7 @@ func heartbeat(ctx context.Context, schedulerURL, jobID, requestToken string, do
 func getPresignedArchiveURL(ctx context.Context, docstoreURL, repo, requestToken string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	u := fmt.Sprintf("%s/repos/%s/-/archive/presign", docstoreURL, url.PathEscape(repo))
+	u := fmt.Sprintf("%s/repos/%s/-/archive/presign", docstoreURL, repo)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
 	if err != nil {
 		return "", fmt.Errorf("build presign request: %w", err)

--- a/internal/server/handlers_archive.go
+++ b/internal/server/handlers_archive.go
@@ -55,7 +55,7 @@ func (s *server) handleArchivePresign(w http.ResponseWriter, r *http.Request) {
 
 	presignedURL := fmt.Sprintf("%s/repos/%s/-/archive?branch=%s&at=%d&expires=%d&sig=%s",
 		s.archiveBaseURL,
-		url.PathEscape(job.Repo),
+		job.Repo,
 		url.QueryEscape(job.Branch),
 		job.Sequence,
 		expiresUnix,


### PR DESCRIPTION
## Summary

- **deploy.yml**: Change `ARCHIVE_BASE_URL` from `https://docstore.dev` (IAP-protected) to `https://docstore-efuj4cj54a-uc.a.run.app` (internal Cloud Run URL). The IAP-protected URL caused BuildKit to receive a 302 redirect to Google login, saving HTML as `source.tar`, which then fails with `invalid tar magic`.
- **internal/server/handlers_archive.go**: Use `job.Repo` directly instead of `url.PathEscape(job.Repo)` in presigned URL construction. `PathEscape` encodes `/` as `%2F` for `org/repo` paths, which is unnecessarily confusing.
- **cmd/ci-worker/main.go**: Same fix in `getPresignedArchiveURL` — use `repo` directly instead of `url.PathEscape(repo)`.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` passes (all packages green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)