### PR TITLE
fix(db/ci): return ErrCIJobNotFound on not-found and clear tokens on completion/reap

### DIFF
--- a/internal/db/ci_jobs.go
+++ b/internal/db/ci_jobs.go
@@ -149,7 +149,7 @@ func (s *Store) GetCIJob(ctx context.Context, id string) (*model.CIJob, error) {
 	)
 	j, err := scanCIJob(row)
 	if err == sql.ErrNoRows {
-		return nil, nil
+		return nil, ErrCIJobNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get ci job: %w", err)
@@ -198,7 +198,7 @@ func (s *Store) HeartbeatCIJob(ctx context.Context, id string) error {
 // CompleteCIJob sets a terminal status, log URL, and error message on the job.
 func (s *Store) CompleteCIJob(ctx context.Context, id, status string, logURL, errorMessage *string) error {
 	_, err := s.db.ExecContext(ctx,
-		`UPDATE ci_jobs SET status = $2, log_url = $3, error_message = $4 WHERE id = $1`,
+		`UPDATE ci_jobs SET status = $2, log_url = $3, error_message = $4, request_token = NULL, request_token_exp = NULL WHERE id = $1`,
 		id, status, logURL, errorMessage,
 	)
 	if err != nil {
@@ -258,11 +258,13 @@ func (s *Store) CountQueuedCIJobs(ctx context.Context) (int64, error) {
 func (s *Store) ReapStaleCIJobs(ctx context.Context) ([]model.CIJob, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`UPDATE ci_jobs
-		SET status            = 'queued',
-		    claimed_at        = NULL,
-		    last_heartbeat_at = NULL,
-		    worker_pod        = NULL,
-		    worker_pod_ip     = NULL
+		SET status              = 'queued',
+		    claimed_at          = NULL,
+		    last_heartbeat_at   = NULL,
+		    worker_pod          = NULL,
+		    worker_pod_ip       = NULL,
+		    request_token       = NULL,
+		    request_token_exp   = NULL
 		WHERE status = 'claimed'
 		  AND COALESCE(last_heartbeat_at, claimed_at) < now() - interval '2 minutes'
 		RETURNING `+ciJobColumns,

--- a/internal/db/ci_jobs_test.go
+++ b/internal/db/ci_jobs_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
@@ -104,12 +105,9 @@ func TestGetCIJob_NotFound(t *testing.T) {
 	s, _ := newCIJobStore(t)
 	ctx := context.Background()
 
-	got, err := s.GetCIJob(ctx, "00000000-0000-0000-0000-000000000000")
-	if err != nil {
-		t.Fatalf("GetCIJob: %v", err)
-	}
-	if got != nil {
-		t.Errorf("expected nil for missing job, got %+v", got)
+	_, err := s.GetCIJob(ctx, "00000000-0000-0000-0000-000000000000")
+	if !errors.Is(err, ErrCIJobNotFound) {
+		t.Fatalf("expected ErrCIJobNotFound, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Bug 1 & 2 (nil-panic + ErrCIJobNotFound never returned):** `GetCIJob` was returning `(nil, nil)` on `sql.ErrNoRows` instead of `ErrCIJobNotFound`. The `errors.Is(err, db.ErrCIJobNotFound)` checks in `handleGetRun` and `handleGetLogs` in `cmd/ci-scheduler/main.go` would always be false, so the code would dereference a nil `*model.CIJob` — a guaranteed panic on any unknown job ID. Fixed by returning `ErrCIJobNotFound` from `GetCIJob` on not-found.

- **Bug 3 (ReapStaleCIJobs leaves stale tokens):** `ReapStaleCIJobs` was resetting `status`, `claimed_at`, `last_heartbeat_at`, `worker_pod`, and `worker_pod_ip` back to null/queued but left `request_token` and `request_token_exp` intact. A crashed worker's token would survive job re-assignment. Fixed by adding `request_token = NULL, request_token_exp = NULL` to the UPDATE SET clause.

- **Bug 4 (CompleteCIJob leaves token in DB):** `CompleteCIJob` left the hashed request token in the DB after completion. Fixed by adding `request_token = NULL, request_token_exp = NULL` to the UPDATE SET clause.

- Updated `TestGetCIJob_NotFound` to expect `ErrCIJobNotFound` instead of `(nil, nil)`.

## Test plan

- [ ] `go build ./...` — passes
- [ ] `go vet ./...` — passes
- [ ] `go test ./...` — `internal/db`, `cmd/ci-scheduler`, `cmd/ci-worker`, `cmd/ci-oidc` all pass; `internal/server` failures are pre-existing (require Postgres at a non-default port); `TestDockerSmoke` is pre-existing (requires Docker image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)