### PR TITLE
feat: add POST /repos/:repo/-/check/:name/logs endpoint; migrate ci-worker off logstore

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/dlorenc/docstore/internal/ciconfig"
 	"github.com/dlorenc/docstore/internal/executor"
-	"github.com/dlorenc/docstore/internal/logstore"
 	"github.com/dlorenc/docstore/internal/model"
 )
 
@@ -251,6 +250,39 @@ func getPresignedArchiveURL(ctx context.Context, docstoreURL, repo, requestToken
 	return body.URL, nil
 }
 
+// postCheckLogs uploads the logs for a check run to the docstore server via
+// POST /repos/{repo}/-/check/{checkName}/logs. The server writes the log to GCS
+// using the job metadata bound to the request_token. Returns the log URL on success.
+func postCheckLogs(ctx context.Context, docstoreURL, repo, checkName, requestToken, logs string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	u := fmt.Sprintf("%s/repos/%s/-/check/%s/logs", docstoreURL, repo, url.PathEscape(checkName))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, strings.NewReader(logs))
+	if err != nil {
+		return "", fmt.Errorf("build log upload request: %w", err)
+	}
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("Authorization", "Bearer "+requestToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("log upload request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("log upload: unexpected status %d", resp.StatusCode)
+	}
+	var body struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("decode log upload response: %w", err)
+	}
+	if body.URL == "" {
+		return "", fmt.Errorf("log upload: empty URL in response")
+	}
+	return body.URL, nil
+}
+
 // getDocstoreOIDCToken exchanges the request_token for a short-lived OIDC JWT
 // with aud=docstore. This token is used to authenticate API calls to docstore.
 // Returns empty string if oidcTokenURL is empty (local dev / OIDC not configured).
@@ -407,7 +439,6 @@ func runJob(
 	ctx context.Context,
 	httpClient *http.Client,
 	exec runner,
-	ls logstore.LogStore,
 	docstoreURL string,
 	job *model.CIJob,
 	requestToken string,
@@ -475,15 +506,13 @@ func runJob(
 		_ = os.WriteFile(filepath.Join(logDir, safeName+".log"), []byte(result.Logs), 0o644)
 
 		var checkLogURL *string
-		if ls != nil {
-			u, err := ls.Write(ctx, job.Repo, job.Branch, job.Sequence, result.Name, result.Logs)
-			if err != nil {
-				slog.Warn("log upload failed", "check", result.Name, "error", err)
-			} else {
-				checkLogURL = &u
-				if firstLogURL == nil {
-					firstLogURL = &u
-				}
+		u, err := postCheckLogs(ctx, docstoreURL, job.Repo, result.Name, requestToken, result.Logs)
+		if err != nil {
+			slog.Warn("log upload failed", "check", result.Name, "error", err)
+		} else {
+			checkLogURL = &u
+			if firstLogURL == nil {
+				firstLogURL = &u
 			}
 		}
 
@@ -548,13 +577,6 @@ func main() {
 		os.Exit(1)
 	}
 	defer exec.Close()
-
-	// Build log store.
-	ls, err := logstore.NewFromEnv(ctx)
-	if err != nil {
-		slog.Error("create log store", "error", err)
-		os.Exit(1)
-	}
 
 	// HTTP client for docstore requests.
 	httpClient := &http.Client{Timeout: 5 * time.Minute}
@@ -637,7 +659,7 @@ func main() {
 		}
 
 		// Execute the job.
-		jobStatus, jobLogURL, jobErrMsg := runJob(ctx, httpClient, exec, ls, docstoreURL, job, requestToken, jwt, logDir, triggerCtx, extraEnv)
+		jobStatus, jobLogURL, jobErrMsg := runJob(ctx, httpClient, exec, docstoreURL, job, requestToken, jwt, logDir, triggerCtx, extraEnv)
 
 		// Stop heartbeat and clear log dir.
 		close(hbDone)

--- a/cmd/ci-worker/main_test.go
+++ b/cmd/ci-worker/main_test.go
@@ -34,18 +34,6 @@ func (m *mockRunner) Run(_ context.Context, _ string, _ executor.Config, _ cicon
 	return m.results, m.err
 }
 
-// mockLogStore implements logstore.LogStore for tests.
-type mockLogStore struct {
-	writeURL string
-	writeErr error
-	calls    atomic.Int32
-}
-
-func (m *mockLogStore) Write(_ context.Context, _, _ string, _ int64, _, _ string) (string, error) {
-	m.calls.Add(1)
-	return m.writeURL, m.writeErr
-}
-
 // mockScheduler is a minimal httptest scheduler for heartbeat/complete tests.
 type mockScheduler struct {
 	calls    atomic.Int32
@@ -491,6 +479,11 @@ func docstoreHandler(t *testing.T, ciYAML string, tarData []byte, checkStatus in
 		case strings.Contains(path, "/-/archive"):
 			w.Header().Set("Content-Type", "application/x-tar")
 			w.Write(tarData) //nolint:errcheck
+		case r.Method == http.MethodPost && strings.Contains(path, "/-/check/") && strings.HasSuffix(path, "/logs"):
+			// Log upload endpoint: return a fake log URL.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"url":"file:///tmp/ci-logs/test.log"}`)) //nolint:errcheck
 		case strings.Contains(path, "/-/check"):
 			w.WriteHeader(checkStatus)
 		default:
@@ -507,7 +500,7 @@ func TestRunJob_NoCIYAML_ReturnsPassed(t *testing.T) {
 	defer srv.Close()
 
 	status, logURL, errMsg := runJob(
-		context.Background(), srv.Client(), &mockRunner{}, nil,
+		context.Background(), srv.Client(), &mockRunner{},
 		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, nil,
 	)
 	if status != "passed" {
@@ -530,7 +523,7 @@ func TestRunJob_FetchConfigError_ReturnsFailed(t *testing.T) {
 	defer srv.Close()
 
 	status, _, errMsg := runJob(
-		context.Background(), srv.Client(), &mockRunner{}, nil,
+		context.Background(), srv.Client(), &mockRunner{},
 		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, nil,
 	)
 	if status != "failed" {
@@ -550,7 +543,7 @@ func TestRunJob_ExecutorError_ReturnsFailed(t *testing.T) {
 
 	mockExec := &mockRunner{err: fmt.Errorf("buildkit unavailable")}
 	status, _, errMsg := runJob(
-		context.Background(), srv.Client(), mockExec, nil,
+		context.Background(), srv.Client(), mockExec,
 		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, nil,
 	)
 	if status != "failed" {
@@ -571,30 +564,52 @@ func TestRunJob_AllChecksPassed(t *testing.T) {
   steps: ["golangci-lint run"]
 `
 	tarData := makeTar(t, map[string]string{"main.go": "package main"})
-	srv := httptest.NewServer(docstoreHandler(t, ciYAML, tarData, http.StatusCreated))
+	var logUploadCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case strings.Contains(path, "/-/file/"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(fileResponseJSON(t, ciYAML)) //nolint:errcheck
+		case r.Method == http.MethodPost && strings.Contains(path, "/-/archive/presign"):
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"url":"http://test-archive.example.com/archive.tar"}`)) //nolint:errcheck
+		case strings.Contains(path, "/-/archive"):
+			w.Header().Set("Content-Type", "application/x-tar")
+			w.Write(tarData) //nolint:errcheck
+		case r.Method == http.MethodPost && strings.Contains(path, "/-/check/") && strings.HasSuffix(path, "/logs"):
+			logUploadCount.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"url":"file:///tmp/ci-logs/test.log"}`)) //nolint:errcheck
+		case strings.Contains(path, "/-/check"):
+			w.WriteHeader(http.StatusCreated)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
 	defer srv.Close()
 
 	mockExec := &mockRunner{results: []executor.CheckResult{
 		{Name: "test", Status: "passed", Logs: "ok"},
 		{Name: "lint", Status: "passed", Logs: "clean"},
 	}}
-	ls := &mockLogStore{writeURL: "file:///tmp/ci-logs/test.log"}
 
 	status, logURL, errMsg := runJob(
-		context.Background(), srv.Client(), mockExec, ls,
-		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, nil,
+		context.Background(), srv.Client(), mockExec,
+		srv.URL, testJob(), "test-request-token", "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, nil,
 	)
 	if status != "passed" {
 		t.Errorf("expected passed, got %q", status)
 	}
 	if logURL == nil {
-		t.Error("expected logURL to be set from log store")
+		t.Error("expected logURL to be set from log upload")
 	}
 	if errMsg != nil {
 		t.Errorf("expected nil errMsg, got %q", *errMsg)
 	}
-	if n := ls.calls.Load(); n != 2 {
-		t.Errorf("expected 2 log store writes, got %d", n)
+	if n := logUploadCount.Load(); n != 2 {
+		t.Errorf("expected 2 log uploads, got %d", n)
 	}
 }
 
@@ -617,7 +632,7 @@ func TestRunJob_OneCheckFailed_OverallFailed(t *testing.T) {
 	}}
 
 	status, _, errMsg := runJob(
-		context.Background(), srv.Client(), mockExec, nil,
+		context.Background(), srv.Client(), mockExec,
 		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, nil,
 	)
 	if status != "failed" {
@@ -628,7 +643,9 @@ func TestRunJob_OneCheckFailed_OverallFailed(t *testing.T) {
 	}
 }
 
-func TestRunJob_NilLogStore_StillPosts(t *testing.T) {
+func TestRunJob_LogUploadFails_StillPosts(t *testing.T) {
+	// Verifies that even when the log upload endpoint returns an error,
+	// check run results are still posted and the job succeeds.
 	const ciYAML = "checks:\n- name: build\n  image: golang:1.22\n  steps: [\"go build\"]\n"
 	tarData := makeTar(t, map[string]string{"main.go": "package main"})
 
@@ -644,6 +661,9 @@ func TestRunJob_NilLogStore_StillPosts(t *testing.T) {
 			w.Write([]byte(`{"url":"http://test-archive.example.com/archive.tar"}`)) //nolint:errcheck
 		case strings.Contains(path, "/-/archive"):
 			w.Write(tarData) //nolint:errcheck
+		case r.Method == http.MethodPost && strings.Contains(path, "/-/check/") && strings.HasSuffix(path, "/logs"):
+			// Log upload fails — server unavailable.
+			w.WriteHeader(http.StatusServiceUnavailable)
 		case strings.Contains(path, "/-/check"):
 			checkPostCount++
 			w.WriteHeader(http.StatusCreated)
@@ -656,14 +676,14 @@ func TestRunJob_NilLogStore_StillPosts(t *testing.T) {
 	}}
 
 	status, logURL, _ := runJob(
-		context.Background(), srv.Client(), mockExec, nil, // nil log store
+		context.Background(), srv.Client(), mockExec,
 		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, nil,
 	)
 	if status != "passed" {
 		t.Errorf("expected passed, got %q", status)
 	}
 	if logURL != nil {
-		t.Errorf("expected nil logURL with nil log store, got %v", logURL)
+		t.Errorf("expected nil logURL when log upload fails, got %v", logURL)
 	}
 	// Expect: 1 pending post + 1 result post = 2
 	if checkPostCount != 2 {
@@ -683,7 +703,7 @@ func TestRunJob_LogsWrittenToDir(t *testing.T) {
 	}}
 
 	logDir := t.TempDir()
-	runJob(context.Background(), srv.Client(), mockExec, nil, srv.URL, testJob(), "", "", logDir, ciconfig.TriggerContext{}, nil) //nolint:errcheck
+	runJob(context.Background(), srv.Client(), mockExec, srv.URL, testJob(), "", "", logDir, ciconfig.TriggerContext{}, nil) //nolint:errcheck
 
 	data, err := os.ReadFile(filepath.Join(logDir, "test.log"))
 	if err != nil {

--- a/cmd/docstore/main.go
+++ b/cmd/docstore/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dlorenc/docstore/internal/blob"
 	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/events"
+	"github.com/dlorenc/docstore/internal/logstore"
 	"github.com/dlorenc/docstore/internal/policy"
 	"github.com/dlorenc/docstore/internal/server"
 	"github.com/dlorenc/docstore/internal/store"
@@ -191,11 +192,18 @@ func main() {
 		logger.Warn("OIDC_JWKS_URL not set — job OIDC token authentication disabled")
 	}
 
+	// Initialize log store for CI check log uploads.
+	ls, err := logstore.NewFromEnv(context.Background())
+	if err != nil {
+		logger.Error("failed to create log store", "error", err)
+		os.Exit(1)
+	}
+
 	jobStore := db.NewStore(database)
 	srv := server.NewWithOIDC(commitStore, database, bs, broker,
 		*devIdentity, *bootstrapAdmin, *iapClientID, *iapClientSecret,
 		jobStore, archiveHMACSecret, archiveBaseURL,
-		oidcJWKSURL, oidcAudience, oidcIssuer)
+		oidcJWKSURL, oidcAudience, oidcIssuer, ls)
 
 	// Start the auto-merge worker. It subscribes to check.reported and
 	// review.submitted events and merges branches with auto_merge=true.

--- a/internal/server/handlers_check_logs.go
+++ b/internal/server/handlers_check_logs.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/dlorenc/docstore/internal/citoken"
+	"github.com/dlorenc/docstore/internal/db"
+)
+
+// handleCheckLogs implements POST /repos/:repo/-/check/:checkName/logs.
+// Authenticated via request_token (Authorization: Bearer <plaintext>).
+// Reads the log body as text/plain and writes to GCS via the logStore.
+// Returns JSON {"url": "<gs://...>"} on success.
+func (s *server) handleCheckLogs(w http.ResponseWriter, r *http.Request) {
+	if s.logStore == nil || s.jobTokenStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "log upload not configured")
+		return
+	}
+
+	// 1. Extract and validate request_token from Authorization header.
+	authHdr := r.Header.Get("Authorization")
+	plaintext := strings.TrimPrefix(authHdr, "Bearer ")
+	if plaintext == "" || plaintext == authHdr {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	hashed := citoken.HashRequestToken(plaintext)
+	job, err := s.jobTokenStore.LookupRequestToken(r.Context(), hashed)
+	if errors.Is(err, db.ErrTokenInvalid) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// 2. Verify repo in token matches the request path.
+	repoName := r.PathValue("name")
+	if job.Repo != repoName {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// 3. Extract check name from path value.
+	checkName := r.PathValue("checkName")
+	if checkName == "" {
+		writeError(w, http.StatusBadRequest, "check name required")
+		return
+	}
+
+	// 4. Read log body (limit to 10 MB).
+	const maxLogSize = 10 << 20
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxLogSize))
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// 5. Write logs to the store using job metadata from the token.
+	logURL, err := s.logStore.Write(r.Context(), job.Repo, job.Branch, job.Sequence, checkName, string(body))
+	if err != nil {
+		slog.Error("log write failed", "repo", job.Repo, "check", checkName, "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"url": logURL}) //nolint:errcheck
+}

--- a/internal/server/handlers_check_logs_test.go
+++ b/internal/server/handlers_check_logs_test.go
@@ -1,0 +1,227 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/citoken"
+	"github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/logstore"
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// mockLogStore implements logstore.LogStore for tests.
+type mockLogStore struct {
+	writeURL string
+	writeErr error
+	calls    int
+}
+
+func (m *mockLogStore) Write(_ context.Context, _, _ string, _ int64, _, _ string) (string, error) {
+	m.calls++
+	return m.writeURL, m.writeErr
+}
+
+var _ logstore.LogStore = (*mockLogStore)(nil)
+
+// buildCheckLogsServer creates a server wired for testing handleCheckLogs.
+func buildCheckLogsServer(jobStore jobTokenStore, ls logstore.LogStore) *server {
+	return &server{
+		commitStore:   &mockStore{},
+		jobTokenStore: jobStore,
+		logStore:      ls,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleCheckLogs tests
+// ---------------------------------------------------------------------------
+
+func TestHandleCheckLogs_NotConfigured(t *testing.T) {
+	// logStore is nil → 503
+	s := buildCheckLogsServer(&stubJobTokenStore{
+		lookupFn: func(_ context.Context, _ string) (*model.CIJob, error) {
+			return nil, db.ErrTokenInvalid
+		},
+	}, nil)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/check/ci_build/logs", strings.NewReader("log output"))
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("Authorization", "Bearer sometoken")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCheckLogs_MissingAuth(t *testing.T) {
+	ls := &mockLogStore{writeURL: "gs://bucket/key"}
+	s := buildCheckLogsServer(&stubJobTokenStore{
+		lookupFn: func(_ context.Context, _ string) (*model.CIJob, error) {
+			return nil, db.ErrTokenInvalid
+		},
+	}, ls)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+
+	// No Authorization header.
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/check/ci_build/logs", strings.NewReader("logs"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCheckLogs_InvalidToken(t *testing.T) {
+	ls := &mockLogStore{writeURL: "gs://bucket/key"}
+	s := buildCheckLogsServer(&stubJobTokenStore{
+		lookupFn: func(_ context.Context, _ string) (*model.CIJob, error) {
+			return nil, db.ErrTokenInvalid
+		},
+	}, ls)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/check/ci_build/logs", strings.NewReader("logs"))
+	req.Header.Set("Authorization", "Bearer bad-token")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for invalid token, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCheckLogs_RepoMismatch(t *testing.T) {
+	ls := &mockLogStore{writeURL: "gs://bucket/key"}
+	// Token is valid but job.Repo doesn't match URL repo.
+	store := &stubJobTokenStore{
+		lookupFn: func(_ context.Context, _ string) (*model.CIJob, error) {
+			return &model.CIJob{
+				ID:       "job-1",
+				Repo:     "org/other-repo",
+				Branch:   "main",
+				Sequence: 1,
+			}, nil
+		},
+	}
+	s := buildCheckLogsServer(store, ls)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+
+	plaintext, _, _ := citoken.GenerateRequestToken()
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/check/ci_build/logs", strings.NewReader("logs"))
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for repo mismatch, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCheckLogs_ValidToken_WritesLogs(t *testing.T) {
+	wantLogURL := "gs://my-bucket/org/myrepo/feature/42/ci_build.log"
+	ls := &mockLogStore{writeURL: wantLogURL}
+
+	plaintext, hashed, err := citoken.GenerateRequestToken()
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	store := &stubJobTokenStore{
+		lookupFn: func(_ context.Context, h string) (*model.CIJob, error) {
+			if h != hashed {
+				return nil, db.ErrTokenInvalid
+			}
+			return &model.CIJob{
+				ID:       "job-1",
+				Repo:     "org/myrepo",
+				Branch:   "feature",
+				Sequence: 42,
+			}, nil
+		},
+	}
+	s := buildCheckLogsServer(store, ls)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+
+	const logBody = "=== build output ===\nok\n"
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/check/ci_build/logs", strings.NewReader(logBody))
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	ct := rec.Header().Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Errorf("expected application/json content type, got %q", ct)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, wantLogURL) {
+		t.Errorf("expected response to contain URL %q; got %q", wantLogURL, body)
+	}
+	if ls.calls != 1 {
+		t.Errorf("expected 1 log store write, got %d", ls.calls)
+	}
+}
+
+func TestHandleCheckLogs_CheckNameWithSlash(t *testing.T) {
+	// Check names with "/" should be handled correctly.
+	ls := &mockLogStore{writeURL: "gs://bucket/key"}
+	plaintext, hashed, _ := citoken.GenerateRequestToken()
+	store := &stubJobTokenStore{
+		lookupFn: func(_ context.Context, h string) (*model.CIJob, error) {
+			if h != hashed {
+				return nil, db.ErrTokenInvalid
+			}
+			return &model.CIJob{
+				ID:     "job-1",
+				Repo:   "org/myrepo",
+				Branch: "main",
+			}, nil
+		},
+	}
+	s := buildCheckLogsServer(store, ls)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+
+	// "ci/build" as check name — encoded in URL as "ci%2Fbuild" or "ci/build"
+	// The router receives endpoint = "check/ci/build/logs".
+	// The handler strips "check/" prefix and "/logs" suffix → "ci/build".
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/check/ci%2Fbuild/logs", strings.NewReader("logs"))
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// Should succeed (200) or reach the logStore — either way, not 401/404.
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCheckLogs_MethodNotAllowed(t *testing.T) {
+	ls := &mockLogStore{}
+	s := buildCheckLogsServer(&stubJobTokenStore{
+		lookupFn: func(_ context.Context, _ string) (*model.CIJob, error) {
+			return nil, db.ErrTokenInvalid
+		},
+	}, ls)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+
+	// GET is not allowed on this endpoint.
+	req := httptest.NewRequest(http.MethodGet, "/repos/org/myrepo/-/check/ci_build/logs", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// GET requests fall through to the IAP + inner mux, which won't match check/ci_build/logs.
+	// We just verify it's not a 200.
+	if rec.Code == http.StatusOK {
+		t.Fatalf("expected non-200 for GET, got 200")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dlorenc/docstore/internal/blob"
 	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/events"
+	"github.com/dlorenc/docstore/internal/logstore"
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/policy"
 	"github.com/dlorenc/docstore/internal/service"
@@ -214,7 +215,7 @@ func NewWithPresign(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, 
 	return NewWithOIDC(writeStore, database, bs, broker,
 		devIdentity, bootstrapAdmin, iapClientID, iapClientSecret,
 		jobStore, archiveHMACSecret, archiveBaseURL,
-		"", "", "")
+		"", "", "", nil)
 }
 
 // NewWithOIDC is like NewWithPresign but also enables OIDC job token authentication
@@ -225,10 +226,11 @@ func NewWithPresign(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, 
 // oidcAudience is the expected audience claim (e.g. "docstore").
 // oidcIssuer is the expected issuer claim (e.g. "https://oidc.docstore.dev").
 // If oidcJWKSURL is empty, OIDC job token auth is disabled.
+// ls is the LogStore used by POST /repos/:repo/-/check/:name/logs; if nil the endpoint returns 503.
 func NewWithOIDC(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker,
 	devIdentity, bootstrapAdmin, iapClientID, iapClientSecret string,
 	jobStore jobTokenStore, archiveHMACSecret []byte, archiveBaseURL string,
-	oidcJWKSURL, oidcAudience, oidcIssuer string) http.Handler {
+	oidcJWKSURL, oidcAudience, oidcIssuer string, ls logstore.LogStore) http.Handler {
 	pc := policy.NewCache()
 	s := &server{
 		commitStore:       writeStore,
@@ -243,6 +245,7 @@ func NewWithOIDC(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, bro
 		oidcJWKSURL:       oidcJWKSURL,
 		oidcAudience:      oidcAudience,
 		oidcIssuer:        oidcIssuer,
+		logStore:          ls,
 	}
 	if oidcJWKSURL != "" {
 		s.oidcKeyCache = newKeyCacheForURL(oidcJWKSURL)
@@ -394,6 +397,18 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 				s.handlePresignedArchive(w, r)
 				return
 			}
+			// Log upload (worker → upload check logs): auth via request_token.
+			// Endpoint format: check/{checkName}/logs
+			if r.Method == http.MethodPost && strings.HasPrefix(endpoint, "check/") && strings.HasSuffix(endpoint, "/logs") {
+				middle := strings.TrimPrefix(endpoint, "check/")
+				checkName := strings.TrimSuffix(middle, "/logs")
+				if checkName != "" {
+					r.SetPathValue("name", repoName)
+					r.SetPathValue("checkName", checkName)
+					s.handleCheckLogs(w, r)
+					return
+				}
+			}
 		}
 
 		// Job OIDC token auth: if a Bearer token is present and OIDC is configured,
@@ -459,6 +474,9 @@ type server struct {
 	oidcAudience string
 	oidcIssuer   string
 	oidcKeyCache *keyCache
+	// logStore writes CI check logs; used by POST /repos/:repo/-/check/:name/logs.
+	// nil means the endpoint is disabled (returns 503).
+	logStore logstore.LogStore
 }
 
 // handleDSConfig serves GET /.well-known/ds-config — unauthenticated.


### PR DESCRIPTION
## Summary

- Adds `POST /repos/:repo/-/check/:name/logs` endpoint to the main server, authenticated via `request_token` (same pattern as `POST /repos/:repo/-/archive/presign`). The server looks up the job from the token, verifies the repo claim, reads the log body, and writes to GCS via `logstore.LogStore`.
- Wires the route in the outer handler (before IAP) so it bypasses IAP/RBAC like the presign endpoint.
- Adds `logStore logstore.LogStore` field to the server struct; updates `NewWithOIDC` to accept it. Updates `cmd/docstore/main.go` to call `logstore.NewFromEnv` and pass the store.
- Removes `logstore.LogStore` from `ci-worker/main.go` entirely. Workers now POST logs to the new server endpoint using their `requestToken`, and receive the GCS URL in the JSON response.

This is issue #366 step 1.

## Key files changed

- `internal/server/handlers_check_logs.go` — new handler + tests
- `internal/server/handlers_check_logs_test.go` — unit tests (auth, repo mismatch, valid write, slash check names)
- `internal/server/server.go` — server struct, constructor, outer handler routing
- `cmd/docstore/main.go` — logstore init wiring
- `cmd/ci-worker/main.go` — `postCheckLogs()` helper, `runJob()` updated, logstore removed
- `cmd/ci-worker/main_test.go` — tests updated to use HTTP mock server for log uploads

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/ci-worker/... -count=1` — all pass
- [x] `go test ./internal/server/... -run TestHandleCheckLogs -count=1` — all pass
- [x] `go test ./internal/server/... -run "TestHandleArchivePresign|TestHandleCIJobLogs" -count=1` — all pass (existing tests unaffected)
- Integration tests that require Postgres have pre-existing Docker resource failures unrelated to this change

## Notes for follow-up

- The `LOG_STORE`, `LOG_LOCAL_DIR`, `LOG_BUCKET` env vars still control log storage in the server. Workers no longer need these.
- The `logstore` package remains used by the server; only `ci-worker` is migrated off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)