### PR TITLE
fix(ci-registry): make TestE2ECacheRoundTrip pass with BuildKit v0.29.0

### DIFF
--- a/internal/registry/auth.go
+++ b/internal/registry/auth.go
@@ -37,17 +37,18 @@ func authMiddleware(inner http.Handler, validate func(string) (*server.JobIdenti
 		}
 
 		if tokenStr == "" {
-			// Send a Bearer realm challenge. BuildKit uses Bearer challenges
-			// to trigger its session auth provider (which falls back to Basic
-			// credentials from the docker config when the realm is not a URL).
-			w.Header().Set("WWW-Authenticate", `Bearer realm="ci-registry"`)
+			// Send a Basic realm challenge. BuildKit reads Basic credentials
+			// from the docker config (username "ci-worker", password = OIDC
+			// token). Bearer challenges cause BuildKit to POST to the realm
+			// as a token URL, which fails when the realm is not an HTTP URL.
+			w.Header().Set("WWW-Authenticate", `Basic realm="ci-registry"`)
 			http.Error(w, "authentication required", http.StatusUnauthorized)
 			return
 		}
 
 		identity, err := validate(tokenStr)
 		if err != nil {
-			w.Header().Set("WWW-Authenticate", `Bearer realm="ci-registry"`)
+			w.Header().Set("WWW-Authenticate", `Basic realm="ci-registry"`)
 			http.Error(w, "invalid token", http.StatusUnauthorized)
 			return
 		}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,7 +1,11 @@
 package registry
 
 import (
+	"bytes"
+	"io"
 	"net/http"
+	"strconv"
+	"strings"
 
 	gcrregistry "github.com/google/go-containerregistry/pkg/registry"
 
@@ -22,5 +26,66 @@ func New(blobHandler BlobHandler, jwksURL, audience, issuer string) http.Handler
 		gcrregistry.WithBlobHandler(blobHandler),
 	)
 
-	return authMiddleware(inner, validate)
+	return authMiddleware(ociManifest404Middleware(inner), validate)
+}
+
+// responseRecorder is a minimal http.ResponseWriter that buffers the response
+// status code and body so the calling middleware can inspect and optionally
+// rewrite the response before flushing it to the real writer.
+//
+// Note: Header() calls are NOT intercepted — they operate directly on the
+// underlying ResponseWriter's header map, which the caller can modify between
+// the inner ServeHTTP call and the flush.
+type responseRecorder struct {
+	http.ResponseWriter
+	code int
+	body bytes.Buffer
+}
+
+func (r *responseRecorder) WriteHeader(code int) { r.code = code }
+func (r *responseRecorder) Write(b []byte) (int, error) {
+	return r.body.Write(b)
+}
+
+// flush writes the buffered status and body to the underlying ResponseWriter.
+func (r *responseRecorder) flush() {
+	code := r.code
+	if code == 0 {
+		code = http.StatusOK
+	}
+	r.ResponseWriter.WriteHeader(code)
+	r.ResponseWriter.Write(r.body.Bytes()) //nolint:errcheck
+}
+
+const manifestUnknownBody = `{"errors":[{"code":"MANIFEST_UNKNOWN","message":"Unknown manifest"}]}` + "\n"
+
+// ociManifest404Middleware ensures that any 404 response from a manifest
+// endpoint carries an OCI Distribution Spec–compliant JSON error body with the
+// MANIFEST_UNKNOWN error code.
+//
+// go-containerregistry returns NAME_UNKNOWN (not MANIFEST_UNKNOWN) when a
+// repository has no manifests yet. BuildKit v0.29.x treats MANIFEST_UNKNOWN as
+// "no existing cache, proceed with full push" but may not handle NAME_UNKNOWN
+// gracefully, causing the cache export to abort on the first-ever push.
+func ociManifest404Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/manifests/") {
+			next.ServeHTTP(w, r)
+			return
+		}
+		rec := &responseRecorder{ResponseWriter: w}
+		next.ServeHTTP(rec, r)
+		if rec.code == http.StatusNotFound {
+			w.Header().Set("Content-Type", "application/json")
+			if r.Method != http.MethodHead {
+				w.Header().Set("Content-Length", strconv.Itoa(len(manifestUnknownBody)))
+				w.WriteHeader(http.StatusNotFound)
+				io.WriteString(w, manifestUnknownBody) //nolint:errcheck
+			} else {
+				w.WriteHeader(http.StatusNotFound)
+			}
+			return
+		}
+		rec.flush()
+	})
 }

--- a/internal/registry/registry_e2e_test.go
+++ b/internal/registry/registry_e2e_test.go
@@ -77,6 +77,16 @@ func TestE2ECacheRoundTrip(t *testing.T) {
 	}
 	defer bkClient.Close()
 
+	// Detect the buildkitd worker platform so that llb.Image resolves the
+	// correct manifest from Docker Hub. Without this, llb.Image uses the Go
+	// test binary's host platform (e.g. darwin/arm64 on macOS) which has no
+	// Alpine manifest entry and causes "no match for platform in manifest".
+	workers, err := bkClient.ListWorkers(ctx)
+	if err != nil || len(workers) == 0 || len(workers[0].Platforms) == 0 {
+		t.Fatalf("list buildkit workers: %v", err)
+	}
+	workerPlatform := workers[0].Platforms[0]
+
 	cacheRef := regHost + "/testorg/cache:buildkit"
 
 	// Write a temp docker config with the OIDC token as Basic auth password so
@@ -94,12 +104,17 @@ func TestE2ECacheRoundTrip(t *testing.T) {
 	authSession := authprovider.NewDockerAuthProvider(ap)
 
 	// --- First build: export cache ---
-	def, err := llb.Image("alpine").Run(llb.Shlex("echo cache-test")).Root().Marshal(ctx)
+	// Use the buildkitd worker's platform so Alpine resolves a matching manifest.
+	def, err := llb.Image("alpine", llb.Platform(workerPlatform)).Run(llb.Shlex("echo cache-test")).Root().Marshal(ctx)
 	if err != nil {
 		t.Fatalf("marshal llb: %v", err)
 	}
 
 	_, err = bkClient.Build(ctx, client.SolveOpt{
+		// FrontendAttrs must be non-nil: BuildKit v0.29.0 calls maps.Clone on
+		// it and then maps.Copy(clone, cacheOpt.frontendAttrs), which panics
+		// when the clone is nil and cacheOpt.frontendAttrs is non-empty.
+		FrontendAttrs: map[string]string{},
 		CacheExports: []client.CacheOptionsEntry{{
 			Type: "registry",
 			Attrs: map[string]string{
@@ -132,6 +147,7 @@ func TestE2ECacheRoundTrip(t *testing.T) {
 	}()
 
 	_, err = bkClient.Build(ctx, client.SolveOpt{
+		FrontendAttrs: map[string]string{}, // see note on first build above
 		CacheImports: []client.CacheOptionsEntry{{
 			Type: "registry",
 			Attrs: map[string]string{
@@ -221,43 +237,10 @@ func hostAccessibleAddr(srv *httptest.Server) string {
 		// Buildkitd is running on the host.
 		return addr
 	}
-	// Buildkitd is a container — use host.docker.internal or local LAN IP.
+	// Buildkitd is a container (testcontainers). Docker Desktop injects
+	// host.docker.internal into every container's /etc/hosts, routing to the
+	// host loopback. We do NOT rely on host-side DNS resolution because Docker
+	// Desktop only adds this name inside containers, not to the macOS host.
 	_, port, _ := net.SplitHostPort(addr)
-	if addrs, err := net.LookupHost("host.docker.internal"); err == nil && len(addrs) > 0 {
-		return "host.docker.internal:" + port
-	}
-	if ip := localIP(); ip != "" {
-		return ip + ":" + port
-	}
-	return addr
-}
-
-// localIP returns the first non-loopback IPv4 address.
-func localIP() string {
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return ""
-	}
-	for _, iface := range ifaces {
-		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
-			continue
-		}
-		addrs, err := iface.Addrs()
-		if err != nil {
-			continue
-		}
-		for _, a := range addrs {
-			var ip net.IP
-			switch v := a.(type) {
-			case *net.IPNet:
-				ip = v.IP
-			case *net.IPAddr:
-				ip = v.IP
-			}
-			if ip != nil && ip.To4() != nil && !ip.IsLoopback() {
-				return ip.String()
-			}
-		}
-	}
-	return ""
+	return "host.docker.internal:" + port
 }


### PR DESCRIPTION
## Summary

Fixes the skipping `TestE2ECacheRoundTrip` in `internal/registry/`. Five cascading issues blocked the test from passing when buildkitd is available:

### 1. `ociManifest404Middleware` in `registry.go`
go-containerregistry returns `NAME_UNKNOWN` when a repo has no manifests yet. BuildKit v0.29.0's pusher does a HEAD before pushing; it only cleanly handles `MANIFEST_UNKNOWN` 404s. The new middleware normalizes all manifest-path 404 responses to `MANIFEST_UNKNOWN` JSON so the pusher proceeds correctly.

### 2. `llb.Image("alpine")` used darwin/arm64 platform (`registry_e2e_test.go`)
`llb.Image()` picks up `platforms.DefaultSpec()` from the Go test binary (darwin/arm64 on macOS Apple Silicon). Alpine has no darwin manifest entries → "no match for platform in manifest". Fixed by querying buildkitd's worker platform via `ListWorkers()` and passing it to `llb.Platform()`.

### 3. `host.docker.internal` not resolvable from macOS host (`registry_e2e_test.go`)
Docker Desktop adds `host.docker.internal` to container `/etc/hosts`, NOT to the macOS host's DNS. The old `hostAccessibleAddr` checked host-side DNS and fell back to the LAN IP (`192.168.4.118`), which is unreachable from containers. Fixed to always use `host.docker.internal` in testcontainers mode.

### 4. Bearer realm causes OAuth token POST failure (`auth.go`)
The `WWW-Authenticate: Bearer realm="ci-registry"` header causes BuildKit v0.29.0 to POST to `ci-registry` as an OAuth token URL. Since `ci-registry` is not a URL, this fails. Changed to `Basic realm="ci-registry"` so BuildKit reads credentials from the docker config directly.

### 5. nil `FrontendAttrs` panic in BuildKit v0.29.0 (`registry_e2e_test.go`)
BuildKit calls `maps.Clone(opt.FrontendAttrs)` then `maps.Copy(clone, cacheOpt.frontendAttrs)`, which panics when `FrontendAttrs` is nil. Worked around by providing `FrontendAttrs: map[string]string{}` in both `SolveOpt` calls.

## Test plan
- [x] `TestE2ECacheRoundTrip` — PASS (was skip)
- [x] `TestE2ECrossOrgRejected` — PASS
- [x] All other registry tests — PASS
- [x] `go test ./... -count=1` — all pass
- [x] `go build ./...` and `go vet ./...` — clean

## Notes for future work
- The `localIP()` helper was removed since it's no longer used
- The `ociManifest404Middleware` would be the right fix if a future BuildKit version properly handles NAME_UNKNOWN; this middleware is conservative and also handles the case where the 404 body is plain-text rather than JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)