### PR TITLE
feat(docs): add docs.docstore.dev documentation site

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,60 @@
+name: Deploy Docs
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'cmd/docs/**'
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: ko-build/setup-ko@v0.7
+      - name: Set up Python + MkDocs
+        run: pip install mkdocs-material
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/320310132788/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: docstore-deployer@dlorenc-chainguard.iam.gserviceaccount.com
+      - uses: google-github-actions/setup-gcloud@v2
+      - name: Configure ko registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+      - name: Build docs site
+        run: |
+          mkdocs build
+          ln -s ../../../site cmd/docs/.kodata/site
+      - name: Build and push image
+        id: build
+        env:
+          KO_DOCKER_REPO: us-central1-docker.pkg.dev/dlorenc-chainguard/images/docs
+        run: |
+          IMAGE=$(ko build --bare --tags latest,$(git rev-parse --short HEAD) ./cmd/docs)
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy docs \
+            --image=${{ steps.build.outputs.image }} \
+            --project=dlorenc-chainguard \
+            --region=us-central1 \
+            --service-account=docstore-server@dlorenc-chainguard.iam.gserviceaccount.com \
+            --ingress=all \
+            --allow-unauthenticated \
+            --min-instances=1 \
+            --max-instances=3 \
+            --port=8080
+      - name: Create domain mapping (idempotent)
+        run: |
+          gcloud run domain-mappings create \
+            --service=docs \
+            --domain=docs.docstore.dev \
+            --region=us-central1 \
+            --project=dlorenc-chainguard \
+            2>/dev/null || echo 'domain mapping already exists'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 bin/
+cmd/docs/.kodata/site
+site/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,28 @@ For repo-scoped endpoints, add a case in the `handleReposPrefix` dispatcher in `
 
 Add handler tests to `internal/server/integration_test.go`. Use the `newTestServer` helper to spin up a test server with a real database via testcontainers.
 
+## Documentation
+
+Documentation source lives in `docs/` as Markdown files, rendered by MkDocs with the Material theme.
+
+**Local preview:**
+
+```bash
+pip install mkdocs-material
+mkdocs serve
+```
+
+The live site reloads on each save at `http://127.0.0.1:8000`.
+
+**Test the Go server locally:**
+
+```bash
+mkdocs build
+KO_DATA_PATH=cmd/docs/.kodata go run ./cmd/docs
+```
+
+This builds the static site into `site/` and serves it via the Go server at `http://localhost:8080`.
+
 ## Before submitting a PR
 
 Run the full test suite and verify the build:

--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var siteDir = func() string {
+	if v := os.Getenv("KO_DATA_PATH"); v != "" {
+		return v
+	}
+	return "cmd/docs/.kodata"
+}()
+
+func main() {
+	port := "8080"
+	if p := os.Getenv("PORT"); p != "" {
+		port = p
+	}
+
+	sitePath := filepath.Join(siteDir, "site")
+
+	mux := http.NewServeMux()
+	mux.Handle("/", handler(sitePath))
+
+	addr := fmt.Sprintf(":%s", port)
+	slog.Info("starting docs server", "addr", addr, "site", sitePath)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		slog.Error("server error", "err", err)
+		os.Exit(1)
+	}
+}
+
+func handler(sitePath string) http.Handler {
+	fs := http.FileServer(http.Dir(sitePath))
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Security headers on all responses.
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+
+		// Cache-Control: immutable for hashed assets, no-cache for everything else.
+		if strings.HasPrefix(r.URL.Path, "/assets/") {
+			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		} else {
+			w.Header().Set("Cache-Control", "no-cache")
+		}
+
+		// Custom 404.
+		rw := &responseWriter{ResponseWriter: w}
+		fs.ServeHTTP(rw, r)
+		if rw.status == http.StatusNotFound {
+			serve404(w, sitePath)
+		}
+	})
+}
+
+func serve404(w http.ResponseWriter, sitePath string) {
+	data, err := os.ReadFile(filepath.Join(sitePath, "404.html"))
+	if err != nil {
+		http.Error(w, "404 not found", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusNotFound)
+	w.Write(data) //nolint:errcheck
+}
+
+// responseWriter wraps http.ResponseWriter to capture the status code.
+type responseWriter struct {
+	http.ResponseWriter
+	status int
+	wrote  bool
+}
+
+func (rw *responseWriter) WriteHeader(status int) {
+	rw.status = status
+	if status != http.StatusNotFound {
+		rw.ResponseWriter.WriteHeader(status)
+		rw.wrote = true
+	}
+}
+
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	if rw.status == http.StatusNotFound {
+		// Discard the default 404 body; serve404 will write the custom one.
+		return len(b), nil
+	}
+	rw.wrote = true
+	return rw.ResponseWriter.Write(b)
+}

--- a/docs/hooks/raw_link.py
+++ b/docs/hooks/raw_link.py
@@ -1,0 +1,7 @@
+REPO_RAW = 'https://raw.githubusercontent.com/dlorenc/docstore/main'
+
+def on_page_content(html, page, config, files):
+    src = page.file.src_path
+    url = f'{REPO_RAW}/docs/{src}'
+    link = f'<hr><p><small><a href="{url}">Raw markdown</a> — machine-readable source for this page.</small></p>'
+    return html + link

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Docstore
+
+Docstore is a document storage and CI system with cryptographic verifiability.
+
+See the [Getting Started](getting-started.md) guide to set up your first repository, or browse the navigation to learn about [Concepts](concepts.md), the [CLI Reference](cli-reference.md), and more.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,43 @@
+site_name: Docstore
+site_url: https://docs.docstore.dev
+repo_url: https://github.com/dlorenc/docstore
+repo_name: dlorenc/docstore
+edit_uri: blob/main/docs/
+theme:
+  name: material
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - content.action.edit
+    - content.action.view
+plugins:
+  - search
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Concepts: concepts.md
+  - CLI Reference: cli-reference.md
+  - CI:
+    - Overview: ci.md
+    - Architecture: ci-architecture.md
+    - Local Development: ci-local.md
+    - Proposals & Triggers: proposals-and-ci-triggers.md
+  - API Reference: api-reference.md
+  - Canonical URIs: canonical-resource-uris.md
+  - Events: events.md
+  - Policy: policy.md
+  - SDK: sdk.md
+  - Cryptographic Verifiability: cryptographic-verifiability.md
+  - Deployment: deployment.md
+hooks:
+  - docs/hooks/raw_link.py


### PR DESCRIPTION
## Summary

- Implements issue #401: MkDocs + Material theme static docs site served by a Go HTTP server on Cloud Run, built with ko
- `mkdocs.yml` configures MkDocs with Material theme, full nav for all 14 existing docs pages, and a new `docs/index.md`
- `docs/hooks/raw_link.py` appends a raw markdown link to every page for agent/machine consumption
- `cmd/docs/main.go` serves the static site with custom 404, cache-control headers (immutable for `/assets/*`, no-cache otherwise), and security headers
- `.github/workflows/deploy-docs.yml` builds on changes to `docs/**`, `mkdocs.yml`, `cmd/docs/**` and deploys to Cloud Run at `docs.docstore.dev`
- `CONTRIBUTING.md` updated with Documentation section

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` all pass
- [ ] `pip install mkdocs-material && mkdocs build` (verified config is structurally correct; all 14 docs pages + index.md present in nav)
- [ ] After merge, CI deploys to Cloud Run and domain mapping creates TLS cert automatically

## DNS note

One-time manual step (done by operator, not in code): add CNAME `docs.docstore.dev → ghs.googlehosted.com` in the `docstore.dev` DNS zone.

## Notes / Opportunities

- `.ko.yaml` already existed with correct `defaultBaseImage: gcr.io/distroless/static:nonroot` — not duplicated
- The `plugins.hooks` entry was removed from `mkdocs.yml` (the hook is wired via the top-level `hooks:` key, which is the correct MkDocs 1.x approach for standalone hook scripts)
- Could add `go test ./cmd/docs/...` with a test server in future

🤖 Generated with [Claude Code](https://claude.com/claude-code)