### PR TITLE
fix(deploy): activate BuildKit registry cache end-to-end

### DIFF
--- a/deploy/k8s/ci-registry.yaml
+++ b/deploy/k8s/ci-registry.yaml
@@ -36,7 +36,7 @@ spec:
         - name: JWKS_URL
           value: https://oidc.docstore.dev/.well-known/jwks.json
         - name: OIDC_AUDIENCE
-          value: docstore
+          value: ci-registry
         - name: OIDC_ISSUER
           value: https://oidc.docstore.dev
         - name: PORT

--- a/deploy/k8s/ci-scheduler.yaml
+++ b/deploy/k8s/ci-scheduler.yaml
@@ -62,7 +62,7 @@ spec:
         - name: OIDC_TOKEN_URL
           value: ''  # set at deploy time by workflow via kubectl set env
         - name: CACHE_REGISTRY_URL
-          value: ''  # set at deploy time; empty = cache disabled
+          value: 'ci-registry.docstore-ci.svc.cluster.local'
         ports:
         - containerPort: 8080
         resources:


### PR DESCRIPTION
## Summary

- **ci-registry.yaml**: Change `OIDC_AUDIENCE` from `'docstore'` to `'ci-registry'`. The ci-worker requests `aud=ci-registry` when exchanging a `request_token` for a cache registry OIDC token (see `cmd/ci-worker/main.go` ~line 340). With the old value the registry would reject every token due to audience mismatch.
- **ci-scheduler.yaml**: Set `CACHE_REGISTRY_URL` to `'ci-registry.docstore-ci.svc.cluster.local'` (was empty string). An empty value disables the cache path entirely in the scheduler; this sets the in-cluster DNS name of the ci-registry Service defined in the same namespace.

Together these two config changes complete the BuildKit registry cache wiring from scheduler → worker → registry end-to-end in production. No Go code changes are needed.

## Test plan

- [ ] Verify `OIDC_AUDIENCE=ci-registry` in ci-registry deployment matches the `aud` claim in tokens issued by ci-worker
- [ ] Verify ci-scheduler passes `CACHE_REGISTRY_URL` to workers, enabling the cache path (previously disabled by empty string)
- [ ] Deploy to cluster and confirm ci-worker cache hits are no longer rejected with audience errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)