### PR TITLE
feat(deploy): add build-and-deploy-ci-registry job to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,6 +138,50 @@ jobs:
             echo "ci-runner-url updated to ${WANT}"
           fi
 
+  build-and-deploy-ci-registry:
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/320310132788/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: docstore-deployer@dlorenc-chainguard.iam.gserviceaccount.com
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: docstore-ci
+          location: us-central1
+          project_id: dlorenc-chainguard
+
+      - uses: ko-build/setup-ko@v0.7
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - name: Build and push ci-registry image
+        id: build
+        env:
+          KO_DOCKER_REPO: us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-registry
+        run: |
+          IMAGE=$(ko build --bare --tags latest,$(git rev-parse --short HEAD) ./cmd/ci-registry)
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+
+      - name: Deploy ci-registry to GKE
+        run: |
+          kubectl apply -f deploy/k8s/ci-registry.yaml
+          kubectl set image deployment/ci-registry \
+            ci-registry=${{ steps.build.outputs.image }} \
+            -n docstore-ci
+          kubectl rollout status deployment/ci-registry -n docstore-ci --timeout=300s
+
   build-and-deploy-ci-worker:
     runs-on: ubuntu-latest
     needs: [deploy, build-and-deploy-ci-scheduler]


### PR DESCRIPTION
## Summary

- Adds `build-and-deploy-ci-registry` job to `.github/workflows/deploy.yml`, mirroring the `ci-scheduler` pattern: ko-build `cmd/ci-registry`, push to Artifact Registry, `kubectl apply` the manifest, `kubectl set image`, and wait for rollout
- Job depends on `deploy` (same as ci-scheduler)

## One-time GCP bootstrap (already applied)

- Created GCS bucket `dlorenc-chainguard-ci-registry-cache` in us-central1 with uniform bucket-level access
- Created GCP SA `ci-registry@dlorenc-chainguard.iam.gserviceaccount.com` with `roles/storage.objectAdmin` on the bucket
- Bound GCP SA to k8s SA `ci-registry` in `docstore-ci` namespace via Workload Identity (`roles/iam.workloadIdentityUser` for `dlorenc-chainguard.svc.id.goog[docstore-ci/ci-registry]`)
- Applied `deploy/k8s/ci-registry.yaml` to `gke_dlorenc-chainguard_us-central1_docstore-ci` — deployment is running
- Built and pushed initial image so pods are healthy now

## Test plan

- [x] `go test ./... -count=1` — all pass
- [x] `go build ./... && go vet ./...` — clean
- [x] `kubectl rollout status deployment/ci-registry -n docstore-ci` — successfully rolled out

## Notes / opportunities

- The `build-and-deploy-ci-worker` job still depends on `build-and-deploy-ci-scheduler` but ci-registry runs independently — could be parallelized further if desired
- Consider adding a `build-and-deploy-ci-registry` needs entry to any jobs that require the registry to be up before they run

🤖 Generated with [Claude Code](https://claude.com/claude-code)