### PR TITLE
ci: strip GCP registry auth from worker entrypoint and Dockerfile

### DIFF
--- a/Dockerfile.ci-worker
+++ b/Dockerfile.ci-worker
@@ -14,11 +14,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         iptables \
         runc \
     && rm -rf /var/lib/apt/lists/*
-RUN curl -fsSL https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.22/docker-credential-gcr_linux_amd64-2.1.22.tar.gz \
-    -o /tmp/docker-credential-gcr.tar.gz \
-    && echo "443e897dc383d69e55e6dbcb13802f4ec88444848612e83f0381df2ddd721694  /tmp/docker-credential-gcr.tar.gz" | sha256sum -c - \
-    && tar xz -C /usr/local/bin docker-credential-gcr -f /tmp/docker-credential-gcr.tar.gz \
-    && rm /tmp/docker-credential-gcr.tar.gz
 COPY --from=docker-bins /usr/local/bin/docker /usr/local/bin/docker
 COPY --from=docker-bins /usr/local/bin/dockerd /usr/local/bin/dockerd
 COPY --from=docker-bins /usr/local/bin/docker-proxy /usr/local/bin/docker-proxy

--- a/entrypoint-worker.sh
+++ b/entrypoint-worker.sh
@@ -1,20 +1,9 @@
 #!/bin/sh
 set -e
 
-# Configure registry auth for buildkitd using GCP workload identity token.
-TOKEN=$(curl -sf -H "Metadata-Flavor: Google" \
-  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
-  | tr ',' '\n' | grep '"access_token"' | cut -d'"' -f4)
-if [ -n "$TOKEN" ]; then
-  AUTH=$(printf "oauth2accesstoken:%s" "$TOKEN" | base64 | tr -d '\n')
-  mkdir -p "$HOME/.docker"
-  printf '{"auths":{"us-central1-docker.pkg.dev":{"auth":"%s"},"mirror.gcr.io":{"auth":"%s"},"gcr.io":{"auth":"%s"}}}' \
-    "$AUTH" "$AUTH" "$AUTH" > "$HOME/.docker/config.json"
-  echo "registry auth configured" >&2
-else
-  echo "WARNING: could not fetch workload identity token" >&2
-fi
-export DOCKER_CONFIG="$HOME/.docker"
+# Private registry authentication (e.g. GCP Artifact Registry) is a separate
+# concern and is not handled here. Build images must be on public registries.
+# TODO: file a tracking issue for private registry auth support.
 
 # Set up a loop-backed ext4 volume at /var/lib/buildkit so that buildkitd can use the
 # native overlayfs snapshotter. The Kata CLH guest rootfs is virtiofs, which does not


### PR DESCRIPTION
## Summary

- Removes the `metadata.google.internal` curl block from `entrypoint-worker.sh` that fetched a GCP workload identity token and wrote `~/.docker/config.json` for `us-central1-docker.pkg.dev`, `mirror.gcr.io`, and `gcr.io`
- Removes the `docker-credential-gcr` installation layer from `Dockerfile.ci-worker`
- Adds a comment in `entrypoint-worker.sh` noting private registry auth is a separate concern with a TODO to file a tracking issue

Build images must be on public registries. Closes issue #366 step 2.

## Test plan

- [x] `go test ./... -count=1` — all tests pass
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [ ] Verify CI worker builds and pulls public images without the removed auth block (runtime smoke test)

## Notes for follow-up

- `curl` remains in the `apt-get` install list; it could be removed as a follow-up since nothing in the entrypoint uses it anymore
- Private registry auth support should be tracked in a new issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)