### PR TITLE
chore(ci-worker): eliminate all system credentials from CI worker VMs (closes #366)

### DIFF
--- a/Dockerfile.ci-worker
+++ b/Dockerfile.ci-worker
@@ -10,7 +10,6 @@ RUN CGO_ENABLED=0 go build -o /ci-worker ./cmd/ci-worker
 FROM ubuntu:24.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
-        curl \
         iptables \
         runc \
     && rm -rf /var/lib/apt/lists/*

--- a/deploy/k8s/ci-worker.yaml
+++ b/deploy/k8s/ci-worker.yaml
@@ -18,8 +18,6 @@ kind: ServiceAccount
 metadata:
   name: ci-worker
   namespace: docstore-ci
-  annotations:
-    iam.gke.io/gcp-service-account: ci-runner@dlorenc-chainguard.iam.gserviceaccount.com
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
@@ -51,10 +49,6 @@ spec:
             value: https://docstore-efuj4cj54a-uc.a.run.app
           - name: CI_SCHEDULER_URL
             value: http://ci-scheduler.docstore-ci.svc.cluster.local:8080
-          - name: LOG_STORE
-            value: gcs
-          - name: LOG_BUCKET
-            value: docstore-ci-logs
           ports:
           - containerPort: 8081
           resources:

--- a/entrypoint-worker.sh
+++ b/entrypoint-worker.sh
@@ -3,7 +3,7 @@ set -e
 
 # Private registry authentication (e.g. GCP Artifact Registry) is a separate
 # concern and is not handled here. Build images must be on public registries.
-# TODO: file a tracking issue for private registry auth support.
+# Tracked in issue #391.
 
 # Set up a loop-backed ext4 volume at /var/lib/buildkit so that buildkitd can use the
 # native overlayfs snapshotter. The Kata CLH guest rootfs is virtiofs, which does not


### PR DESCRIPTION
## Summary

Cleanup PR completing issue #366 — eliminating all system credentials from CI worker VMs. Three changes:

- **Remove Workload Identity annotation** from the ci-worker ServiceAccount in `deploy/k8s/ci-worker.yaml`. The annotation bound the k8s SA to a GCP service account via Workload Identity Federation, giving workers ambient GCP credentials. Workers now authenticate to the server API instead (PR #392 removed the metadata server fetch).

- **Remove stale `LOG_STORE` and `LOG_BUCKET` env vars** from the ci-worker container spec. The worker no longer reads these — it posts logs to the server API. The server reads these vars, not the worker.

- **Remove `curl`** from the `Dockerfile.ci-worker` apt-get install list. It was only needed for the GCE metadata server fetch removed in PR #392.

- **Update TODO comment** in `entrypoint-worker.sh` to reference issue #391, which already tracks private registry auth support.

## Test plan

- [ ] Verify `deploy/k8s/ci-worker.yaml` has no `annotations:` block under the ServiceAccount
- [ ] Verify `LOG_STORE` and `LOG_BUCKET` are gone from the container env
- [ ] Verify `curl` is removed from `Dockerfile.ci-worker`
- [ ] Verify `entrypoint-worker.sh` references `#391` instead of the old TODO

🤖 Generated with [Claude Code](https://claude.com/claude-code)