### PR TITLE
docs: remove head_sequence from POST /ci/run curl examples

### DIFF
--- a/docs/ci-architecture.md
+++ b/docs/ci-architecture.md
@@ -201,7 +201,7 @@ The manual trigger endpoint moved to the main docstore server (IAP-protected, re
 curl -X POST https://docstore.dev/repos/acme/myrepo/-/ci/run \
   -H "Content-Type: application/json" \
   -H "Proxy-Authorization: Bearer $(gcloud auth print-identity-token)" \
-  -d '{"branch": "feature/x", "head_sequence": 42}'
+  -d '{"branch": "feature/x"}'
 ```
 
 Returns `{"run_id": "..."}`. Manual runs use `trigger_type=manual` and bypass the `on:` block filter — they always enqueue regardless of what triggers are configured.

--- a/docs/proposals-and-ci-triggers.md
+++ b/docs/proposals-and-ci-triggers.md
@@ -225,7 +225,7 @@ Always enabled. Trigger a run via the docstore server (IAP-protected, requires w
 curl -X POST https://docstore.dev/repos/acme/myrepo/-/ci/run \
   -H "Content-Type: application/json" \
   -H "Proxy-Authorization: Bearer $(gcloud auth print-identity-token)" \
-  -d '{"branch": "feature/x", "head_sequence": 42}'
+  -d '{"branch": "feature/x"}'
 # Returns: {"run_id": "..."}
 ```
 


### PR DESCRIPTION
## Summary

- Removes `head_sequence: 42` from the `curl` examples in `docs/ci-architecture.md` and `docs/proposals-and-ci-triggers.md`
- The `POST /repos/:name/-/ci/run` handler (`internal/server/handlers_ci.go`) only accepts `branch` in the request body; it looks up the head sequence server-side
- This was an inaccuracy introduced when PR #388 moved the endpoint into the main server

## Test plan

- [ ] Verify curl examples now show only `{"branch": "feature/x"}` in both docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)