### PR TITLE
feat(server): move POST /run into main server as POST /repos/:name/-/ci/run

### DIFF
--- a/cmd/ci-scheduler/main.go
+++ b/cmd/ci-scheduler/main.go
@@ -375,37 +375,6 @@ func (s *scheduler) handleProposalOpened(w http.ResponseWriter, r *http.Request,
 	w.WriteHeader(http.StatusOK)
 }
 
-// handleRun handles POST /run — manual trigger for a CI job.
-// Accepts JSON body: {"repo": "...", "branch": "...", "head_sequence": 123}
-// No signature verification is required; this is a direct API call.
-func (s *scheduler) handleRun(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		Repo         string `json:"repo"`
-		Branch       string `json:"branch"`
-		HeadSequence int64  `json:"head_sequence"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
-		return
-	}
-	if req.Repo == "" || req.Branch == "" {
-		http.Error(w, "repo and branch are required", http.StatusBadRequest)
-		return
-	}
-
-	job, err := s.store.InsertCIJob(r.Context(), req.Repo, req.Branch, req.HeadSequence, "manual", req.Branch, "", "")
-	if err != nil {
-		slog.Error("insert ci job failed", "repo", req.Repo, "branch", req.Branch, "error", err)
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-
-	slog.Info("ci job manually triggered", "id", job.ID, "repo", req.Repo, "branch", req.Branch)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(map[string]string{"run_id": job.ID}) //nolint:errcheck
-}
-
 // runStatusResponse is the JSON shape returned by GET /run/{id}.
 type runStatusResponse struct {
 	RunID  string `json:"run_id"`
@@ -650,7 +619,6 @@ func (s *scheduler) lookupByToken(r *http.Request) (*model.CIJob, error) {
 func newMux(sched *scheduler) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /webhook", sched.handleWebhook)
-	mux.HandleFunc("POST /run", sched.handleRun)
 	mux.HandleFunc("GET /run/{id}", sched.handleGetRun)
 	mux.HandleFunc("GET /run/{id}/logs/{check}", sched.handleGetLogs)
 	mux.HandleFunc("GET /queue-depth", sched.handleQueueDepth)

--- a/cmd/ci-scheduler/main_test.go
+++ b/cmd/ci-scheduler/main_test.go
@@ -401,56 +401,6 @@ func TestHandleGetLogs_Queued_Returns404(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Tests: POST /run (manual trigger)
-// ---------------------------------------------------------------------------
-
-func TestHandleRun_HappyPath(t *testing.T) {
-	stub := &stubStore{}
-	sched := &scheduler{store: stub}
-
-	body, _ := json.Marshal(map[string]any{
-		"repo":          "org/repo",
-		"branch":        "main",
-		"head_sequence": 10,
-	})
-	req := httptest.NewRequest(http.MethodPost, "/run", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-
-	sched.handleRun(w, req)
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
-	}
-	var resp map[string]string
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if resp["run_id"] == "" {
-		t.Error("expected non-empty run_id")
-	}
-	if len(stub.insertedJobs) != 1 {
-		t.Fatalf("expected 1 inserted job, got %d", len(stub.insertedJobs))
-	}
-}
-
-func TestHandleRun_MissingRepo_Returns400(t *testing.T) {
-	stub := &stubStore{}
-	sched := &scheduler{store: stub}
-
-	body, _ := json.Marshal(map[string]any{"branch": "main"})
-	req := httptest.NewRequest(http.MethodPost, "/run", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-
-	sched.handleRun(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", w.Code)
-	}
-}
-
-// ---------------------------------------------------------------------------
 // Tests: push trigger type is recorded
 // ---------------------------------------------------------------------------
 
@@ -476,33 +426,6 @@ func TestHandleWebhook_SetsTrigerTypePush(t *testing.T) {
 	}
 	if j.TriggerBranch != "feat" {
 		t.Errorf("TriggerBranch = %q, want %q", j.TriggerBranch, "feat")
-	}
-}
-
-func TestHandleRun_SetsTrigerTypeManual(t *testing.T) {
-	stub := &stubStore{}
-	sched := &scheduler{store: stub}
-
-	body, _ := json.Marshal(map[string]any{
-		"repo":          "org/repo",
-		"branch":        "main",
-		"head_sequence": 10,
-	})
-	req := httptest.NewRequest(http.MethodPost, "/run", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-
-	sched.handleRun(w, req)
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d", w.Code)
-	}
-	if len(stub.insertedJobs) != 1 {
-		t.Fatalf("expected 1 job, got %d", len(stub.insertedJobs))
-	}
-	j := stub.insertedJobs[0]
-	if j.TriggerType != "manual" {
-		t.Errorf("TriggerType = %q, want %q", j.TriggerType, "manual")
 	}
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -418,6 +418,13 @@ func (s *server) handleReposPrefix(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusNotFound, "not found")
 		}
 
+	case endpoint == "ci/run":
+		if r.Method == http.MethodPost {
+			s.handleTriggerCIRun(w, r)
+		} else {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+
 	default:
 		writeError(w, http.StatusNotFound, "not found")
 	}

--- a/internal/server/handlers_ci.go
+++ b/internal/server/handlers_ci.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -89,6 +90,53 @@ func (s *server) handleListCIJobs(w http.ResponseWriter, r *http.Request) {
 		jobs = []model.CIJob{}
 	}
 	writeJSON(w, http.StatusOK, model.ListCIJobsResponse{Jobs: jobs})
+}
+
+// handleTriggerCIRun implements POST /repos/:name/-/ci/run (writer+).
+// Request body (JSON, all fields optional):
+//
+//	{"branch": "feat/my-feature"}   // defaults to "main"
+//
+// The server looks up the current head sequence for the branch itself;
+// callers do not supply a sequence number.
+func (s *server) handleTriggerCIRun(w http.ResponseWriter, r *http.Request) {
+	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
+
+	var req struct {
+		Branch string `json:"branch"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Branch == "" {
+		req.Branch = "main"
+	}
+
+	// Validate branch existence and get its current head sequence.
+	branchInfo, err := s.readStore.GetBranch(r.Context(), repo, req.Branch)
+	if err != nil {
+		slog.Error("internal error", "op", "trigger_ci_run", "repo", repo, "branch", req.Branch, "error", err)
+		writeAPIError(w, ErrCodeInternalError, http.StatusInternalServerError, "query failed")
+		return
+	}
+	if branchInfo == nil {
+		writeAPIError(w, ErrCodeBranchNotFound, http.StatusNotFound, "branch not found")
+		return
+	}
+
+	job, err := s.commitStore.InsertCIJob(r.Context(), repo, req.Branch, branchInfo.HeadSequence, "manual", req.Branch, "", "")
+	if err != nil {
+		slog.Error("internal error", "op", "trigger_ci_run", "repo", repo, "branch", req.Branch, "error", err)
+		writeAPIError(w, ErrCodeInternalError, http.StatusInternalServerError, "insert ci job failed")
+		return
+	}
+
+	slog.Info("ci job manually triggered", "repo", repo, "branch", req.Branch, "sequence", branchInfo.HeadSequence, "job_id", job.ID)
+	writeJSON(w, http.StatusCreated, map[string]string{"run_id": job.ID})
 }
 
 // handleGetCIJob implements GET /ci-jobs/{id}

--- a/internal/server/handlers_gap_test.go
+++ b/internal/server/handlers_gap_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/store"
 )
 
 // ---------------------------------------------------------------------------
@@ -1021,5 +1022,100 @@ func TestHandleCreateSubscription_InvalidConfigType(t *testing.T) {
 	srv.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for array config, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleTriggerCIRun tests
+// ---------------------------------------------------------------------------
+
+func TestTriggerCIRun_Success(t *testing.T) {
+	ms := &mockStore{}
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
+			return &store.BranchInfo{HeadSequence: 42}, nil
+		},
+	}
+	srv := NewWithReadStore(ms, rs, devID, devID)
+
+	body, _ := json.Marshal(map[string]string{"branch": "feat/my-feature"})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/ci/run", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["run_id"] == "" {
+		t.Errorf("expected run_id in response, got empty")
+	}
+}
+
+func TestTriggerCIRun_DefaultsBranchToMain(t *testing.T) {
+	var gotBranch string
+	ms := &mockStore{}
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, branch string) (*store.BranchInfo, error) {
+			gotBranch = branch
+			return &store.BranchInfo{HeadSequence: 1}, nil
+		},
+	}
+	srv := NewWithReadStore(ms, rs, devID, devID)
+
+	// Empty body — branch should default to "main".
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/ci/run", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	if gotBranch != "main" {
+		t.Errorf("expected branch 'main', got %q", gotBranch)
+	}
+}
+
+func TestTriggerCIRun_NonexistentRepo(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return nil, db.ErrRepoNotFound
+		},
+	}
+	srv := NewWithReadStore(ms, &mockReadStore{}, devID, devID)
+
+	body, _ := json.Marshal(map[string]string{"branch": "main"})
+	req := httptest.NewRequest(http.MethodPost, "/repos/nonexistent/repo/-/ci/run", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestTriggerCIRun_NonexistentBranch(t *testing.T) {
+	ms := &mockStore{}
+	rs := &mockReadStore{
+		getBranchFn: func(_ context.Context, _, _ string) (*store.BranchInfo, error) {
+			return nil, nil // branch not found
+		},
+	}
+	srv := NewWithReadStore(ms, rs, devID, devID)
+
+	body, _ := json.Marshal(map[string]string{"branch": "no-such-branch"})
+	req := httptest.NewRequest(http.MethodPost, "/repos/default/default/-/ci/run", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d; body: %s", rec.Code, rec.Body.String())
 	}
 }

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -335,6 +335,11 @@ func roleAllows(role model.RoleType, method, subPath string, r *http.Request) bo
 		return role == model.RoleWriter || role == model.RoleMaintainer || role == model.RoleAdmin
 	}
 
+	// POST /ci/run — writer+.
+	if method == http.MethodPost && subPath == "ci/run" {
+		return role == model.RoleWriter || role == model.RoleMaintainer || role == model.RoleAdmin
+	}
+
 	return false
 }
 

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -1085,3 +1085,41 @@ func TestRBACMiddleware_ReleasesAccess(t *testing.T) {
 	}
 }
 
+func TestRBACMiddleware_CIRunAccess(t *testing.T) {
+	// Reader cannot POST /ci/run.
+	storeR := &mockRoleStore{
+		getRoleFn: func(_ context.Context, repo, identity string) (*model.Role, error) {
+			return &model.Role{Identity: identity, Role: model.RoleReader}, nil
+		},
+	}
+	hR := rbacTestServer(storeR, "", "alice@example.com")
+	rec := rbacDo(t, hR, http.MethodPost, "/repos/myrepo/myrepo/-/ci/run", `{"branch":"main"}`)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("reader POST ci/run: expected 403, got %d", rec.Code)
+	}
+
+	// Writer can POST /ci/run.
+	storeW := &mockRoleStore{
+		getRoleFn: func(_ context.Context, repo, identity string) (*model.Role, error) {
+			return &model.Role{Identity: identity, Role: model.RoleWriter}, nil
+		},
+	}
+	hW := rbacTestServer(storeW, "", "bob@example.com")
+	rec = rbacDo(t, hW, http.MethodPost, "/repos/myrepo/myrepo/-/ci/run", `{"branch":"main"}`)
+	if rec.Code != http.StatusOK {
+		t.Errorf("writer POST ci/run: expected 200, got %d", rec.Code)
+	}
+
+	// Maintainer can POST /ci/run.
+	storeM := &mockRoleStore{
+		getRoleFn: func(_ context.Context, repo, identity string) (*model.Role, error) {
+			return &model.Role{Identity: identity, Role: model.RoleMaintainer}, nil
+		},
+	}
+	hM := rbacTestServer(storeM, "", "carol@example.com")
+	rec = rbacDo(t, hM, http.MethodPost, "/repos/myrepo/myrepo/-/ci/run", `{"branch":"main"}`)
+	if rec.Code != http.StatusOK {
+		t.Errorf("maintainer POST ci/run: expected 200, got %d", rec.Code)
+	}
+}
+

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -152,6 +152,9 @@ type WriteStore interface {
 	// CI job queries (read-only)
 	GetCIJob(ctx context.Context, id string) (*model.CIJob, error)
 	ListCIJobs(ctx context.Context, repo string, branch, status *string, limit int) ([]model.CIJob, error)
+
+	// CI job management
+	InsertCIJob(ctx context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerBaseBranch, triggerProposalID string) (*model.CIJob, error)
 }
 
 // CommitStore is an alias for backward compatibility with tests.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -543,6 +543,10 @@ func (m *mockStore) ListCIJobs(ctx context.Context, repo string, branch, status 
 	return []model.CIJob{}, nil
 }
 
+func (m *mockStore) InsertCIJob(_ context.Context, _, _ string, _ int64, _, _, _, _ string) (*model.CIJob, error) {
+	return &model.CIJob{ID: "test-job-id"}, nil
+}
+
 func TestHealthEndpoint(t *testing.T) {
 	// /healthz is exempt from IAP auth, so devIdentity="" is fine here.
 	srv := New(nil, nil, "", "")


### PR DESCRIPTION
## Summary

- Moves the unauthenticated `POST /run` endpoint from ci-scheduler into the main docstore server as `POST /repos/:name/-/ci/run`, protected by IAP auth and RBAC (writer+ required)
- Adds `InsertCIJob` to the `WriteStore` interface so the main server can insert CI jobs directly
- Deletes `handleRun` from ci-scheduler and removes `POST /run` from its mux; `InsertCIJob` remains in the `ciJobStore` interface for webhook-triggered jobs

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go vet ./...` — clean
- [ ] `go test ./internal/server/... -count=1` — all pass (including new `TestTriggerCIRun_*` and `TestRBACMiddleware_CIRunAccess`)
- [ ] `go test ./cmd/ci-scheduler/... -count=1` — all pass (removed `TestHandleRun_*` tests that tested the deleted handler)
- [ ] End-to-end: `POST /repos/<repo>/-/ci/run` → 201 with `run_id`; reader identity → 403; nonexistent branch → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)