### PR TITLE
fix(ci-registry): add /healthz endpoint and fix readiness probe

### DIFF
--- a/cmd/ci-registry/main.go
+++ b/cmd/ci-registry/main.go
@@ -42,7 +42,13 @@ func main() {
 	defer gcsClient.Close()
 
 	blobHandler := registry.NewGCSHandler(gcsClient.Bucket(gcsBucket))
-	handler := registry.New(blobHandler, jwksURL, audience, issuer)
+	registryHandler := registry.New(blobHandler, jwksURL, audience, issuer)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.Handle("/", registryHandler)
 
 	addr := ":" + port
 	slog.Info("ci-registry starting",
@@ -55,7 +61,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:    addr,
-		Handler: handler,
+		Handler: mux,
 	}
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		slog.Error("listen", "error", err)

--- a/deploy/k8s/ci-registry.yaml
+++ b/deploy/k8s/ci-registry.yaml
@@ -52,10 +52,8 @@ spec:
             memory: "256Mi"
         readinessProbe:
           httpGet:
-            path: /v2/
+            path: /healthz
             port: 8080
-          # /v2/ returns 401 when unauthenticated, which means the registry is
-          # up and responding; we treat any response as ready.
           failureThreshold: 3
           periodSeconds: 10
 ---


### PR DESCRIPTION
## Summary

- Added an unauthenticated `GET /healthz` handler to `cmd/ci-registry/main.go` that returns `200 OK`
- Updated the `readinessProbe` in `deploy/k8s/ci-registry.yaml` to use `httpGet` on `/healthz` instead of `/v2/`

## Problem

The readiness probe was targeting `/v2/`, which returns `401 Unauthorized` for unauthenticated requests (by OCI Distribution Spec design). Kubernetes `httpGet` probes require a `2xx`–`3xx` response to mark a pod as Ready, so no pod would ever become Ready under this configuration.

## Fix

A minimal mux wraps the registry handler: `/healthz` returns `200 OK` with no auth required; all other paths fall through to the existing authenticated registry handler unchanged.

Fixes the regression introduced in PR #396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)