### PR TITLE
feat(ci): implement archive content checksum for BuildKit cache hits (Option B)

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -221,35 +221,38 @@ func heartbeat(ctx context.Context, schedulerURL, jobID, requestToken string, do
 // ---------------------------------------------------------------------------
 
 // getPresignedArchiveURL calls POST /repos/{repo}/-/archive/presign with the
-// request_token and returns the presigned URL for BuildKit to fetch the archive.
-// This endpoint bypasses IAP and uses the request_token for authentication.
-func getPresignedArchiveURL(ctx context.Context, docstoreURL, repo, requestToken string) (string, error) {
+// request_token and returns the presigned URL and content checksum for BuildKit
+// to fetch the archive. This endpoint bypasses IAP and uses the request_token
+// for authentication. checksum may be empty if the server has not yet been
+// upgraded to return it (backwards compatible).
+func getPresignedArchiveURL(ctx context.Context, docstoreURL, repo, requestToken string) (archiveURL, checksum string, err error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	u := fmt.Sprintf("%s/repos/%s/-/archive/presign", docstoreURL, repo)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
 	if err != nil {
-		return "", fmt.Errorf("build presign request: %w", err)
+		return "", "", fmt.Errorf("build presign request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+requestToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("presign request: %w", err)
+		return "", "", fmt.Errorf("presign request: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("presign: unexpected status %d", resp.StatusCode)
+		return "", "", fmt.Errorf("presign: unexpected status %d", resp.StatusCode)
 	}
 	var body struct {
-		URL string `json:"url"`
+		URL      string `json:"url"`
+		Checksum string `json:"checksum"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return "", fmt.Errorf("decode presign response: %w", err)
+		return "", "", fmt.Errorf("decode presign response: %w", err)
 	}
 	if body.URL == "" {
-		return "", fmt.Errorf("presign: empty URL in response")
+		return "", "", fmt.Errorf("presign: empty URL in response")
 	}
-	return body.URL, nil
+	return body.URL, body.Checksum, nil
 }
 
 // postCheckLogs uploads the logs for a check run to the docstore server via
@@ -559,7 +562,7 @@ func runJob(
 	}
 
 	// 2. Obtain a presigned archive URL for BuildKit to fetch the source.
-	archiveURL, err := getPresignedArchiveURL(ctx, docstoreURL, job.Repo, requestToken)
+	archiveURL, archiveChecksum, err := getPresignedArchiveURL(ctx, docstoreURL, job.Repo, requestToken)
 	if err != nil {
 		return fail(fmt.Sprintf("get presigned archive URL: %v", err))
 	}
@@ -586,6 +589,7 @@ func runJob(
 	// Set cache fields if configured (populated by the caller, not from ci.yaml).
 	cfg.CacheRef = cacheRef
 	cfg.DockerConfigDir = dockerConfigDir
+	cfg.ArchiveChecksum = archiveChecksum
 	results, err := exec.Run(ctx, archiveURL, *cfg, triggerCtx, extraEnv)
 	if err != nil {
 		return fail(fmt.Sprintf("executor: %v", err))

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -21,6 +21,7 @@ import (
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth/authprovider"
+	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/dlorenc/docstore/internal/ciconfig"
@@ -41,6 +42,11 @@ type Config struct {
 	// registry authentication. When set, overrides DOCKER_CONFIG and the
 	// default ~/.docker directory. Not parsed from ci.yaml.
 	DockerConfigDir string `json:"-" yaml:"-"`
+
+	// ArchiveChecksum is an optional content digest for the source archive URL
+	// (format "sha256:hexhash"). When set, passed to llb.HTTP as llb.Checksum()
+	// so BuildKit caches by content rather than URL. Not parsed from ci.yaml.
+	ArchiveChecksum string `json:"-" yaml:"-"`
 }
 
 // Check is a single CI check configuration.
@@ -124,7 +130,7 @@ func (e *Executor) Run(ctx context.Context, source string, cfg Config, triggerCt
 					}
 				}
 			}()
-			results[j] = e.runCheck(ctx, source, check, cfg.CacheRef, cfg.DockerConfigDir, extraEnv)
+			results[j] = e.runCheck(ctx, source, check, cfg.CacheRef, cfg.DockerConfigDir, cfg.ArchiveChecksum, extraEnv)
 		})
 	}
 	wg.Wait()
@@ -139,8 +145,9 @@ func (e *Executor) Close() error {
 // runCheck executes a single check and returns its result.
 // cacheRef, when non-empty, enables BuildKit registry cache export/import.
 // dockerConfigDir, when non-empty, overrides the Docker config directory for auth.
+// archiveChecksum, when non-empty, is passed to llb.HTTP so BuildKit caches by content.
 // extraEnv is injected as additional environment variables into every step.
-func (e *Executor) runCheck(ctx context.Context, source string, check Check, cacheRef, dockerConfigDir string, extraEnv []string) CheckResult {
+func (e *Executor) runCheck(ctx context.Context, source string, check Check, cacheRef, dockerConfigDir, archiveChecksum string, extraEnv []string) CheckResult {
 	isHTTP := strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://")
 	isLocal := source != "" && !isHTTP
 
@@ -269,7 +276,11 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check, cac
 		//   ""          → empty scratch state (tests that do not access source files).
 		var srcMount llb.State
 		if isHTTP {
-			httpSrc := llb.HTTP(source, llb.Filename("source.tar"))
+			httpOpts := []llb.HTTPOption{llb.Filename("source.tar")}
+			if archiveChecksum != "" {
+				httpOpts = append(httpOpts, llb.Checksum(digest.Digest(archiveChecksum)))
+			}
+			httpSrc := llb.HTTP(source, httpOpts...)
 			// /src must be declared as an explicit output mount (via llb.AddMount with
 			// llb.Scratch() as the base) so that GetMount("/src") returns the populated
 			// state. Without it, GetMount returns nil and the golang step sees an empty /src.

--- a/internal/server/handlers_archive.go
+++ b/internal/server/handlers_archive.go
@@ -1,9 +1,12 @@
 package server
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -62,8 +65,21 @@ func (s *server) handleArchivePresign(w http.ResponseWriter, r *http.Request) {
 		sig,
 	)
 
+	// Compute a content checksum so BuildKit can cache by content rather than
+	// URL (presigned URLs include an expiry timestamp and change every run).
+	// Skip if the read store is not configured.
+	checksum := ""
+	if s.readStore != nil {
+		h := sha256.New()
+		if err := writeArchive(r.Context(), s.readStore, h, job.Repo, job.Branch, job.Sequence); err != nil {
+			slog.Warn("presign: checksum computation failed", "repo", job.Repo, "branch", job.Branch, "error", err)
+		} else {
+			checksum = "sha256:" + hex.EncodeToString(h.Sum(nil))
+		}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"url": presignedURL}) //nolint:errcheck
+	json.NewEncoder(w).Encode(map[string]string{"url": presignedURL, "checksum": checksum}) //nolint:errcheck
 }
 
 // handlePresignedArchive serves GET /repos/{repo}/-/archive when the sig and expires

--- a/internal/server/handlers_archive_test.go
+++ b/internal/server/handlers_archive_test.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"archive/tar"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -16,6 +19,7 @@ import (
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/policy"
 	"github.com/dlorenc/docstore/internal/service"
+	"github.com/dlorenc/docstore/internal/store"
 )
 
 // stubJobTokenStore is a minimal jobTokenStore implementation for tests.
@@ -249,6 +253,165 @@ func TestHandlePresignedArchive_ValidSig_PassesHMACCheck(t *testing.T) {
 	// 403 would indicate HMAC failure; any other code means HMAC check passed.
 	if rec.Code == http.StatusForbidden {
 		t.Fatalf("HMAC check should have passed, got 403; body: %s", rec.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleArchivePresign checksum tests
+// ---------------------------------------------------------------------------
+
+// buildPresignServerWithReadStore creates a server with a readStore for checksum tests.
+func buildPresignServerWithReadStore(secret []byte, jobStore jobTokenStore, rs readStore) *server {
+	return &server{
+		commitStore:       &mockStore{},
+		archiveHMACSecret: secret,
+		archiveBaseURL:    "https://example.com",
+		jobTokenStore:     jobStore,
+		readStore:         rs,
+	}
+}
+
+// computeExpectedChecksum builds the same tar that writeArchive would produce
+// for the given entries/content and returns the "sha256:hex" digest.
+func computeExpectedChecksum(t *testing.T, files map[string][]byte) string {
+	t.Helper()
+	h := sha256.New()
+	tw := tar.NewWriter(h)
+	for path, content := range files {
+		hdr := &tar.Header{
+			Name:     path,
+			Size:     int64(len(content)),
+			Mode:     0644,
+			Typeflag: tar.TypeReg,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write tar header: %v", err)
+		}
+		if _, err := tw.Write(content); err != nil {
+			t.Fatalf("write tar content: %v", err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+func TestHandleArchivePresign_ChecksumPresent_WhenReadStoreSet(t *testing.T) {
+	secret := []byte("test-secret")
+	plaintext, hashed, err := citoken.GenerateRequestToken()
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	jobStore := &stubJobTokenStore{
+		lookupFn: func(_ context.Context, h string) (*model.CIJob, error) {
+			if h != hashed {
+				return nil, db.ErrTokenInvalid
+			}
+			return &model.CIJob{
+				ID:       "job-1",
+				Repo:     "org/myrepo",
+				Branch:   "feature",
+				Sequence: 42,
+			}, nil
+		},
+	}
+
+	// Single file for the archive.
+	fileContent := []byte("hello world\n")
+	rs := &mockReadStore{
+		materializeTreeFn: func(_ context.Context, _, _ string, _ *int64, _ int, _ string) ([]store.TreeEntry, error) {
+			return []store.TreeEntry{{Path: "hello.txt", VersionID: "v1"}}, nil
+		},
+		getFileFn: func(_ context.Context, _, _, _ string, _ *int64) (*store.FileContent, error) {
+			return &store.FileContent{
+				Path:      "hello.txt",
+				VersionID: "v1",
+				Content:   fileContent,
+			}, nil
+		},
+	}
+
+	s := buildPresignServerWithReadStore(secret, jobStore, rs)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/archive/presign", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["url"] == "" {
+		t.Fatal("expected non-empty url in response")
+	}
+	checksum := resp["checksum"]
+	if checksum == "" {
+		t.Fatal("expected non-empty checksum in response")
+	}
+	if !strings.HasPrefix(checksum, "sha256:") {
+		t.Errorf("expected checksum to start with 'sha256:', got %q", checksum)
+	}
+	if len(checksum) != len("sha256:")+64 {
+		t.Errorf("expected checksum to be sha256:<64 hex chars>, got %q", checksum)
+	}
+
+	// Verify the checksum matches the expected sha256 of the tar.
+	want := computeExpectedChecksum(t, map[string][]byte{"hello.txt": fileContent})
+	if checksum != want {
+		t.Errorf("checksum mismatch:\n  got  %q\n  want %q", checksum, want)
+	}
+}
+
+func TestHandleArchivePresign_ChecksumEmpty_WhenNoReadStore(t *testing.T) {
+	secret := []byte("test-secret")
+	plaintext, hashed, err := citoken.GenerateRequestToken()
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	jobStore := &stubJobTokenStore{
+		lookupFn: func(_ context.Context, h string) (*model.CIJob, error) {
+			if h != hashed {
+				return nil, db.ErrTokenInvalid
+			}
+			return &model.CIJob{
+				ID:       "job-1",
+				Repo:     "org/myrepo",
+				Branch:   "feature",
+				Sequence: 42,
+			}, nil
+		},
+	}
+
+	// No readStore — should return empty checksum (backwards compat).
+	s := buildPresignServer(secret, jobStore)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/archive/presign", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["url"] == "" {
+		t.Fatal("expected non-empty url in response")
+	}
+	// checksum field must be present but empty when readStore is nil.
+	checksum, ok := resp["checksum"]
+	if !ok {
+		t.Fatal("expected 'checksum' key in response JSON")
+	}
+	if checksum != "" {
+		t.Errorf("expected empty checksum when readStore is nil, got %q", checksum)
 	}
 }
 

--- a/internal/server/handlers_files.go
+++ b/internal/server/handlers_files.go
@@ -2,6 +2,9 @@ package server
 
 import (
 	"archive/tar"
+	"context"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -245,6 +248,46 @@ func (s *server) handleDiff(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// writeArchive streams a tar archive of all files in repo/branch at the given
+// sequence number to w. Individual file fetch errors are logged and skipped;
+// structural errors (tree materialization, tar write failures) are returned.
+func writeArchive(ctx context.Context, rs readStore, w io.Writer, repo, branch string, atSequence int64) error {
+	tw := tar.NewWriter(w)
+	defer tw.Close()
+
+	afterPath := ""
+	for {
+		entries, err := rs.MaterializeTree(ctx, repo, branch, &atSequence, 100, afterPath)
+		if err != nil {
+			return fmt.Errorf("archive: materialize tree: %w", err)
+		}
+		for _, entry := range entries {
+			fc, err := rs.GetFile(ctx, repo, branch, entry.Path, &atSequence)
+			if err != nil || fc == nil {
+				slog.Error("archive: get file error", "repo", repo, "branch", branch, "path", entry.Path, "error", err)
+				continue
+			}
+			hdr := &tar.Header{
+				Name:     entry.Path,
+				Size:     int64(len(fc.Content)),
+				Mode:     0644,
+				Typeflag: tar.TypeReg,
+			}
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+			if _, err := tw.Write(fc.Content); err != nil {
+				return err
+			}
+		}
+		if len(entries) < 100 {
+			break
+		}
+		afterPath = entries[len(entries)-1].Path
+	}
+	return nil
+}
+
 // handleArchive implements GET /repos/:name/-/archive?branch=X
 // Streams all files for the given branch as a tar archive.
 func (s *server) handleArchive(w http.ResponseWriter, r *http.Request) {
@@ -285,40 +328,16 @@ func (s *server) handleArchive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/x-tar")
-	tw := tar.NewWriter(w)
-	defer tw.Close()
+	var seq int64
+	if atSequence != nil {
+		seq = *atSequence
+	} else {
+		seq = bi.HeadSequence
+	}
 
-	afterPath := ""
-	for {
-		entries, err := s.readStore.MaterializeTree(r.Context(), repo, branch, atSequence, 100, afterPath)
-		if err != nil {
-			slog.Error("archive: materialize tree error", "repo", repo, "branch", branch, "error", err)
-			return
-		}
-		for _, entry := range entries {
-			fc, err := s.readStore.GetFile(r.Context(), repo, branch, entry.Path, atSequence)
-			if err != nil || fc == nil {
-				slog.Error("archive: get file error", "repo", repo, "branch", branch, "path", entry.Path, "error", err)
-				continue
-			}
-			hdr := &tar.Header{
-				Name:     entry.Path,
-				Size:     int64(len(fc.Content)),
-				Mode:     0644,
-				Typeflag: tar.TypeReg,
-			}
-			if err := tw.WriteHeader(hdr); err != nil {
-				return
-			}
-			if _, err := tw.Write(fc.Content); err != nil {
-				return
-			}
-		}
-		if len(entries) < 100 {
-			break
-		}
-		afterPath = entries[len(entries)-1].Path
+	w.Header().Set("Content-Type", "application/x-tar")
+	if err := writeArchive(r.Context(), s.readStore, w, repo, branch, seq); err != nil {
+		slog.Error("archive: write error", "repo", repo, "branch", branch, "error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Problem**: BuildKit's `llb.HTTP` cache key is based on the URL. Presigned archive URLs include an expiry timestamp and change every run, causing BuildKit to treat every run as a cache miss even for identical source content.
- **Fix**: Compute a SHA256 hash of the archive content in `handleArchivePresign`. Return it alongside the URL as `checksum`. The ci-worker passes this to `llb.HTTP` via `llb.Checksum()` so BuildKit caches by content rather than URL.

## Changes

### `internal/server/handlers_files.go`
- Extracted `writeArchive(ctx, readStore, w io.Writer, repo, branch string, atSequence int64) error` helper
- Refactored `handleArchive` to use the helper; uses `bi.HeadSequence` when no `at` param provided (same semantics as before)

### `internal/server/handlers_archive.go`
- After generating the presigned URL, streams the archive content through `sha256.New()` using `writeArchive`
- Returns `{"url": "...", "checksum": "sha256:<hex>"}` in the JSON response
- Skips hash computation and returns empty checksum if `readStore` is nil (backwards compatible)

### `internal/executor/executor.go`
- Added `ArchiveChecksum string` to `Config` struct
- Added `archiveChecksum string` param to `runCheck`; passes `llb.Checksum(digest.Digest(archiveChecksum))` to `llb.HTTP` when non-empty

### `cmd/ci-worker/main.go`
- Updated `getPresignedArchiveURL` return type to `(url, checksum string, error)`; parses new `checksum` field; empty checksum is fine (server not yet upgraded)
- Sets `cfg.ArchiveChecksum = archiveChecksum` in `runJob`

### `internal/server/handlers_archive_test.go`
- `TestHandleArchivePresign_ChecksumPresent_WhenReadStoreSet`: verifies checksum field is present, correctly formatted, and matches expected SHA256 of the tar
- `TestHandleArchivePresign_ChecksumEmpty_WhenNoReadStore`: verifies backwards-compat empty checksum when readStore is nil

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/server/... -run TestHandleArchivePresign` — all pass including new tests
- [x] `go test ./cmd/ci-worker/... ./internal/executor/...` — pass
- [ ] DB-dependent integration tests skipped (no Postgres in dev env — pre-existing condition)

## Notes / Future opportunities

- The archive is streamed twice per presign request (once for the hash, once later by BuildKit). A future optimization (Option C) could store the hash in the DB alongside sequence numbers.
- The `digest.Digest` type cast is safe since we always generate `"sha256:" + 64 hex chars`; no validation needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)