### PR TITLE
feat(archive): add sha256 checksum to presigned archive response

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -221,35 +221,38 @@ func heartbeat(ctx context.Context, schedulerURL, jobID, requestToken string, do
 // ---------------------------------------------------------------------------
 
 // getPresignedArchiveURL calls POST /repos/{repo}/-/archive/presign with the
-// request_token and returns the presigned URL for BuildKit to fetch the archive.
-// This endpoint bypasses IAP and uses the request_token for authentication.
-func getPresignedArchiveURL(ctx context.Context, docstoreURL, repo, requestToken string) (string, error) {
+// request_token and returns the presigned URL and checksum for BuildKit to fetch
+// the archive. checksum is "sha256:<hex>" when the server computed it, or ""
+// if the server did not provide one. This endpoint bypasses IAP and uses the
+// request_token for authentication.
+func getPresignedArchiveURL(ctx context.Context, docstoreURL, repo, requestToken string) (url, checksum string, err error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	u := fmt.Sprintf("%s/repos/%s/-/archive/presign", docstoreURL, repo)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
 	if err != nil {
-		return "", fmt.Errorf("build presign request: %w", err)
+		return "", "", fmt.Errorf("build presign request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+requestToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("presign request: %w", err)
+		return "", "", fmt.Errorf("presign request: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("presign: unexpected status %d", resp.StatusCode)
+		return "", "", fmt.Errorf("presign: unexpected status %d", resp.StatusCode)
 	}
 	var body struct {
-		URL string `json:"url"`
+		URL      string `json:"url"`
+		Checksum string `json:"checksum"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return "", fmt.Errorf("decode presign response: %w", err)
+		return "", "", fmt.Errorf("decode presign response: %w", err)
 	}
 	if body.URL == "" {
-		return "", fmt.Errorf("presign: empty URL in response")
+		return "", "", fmt.Errorf("presign: empty URL in response")
 	}
-	return body.URL, nil
+	return body.URL, body.Checksum, nil
 }
 
 // postCheckLogs uploads the logs for a check run to the docstore server via
@@ -559,7 +562,7 @@ func runJob(
 	}
 
 	// 2. Obtain a presigned archive URL for BuildKit to fetch the source.
-	archiveURL, err := getPresignedArchiveURL(ctx, docstoreURL, job.Repo, requestToken)
+	archiveURL, archiveChecksum, err := getPresignedArchiveURL(ctx, docstoreURL, job.Repo, requestToken)
 	if err != nil {
 		return fail(fmt.Sprintf("get presigned archive URL: %v", err))
 	}
@@ -586,6 +589,7 @@ func runJob(
 	// Set cache fields if configured (populated by the caller, not from ci.yaml).
 	cfg.CacheRef = cacheRef
 	cfg.DockerConfigDir = dockerConfigDir
+	cfg.ArchiveChecksum = archiveChecksum
 	results, err := exec.Run(ctx, archiveURL, *cfg, triggerCtx, extraEnv)
 	if err != nil {
 		return fail(fmt.Sprintf("executor: %v", err))

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -21,6 +21,7 @@ import (
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth/authprovider"
+	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/dlorenc/docstore/internal/ciconfig"
@@ -41,6 +42,11 @@ type Config struct {
 	// registry authentication. When set, overrides DOCKER_CONFIG and the
 	// default ~/.docker directory. Not parsed from ci.yaml.
 	DockerConfigDir string `json:"-" yaml:"-"`
+
+	// ArchiveChecksum is the expected sha256 digest of the source archive in
+	// the format "sha256:<hex>". When non-empty, passed to llb.HTTP so BuildKit
+	// verifies the downloaded archive before use. Not parsed from ci.yaml.
+	ArchiveChecksum string `json:"-" yaml:"-"`
 }
 
 // Check is a single CI check configuration.
@@ -124,7 +130,7 @@ func (e *Executor) Run(ctx context.Context, source string, cfg Config, triggerCt
 					}
 				}
 			}()
-			results[j] = e.runCheck(ctx, source, check, cfg.CacheRef, cfg.DockerConfigDir, extraEnv)
+			results[j] = e.runCheck(ctx, source, check, cfg.CacheRef, cfg.DockerConfigDir, cfg.ArchiveChecksum, extraEnv)
 		})
 	}
 	wg.Wait()
@@ -139,8 +145,9 @@ func (e *Executor) Close() error {
 // runCheck executes a single check and returns its result.
 // cacheRef, when non-empty, enables BuildKit registry cache export/import.
 // dockerConfigDir, when non-empty, overrides the Docker config directory for auth.
+// archiveChecksum, when non-empty, passes llb.Checksum to BuildKit for HTTP sources.
 // extraEnv is injected as additional environment variables into every step.
-func (e *Executor) runCheck(ctx context.Context, source string, check Check, cacheRef, dockerConfigDir string, extraEnv []string) CheckResult {
+func (e *Executor) runCheck(ctx context.Context, source string, check Check, cacheRef, dockerConfigDir, archiveChecksum string, extraEnv []string) CheckResult {
 	isHTTP := strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://")
 	isLocal := source != "" && !isHTTP
 
@@ -269,7 +276,11 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check, cac
 		//   ""          → empty scratch state (tests that do not access source files).
 		var srcMount llb.State
 		if isHTTP {
-			httpSrc := llb.HTTP(source, llb.Filename("source.tar"))
+			httpOpts := []llb.HTTPOption{llb.Filename("source.tar")}
+			if archiveChecksum != "" {
+				httpOpts = append(httpOpts, llb.Checksum(digest.Digest(archiveChecksum)))
+			}
+			httpSrc := llb.HTTP(source, httpOpts...)
 			// /src must be declared as an explicit output mount (via llb.AddMount with
 			// llb.Scratch() as the base) so that GetMount("/src") returns the populated
 			// state. Without it, GetMount returns nil and the golang step sees an empty /src.

--- a/internal/server/handlers_archive.go
+++ b/internal/server/handlers_archive.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -62,8 +64,20 @@ func (s *server) handleArchivePresign(w http.ResponseWriter, r *http.Request) {
 		sig,
 	)
 
+	// 4. Compute sha256 checksum by streaming the archive through a hasher.
+	// Skip if readStore is not configured (returns empty checksum).
+	var checksum string
+	if s.readStore != nil {
+		h := sha256.New()
+		if err := writeArchive(r.Context(), s.readStore, h, job.Repo, job.Branch, job.Sequence); err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		checksum = "sha256:" + hex.EncodeToString(h.Sum(nil))
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"url": presignedURL}) //nolint:errcheck
+	json.NewEncoder(w).Encode(map[string]string{"url": presignedURL, "checksum": checksum}) //nolint:errcheck
 }
 
 // handlePresignedArchive serves GET /repos/{repo}/-/archive when the sig and expires

--- a/internal/server/handlers_archive_test.go
+++ b/internal/server/handlers_archive_test.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -16,6 +18,7 @@ import (
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/policy"
 	"github.com/dlorenc/docstore/internal/service"
+	"github.com/dlorenc/docstore/internal/store"
 )
 
 // stubJobTokenStore is a minimal jobTokenStore implementation for tests.
@@ -170,6 +173,103 @@ func containsAt(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// ---------------------------------------------------------------------------
+// Checksum tests
+// ---------------------------------------------------------------------------
+
+func buildPresignJob(t *testing.T, secret []byte, repo, branch string, seq int64) (plaintext string, jobStore *stubJobTokenStore) {
+	t.Helper()
+	var hashed string
+	var err error
+	plaintext, hashed, err = citoken.GenerateRequestToken()
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	jobStore = &stubJobTokenStore{
+		lookupFn: func(_ context.Context, h string) (*model.CIJob, error) {
+			if h != hashed {
+				return nil, db.ErrTokenInvalid
+			}
+			return &model.CIJob{ID: "job-1", Repo: repo, Branch: branch, Sequence: seq}, nil
+		},
+	}
+	return
+}
+
+func TestHandleArchivePresign_ChecksumNilReadStore(t *testing.T) {
+	secret := []byte("test-secret")
+	plaintext, jobStore := buildPresignJob(t, secret, "org/myrepo", "feature", 42)
+
+	s := buildPresignServer(secret, jobStore)
+	// readStore is nil (buildPresignServer does not set it)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/archive/presign", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["checksum"] != "" {
+		t.Fatalf("expected empty checksum when readStore is nil, got %q", resp["checksum"])
+	}
+}
+
+func TestHandleArchivePresign_ChecksumWithReadStore(t *testing.T) {
+	secret := []byte("test-secret")
+	plaintext, jobStore := buildPresignJob(t, secret, "org/myrepo", "feature", 42)
+
+	fileContent := []byte("hello world\n")
+	rs := &mockReadStore{
+		materializeTreeFn: func(_ context.Context, _, _ string, _ *int64, _ int, afterPath string) ([]store.TreeEntry, error) {
+			if afterPath == "" {
+				return []store.TreeEntry{{Path: "test.txt"}}, nil
+			}
+			return nil, nil
+		},
+		getFileFn: func(_ context.Context, _, _, _ string, _ *int64) (*store.FileContent, error) {
+			return &store.FileContent{Content: fileContent}, nil
+		},
+	}
+
+	s := buildPresignServer(secret, jobStore)
+	s.readStore = rs
+	handler := s.buildHandler(devID, devID, s.commitStore)
+
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/archive/presign", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	checksum := resp["checksum"]
+	if !strings.HasPrefix(checksum, "sha256:") {
+		t.Fatalf("expected checksum to start with sha256:, got %q", checksum)
+	}
+
+	// Verify the checksum matches what writeArchive produces.
+	h := sha256.New()
+	if err := writeArchive(context.Background(), rs, h, "org/myrepo", "feature", 42); err != nil {
+		t.Fatalf("writeArchive: %v", err)
+	}
+	expected := "sha256:" + hex.EncodeToString(h.Sum(nil))
+	if checksum != expected {
+		t.Fatalf("checksum mismatch: got %q, want %q", checksum, expected)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/server/handlers_files.go
+++ b/internal/server/handlers_files.go
@@ -2,6 +2,9 @@ package server
 
 import (
 	"archive/tar"
+	"context"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -245,6 +248,48 @@ func (s *server) handleDiff(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// writeArchive streams all files for the given repo/branch as a tar archive to w.
+// If atSequence is 0, the latest sequence is used.
+func writeArchive(ctx context.Context, rs readStore, w io.Writer, repo, branch string, atSequence int64) error {
+	var seqPtr *int64
+	if atSequence != 0 {
+		seqPtr = &atSequence
+	}
+	tw := tar.NewWriter(w)
+	defer tw.Close()
+	afterPath := ""
+	for {
+		entries, err := rs.MaterializeTree(ctx, repo, branch, seqPtr, 100, afterPath)
+		if err != nil {
+			return fmt.Errorf("materialize tree: %w", err)
+		}
+		for _, entry := range entries {
+			fc, err := rs.GetFile(ctx, repo, branch, entry.Path, seqPtr)
+			if err != nil || fc == nil {
+				slog.Error("archive: get file error", "repo", repo, "branch", branch, "path", entry.Path, "error", err)
+				continue
+			}
+			hdr := &tar.Header{
+				Name:     entry.Path,
+				Size:     int64(len(fc.Content)),
+				Mode:     0644,
+				Typeflag: tar.TypeReg,
+			}
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+			if _, err := tw.Write(fc.Content); err != nil {
+				return err
+			}
+		}
+		if len(entries) < 100 {
+			break
+		}
+		afterPath = entries[len(entries)-1].Path
+	}
+	return nil
+}
+
 // handleArchive implements GET /repos/:name/-/archive?branch=X
 // Streams all files for the given branch as a tar archive.
 func (s *server) handleArchive(w http.ResponseWriter, r *http.Request) {
@@ -263,14 +308,14 @@ func (s *server) handleArchive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var atSequence *int64
+	var atSequence int64
 	if v := r.URL.Query().Get("at"); v != "" {
 		n, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "invalid 'at' parameter")
 			return
 		}
-		atSequence = &n
+		atSequence = n
 	}
 
 	// Verify the branch exists before we start streaming.
@@ -286,39 +331,8 @@ func (s *server) handleArchive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/x-tar")
-	tw := tar.NewWriter(w)
-	defer tw.Close()
-
-	afterPath := ""
-	for {
-		entries, err := s.readStore.MaterializeTree(r.Context(), repo, branch, atSequence, 100, afterPath)
-		if err != nil {
-			slog.Error("archive: materialize tree error", "repo", repo, "branch", branch, "error", err)
-			return
-		}
-		for _, entry := range entries {
-			fc, err := s.readStore.GetFile(r.Context(), repo, branch, entry.Path, atSequence)
-			if err != nil || fc == nil {
-				slog.Error("archive: get file error", "repo", repo, "branch", branch, "path", entry.Path, "error", err)
-				continue
-			}
-			hdr := &tar.Header{
-				Name:     entry.Path,
-				Size:     int64(len(fc.Content)),
-				Mode:     0644,
-				Typeflag: tar.TypeReg,
-			}
-			if err := tw.WriteHeader(hdr); err != nil {
-				return
-			}
-			if _, err := tw.Write(fc.Content); err != nil {
-				return
-			}
-		}
-		if len(entries) < 100 {
-			break
-		}
-		afterPath = entries[len(entries)-1].Path
+	if err := writeArchive(r.Context(), s.readStore, w, repo, branch, atSequence); err != nil {
+		slog.Error("archive: write error", "repo", repo, "branch", branch, "error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extracts `writeArchive(ctx, readStore, w io.Writer, repo, branch string, atSequence int64) error` helper from `handleArchive` in `handlers_files.go` that streams the tar archive to any `io.Writer`
- `handleArchivePresign` now streams the archive through `sha256.New()` using the helper and returns `{"url": "...", "checksum": "sha256:<hex>"}` (empty string when `readStore` is nil)
- Adds `ArchiveChecksum string` field to `executor.Config`; `runCheck` passes `llb.Checksum(digest.Digest(...))` to `llb.HTTP` when non-empty, enabling BuildKit to verify the downloaded archive
- `getPresignedArchiveURL` in `cmd/ci-worker/main.go` updated to return `(url, checksum string, error)`, with the checksum propagated into `cfg.ArchiveChecksum`
- New tests: `TestHandleArchivePresign_ChecksumNilReadStore` and `TestHandleArchivePresign_ChecksumWithReadStore` verify correct behavior in both cases

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/server/ ./internal/executor/ ./cmd/ci-worker/ -count=1` — all pass
- [x] Pre-existing `internal/automerge` failures confirmed as database connection flakiness, not caused by this change

## Notes / Opportunities

- The checksum is computed on every presign request, which adds latency proportional to repo size. If this becomes a bottleneck, the checksum could be cached by `(repo, branch, sequence)` tuple.
- `atSequence=0` in `writeArchive` is treated as "latest"; consider making this more explicit in future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)