### PR TITLE
feat(ci-registry): GCS-backed manifest store for multi-replica consistency

### DIFF
--- a/cmd/ci-registry/main.go
+++ b/cmd/ci-registry/main.go
@@ -41,8 +41,10 @@ func main() {
 	}
 	defer gcsClient.Close()
 
-	blobHandler := registry.NewGCSHandler(gcsClient.Bucket(gcsBucket))
-	registryHandler := registry.New(blobHandler, jwksURL, audience, issuer)
+	bucket := gcsClient.Bucket(gcsBucket)
+	blobHandler := registry.NewGCSHandler(bucket)
+	manifestStore := registry.NewGCSManifestStore(bucket)
+	registryHandler := registry.New(blobHandler, manifestStore, jwksURL, audience, issuer)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/registry/manifest_store_test.go
+++ b/internal/registry/manifest_store_test.go
@@ -1,0 +1,341 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/citoken"
+)
+
+// memManifestStore is an in-memory ManifestStore for use in tests.
+type memManifestStore struct {
+	mu   sync.RWMutex
+	data map[string]struct {
+		blob []byte
+		ct   string
+	}
+}
+
+func newMemManifestStore() *memManifestStore {
+	return &memManifestStore{
+		data: make(map[string]struct {
+			blob []byte
+			ct   string
+		}),
+	}
+}
+
+func (m *memManifestStore) storeKey(repo, ref string) string { return repo + "\x00" + ref }
+
+func (m *memManifestStore) Get(_ context.Context, repo, ref string) ([]byte, string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	v, ok := m.data[m.storeKey(repo, ref)]
+	if !ok {
+		return nil, "", errNotFound
+	}
+	return v.blob, v.ct, nil
+}
+
+func (m *memManifestStore) Put(_ context.Context, repo, ref string, data []byte, ct string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data[m.storeKey(repo, ref)] = struct {
+		blob []byte
+		ct   string
+	}{blob: data, ct: ct}
+	return nil
+}
+
+func (m *memManifestStore) Delete(_ context.Context, repo, ref string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k := m.storeKey(repo, ref)
+	if _, ok := m.data[k]; !ok {
+		return errNotFound
+	}
+	delete(m.data, k)
+	return nil
+}
+
+func (m *memManifestStore) Tags(_ context.Context, repo string) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	prefix := repo + "\x00"
+	var tags []string
+	for k := range m.data {
+		if !strings.HasPrefix(k, prefix) {
+			continue
+		}
+		ref := strings.TrimPrefix(k, prefix)
+		if strings.HasPrefix(ref, "sha256:") {
+			continue
+		}
+		tags = append(tags, ref)
+	}
+	sort.Strings(tags)
+	return tags, nil
+}
+
+func (m *memManifestStore) Repos(_ context.Context) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	seen := make(map[string]bool)
+	var repos []string
+	for k := range m.data {
+		parts := strings.SplitN(k, "\x00", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		repo := parts[0]
+		if !seen[repo] {
+			seen[repo] = true
+			repos = append(repos, repo)
+		}
+	}
+	sort.Strings(repos)
+	return repos, nil
+}
+
+// makeRegistryWithStore creates a test registry with a given manifest store and
+// a fresh LocalSigner. Returns the server, signer, and JWKS server for token issuance.
+func makeRegistryWithStore(t *testing.T, store ManifestStore) (*httptest.Server, *citoken.LocalSigner) {
+	t.Helper()
+	signer, err := citoken.NewLocalSigner()
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, _ := signer.PublicKeys(r.Context())
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data) //nolint:errcheck
+	}))
+	t.Cleanup(jwksSrv.Close)
+
+	h := New(NewMemoryHandler(), store, jwksSrv.URL, "ci-registry", "https://oidc.test")
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv, signer
+}
+
+func TestManifestMiddleware_PutGet(t *testing.T) {
+	store := newMemManifestStore()
+	srv, signer := makeRegistryWithStore(t, store)
+	tok := makeTestToken(t, signer, "acme/cache")
+
+	manifestBody := `{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","layers":[]}`
+
+	// PUT manifest.
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodPut,
+		srv.URL+"/v2/acme/cache/manifests/latest",
+		strings.NewReader(manifestBody))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("put manifest: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 on PUT, got %d", resp.StatusCode)
+	}
+	digest := resp.Header.Get("Docker-Content-Digest")
+	if digest == "" {
+		t.Fatal("expected Docker-Content-Digest header")
+	}
+
+	// GET manifest by tag.
+	req, _ = http.NewRequestWithContext(context.Background(),
+		http.MethodGet,
+		srv.URL+"/v2/acme/cache/manifests/latest", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get manifest: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 on GET, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != manifestBody {
+		t.Errorf("body mismatch: got %q want %q", body, manifestBody)
+	}
+	if resp.Header.Get("Docker-Content-Digest") != digest {
+		t.Errorf("digest mismatch: got %q want %q", resp.Header.Get("Docker-Content-Digest"), digest)
+	}
+
+	// GET manifest by digest.
+	req, _ = http.NewRequestWithContext(context.Background(),
+		http.MethodGet,
+		srv.URL+"/v2/acme/cache/manifests/"+digest, nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get by digest: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 GET by digest, got %d", resp.StatusCode)
+	}
+}
+
+func TestManifestMiddleware_HeadNotFound(t *testing.T) {
+	store := newMemManifestStore()
+	srv, signer := makeRegistryWithStore(t, store)
+	tok := makeTestToken(t, signer, "acme/cache")
+
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodHead,
+		srv.URL+"/v2/acme/cache/manifests/latest", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestManifestMiddleware_Delete(t *testing.T) {
+	store := newMemManifestStore()
+	srv, signer := makeRegistryWithStore(t, store)
+	tok := makeTestToken(t, signer, "acme/cache")
+
+	// Seed a manifest directly in store.
+	store.Put(context.Background(), "acme/cache", "v1", []byte(`{"test":1}`), "application/json") //nolint:errcheck
+
+	// DELETE it.
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodDelete,
+		srv.URL+"/v2/acme/cache/manifests/v1", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Errorf("expected 202, got %d", resp.StatusCode)
+	}
+
+	// Verify it's gone.
+	_, _, err = store.Get(context.Background(), "acme/cache", "v1")
+	if !errors.Is(err, errNotFound) {
+		t.Errorf("expected errNotFound after delete, got %v", err)
+	}
+}
+
+func TestManifestMiddleware_TagsList(t *testing.T) {
+	store := newMemManifestStore()
+	srv, signer := makeRegistryWithStore(t, store)
+	tok := makeTestToken(t, signer, "acme/cache")
+
+	// Seed some tags.
+	ctx := context.Background()
+	for _, tag := range []string{"v1", "v2", "latest"} {
+		store.Put(ctx, "acme/cache", tag, []byte(fmt.Sprintf(`{"tag":%q}`, tag)), "application/json") //nolint:errcheck
+	}
+	// Also add a digest key — should not appear in tags list.
+	store.Put(ctx, "acme/cache", "sha256:abc123", []byte(`{}`), "application/json") //nolint:errcheck
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
+		srv.URL+"/v2/acme/cache/tags/list", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("tags list: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Tags []string `json:"tags"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	wantTags := []string{"latest", "v1", "v2"}
+	sort.Strings(result.Tags)
+	if fmt.Sprint(result.Tags) != fmt.Sprint(wantTags) {
+		t.Errorf("tags = %v, want %v", result.Tags, wantTags)
+	}
+}
+
+// TestManifestMiddleware_SharedState verifies that two handler instances backed
+// by the same ManifestStore share manifest state — simulating the multi-replica
+// scenario where a manifest pushed to one pod must be visible from another.
+func TestManifestMiddleware_SharedState(t *testing.T) {
+	signer, err := citoken.NewLocalSigner()
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, _ := signer.PublicKeys(r.Context())
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data) //nolint:errcheck
+	}))
+	defer jwksSrv.Close()
+
+	sharedStore := newMemManifestStore()
+
+	h1 := New(NewMemoryHandler(), sharedStore, jwksSrv.URL, "ci-registry", "https://oidc.test")
+	h2 := New(NewMemoryHandler(), sharedStore, jwksSrv.URL, "ci-registry", "https://oidc.test")
+	srv1 := httptest.NewServer(h1)
+	srv2 := httptest.NewServer(h2)
+	defer srv1.Close()
+	defer srv2.Close()
+
+	tok := makeTestToken(t, signer, "acme/cache")
+	manifestBody := `{"schemaVersion":2}`
+
+	// Push to replica 1.
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodPut,
+		srv1.URL+"/v2/acme/cache/manifests/latest",
+		strings.NewReader(manifestBody))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+
+	// Pull from replica 2.
+	req, _ = http.NewRequestWithContext(context.Background(),
+		http.MethodGet,
+		srv2.URL+"/v2/acme/cache/manifests/latest", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("replica 2 cannot see manifest from replica 1: got %d", resp.StatusCode)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -2,31 +2,245 @@ package registry
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	gcrregistry "github.com/google/go-containerregistry/pkg/registry"
 
 	"github.com/dlorenc/docstore/internal/server"
 )
 
 // New creates an OCI Distribution Spec registry http.Handler using the given
-// blob handler for blob storage (manifests are stored in-memory).
+// blob handler for blob storage.
+//
+// When manifestStore is non-nil, manifests are stored and retrieved via that
+// store (e.g. GCS) so that all replicas share state and pod restarts do not
+// lose manifest refs.  When manifestStore is nil, go-containerregistry's
+// default in-memory manifest store is used.
 //
 // Every request is authenticated with a CI job OIDC token validated against
 // the provided JWKS endpoint, audience, and issuer.  The token's repo claim
 // is used to restrict access so that a token for org "acme" can only push/pull
 // images whose name starts with "acme/".
-func New(blobHandler BlobHandler, jwksURL, audience, issuer string) http.Handler {
+func New(blobHandler BlobHandler, manifestStore ManifestStore, jwksURL, audience, issuer string) http.Handler {
 	validate := server.NewJobTokenValidator(jwksURL, audience, issuer)
 
 	inner := gcrregistry.New(
 		gcrregistry.WithBlobHandler(blobHandler),
 	)
 
-	return authMiddleware(ociManifest404Middleware(inner), validate)
+	var outer http.Handler
+	if manifestStore != nil {
+		outer = newManifestStoreMiddleware(manifestStore, inner)
+	} else {
+		outer = ociManifest404Middleware(inner)
+	}
+
+	return authMiddleware(outer, validate)
+}
+
+// writeRegError writes an OCI Distribution Spec JSON error response.
+func writeRegError(w http.ResponseWriter, status int, code, message string) {
+	type regErr struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	type regErrWrap struct {
+		Errors []regErr `json:"errors"`
+	}
+	body, _ := json.Marshal(regErrWrap{Errors: []regErr{{Code: code, Message: message}}})
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	w.WriteHeader(status)
+	w.Write(body) //nolint:errcheck
+}
+
+// newManifestStoreMiddleware returns an http.Handler that intercepts
+// manifest, tags, and catalog requests and serves them from store.  All
+// other requests are delegated to next.
+func newManifestStoreMiddleware(store ManifestStore, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if isManifest(r) {
+			elem := strings.Split(r.URL.Path, "/")
+			elem = elem[1:]
+			ref := elem[len(elem)-1]
+			repo := strings.Join(elem[1:len(elem)-2], "/")
+			serveManifest(ctx, store, w, r, repo, ref)
+			return
+		}
+
+		if isTags(r) && r.Method == http.MethodGet {
+			elem := strings.Split(r.URL.Path, "/")
+			elem = elem[1:]
+			repo := strings.Join(elem[1:len(elem)-2], "/")
+			serveTagsList(ctx, store, w, r, repo)
+			return
+		}
+
+		if isCatalog(r) && r.Method == http.MethodGet {
+			serveCatalog(ctx, store, w, r)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isManifest is copied from go-containerregistry's unexported helper.
+func isManifest(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 4 {
+		return false
+	}
+	return elems[len(elems)-2] == "manifests"
+}
+
+// isTags is copied from go-containerregistry's unexported helper.
+func isTags(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 4 {
+		return false
+	}
+	return elems[len(elems)-2] == "tags"
+}
+
+// isCatalog is copied from go-containerregistry's unexported helper.
+func isCatalog(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 2 {
+		return false
+	}
+	return elems[len(elems)-1] == "_catalog"
+}
+
+func serveManifest(ctx context.Context, store ManifestStore, w http.ResponseWriter, r *http.Request, repo, ref string) {
+	switch r.Method {
+	case http.MethodGet, http.MethodHead:
+		data, contentType, err := store.Get(ctx, repo, ref)
+		if err != nil {
+			if errors.Is(err, errNotFound) {
+				writeRegError(w, http.StatusNotFound, "MANIFEST_UNKNOWN", "Unknown manifest")
+				return
+			}
+			writeRegError(w, http.StatusInternalServerError, "INTERNAL_SERVER_ERROR", err.Error())
+			return
+		}
+		h, _, _ := v1.SHA256(bytes.NewReader(data))
+		w.Header().Set("Docker-Content-Digest", h.String())
+		w.Header().Set("Content-Type", contentType)
+		w.Header().Set("Content-Length", fmt.Sprint(len(data)))
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			w.Write(data) //nolint:errcheck
+		}
+
+	case http.MethodPut:
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			writeRegError(w, http.StatusBadRequest, "BLOB_UPLOAD_INVALID", "failed to read body")
+			return
+		}
+		contentType := r.Header.Get("Content-Type")
+		h, _, _ := v1.SHA256(bytes.NewReader(data))
+		digest := h.String()
+		if err := store.Put(ctx, repo, ref, data, contentType); err != nil {
+			writeRegError(w, http.StatusInternalServerError, "INTERNAL_SERVER_ERROR", err.Error())
+			return
+		}
+		// Also index by digest so immutable digest refs resolve.
+		if ref != digest {
+			if err := store.Put(ctx, repo, digest, data, contentType); err != nil {
+				writeRegError(w, http.StatusInternalServerError, "INTERNAL_SERVER_ERROR", err.Error())
+				return
+			}
+		}
+		w.Header().Set("Docker-Content-Digest", digest)
+		w.WriteHeader(http.StatusCreated)
+
+	case http.MethodDelete:
+		if err := store.Delete(ctx, repo, ref); err != nil {
+			if errors.Is(err, errNotFound) {
+				writeRegError(w, http.StatusNotFound, "MANIFEST_UNKNOWN", "Unknown manifest")
+				return
+			}
+			writeRegError(w, http.StatusInternalServerError, "INTERNAL_SERVER_ERROR", err.Error())
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+
+	default:
+		writeRegError(w, http.StatusMethodNotAllowed, "METHOD_UNKNOWN", "unsupported method")
+	}
+}
+
+func serveTagsList(ctx context.Context, store ManifestStore, w http.ResponseWriter, r *http.Request, repo string) {
+	tags, err := store.Tags(ctx, repo)
+	if err != nil {
+		writeRegError(w, http.StatusInternalServerError, "INTERNAL_SERVER_ERROR", err.Error())
+		return
+	}
+
+	// Apply "last" pagination offset.
+	if last := r.URL.Query().Get("last"); last != "" {
+		for i, t := range tags {
+			if t > last {
+				tags = tags[i:]
+				break
+			}
+		}
+	}
+	// Apply "n" limit.
+	if ns := r.URL.Query().Get("n"); ns != "" {
+		if n, err := strconv.Atoi(ns); err == nil && n < len(tags) {
+			tags = tags[:n]
+		}
+	}
+
+	type listTags struct {
+		Name string   `json:"name"`
+		Tags []string `json:"tags"`
+	}
+	body, _ := json.Marshal(listTags{Name: repo, Tags: tags})
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	w.WriteHeader(http.StatusOK)
+	w.Write(body) //nolint:errcheck
+}
+
+func serveCatalog(ctx context.Context, store ManifestStore, w http.ResponseWriter, r *http.Request) {
+	repos, err := store.Repos(ctx)
+	if err != nil {
+		writeRegError(w, http.StatusInternalServerError, "INTERNAL_SERVER_ERROR", err.Error())
+		return
+	}
+
+	// Apply "n" limit.
+	if ns := r.URL.Query().Get("n"); ns != "" {
+		if n, err := strconv.Atoi(ns); err == nil && n < len(repos) {
+			repos = repos[:n]
+		}
+	}
+
+	type catalog struct {
+		Repos []string `json:"repositories"`
+	}
+	body, _ := json.Marshal(catalog{Repos: repos})
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	w.WriteHeader(http.StatusOK)
+	w.Write(body) //nolint:errcheck
 }
 
 // responseRecorder is a minimal http.ResponseWriter that buffers the response

--- a/internal/registry/registry_e2e_test.go
+++ b/internal/registry/registry_e2e_test.go
@@ -61,7 +61,7 @@ func TestE2ECacheRoundTrip(t *testing.T) {
 	defer jwksSrv.Close()
 
 	// Start in-memory registry.
-	regSrv := httptest.NewServer(New(NewMemoryHandler(), jwksSrv.URL, "ci-registry", "https://oidc.test"))
+	regSrv := httptest.NewServer(New(NewMemoryHandler(), nil, jwksSrv.URL, "ci-registry", "https://oidc.test"))
 	defer regSrv.Close()
 
 	// Determine the address buildkitd (possibly in a container) can reach.
@@ -184,7 +184,7 @@ func TestE2ECrossOrgRejected(t *testing.T) {
 	}))
 	defer jwksSrv.Close()
 
-	regSrv := httptest.NewServer(New(NewMemoryHandler(), jwksSrv.URL, "ci-registry", "https://oidc.test"))
+	regSrv := httptest.NewServer(New(NewMemoryHandler(), nil, jwksSrv.URL, "ci-registry", "https://oidc.test"))
 	defer regSrv.Close()
 
 	// Token for the wrong org.

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -36,7 +36,7 @@ func TestRegistry_PingRequiresAuth(t *testing.T) {
 	}))
 	defer jwksSrv.Close()
 
-	h := New(NewMemoryHandler(), jwksSrv.URL, "ci-registry", "https://oidc.test")
+	h := New(NewMemoryHandler(), nil, jwksSrv.URL, "ci-registry", "https://oidc.test")
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/", nil)
 	rec := httptest.NewRecorder()
@@ -59,7 +59,7 @@ func TestRegistry_PushPullBlob(t *testing.T) {
 	}))
 	defer jwksSrv.Close()
 
-	h := New(NewMemoryHandler(), jwksSrv.URL, "ci-registry", "https://oidc.test")
+	h := New(NewMemoryHandler(), nil, jwksSrv.URL, "ci-registry", "https://oidc.test")
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -93,7 +93,7 @@ func TestRegistry_OrgIsolation(t *testing.T) {
 	}))
 	defer jwksSrv.Close()
 
-	h := New(NewMemoryHandler(), jwksSrv.URL, "ci-registry", "https://oidc.test")
+	h := New(NewMemoryHandler(), nil, jwksSrv.URL, "ci-registry", "https://oidc.test")
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 

--- a/internal/registry/storage.go
+++ b/internal/registry/storage.go
@@ -8,9 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
+	"strings"
 	"sync"
 
 	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	gcrregistry "github.com/google/go-containerregistry/pkg/registry"
 )
@@ -190,4 +193,129 @@ func (g *GCSHandler) Delete(ctx context.Context, repo string, h v1.Hash) error {
 // isGCSNotFound reports whether err is a GCS "not found" error.
 func isGCSNotFound(err error) bool {
 	return errors.Is(err, storage.ErrObjectNotExist)
+}
+
+// ManifestStore handles durable manifest storage for the OCI registry.
+// Implementations must be safe for concurrent use.
+type ManifestStore interface {
+	// Get retrieves the manifest bytes and content-type for the given repo+ref.
+	// Returns errNotFound if absent.
+	Get(ctx context.Context, repo, ref string) (data []byte, contentType string, err error)
+	// Put stores the manifest bytes and content-type for the given repo+ref.
+	Put(ctx context.Context, repo, ref string, data []byte, contentType string) error
+	// Delete removes the manifest for the given repo+ref.
+	Delete(ctx context.Context, repo, ref string) error
+	// Tags returns the non-digest tag names for the given repo.
+	Tags(ctx context.Context, repo string) ([]string, error)
+	// Repos returns the names of all repositories that have at least one manifest.
+	Repos(ctx context.Context) ([]string, error)
+}
+
+// GCSManifestStore implements ManifestStore backed by Google Cloud Storage.
+// Manifests are stored as GCS objects keyed by <repo>/manifests/<ref>.
+// The OCI content-type is stored as the GCS object's ContentType.
+type GCSManifestStore struct {
+	bucket *storage.BucketHandle
+}
+
+// NewGCSManifestStore returns a GCSManifestStore that stores manifests in the
+// given GCS bucket.
+func NewGCSManifestStore(bucket *storage.BucketHandle) *GCSManifestStore {
+	return &GCSManifestStore{bucket: bucket}
+}
+
+func gcsManifestKey(repo, ref string) string {
+	return repo + "/manifests/" + ref
+}
+
+func (s *GCSManifestStore) Get(ctx context.Context, repo, ref string) ([]byte, string, error) {
+	obj := s.bucket.Object(gcsManifestKey(repo, ref))
+	rc, err := obj.NewReader(ctx)
+	if err != nil {
+		if isGCSNotFound(err) {
+			return nil, "", errNotFound
+		}
+		return nil, "", fmt.Errorf("gcs manifest get %s@%s: %w", repo, ref, err)
+	}
+	defer rc.Close()
+	contentType := rc.Attrs.ContentType
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, "", fmt.Errorf("gcs manifest read %s@%s: %w", repo, ref, err)
+	}
+	return data, contentType, nil
+}
+
+func (s *GCSManifestStore) Put(ctx context.Context, repo, ref string, data []byte, contentType string) error {
+	key := gcsManifestKey(repo, ref)
+	w := s.bucket.Object(key).NewWriter(ctx)
+	w.ObjectAttrs.ContentType = contentType
+	if _, err := io.Copy(w, bytes.NewReader(data)); err != nil {
+		_ = w.Close()
+		return fmt.Errorf("gcs manifest put %s@%s: write: %w", repo, ref, err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("gcs manifest put %s@%s: close: %w", repo, ref, err)
+	}
+	return nil
+}
+
+func (s *GCSManifestStore) Delete(ctx context.Context, repo, ref string) error {
+	key := gcsManifestKey(repo, ref)
+	if err := s.bucket.Object(key).Delete(ctx); err != nil {
+		if isGCSNotFound(err) {
+			return errNotFound
+		}
+		return fmt.Errorf("gcs manifest delete %s@%s: %w", repo, ref, err)
+	}
+	return nil
+}
+
+func (s *GCSManifestStore) Tags(ctx context.Context, repo string) ([]string, error) {
+	prefix := repo + "/manifests/"
+	it := s.bucket.Objects(ctx, &storage.Query{Prefix: prefix})
+	var tags []string
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("gcs list tags %s: %w", repo, err)
+		}
+		ref := strings.TrimPrefix(attrs.Name, prefix)
+		if ref == "" || strings.HasPrefix(ref, "sha256:") {
+			continue
+		}
+		tags = append(tags, ref)
+	}
+	sort.Strings(tags)
+	return tags, nil
+}
+
+func (s *GCSManifestStore) Repos(ctx context.Context) ([]string, error) {
+	it := s.bucket.Objects(ctx, &storage.Query{})
+	seen := make(map[string]bool)
+	var repos []string
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("gcs list repos: %w", err)
+		}
+		// Object key format: <repo>/manifests/<ref>
+		parts := strings.SplitN(attrs.Name, "/manifests/", 2)
+		if len(parts) != 2 || parts[1] == "" {
+			continue
+		}
+		repo := parts[0]
+		if !seen[repo] {
+			seen[repo] = true
+			repos = append(repos, repo)
+		}
+	}
+	sort.Strings(repos)
+	return repos, nil
 }


### PR DESCRIPTION
## Summary

- **Root cause**: The ci-registry used go-containerregistry's default in-memory manifest store alongside the GCS blob store. With 2 replicas, a manifest pushed to pod A was invisible to pod B; after any restart, all manifest refs were lost.
- **Fix**: Added a `ManifestStore` interface and `GCSManifestStore` implementation that stores each manifest as a GCS object at `<repo>/manifests/<ref>` (both tag and digest-addressed). Wired it into a new `manifestStoreMiddleware` that intercepts manifest/tags/catalog HTTP routes, completely bypassing go-containerregistry's in-memory store.
- **Backward compat**: `registry.New()` now accepts `ManifestStore` as a parameter; passing `nil` falls back to the existing in-memory behavior (used by all existing tests).

## Changes

- `internal/registry/storage.go`: `ManifestStore` interface + `GCSManifestStore` (Get/Put/Delete/Tags/Repos via GCS objects; content-type stored as GCS object ContentType)
- `internal/registry/registry.go`: `manifestStoreMiddleware` intercepts manifest/tags/catalog endpoints; `New()` signature updated
- `cmd/ci-registry/main.go`: wires `GCSManifestStore` using the same bucket as blobs
- `internal/registry/manifest_store_test.go`: unit tests for PUT/GET by tag+digest, HEAD not-found, DELETE, tags list, and the shared-state (two-replica) scenario

## Test plan

- [ ] All existing tests pass (`go test ./...`)
- [ ] `TestManifestMiddleware_SharedState` explicitly verifies that two handler instances backed by the same store share state
- [ ] Manual verification: deploy to staging with 2 replicas, push a BuildKit cache layer, kill the pushing pod, confirm cache is still accessible

## Opportunities (not in scope)

- GCS listing for `_catalog` and tags/list does a full bucket scan with a prefix; for very large deployments a GCS index object or Firestore would be more efficient
- `GCSManifestStore.Delete` currently only deletes the tag ref; a future PR could also clean up the associated digest ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)