### PR TITLE
feat(infra): add api.docstore.dev domain to docstore LB (#412)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
             --service-account=docstore-server@dlorenc-chainguard.iam.gserviceaccount.com \
             --add-cloudsql-instances=dlorenc-chainguard:us-central1:docstore-mvp \
             --update-secrets=DATABASE_URL=docstore-db-url:latest,IAP_CLIENT_SECRET=iap-oauth-client-secret:latest,ARCHIVE_HMAC_SECRET=archive-hmac-secret:latest \
-            --set-env-vars=ARCHIVE_BASE_URL=https://docstore-efuj4cj54a-uc.a.run.app,OIDC_JWKS_URL=https://oidc.docstore.dev/.well-known/jwks.json,OIDC_AUDIENCE=docstore,OIDC_ISSUER=https://oidc.docstore.dev \
+            --set-env-vars=ARCHIVE_BASE_URL=https://api.docstore.dev,OIDC_JWKS_URL=https://oidc.docstore.dev/.well-known/jwks.json,OIDC_AUDIENCE=docstore,OIDC_ISSUER=https://oidc.docstore.dev \
             --ingress=internal-and-cloud-load-balancing \
             --min-instances=1 \
             --max-instances=1 \

--- a/deploy/k8s/ci-scheduler.yaml
+++ b/deploy/k8s/ci-scheduler.yaml
@@ -41,7 +41,7 @@ spec:
         image: us-central1-docker.pkg.dev/dlorenc-chainguard/images/ci-scheduler:latest
         env:
         - name: DOCSTORE_URL
-          value: https://docstore-efuj4cj54a-uc.a.run.app
+          value: https://api.docstore.dev
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/deploy/k8s/ci-worker.yaml
+++ b/deploy/k8s/ci-worker.yaml
@@ -46,7 +46,7 @@ spec:
             privileged: true
           env:
           - name: DOCSTORE_URL
-            value: https://docstore-efuj4cj54a-uc.a.run.app
+            value: https://api.docstore.dev
           - name: CI_SCHEDULER_URL
             value: http://ci-scheduler.docstore-ci.svc.cluster.local:8080
           ports:


### PR DESCRIPTION
## Summary

- Added DNS A record for `api.docstore.dev → 34.54.166.224` in the `docstore-dev` Cloud DNS zone
- Created Google-managed SSL cert `docstore-cert-v2` covering both `docstore.dev` and `api.docstore.dev`; attached to `docstore-https-proxy` alongside `docstore-cert` (old cert retained until new one is ACTIVE)
- Updated `DOCSTORE_URL` in `deploy/k8s/ci-worker.yaml` and `deploy/k8s/ci-scheduler.yaml` from internal Cloud Run URL → `https://api.docstore.dev`
- Updated `ARCHIVE_BASE_URL` in `.github/workflows/deploy.yml` → `https://api.docstore.dev`

## Infrastructure steps already applied

```
gcloud dns record-sets create api.docstore.dev. --zone=docstore-dev --type=A --ttl=300 --rrdatas=34.54.166.224 --project=dlorenc-chainguard
gcloud compute ssl-certificates create docstore-cert-v2 --domains=docstore.dev,api.docstore.dev --global --project=dlorenc-chainguard
gcloud compute target-https-proxies update docstore-https-proxy --ssl-certificates=docstore-cert,docstore-cert-v2 --global --project=dlorenc-chainguard
```

`docstore-cert-v2` is currently PROVISIONING. Once it reaches ACTIVE status, `docstore-cert` can be removed in a follow-up.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` all pass

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)