### PR TITLE
docs: update manual CI trigger endpoint after PR #388

### DIFF
--- a/docs/ci-architecture.md
+++ b/docs/ci-architecture.md
@@ -11,7 +11,6 @@ docstore events (CloudEvents via outbox)
                                                                  ▼
                                                ci-scheduler (standard GKE node, :8080)
                                                ├─ POST /webhook   ← webhook delivery
-                                               ├─ POST /run       ← manual trigger
                                                ├─ POST /claim     ← K8s SA token auth
                                                ├─ POST /jobs/{id}/heartbeat ← request_token auth
                                                ├─ POST /jobs/{id}/complete  ← request_token auth
@@ -34,7 +33,7 @@ docstore events (CloudEvents via outbox)
 
 | File | Role |
 |---|---|
-| `cmd/ci-scheduler/main.go` | Webhook receiver; inserts `ci_jobs` rows; serves `/run` for manual triggers; validates K8s SA tokens; issues request_tokens; reaps stale claimed jobs |
+| `cmd/ci-scheduler/main.go` | Webhook receiver; inserts `ci_jobs` rows; validates K8s SA tokens; issues request_tokens; reaps stale claimed jobs |
 | `cmd/ci-worker/main.go` | Claims job via POST /claim with K8s SA token; exchanges request_token for OIDC JWT; runs executor; uploads logs; posts check run results; then exits |
 | `cmd/ci-oidc/main.go` | Exchanges request_tokens for signed OIDC JWTs; serves OIDC discovery and JWKS endpoints |
 | `internal/k8sproof/k8sproof.go` | Validates K8s projected SA tokens and pod provenance (owner chain, age, service account) |
@@ -160,13 +159,13 @@ Deliveries are HMAC-SHA256 signed using `WEBHOOK_SECRET`. The scheduler verifies
 | `com.docstore.commit.created` | `proposal_synchronized` | Additionally, if the pushed branch has an open proposal and `on.proposal` is configured |
 | `com.docstore.proposal.opened` | `proposal` | If `on.proposal.base_branches` matches the proposal's base branch |
 | *(cron runner)* | `schedule` | If the current minute matches a `on.schedule[].cron` expression |
-| `POST /run` (manual) | `manual` | Always |
+| `POST /repos/:name/-/ci/run` on docstore (IAP-protected, writer+) | `manual` | Always |
 
 The `proposal_synchronized` trigger is synthetic — ci-scheduler detects it by querying `GET /repos/:name/-/proposals?state=open&branch=<branch>` after receiving a `commit.created` event. No separate event is emitted by docstore.
 
 ### Job lifecycle
 
-1. An event arrives at `POST /webhook` (or the cron runner fires, or `POST /run` is called).
+1. An event arrives at `POST /webhook` (or the cron runner fires, or `POST /repos/:name/-/ci/run` is called on the docstore server).
 2. ci-scheduler verifies the HMAC signature (webhook path only), parses the CloudEvent, and reads `.docstore/ci.yaml` from the branch under test.
 3. The `on:` block in ci.yaml is evaluated against the event. If no trigger matches, the request is acknowledged and no job is enqueued.
 4. A `ci_jobs` row is inserted with `status='queued'` and trigger metadata (`trigger_type`, `trigger_branch`, `trigger_base_branch`, `trigger_proposal_id`).
@@ -196,13 +195,16 @@ These map directly to the `event.*` fields available in `if:` expressions (see [
 
 ### Manual trigger
 
+The manual trigger endpoint moved to the main docstore server (IAP-protected, requires writer role):
+
 ```bash
-curl -X POST http://<ci-scheduler-ip>:8080/run \
+curl -X POST https://docstore.dev/repos/acme/myrepo/-/ci/run \
   -H "Content-Type: application/json" \
-  -d '{"repo": "acme/myrepo", "branch": "feature/x", "head_sequence": 42}'
+  -H "Proxy-Authorization: Bearer $(gcloud auth print-identity-token)" \
+  -d '{"branch": "feature/x", "head_sequence": 42}'
 ```
 
-Returns `{"run_id": "..."}`. Poll status with `GET /run/{id}`. Manual runs use `trigger_type=manual` and bypass the `on:` block filter — they always enqueue regardless of what triggers are configured.
+Returns `{"run_id": "..."}`. Manual runs use `trigger_type=manual` and bypass the `on:` block filter — they always enqueue regardless of what triggers are configured.
 
 ---
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -40,7 +40,7 @@ A lightweight HTTP service that:
 - Parses `com.docstore.commit.created` events and inserts a row into `ci_jobs`.
 - Serves job status at `GET /run/{id}`.
 - Proxies live logs at `GET /run/{id}/logs/{check}` — either reverse-proxying to the worker pod (while the job is claimed) or redirecting to the GCS log URL (after completion).
-- Provides a manual trigger at `POST /run`.
+- Manual CI triggers are handled by the main docstore server at `POST /repos/:name/-/ci/run` (IAP-protected, writer+ RBAC).
 - Runs a stale-job reaper every 30 seconds to reclaim jobs that have missed their heartbeat.
 - Serves `POST /claim` — validates K8s projected SA tokens with pod provenance checks, claims the next queued job, and returns a `request_token`.
 - Serves `POST /jobs/{id}/heartbeat` — request_token authenticated; updates the job heartbeat.

--- a/docs/proposals-and-ci-triggers.md
+++ b/docs/proposals-and-ci-triggers.md
@@ -152,7 +152,7 @@ on:
     base_branches: [main]       # trigger when a proposal targeting main is opened
   schedule:
     - cron: '0 2 * * *'         # nightly at 2 AM UTC
-  # manual: trigger via API POST /run — no config needed, always enabled
+  # manual: trigger via POST /repos/:name/-/ci/run on docstore (IAP-protected, writer+) — no config needed, always enabled
 
 checks:
   - name: ci/test
@@ -219,12 +219,13 @@ on:
 
 #### `manual`
 
-Always enabled. Trigger a run via the scheduler API:
+Always enabled. Trigger a run via the docstore server (IAP-protected, requires writer role):
 
 ```bash
-curl -X POST http://<ci-scheduler>:8080/run \
+curl -X POST https://docstore.dev/repos/acme/myrepo/-/ci/run \
   -H "Content-Type: application/json" \
-  -d '{"repo": "acme/myrepo", "branch": "feature/x", "head_sequence": 42}'
+  -H "Proxy-Authorization: Bearer $(gcloud auth print-identity-token)" \
+  -d '{"branch": "feature/x", "head_sequence": 42}'
 # Returns: {"run_id": "..."}
 ```
 


### PR DESCRIPTION
## Summary

- Updates all stale references to `POST /run` on ci-scheduler across three doc files
- The endpoint moved to `POST /repos/:name/-/ci/run` on the main docstore server (PR #388)
- New endpoint is IAP-protected and requires writer+ RBAC (old one was unauthenticated)

## Changes

- **docs/ci-architecture.md**: Removed `POST /run` from ci-scheduler's endpoint list in the architecture diagram; removed "serves `/run` for manual triggers" from the components table; updated the trigger sources table, job lifecycle description, and the Manual trigger section (new curl example with IAP auth header)
- **docs/proposals-and-ci-triggers.md**: Updated the `manual:` comment in the annotated YAML example and the curl example in the `manual` trigger section
- **docs/ci.md**: Updated the ci-scheduler component description to note the endpoint now lives on the docstore server

## Test plan

- [ ] Doc-only change; no code modified
- [ ] Verified no remaining references to the old `POST /run` endpoint on ci-scheduler

🤖 Generated with [Claude Code](https://claude.com/claude-code)