### PR TITLE
feat(ui): add Docs nav link and root redirect to /ui/

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -302,6 +302,9 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 	outer := http.NewServeMux()
 	outer.HandleFunc("GET /healthz", handleHealth)
 	outer.HandleFunc("GET /.well-known/ds-config", s.handleDSConfig)
+	outer.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/ui/", http.StatusFound)
+	})
 
 	// All other routes require IAP authentication.
 	inner := http.NewServeMux()

--- a/internal/ui/static/styles.css
+++ b/internal/ui/static/styles.css
@@ -65,6 +65,8 @@ nav.top .crumbs a:hover { color: var(--text); text-decoration: none; }
 nav.top .crumbs .sep { margin: 0 8px; color: var(--text-dim); opacity: 0.5; }
 nav.top .spacer { flex: 1; }
 nav.top .nav-identity { font-size: 11px; color: var(--text-dim); opacity: 0.7; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 220px; }
+nav.top .nav-docs { font-size: 11px; color: var(--text-dim); opacity: 0.7; white-space: nowrap; text-decoration: none; }
+nav.top .nav-docs:hover { opacity: 1; color: var(--text); text-decoration: none; }
 nav.top .theme-toggle {
   background: transparent;
   color: var(--text-dim);

--- a/internal/ui/templates/layout.html
+++ b/internal/ui/templates/layout.html
@@ -16,6 +16,7 @@
   {{range $i, $c := .Breadcrumbs}}{{if $i}}<span class="sep">›</span>{{end}}{{if $c.Href}}<a href="{{$c.Href}}">{{$c.Label}}</a>{{else}}{{$c.Label}}{{end}}{{end}}
   </span>
   <span class="spacer"></span>
+  <a href="https://docs.docstore.dev" class="nav-docs" target="_blank" rel="noopener">Docs</a>
   {{if .Identity}}<a href="/ui/u/{{.Identity}}" class="nav-identity" title="Signed in as {{.Identity}}">{{.Identity}}</a>{{end}}
   <button class="theme-toggle" data-theme-toggle type="button" aria-label="Toggle theme" title="Toggle theme"><span data-theme-icon-dark>☾</span><span data-theme-icon-light>☀</span></button>
 </nav>


### PR DESCRIPTION
## Summary

- Adds a **Docs** link (`<a class="nav-docs">`) in `internal/ui/templates/layout.html` between the spacer and the identity link, pointing to `https://docs.docstore.dev` with `target="_blank" rel="noopener"`
- Styles `.nav-docs` in `internal/ui/static/styles.css` to match the existing `.nav-identity` quiet/muted appearance (11px, `--text-dim`, 0.7 opacity, hover brightens)
- Registers `GET /{$}` on the outer mux in `internal/server/server.go` to 302-redirect the bare root to `/ui/`, so visiting `docstore.dev` sends humans to the UI instead of a 404

## Test plan

- [x] All existing tests pass (`go test ./... -count=1`)
- [x] Build and vet clean (`go build ./... && go vet ./...`)
- [ ] Manual: nav bar shows "Docs" link that opens docs site in new tab
- [ ] Manual: `GET /` returns 302 → `/ui/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)