### PR TITLE
fix(deploy-docs): use cp instead of symlink and gcloud beta for domain mapping

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build docs site
         run: |
           mkdocs build
-          ln -s ../../../site cmd/docs/.kodata/site
+          cp -r site cmd/docs/.kodata/
       - name: Build and push image
         id: build
         env:
@@ -52,7 +52,7 @@ jobs:
             --port=8080
       - name: Create domain mapping (idempotent)
         run: |
-          gcloud run domain-mappings create \
+          gcloud beta run domain-mappings create \
             --service=docs \
             --domain=docs.docstore.dev \
             --region=us-central1 \


### PR DESCRIPTION
## Summary

- **Build docs site step**: replace `ln -s ../../../site cmd/docs/.kodata/site` with `cp -r site cmd/docs/.kodata/` — ko does not follow symlinks that point outside the module tree, so the symlink caused the site directory to be missing from the built image.
- **Create domain mapping step**: change `gcloud run domain-mappings create` to `gcloud beta run domain-mappings create` — the `domain-mappings` subcommand is only available under the `beta` surface of gcloud.

No other files were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)