### PR TITLE
fix(ci-scheduler): replace fetchAllRepos HTTP call with direct DB query

### DIFF
--- a/cmd/ci-scheduler/main.go
+++ b/cmd/ci-scheduler/main.go
@@ -56,6 +56,7 @@ type ciJobStore interface {
 	CompleteCIJob(ctx context.Context, id, status string, logURL, errorMessage *string) error
 	ReapStaleCIJobs(ctx context.Context) ([]model.CIJob, error)
 	CountQueuedCIJobs(ctx context.Context) (int64, error)
+	ListRepos(ctx context.Context) ([]model.Repo, error)
 }
 
 // ---------------------------------------------------------------------------
@@ -665,30 +666,14 @@ func (s *scheduler) fetchBranchHead(ctx context.Context, repo, branch string) (i
 	return 0, fmt.Errorf("branch %q not found in repo %q", branch, repo)
 }
 
-// fetchAllRepos fetches all repo names from docstore (GET /repos).
+// fetchAllRepos returns all repo names from the database.
 func (s *scheduler) fetchAllRepos(ctx context.Context) ([]string, error) {
-	if s.docstoreURL == "" {
-		return nil, nil
-	}
-	reposURL := s.docstoreURL + "/repos"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reposURL, nil)
+	repos, err := s.store.ListRepos(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("build repos request: %w", err)
+		return nil, fmt.Errorf("list repos: %w", err)
 	}
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("fetch repos: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fetch repos: unexpected status %d", resp.StatusCode)
-	}
-	var result model.ReposResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("decode repos response: %w", err)
-	}
-	names := make([]string, 0, len(result.Repos))
-	for _, r := range result.Repos {
+	names := make([]string, 0, len(repos))
+	for _, r := range repos {
 		names = append(names, r.Name)
 	}
 	return names, nil

--- a/cmd/ci-scheduler/main_test.go
+++ b/cmd/ci-scheduler/main_test.go
@@ -37,6 +37,8 @@ type stubStore struct {
 	lookupErr     error
 	tokenStored   bool
 	storeTokenErr error
+	reposList     []model.Repo
+	reposErr      error
 }
 
 func (s *stubStore) InsertCIJob(_ context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerBaseBranch, triggerProposalID string) (*model.CIJob, error) {
@@ -88,6 +90,10 @@ func (s *stubStore) ReapStaleCIJobs(_ context.Context) ([]model.CIJob, error) {
 
 func (s *stubStore) CountQueuedCIJobs(_ context.Context) (int64, error) {
 	return s.queueDepth, nil
+}
+
+func (s *stubStore) ListRepos(_ context.Context) ([]model.Repo, error) {
+	return s.reposList, s.reposErr
 }
 
 // ---------------------------------------------------------------------------
@@ -776,6 +782,10 @@ func (s *countingStore) CountQueuedCIJobs(_ context.Context) (int64, error) {
 	return 0, nil
 }
 
+func (s *countingStore) ListRepos(_ context.Context) ([]model.Repo, error) {
+	return nil, nil
+}
+
 func (s *countingStore) calls() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -785,22 +795,17 @@ func (s *countingStore) calls() int {
 // ---------------------------------------------------------------------------
 // newScheduleDocstoreServer creates a test docstore server for schedule tests.
 // It handles:
-//   - GET /repos                                     → {"repos":[...]}
-//   - GET /repos/{repo}/-/branches                   → {"branches":[{"name":"main",...}]}
+//   - GET /repos/{repo}/-/branches                   → [{"name":"main",...}]
 //   - GET /repos/{repo}/-/file/.docstore/ci.yaml     → FileResponse (or 404 if ciYAML == "")
+//
+// Repos are no longer fetched via HTTP; callers must set stubStore.reposList instead.
 // ---------------------------------------------------------------------------
 
-func newScheduleDocstoreServer(t *testing.T, repoNames []string, headSeq int64, ciYAML string) *httptest.Server {
+func newScheduleDocstoreServer(t *testing.T, headSeq int64, ciYAML string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.URL.Path == "/repos":
-			repos := make([]map[string]any, 0, len(repoNames))
-			for _, name := range repoNames {
-				repos = append(repos, map[string]any{"name": name})
-			}
-			json.NewEncoder(w).Encode(map[string]any{"repos": repos}) //nolint:errcheck
 		case strings.Contains(r.URL.Path, "/-/file/.docstore/ci.yaml"):
 			if ciYAML == "" {
 				http.NotFound(w, r)
@@ -898,18 +903,13 @@ func TestFetchBranchHead_NoDocstoreURL(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestFetchAllRepos_HappyPath(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
-			"repos": []map[string]any{
-				{"name": "org/alpha"},
-				{"name": "org/beta"},
-			},
-		})
-	}))
-	defer srv.Close()
-
-	sched := &scheduler{docstoreURL: srv.URL, httpClient: &http.Client{}}
+	stub := &stubStore{
+		reposList: []model.Repo{
+			{Name: "org/alpha"},
+			{Name: "org/beta"},
+		},
+	}
+	sched := &scheduler{store: stub}
 	repos, err := sched.fetchAllRepos(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -922,27 +922,24 @@ func TestFetchAllRepos_HappyPath(t *testing.T) {
 	}
 }
 
-func TestFetchAllRepos_NonOKStatus(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "forbidden", http.StatusForbidden)
-	}))
-	defer srv.Close()
-
-	sched := &scheduler{docstoreURL: srv.URL, httpClient: &http.Client{}}
+func TestFetchAllRepos_StoreError(t *testing.T) {
+	stub := &stubStore{reposErr: errors.New("db unavailable")}
+	sched := &scheduler{store: stub}
 	_, err := sched.fetchAllRepos(context.Background())
 	if err == nil {
-		t.Fatal("expected error for non-200 status, got nil")
+		t.Fatal("expected error from store, got nil")
 	}
 }
 
-func TestFetchAllRepos_NoDocstoreURL(t *testing.T) {
-	sched := &scheduler{docstoreURL: "", httpClient: &http.Client{}}
+func TestFetchAllRepos_EmptyStore(t *testing.T) {
+	stub := &stubStore{}
+	sched := &scheduler{store: stub}
 	repos, err := sched.fetchAllRepos(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if repos != nil {
-		t.Errorf("expected nil repos for empty docstore URL, got %v", repos)
+	if len(repos) != 0 {
+		t.Errorf("expected empty repos, got %v", repos)
 	}
 }
 
@@ -957,10 +954,10 @@ func TestRunScheduledJobs_CronMatchesCurrentMinute_EnqueuesJob(t *testing.T) {
 	now := time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC)
 	ciYAML := "on:\n  schedule:\n    - cron: \"30 14 * * *\"\n"
 
-	srv := newScheduleDocstoreServer(t, []string{"org/repo"}, 10, ciYAML)
+	srv := newScheduleDocstoreServer(t, 10, ciYAML)
 	defer srv.Close()
 
-	stub := &stubStore{}
+	stub := &stubStore{reposList: []model.Repo{{Name: "org/repo"}}}
 	sched := &scheduler{store: stub, docstoreURL: srv.URL, httpClient: &http.Client{}}
 
 	sched.runScheduledJobs(context.Background(), now)
@@ -990,10 +987,10 @@ func TestRunScheduledJobs_CronDoesNotMatchCurrentMinute_NoJob(t *testing.T) {
 	now := time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC)
 	ciYAML := "on:\n  schedule:\n    - cron: \"0 0 * * *\"\n"
 
-	srv := newScheduleDocstoreServer(t, []string{"org/repo"}, 10, ciYAML)
+	srv := newScheduleDocstoreServer(t, 10, ciYAML)
 	defer srv.Close()
 
-	stub := &stubStore{}
+	stub := &stubStore{reposList: []model.Repo{{Name: "org/repo"}}}
 	sched := &scheduler{store: stub, docstoreURL: srv.URL, httpClient: &http.Client{}}
 
 	sched.runScheduledJobs(context.Background(), now)
@@ -1010,10 +1007,10 @@ func TestRunScheduledJobs_InvalidCronExpression_NoJob(t *testing.T) {
 	now := time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC)
 	ciYAML := "on:\n  schedule:\n    - cron: \"not-a-cron\"\n"
 
-	srv := newScheduleDocstoreServer(t, []string{"org/repo"}, 10, ciYAML)
+	srv := newScheduleDocstoreServer(t, 10, ciYAML)
 	defer srv.Close()
 
-	stub := &stubStore{}
+	stub := &stubStore{reposList: []model.Repo{{Name: "org/repo"}}}
 	sched := &scheduler{store: stub, docstoreURL: srv.URL, httpClient: &http.Client{}}
 
 	sched.runScheduledJobs(context.Background(), now)
@@ -1028,10 +1025,10 @@ func TestRunScheduledJobs_InvalidCronExpression_NoJob(t *testing.T) {
 func TestRunScheduledJobs_NoCIConfig_NoJob(t *testing.T) {
 	now := time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC)
 	// Pass empty ciYAML so the server returns 404 for ci.yaml requests.
-	srv := newScheduleDocstoreServer(t, []string{"org/repo"}, 10, "")
+	srv := newScheduleDocstoreServer(t, 10, "")
 	defer srv.Close()
 
-	stub := &stubStore{}
+	stub := &stubStore{reposList: []model.Repo{{Name: "org/repo"}}}
 	sched := &scheduler{store: stub, docstoreURL: srv.URL, httpClient: &http.Client{}}
 
 	sched.runScheduledJobs(context.Background(), now)
@@ -1047,10 +1044,10 @@ func TestRunScheduledJobs_NoScheduleEntries_NoJob(t *testing.T) {
 	now := time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC)
 	ciYAML := "on:\n  push:\n    branches:\n      - main\n"
 
-	srv := newScheduleDocstoreServer(t, []string{"org/repo"}, 10, ciYAML)
+	srv := newScheduleDocstoreServer(t, 10, ciYAML)
 	defer srv.Close()
 
-	stub := &stubStore{}
+	stub := &stubStore{reposList: []model.Repo{{Name: "org/repo"}}}
 	sched := &scheduler{store: stub, docstoreURL: srv.URL, httpClient: &http.Client{}}
 
 	sched.runScheduledJobs(context.Background(), now)
@@ -1070,13 +1067,6 @@ func TestRunScheduledJobs_MultipleRepos_OnlyMatchingEnqueues(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.URL.Path == "/repos":
-			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
-				"repos": []map[string]any{
-					{"name": "org/matching"},
-					{"name": "org/nomatch"},
-				},
-			})
 		case strings.Contains(r.URL.Path, "/-/file/.docstore/ci.yaml"):
 			var ciYAML string
 			if strings.Contains(r.URL.Path, "org/matching") {
@@ -1099,7 +1089,12 @@ func TestRunScheduledJobs_MultipleRepos_OnlyMatchingEnqueues(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	stub := &stubStore{}
+	stub := &stubStore{
+		reposList: []model.Repo{
+			{Name: "org/matching"},
+			{Name: "org/nomatch"},
+		},
+	}
 	sched := &scheduler{store: stub, docstoreURL: srv.URL, httpClient: &http.Client{}}
 
 	sched.runScheduledJobs(context.Background(), now)


### PR DESCRIPTION
## Summary

- The `ci-scheduler` was calling `GET /repos` on the docstore HTTP server once per minute (from the cron runner) without auth credentials, producing a `fetch repos: unexpected status 401` error in logs every minute
- `ListRepos(ctx)` was added to the `ciJobStore` interface (already implemented by `*db.Store`)
- `fetchAllRepos` now calls `s.store.ListRepos(ctx)` directly instead of making an unauthenticated HTTP request

## Changes

**`cmd/ci-scheduler/main.go`**
- Added `ListRepos(ctx context.Context) ([]model.Repo, error)` to `ciJobStore` interface
- Replaced `fetchAllRepos` HTTP implementation with direct `s.store.ListRepos(ctx)` call

**`cmd/ci-scheduler/main_test.go`**
- Added `reposList`/`reposErr` fields and `ListRepos` method to `stubStore`
- Added `ListRepos` method to `countingStore`
- Replaced HTTP-server-based `TestFetchAllRepos_*` tests with store-based equivalents
- Updated `newScheduleDocstoreServer` to drop the `repoNames` param and `/repos` HTTP route (repos now come from the store)
- Updated all `TestRunScheduledJobs_*` callers to set `stub.reposList` instead of relying on HTTP `/repos`

## Test plan

- [x] `go test ./... -count=1` — all packages pass
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean

## Notes / opportunities

- The `fetchAllRepos` method is kept as a named method for testability; it could be inlined into `runScheduledJobs` in a future cleanup
- The `/repos` route on the docstore HTTP server is still authenticated (unchanged); this fix removes the only caller that bypassed auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)