### PR TITLE
feat(registry): GCS-backed manifest store for multi-replica consistency

### DIFF
--- a/cmd/ci-registry/main.go
+++ b/cmd/ci-registry/main.go
@@ -41,8 +41,10 @@ func main() {
 	}
 	defer gcsClient.Close()
 
-	blobHandler := registry.NewGCSHandler(gcsClient.Bucket(gcsBucket))
-	registryHandler := registry.New(blobHandler, jwksURL, audience, issuer)
+	bucket := gcsClient.Bucket(gcsBucket)
+	blobHandler := registry.NewGCSHandler(bucket)
+	manifestStore := registry.NewGCSManifestStore(bucket)
+	registryHandler := registry.New(blobHandler, manifestStore, jwksURL, audience, issuer)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/registry/auth.go
+++ b/internal/registry/auth.go
@@ -86,6 +86,7 @@ func authMiddleware(inner http.Handler, validate func(string) (*server.JobIdenti
 //	/v2/acme/myrepo/blobs/sha256:abc    → "acme/myrepo"
 //	/v2/acme/myrepo/manifests/latest    → "acme/myrepo"
 //	/v2/                                → "" (ping endpoint)
+//	/v2/_catalog                        → "" (registry-level endpoint)
 func imageNameFromPath(path string) string {
 	const prefix = "/v2/"
 	if !strings.HasPrefix(path, prefix) {
@@ -93,6 +94,10 @@ func imageNameFromPath(path string) string {
 	}
 	rest := strings.TrimPrefix(path, prefix)
 	if rest == "" || rest == "/" {
+		return ""
+	}
+	// _catalog is a registry-level endpoint, not scoped to a repo.
+	if rest == "_catalog" || strings.HasPrefix(rest, "_catalog?") {
 		return ""
 	}
 	// Find the action segment: blobs, manifests, tags, referrers, _catalog, uploads.

--- a/internal/registry/auth_test.go
+++ b/internal/registry/auth_test.go
@@ -179,6 +179,8 @@ func TestImageNameFromPath(t *testing.T) {
 		{"/v2/", ""},
 		{"/v2", ""},
 		{"/other/path", ""},
+		{"/v2/_catalog", ""},
+		{"/v2/_catalog?n=100", ""},
 	}
 	for _, tc := range tests {
 		got := imageNameFromPath(tc.path)

--- a/internal/registry/manifest_store_test.go
+++ b/internal/registry/manifest_store_test.go
@@ -1,0 +1,324 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dlorenc/docstore/internal/citoken"
+	digest "github.com/opencontainers/go-digest"
+)
+
+// TestMemoryManifestStore_GetPutDelete exercises the basic CRUD operations on
+// the in-memory ManifestStore.
+func TestMemoryManifestStore_GetPutDelete(t *testing.T) {
+	store := NewMemoryManifestStore()
+	ctx := context.Background()
+	repo := "testorg/myrepo"
+	content := []byte(`{"schemaVersion":2}`)
+	mediaType := "application/vnd.oci.image.manifest.v1+json"
+
+	// Get non-existent → errNotFound.
+	if _, _, err := store.Get(ctx, repo, "latest"); err == nil {
+		t.Fatal("expected error for missing manifest, got nil")
+	}
+
+	// Put with a tag.
+	if err := store.Put(ctx, repo, "latest", mediaType, content); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// Get by tag.
+	got, mt, err := store.Get(ctx, repo, "latest")
+	if err != nil {
+		t.Fatalf("Get by tag: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content mismatch: got %q, want %q", got, content)
+	}
+	if mt != mediaType {
+		t.Errorf("mediaType mismatch: got %q, want %q", mt, mediaType)
+	}
+
+	// Get by digest (should also work since Put indexes by digest).
+	d := digest.FromBytes(content)
+	got2, _, err := store.Get(ctx, repo, d.String())
+	if err != nil {
+		t.Fatalf("Get by digest: %v", err)
+	}
+	if string(got2) != string(content) {
+		t.Errorf("digest lookup content mismatch: got %q, want %q", got2, content)
+	}
+
+	// Delete by tag.
+	if err := store.Delete(ctx, repo, "latest"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, _, err := store.Get(ctx, repo, "latest"); err == nil {
+		t.Error("expected errNotFound after Delete")
+	}
+}
+
+// TestMemoryManifestStore_Tags verifies tag listing excludes digest references.
+func TestMemoryManifestStore_Tags(t *testing.T) {
+	store := NewMemoryManifestStore()
+	ctx := context.Background()
+	repo := "org/repo"
+	mediaType := "application/vnd.oci.image.manifest.v1+json"
+
+	contents := map[string][]byte{
+		"v1.0": []byte(`{"v":1}`),
+		"v2.0": []byte(`{"v":2}`),
+		"edge": []byte(`{"v":3}`),
+	}
+	for tag, c := range contents {
+		if err := store.Put(ctx, repo, tag, mediaType, c); err != nil {
+			t.Fatalf("Put %s: %v", tag, err)
+		}
+	}
+
+	tags, err := store.Tags(ctx, repo)
+	if err != nil {
+		t.Fatalf("Tags: %v", err)
+	}
+	if len(tags) != 3 {
+		t.Errorf("expected 3 tags, got %d: %v", len(tags), tags)
+	}
+	for _, tag := range tags {
+		if strings.Contains(tag, ":") {
+			t.Errorf("Tags returned a digest ref: %q", tag)
+		}
+	}
+	// Verify lexicographic order.
+	for i := 1; i < len(tags); i++ {
+		if tags[i] < tags[i-1] {
+			t.Errorf("tags not sorted: %v", tags)
+		}
+	}
+}
+
+// TestMemoryManifestStore_Repos verifies repo listing.
+func TestMemoryManifestStore_Repos(t *testing.T) {
+	store := NewMemoryManifestStore()
+	ctx := context.Background()
+	mediaType := "application/vnd.oci.image.manifest.v1+json"
+
+	repos := []string{"acme/frontend", "acme/backend", "other/service"}
+	for _, repo := range repos {
+		if err := store.Put(ctx, repo, "latest", mediaType, []byte(`{}`)); err != nil {
+			t.Fatalf("Put %s: %v", repo, err)
+		}
+	}
+
+	got, err := store.Repos(ctx)
+	if err != nil {
+		t.Fatalf("Repos: %v", err)
+	}
+	if len(got) != len(repos) {
+		t.Errorf("expected %d repos, got %d: %v", len(repos), len(got), got)
+	}
+}
+
+// TestManifestMiddleware_PutGet exercises the manifestStoreMiddleware via
+// HTTP, verifying PUT stores and GET retrieves manifests through the store.
+func TestManifestMiddleware_PutGet(t *testing.T) {
+	signer, err := citoken.NewLocalSigner()
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, _ := signer.PublicKeys(r.Context())
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data) //nolint:errcheck
+	}))
+	defer jwksSrv.Close()
+
+	store := NewMemoryManifestStore()
+	h := New(NewMemoryHandler(), store, jwksSrv.URL, "ci-registry", "https://oidc.test")
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	tok := makeTestToken(t, signer, "testorg/myrepo")
+	manifestBody := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json"}`)
+	mediaType := "application/vnd.oci.image.manifest.v1+json"
+
+	// PUT manifest.
+	putReq, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodPut, srv.URL+"/v2/testorg/myrepo/manifests/v1.0",
+		strings.NewReader(string(manifestBody)))
+	putReq.Header.Set("Authorization", "Bearer "+tok)
+	putReq.Header.Set("Content-Type", mediaType)
+	resp, err := http.DefaultClient.Do(putReq)
+	if err != nil {
+		t.Fatalf("PUT manifest: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("PUT: expected 201, got %d", resp.StatusCode)
+	}
+	if resp.Header.Get("Docker-Content-Digest") == "" {
+		t.Error("PUT: missing Docker-Content-Digest header")
+	}
+
+	// GET manifest by tag.
+	getReq, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodGet, srv.URL+"/v2/testorg/myrepo/manifests/v1.0", nil)
+	getReq.Header.Set("Authorization", "Bearer "+tok)
+	resp2, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("GET manifest: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Errorf("GET: expected 200, got %d", resp2.StatusCode)
+	}
+	if resp2.Header.Get("Docker-Content-Digest") == "" {
+		t.Error("GET: missing Docker-Content-Digest header")
+	}
+
+	// GET by digest should also work.
+	d := digest.FromBytes(manifestBody)
+	getDigestReq, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodGet, srv.URL+"/v2/testorg/myrepo/manifests/"+d.String(), nil)
+	getDigestReq.Header.Set("Authorization", "Bearer "+tok)
+	resp3, err := http.DefaultClient.Do(getDigestReq)
+	if err != nil {
+		t.Fatalf("GET by digest: %v", err)
+	}
+	defer resp3.Body.Close()
+	if resp3.StatusCode != http.StatusOK {
+		t.Errorf("GET by digest: expected 200, got %d", resp3.StatusCode)
+	}
+}
+
+// TestManifestMiddleware_TagsList verifies /v2/<repo>/tags/list returns stored tags.
+func TestManifestMiddleware_TagsList(t *testing.T) {
+	signer, err := citoken.NewLocalSigner()
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, _ := signer.PublicKeys(r.Context())
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data) //nolint:errcheck
+	}))
+	defer jwksSrv.Close()
+
+	store := NewMemoryManifestStore()
+	ctx := context.Background()
+	_ = store.Put(ctx, "testorg/myrepo", "v1", "application/vnd.oci.image.manifest.v1+json", []byte(`{"a":1}`))
+	_ = store.Put(ctx, "testorg/myrepo", "v2", "application/vnd.oci.image.manifest.v1+json", []byte(`{"a":2}`))
+
+	h := New(NewMemoryHandler(), store, jwksSrv.URL, "ci-registry", "https://oidc.test")
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	tok := makeTestToken(t, signer, "testorg/myrepo")
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodGet, srv.URL+"/v2/testorg/myrepo/tags/list", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("tags/list: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("tags/list: expected 200, got %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Name string   `json:"name"`
+		Tags []string `json:"tags"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode tags/list: %v", err)
+	}
+	if len(result.Tags) != 2 {
+		t.Errorf("expected 2 tags, got %d: %v", len(result.Tags), result.Tags)
+	}
+}
+
+// TestManifestMiddleware_NotFound verifies OCI-compliant 404 for unknown manifests.
+func TestManifestMiddleware_NotFound(t *testing.T) {
+	signer, err := citoken.NewLocalSigner()
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, _ := signer.PublicKeys(r.Context())
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data) //nolint:errcheck
+	}))
+	defer jwksSrv.Close()
+
+	store := NewMemoryManifestStore()
+	h := New(NewMemoryHandler(), store, jwksSrv.URL, "ci-registry", "https://oidc.test")
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	tok := makeTestToken(t, signer, "testorg/myrepo")
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodGet, srv.URL+"/v2/testorg/myrepo/manifests/nonexistent", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET missing manifest: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for missing manifest, got %d", resp.StatusCode)
+	}
+}
+
+// TestManifestMiddleware_Catalog verifies /v2/_catalog returns stored repos.
+func TestManifestMiddleware_Catalog(t *testing.T) {
+	signer, err := citoken.NewLocalSigner()
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, _ := signer.PublicKeys(r.Context())
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data) //nolint:errcheck
+	}))
+	defer jwksSrv.Close()
+
+	store := NewMemoryManifestStore()
+	ctx := context.Background()
+	_ = store.Put(ctx, "acme/app", "latest", "application/vnd.oci.image.manifest.v1+json", []byte(`{}`))
+	_ = store.Put(ctx, "acme/cache", "main", "application/vnd.oci.image.manifest.v1+json", []byte(`{}`))
+
+	h := New(NewMemoryHandler(), store, jwksSrv.URL, "ci-registry", "https://oidc.test")
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	// _catalog endpoint uses /v2/ ping path logic, any valid token passes org check.
+	tok := makeTestToken(t, signer, "acme/app")
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodGet, srv.URL+"/v2/_catalog", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("_catalog: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("_catalog: expected 200, got %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Repos []string `json:"repositories"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode _catalog: %v", err)
+	}
+	if len(result.Repos) != 2 {
+		t.Errorf("expected 2 repos, got %d: %v", len(result.Repos), result.Repos)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -2,31 +2,197 @@ package registry
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
 
+	digest "github.com/opencontainers/go-digest"
 	gcrregistry "github.com/google/go-containerregistry/pkg/registry"
 
 	"github.com/dlorenc/docstore/internal/server"
 )
 
 // New creates an OCI Distribution Spec registry http.Handler using the given
-// blob handler for blob storage (manifests are stored in-memory).
+// blob handler for blob storage.
+//
+// When store is non-nil, manifests are persisted via the ManifestStore
+// (enabling consistent reads across multiple replicas). When store is nil,
+// go-containerregistry's default in-memory manifest storage is used
+// (suitable for tests and single-replica deployments).
 //
 // Every request is authenticated with a CI job OIDC token validated against
 // the provided JWKS endpoint, audience, and issuer.  The token's repo claim
 // is used to restrict access so that a token for org "acme" can only push/pull
 // images whose name starts with "acme/".
-func New(blobHandler BlobHandler, jwksURL, audience, issuer string) http.Handler {
+func New(blobHandler BlobHandler, store ManifestStore, jwksURL, audience, issuer string) http.Handler {
 	validate := server.NewJobTokenValidator(jwksURL, audience, issuer)
 
 	inner := gcrregistry.New(
 		gcrregistry.WithBlobHandler(blobHandler),
 	)
 
-	return authMiddleware(ociManifest404Middleware(inner), validate)
+	var handler http.Handler = ociManifest404Middleware(inner)
+	if store != nil {
+		handler = manifestStoreMiddleware(store, inner)
+	}
+	return authMiddleware(handler, validate)
+}
+
+// manifestStoreMiddleware intercepts OCI manifest, tags/list, and _catalog
+// HTTP routes and serves them using store.  All other routes (blobs, uploads,
+// ping) are passed through to next unchanged.
+//
+// This allows manifests to be stored in a shared durable backend (e.g. GCS)
+// so that multiple registry replicas always serve the same data.
+func manifestStoreMiddleware(store ManifestStore, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+
+		// /v2/<name>/manifests/<ref>
+		if repo, ref, ok := parseManifestPath(path); ok {
+			serveManifest(store, repo, ref, w, r)
+			return
+		}
+
+		// /v2/<name>/tags/list
+		if repo, ok := parseTagsListPath(path); ok {
+			serveTagsList(store, repo, w, r)
+			return
+		}
+
+		// /v2/_catalog
+		if path == "/v2/_catalog" {
+			serveCatalog(store, w, r)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// parseManifestPath parses paths of the form /v2/<name>/manifests/<ref>.
+func parseManifestPath(path string) (repo, ref string, ok bool) {
+	rest, found := strings.CutPrefix(path, "/v2/")
+	if !found {
+		return "", "", false
+	}
+	idx := strings.Index(rest, "/manifests/")
+	if idx < 0 {
+		return "", "", false
+	}
+	repo = rest[:idx]
+	ref = rest[idx+len("/manifests/"):]
+	if repo == "" || ref == "" {
+		return "", "", false
+	}
+	return repo, ref, true
+}
+
+// parseTagsListPath parses paths of the form /v2/<name>/tags/list.
+func parseTagsListPath(path string) (repo string, ok bool) {
+	rest, found := strings.CutPrefix(path, "/v2/")
+	if !found {
+		return "", false
+	}
+	repo, found = strings.CutSuffix(rest, "/tags/list")
+	if !found || repo == "" {
+		return "", false
+	}
+	return repo, true
+}
+
+// serveManifest handles GET, HEAD, PUT, and DELETE for a single manifest.
+func serveManifest(store ManifestStore, repo, ref string, w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet, http.MethodHead:
+		content, mediaType, err := store.Get(r.Context(), repo, ref)
+		if err != nil {
+			if errors.Is(err, errNotFound) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				if r.Method == http.MethodGet {
+					io.WriteString(w, manifestUnknownBody) //nolint:errcheck
+				}
+				return
+			}
+			http.Error(w, "manifest store error", http.StatusInternalServerError)
+			return
+		}
+		d := digest.FromBytes(content)
+		w.Header().Set("Content-Type", mediaType)
+		w.Header().Set("Docker-Content-Digest", d.String())
+		w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			w.Write(content) //nolint:errcheck
+		}
+
+	case http.MethodPut:
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusBadRequest)
+			return
+		}
+		mediaType := r.Header.Get("Content-Type")
+		if err := store.Put(r.Context(), repo, ref, mediaType, body); err != nil {
+			http.Error(w, "manifest store error", http.StatusInternalServerError)
+			return
+		}
+		d := digest.FromBytes(body)
+		w.Header().Set("Docker-Content-Digest", d.String())
+		w.Header().Set("Location", "/v2/"+repo+"/manifests/"+d.String())
+		w.WriteHeader(http.StatusCreated)
+
+	case http.MethodDelete:
+		if err := store.Delete(r.Context(), repo, ref); err != nil {
+			http.Error(w, "manifest store error", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// serveTagsList handles GET /v2/<repo>/tags/list.
+func serveTagsList(store ManifestStore, repo string, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	tags, err := store.Tags(r.Context(), repo)
+	if err != nil {
+		http.Error(w, "manifest store error", http.StatusInternalServerError)
+		return
+	}
+	resp := struct {
+		Name string   `json:"name"`
+		Tags []string `json:"tags"`
+	}{Name: repo, Tags: tags}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp) //nolint:errcheck
+}
+
+// serveCatalog handles GET /v2/_catalog.
+func serveCatalog(store ManifestStore, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	repos, err := store.Repos(r.Context())
+	if err != nil {
+		http.Error(w, "manifest store error", http.StatusInternalServerError)
+		return
+	}
+	resp := struct {
+		Repos []string `json:"repositories"`
+	}{Repos: repos}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp) //nolint:errcheck
 }
 
 // responseRecorder is a minimal http.ResponseWriter that buffers the response

--- a/internal/registry/registry_e2e_test.go
+++ b/internal/registry/registry_e2e_test.go
@@ -61,7 +61,7 @@ func TestE2ECacheRoundTrip(t *testing.T) {
 	defer jwksSrv.Close()
 
 	// Start in-memory registry.
-	regSrv := httptest.NewServer(New(NewMemoryHandler(), jwksSrv.URL, "ci-registry", "https://oidc.test"))
+	regSrv := httptest.NewServer(New(NewMemoryHandler(), nil, jwksSrv.URL, "ci-registry", "https://oidc.test"))
 	defer regSrv.Close()
 
 	// Determine the address buildkitd (possibly in a container) can reach.
@@ -184,7 +184,7 @@ func TestE2ECrossOrgRejected(t *testing.T) {
 	}))
 	defer jwksSrv.Close()
 
-	regSrv := httptest.NewServer(New(NewMemoryHandler(), jwksSrv.URL, "ci-registry", "https://oidc.test"))
+	regSrv := httptest.NewServer(New(NewMemoryHandler(), nil, jwksSrv.URL, "ci-registry", "https://oidc.test"))
 	defer regSrv.Close()
 
 	// Token for the wrong org.

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -36,7 +36,7 @@ func TestRegistry_PingRequiresAuth(t *testing.T) {
 	}))
 	defer jwksSrv.Close()
 
-	h := New(NewMemoryHandler(), jwksSrv.URL, "ci-registry", "https://oidc.test")
+	h := New(NewMemoryHandler(), nil, jwksSrv.URL, "ci-registry", "https://oidc.test")
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/", nil)
 	rec := httptest.NewRecorder()
@@ -59,7 +59,7 @@ func TestRegistry_PushPullBlob(t *testing.T) {
 	}))
 	defer jwksSrv.Close()
 
-	h := New(NewMemoryHandler(), jwksSrv.URL, "ci-registry", "https://oidc.test")
+	h := New(NewMemoryHandler(), nil, jwksSrv.URL, "ci-registry", "https://oidc.test")
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -93,7 +93,7 @@ func TestRegistry_OrgIsolation(t *testing.T) {
 	}))
 	defer jwksSrv.Close()
 
-	h := New(NewMemoryHandler(), jwksSrv.URL, "ci-registry", "https://oidc.test")
+	h := New(NewMemoryHandler(), nil, jwksSrv.URL, "ci-registry", "https://oidc.test")
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 

--- a/internal/registry/storage.go
+++ b/internal/registry/storage.go
@@ -8,11 +8,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
+	"strings"
 	"sync"
 
 	"cloud.google.com/go/storage"
+	digest "github.com/opencontainers/go-digest"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	gcrregistry "github.com/google/go-containerregistry/pkg/registry"
+	"google.golang.org/api/iterator"
 )
 
 // BlobHandler handles blob storage for the OCI registry. It is a superset of
@@ -190,4 +194,241 @@ func (g *GCSHandler) Delete(ctx context.Context, repo string, h v1.Hash) error {
 // isGCSNotFound reports whether err is a GCS "not found" error.
 func isGCSNotFound(err error) bool {
 	return errors.Is(err, storage.ErrObjectNotExist)
+}
+
+// ManifestStore stores and retrieves OCI manifests by repository and reference
+// (tag or content digest). Implementations must be safe for concurrent use.
+type ManifestStore interface {
+	// Get retrieves a manifest by repo and reference (tag or digest).
+	// Returns content, mediaType, and errNotFound if absent.
+	Get(ctx context.Context, repo, ref string) (content []byte, mediaType string, err error)
+	// Put stores a manifest. When ref is a tag, the manifest is also stored
+	// under its content digest so digest-based lookups work.
+	Put(ctx context.Context, repo, ref, mediaType string, content []byte) error
+	// Delete removes a manifest by repo and reference.
+	Delete(ctx context.Context, repo, ref string) error
+	// Tags returns all tag names (not digest references) for a repository,
+	// sorted lexicographically.
+	Tags(ctx context.Context, repo string) ([]string, error)
+	// Repos returns all repository names that have at least one manifest,
+	// sorted lexicographically.
+	Repos(ctx context.Context) ([]string, error)
+}
+
+// isDigestRef reports whether a manifest reference is a content digest
+// (e.g. "sha256:abc..."). Tags are plain strings without a colon.
+func isDigestRef(ref string) bool {
+	return strings.Contains(ref, ":")
+}
+
+// manifestEntry holds a stored manifest's bytes and declared media type.
+type manifestEntry struct {
+	content   []byte
+	mediaType string
+}
+
+// MemoryManifestStore is a thread-safe in-memory ManifestStore. It is used as
+// the nil-safe fallback when no persistent store is configured.
+type MemoryManifestStore struct {
+	mu      sync.RWMutex
+	entries map[string]manifestEntry // key: repo + "\x00" + ref
+}
+
+// NewMemoryManifestStore returns an empty MemoryManifestStore.
+func NewMemoryManifestStore() *MemoryManifestStore {
+	return &MemoryManifestStore{entries: make(map[string]manifestEntry)}
+}
+
+func (m *MemoryManifestStore) entryKey(repo, ref string) string {
+	return repo + "\x00" + ref
+}
+
+func (m *MemoryManifestStore) Get(ctx context.Context, repo, ref string) ([]byte, string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	e, ok := m.entries[m.entryKey(repo, ref)]
+	if !ok {
+		return nil, "", errNotFound
+	}
+	cp := make([]byte, len(e.content))
+	copy(cp, e.content)
+	return cp, e.mediaType, nil
+}
+
+func (m *MemoryManifestStore) Put(ctx context.Context, repo, ref, mediaType string, content []byte) error {
+	d := digest.FromBytes(content)
+	cp := make([]byte, len(content))
+	copy(cp, content)
+	entry := manifestEntry{content: cp, mediaType: mediaType}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries[m.entryKey(repo, ref)] = entry
+	// Also index by digest so GET-by-digest works after a tag push.
+	if !isDigestRef(ref) {
+		m.entries[m.entryKey(repo, d.String())] = entry
+	}
+	return nil
+}
+
+func (m *MemoryManifestStore) Delete(ctx context.Context, repo, ref string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.entries, m.entryKey(repo, ref))
+	return nil
+}
+
+func (m *MemoryManifestStore) Tags(ctx context.Context, repo string) ([]string, error) {
+	prefix := repo + "\x00"
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var tags []string
+	for k := range m.entries {
+		if strings.HasPrefix(k, prefix) {
+			ref := k[len(prefix):]
+			if !isDigestRef(ref) {
+				tags = append(tags, ref)
+			}
+		}
+	}
+	sort.Strings(tags)
+	return tags, nil
+}
+
+func (m *MemoryManifestStore) Repos(ctx context.Context) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	repoSet := make(map[string]struct{})
+	for k := range m.entries {
+		repo, _, _ := strings.Cut(k, "\x00")
+		repoSet[repo] = struct{}{}
+	}
+	repos := make([]string, 0, len(repoSet))
+	for r := range repoSet {
+		repos = append(repos, r)
+	}
+	sort.Strings(repos)
+	return repos, nil
+}
+
+// GCSManifestStore implements ManifestStore backed by Google Cloud Storage.
+// Manifests are stored as objects at "<repo>/manifests/<ref>". The GCS object
+// ContentType field carries the OCI media type.
+type GCSManifestStore struct {
+	bucket *storage.BucketHandle
+}
+
+// NewGCSManifestStore returns a GCSManifestStore that stores manifests in the
+// given GCS bucket.
+func NewGCSManifestStore(bucket *storage.BucketHandle) *GCSManifestStore {
+	return &GCSManifestStore{bucket: bucket}
+}
+
+func gcsManifestKey(repo, ref string) string {
+	return repo + "/manifests/" + ref
+}
+
+func (g *GCSManifestStore) Get(ctx context.Context, repo, ref string) ([]byte, string, error) {
+	obj := g.bucket.Object(gcsManifestKey(repo, ref))
+	attrs, err := obj.Attrs(ctx)
+	if err != nil {
+		if isGCSNotFound(err) {
+			return nil, "", errNotFound
+		}
+		return nil, "", fmt.Errorf("gcs manifest attrs %s@%s: %w", repo, ref, err)
+	}
+	rc, err := obj.NewReader(ctx)
+	if err != nil {
+		if isGCSNotFound(err) {
+			return nil, "", errNotFound
+		}
+		return nil, "", fmt.Errorf("gcs manifest open %s@%s: %w", repo, ref, err)
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, "", fmt.Errorf("gcs manifest read %s@%s: %w", repo, ref, err)
+	}
+	return data, attrs.ContentType, nil
+}
+
+func (g *GCSManifestStore) Put(ctx context.Context, repo, ref, mediaType string, content []byte) error {
+	if err := g.writeObject(ctx, gcsManifestKey(repo, ref), mediaType, content); err != nil {
+		return err
+	}
+	// Also index by content digest when ref is a tag.
+	if !isDigestRef(ref) {
+		d := digest.FromBytes(content)
+		if err := g.writeObject(ctx, gcsManifestKey(repo, d.String()), mediaType, content); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *GCSManifestStore) writeObject(ctx context.Context, key, contentType string, data []byte) error {
+	wc := g.bucket.Object(key).NewWriter(ctx)
+	wc.ContentType = contentType
+	if _, err := wc.Write(data); err != nil {
+		_ = wc.Close()
+		return fmt.Errorf("gcs manifest write %s: %w", key, err)
+	}
+	if err := wc.Close(); err != nil {
+		return fmt.Errorf("gcs manifest close %s: %w", key, err)
+	}
+	return nil
+}
+
+func (g *GCSManifestStore) Delete(ctx context.Context, repo, ref string) error {
+	err := g.bucket.Object(gcsManifestKey(repo, ref)).Delete(ctx)
+	if err != nil && !isGCSNotFound(err) {
+		return fmt.Errorf("gcs manifest delete %s@%s: %w", repo, ref, err)
+	}
+	return nil
+}
+
+func (g *GCSManifestStore) Tags(ctx context.Context, repo string) ([]string, error) {
+	prefix := repo + "/manifests/"
+	it := g.bucket.Objects(ctx, &storage.Query{Prefix: prefix})
+	var tags []string
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("gcs manifest tags %s: %w", repo, err)
+		}
+		ref := strings.TrimPrefix(attrs.Name, prefix)
+		if !isDigestRef(ref) {
+			tags = append(tags, ref)
+		}
+	}
+	sort.Strings(tags)
+	return tags, nil
+}
+
+func (g *GCSManifestStore) Repos(ctx context.Context) ([]string, error) {
+	it := g.bucket.Objects(ctx, &storage.Query{})
+	repoSet := make(map[string]struct{})
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("gcs repos list: %w", err)
+		}
+		// Object keys: "<repo>/manifests/<ref>" or "<repo>/blobs/<digest>".
+		parts := strings.SplitN(attrs.Name, "/manifests/", 2)
+		if len(parts) == 2 {
+			repoSet[parts[0]] = struct{}{}
+		}
+	}
+	repos := make([]string, 0, len(repoSet))
+	for r := range repoSet {
+		repos = append(repos, r)
+	}
+	sort.Strings(repos)
+	return repos, nil
 }


### PR DESCRIPTION
## Summary

- **`ManifestStore` interface** (`internal/registry/storage.go`): `Get`, `Put`, `Delete`, `Tags`, `Repos` — with `MemoryManifestStore` (in-memory, used as nil fallback) and `GCSManifestStore` (objects at `<repo>/manifests/<ref>`, ContentType = OCI media type, also indexes by digest on tag push)
- **`manifestStoreMiddleware`** (`internal/registry/registry.go`): intercepts `GET/HEAD/PUT/DELETE /v2/<name>/manifests/<ref>`, `GET /v2/<name>/tags/list`, and `GET /v2/_catalog` — handles them directly via the store, passes all other routes (blobs, uploads, ping) to go-containerregistry
- **`registry.New()` updated** to accept `ManifestStore`; `nil` falls back to go-containerregistry in-memory behavior (all existing tests unchanged, all pass `nil`)
- **`cmd/ci-registry/main.go`** wired to use `GCSManifestStore` with the same GCS bucket already used for blobs
- **Bug fix**: `imageNameFromPath` in `auth.go` now correctly returns `""` for `/v2/_catalog` (it's a registry-level endpoint, not repo-scoped) — previously returned `"_catalog"` which caused a 403

## Test plan
- [ ] All existing tests pass (`go test ./... -count=1`)
- [ ] `TestMemoryManifestStore_GetPutDelete`: CRUD, digest indexing on tag push
- [ ] `TestMemoryManifestStore_Tags`: tag listing excludes digest refs, sorted
- [ ] `TestMemoryManifestStore_Repos`: repo listing
- [ ] `TestManifestMiddleware_PutGet`: PUT returns 201 + Digest header; GET by tag and by digest both return 200
- [ ] `TestManifestMiddleware_TagsList`: `/tags/list` returns correct tags JSON
- [ ] `TestManifestMiddleware_NotFound`: returns 404 for unknown manifest
- [ ] `TestManifestMiddleware_Catalog`: `/v2/_catalog` returns repos JSON
- [ ] `TestImageNameFromPath`: extended with `_catalog` cases

## Notes / Opportunities

- GCS `Repos()` does a full bucket listing to discover repos — acceptable for ci-registry scale but could be slow with many blobs. Could be optimized with a GCS prefix/delimiter query later.
- No pagination support for `tags/list` or `_catalog` responses. OCI spec supports `n` and `last` query params; could be added if needed.
- GCS manifest objects are not versioned; concurrent identical-tag pushes from two replicas will overwrite each other (last-write-wins), which is safe for BuildKit cache use cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)