### PR TITLE
fix(citoken): promote cloud.google.com/go/kms to direct dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/dlorenc/docstore
 go 1.26.2
 
 require (
+	cloud.google.com/go/kms v1.29.0
 	cloud.google.com/go/storage v1.62.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
@@ -37,7 +38,6 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.7.0 // indirect
-	cloud.google.com/go/kms v1.29.0 // indirect
 	cloud.google.com/go/longrunning v0.9.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	dario.cat/mergo v1.0.2 // indirect


### PR DESCRIPTION
## Summary

- The `KMSSigner` in `internal/citoken/citoken.go` (implemented in phase 3, #371) directly imports `cloud.google.com/go/kms/apiv1` and `cloud.google.com/go/kms/apiv1/kmspb`
- `go.mod` had the package marked `// indirect`, which is incorrect
- Running `go mod tidy` promotes it to a direct dependency

## Background

This task was assigned to implement `KMSSigner` for production JWT signing. On inspection, the full `KMSSigner` implementation already exists (from phase 3 PR #371), including:
- `fetchPublicKey` — caches RSA public key from KMS via `GetPublicKey`
- `PublicKeys` — returns JWKS JSON with RS256 algorithm and key usage set
- `Sign` — builds JWT header+payload, computes SHA-256 digest, calls KMS `AsymmetricSign`, assembles compact JWS

The only gap was the incorrect `// indirect` marker in `go.mod`, which `go mod tidy` corrects.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/citoken/... -count=1` passes (all 5 tests)
- [x] `go test ./... -count=1` — non-server packages pass; `internal/server` failures are pre-existing and require a local Postgres instance

## Opportunities noted (not implemented)

- `NewKMSSigner` could accept a `*kms.KeyManagementClient` parameter to enable unit testing without real KMS credentials (currently the constructor always creates a live client)
- A mock-based unit test for `KMSSigner.Sign` / `KMSSigner.PublicKeys` could be added once the client is injectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)