### PR TITLE
feat(archive): add sha256 checksum to presigned archive response

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -221,35 +221,38 @@ func heartbeat(ctx context.Context, schedulerURL, jobID, requestToken string, do
 // ---------------------------------------------------------------------------
 
 // getPresignedArchiveURL calls POST /repos/{repo}/-/archive/presign with the
-// request_token and returns the presigned URL for BuildKit to fetch the archive.
-// This endpoint bypasses IAP and uses the request_token for authentication.
-func getPresignedArchiveURL(ctx context.Context, docstoreURL, repo, requestToken string) (string, error) {
+// request_token and returns the presigned URL and optional SHA256 checksum for
+// BuildKit to fetch the archive. The checksum may be empty if the server does
+// not yet return one. This endpoint bypasses IAP and uses the request_token for
+// authentication.
+func getPresignedArchiveURL(ctx context.Context, docstoreURL, repo, requestToken string) (string, string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	u := fmt.Sprintf("%s/repos/%s/-/archive/presign", docstoreURL, repo)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
 	if err != nil {
-		return "", fmt.Errorf("build presign request: %w", err)
+		return "", "", fmt.Errorf("build presign request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+requestToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("presign request: %w", err)
+		return "", "", fmt.Errorf("presign request: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("presign: unexpected status %d", resp.StatusCode)
+		return "", "", fmt.Errorf("presign: unexpected status %d", resp.StatusCode)
 	}
 	var body struct {
-		URL string `json:"url"`
+		URL      string `json:"url"`
+		Checksum string `json:"checksum"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return "", fmt.Errorf("decode presign response: %w", err)
+		return "", "", fmt.Errorf("decode presign response: %w", err)
 	}
 	if body.URL == "" {
-		return "", fmt.Errorf("presign: empty URL in response")
+		return "", "", fmt.Errorf("presign: empty URL in response")
 	}
-	return body.URL, nil
+	return body.URL, body.Checksum, nil
 }
 
 // postCheckLogs uploads the logs for a check run to the docstore server via
@@ -559,7 +562,7 @@ func runJob(
 	}
 
 	// 2. Obtain a presigned archive URL for BuildKit to fetch the source.
-	archiveURL, err := getPresignedArchiveURL(ctx, docstoreURL, job.Repo, requestToken)
+	archiveURL, archiveChecksum, err := getPresignedArchiveURL(ctx, docstoreURL, job.Repo, requestToken)
 	if err != nil {
 		return fail(fmt.Sprintf("get presigned archive URL: %v", err))
 	}
@@ -586,6 +589,7 @@ func runJob(
 	// Set cache fields if configured (populated by the caller, not from ci.yaml).
 	cfg.CacheRef = cacheRef
 	cfg.DockerConfigDir = dockerConfigDir
+	cfg.ArchiveChecksum = archiveChecksum
 	results, err := exec.Run(ctx, archiveURL, *cfg, triggerCtx, extraEnv)
 	if err != nil {
 		return fail(fmt.Sprintf("executor: %v", err))

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -21,6 +21,7 @@ import (
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth/authprovider"
+	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/dlorenc/docstore/internal/ciconfig"
@@ -41,6 +42,12 @@ type Config struct {
 	// registry authentication. When set, overrides DOCKER_CONFIG and the
 	// default ~/.docker directory. Not parsed from ci.yaml.
 	DockerConfigDir string `json:"-" yaml:"-"`
+
+	// ArchiveChecksum is an optional "sha256:<hex>" digest of the archive source.
+	// When set, passed to llb.HTTP via llb.Checksum() so BuildKit uses content-
+	// based caching rather than URL-based caching (presigned URLs change every run).
+	// Not parsed from ci.yaml; populated by the CI worker at runtime.
+	ArchiveChecksum string `json:"-" yaml:"-"`
 }
 
 // Check is a single CI check configuration.
@@ -124,7 +131,7 @@ func (e *Executor) Run(ctx context.Context, source string, cfg Config, triggerCt
 					}
 				}
 			}()
-			results[j] = e.runCheck(ctx, source, check, cfg.CacheRef, cfg.DockerConfigDir, extraEnv)
+			results[j] = e.runCheck(ctx, source, check, cfg.CacheRef, cfg.DockerConfigDir, cfg.ArchiveChecksum, extraEnv)
 		})
 	}
 	wg.Wait()
@@ -139,8 +146,9 @@ func (e *Executor) Close() error {
 // runCheck executes a single check and returns its result.
 // cacheRef, when non-empty, enables BuildKit registry cache export/import.
 // dockerConfigDir, when non-empty, overrides the Docker config directory for auth.
+// archiveChecksum, when non-empty, is passed to llb.HTTP for content-based caching.
 // extraEnv is injected as additional environment variables into every step.
-func (e *Executor) runCheck(ctx context.Context, source string, check Check, cacheRef, dockerConfigDir string, extraEnv []string) CheckResult {
+func (e *Executor) runCheck(ctx context.Context, source string, check Check, cacheRef, dockerConfigDir, archiveChecksum string, extraEnv []string) CheckResult {
 	isHTTP := strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://")
 	isLocal := source != "" && !isHTTP
 
@@ -269,7 +277,11 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check, cac
 		//   ""          → empty scratch state (tests that do not access source files).
 		var srcMount llb.State
 		if isHTTP {
-			httpSrc := llb.HTTP(source, llb.Filename("source.tar"))
+			httpOpts := []llb.HTTPOption{llb.Filename("source.tar")}
+			if archiveChecksum != "" {
+				httpOpts = append(httpOpts, llb.Checksum(digest.Digest(archiveChecksum)))
+			}
+			httpSrc := llb.HTTP(source, httpOpts...)
 			// /src must be declared as an explicit output mount (via llb.AddMount with
 			// llb.Scratch() as the base) so that GetMount("/src") returns the populated
 			// state. Without it, GetMount returns nil and the golang step sees an empty /src.

--- a/internal/server/handlers_archive.go
+++ b/internal/server/handlers_archive.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -62,8 +63,19 @@ func (s *server) handleArchivePresign(w http.ResponseWriter, r *http.Request) {
 		sig,
 	)
 
+	// 4. Compute SHA256 checksum of the archive content so BuildKit can cache by
+	// content rather than URL (presigned URLs change on every request).
+	var checksum string
+	if s.readStore != nil {
+		seq := job.Sequence
+		h := sha256.New()
+		if err := writeArchive(r.Context(), s.readStore, h, job.Repo, job.Branch, &seq); err == nil {
+			checksum = fmt.Sprintf("sha256:%x", h.Sum(nil))
+		}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"url": presignedURL}) //nolint:errcheck
+	json.NewEncoder(w).Encode(map[string]string{"url": presignedURL, "checksum": checksum}) //nolint:errcheck
 }
 
 // handlePresignedArchive serves GET /repos/{repo}/-/archive when the sig and expires

--- a/internal/server/handlers_archive_test.go
+++ b/internal/server/handlers_archive_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dlorenc/docstore/internal/model"
 	"github.com/dlorenc/docstore/internal/policy"
 	"github.com/dlorenc/docstore/internal/service"
+	"github.com/dlorenc/docstore/internal/store"
 )
 
 // stubJobTokenStore is a minimal jobTokenStore implementation for tests.
@@ -156,6 +157,94 @@ func TestHandleArchivePresign_ValidToken(t *testing.T) {
 		if !containsStr(u, param) {
 			t.Errorf("expected URL to contain %q; got %q", param, u)
 		}
+	}
+}
+
+// TestHandleArchivePresign_ChecksumEmpty_WhenNoReadStore verifies that when the
+// server has no readStore configured, the presign response returns an empty
+// checksum (backwards-compatible behaviour).
+func TestHandleArchivePresign_ChecksumEmpty_WhenNoReadStore(t *testing.T) {
+	secret := []byte("test-secret")
+	plaintext, hashed, err := citoken.GenerateRequestToken()
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	store := &stubJobTokenStore{
+		lookupFn: func(_ context.Context, h string) (*model.CIJob, error) {
+			if h != hashed {
+				return nil, db.ErrTokenInvalid
+			}
+			return &model.CIJob{ID: "job-1", Repo: "org/myrepo", Branch: "main", Sequence: 1}, nil
+		},
+	}
+	// buildPresignServer does not set readStore.
+	s := buildPresignServer(secret, store)
+	handler := s.buildHandler(devID, devID, s.commitStore)
+
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/archive/presign", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["checksum"] != "" {
+		t.Errorf("expected empty checksum when readStore is nil, got %q", resp["checksum"])
+	}
+}
+
+// TestHandleArchivePresign_ChecksumPresent_WhenReadStoreSet verifies that when
+// the server has a readStore configured, the presign response includes a
+// non-empty "sha256:..." checksum field.
+func TestHandleArchivePresign_ChecksumPresent_WhenReadStoreSet(t *testing.T) {
+	secret := []byte("test-secret")
+	plaintext, hashed, err := citoken.GenerateRequestToken()
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	js := &stubJobTokenStore{
+		lookupFn: func(_ context.Context, h string) (*model.CIJob, error) {
+			if h != hashed {
+				return nil, db.ErrTokenInvalid
+			}
+			return &model.CIJob{ID: "job-1", Repo: "org/myrepo", Branch: "main", Sequence: 1}, nil
+		},
+	}
+	s := buildPresignServer(secret, js)
+	// Wire a readStore that returns a single small file.
+	s.readStore = &mockReadStore{
+		materializeTreeFn: func(_ context.Context, _, _ string, _ *int64, _ int, _ string) ([]store.TreeEntry, error) {
+			return []store.TreeEntry{{Path: "README.md"}}, nil
+		},
+		getFileFn: func(_ context.Context, _, _, _ string, _ *int64) (*store.FileContent, error) {
+			return &store.FileContent{Content: []byte("hello world\n")}, nil
+		},
+	}
+	handler := s.buildHandler(devID, devID, s.commitStore)
+
+	req := httptest.NewRequest(http.MethodPost, "/repos/org/myrepo/-/archive/presign", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	checksum := resp["checksum"]
+	if !strings.HasPrefix(checksum, "sha256:") {
+		t.Errorf("expected checksum to start with 'sha256:', got %q", checksum)
+	}
+	if len(checksum) != len("sha256:")+64 {
+		t.Errorf("expected sha256: + 64 hex chars, got %q (len %d)", checksum, len(checksum))
 	}
 }
 

--- a/internal/server/handlers_files.go
+++ b/internal/server/handlers_files.go
@@ -2,6 +2,9 @@ package server
 
 import (
 	"archive/tar"
+	"context"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -245,6 +248,45 @@ func (s *server) handleDiff(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// writeArchive streams all files for the given branch as a tar archive to w.
+// atSequence may be nil to use the latest head sequence.
+func writeArchive(ctx context.Context, rs readStore, w io.Writer, repo, branch string, atSequence *int64) error {
+	tw := tar.NewWriter(w)
+	defer tw.Close()
+
+	afterPath := ""
+	for {
+		entries, err := rs.MaterializeTree(ctx, repo, branch, atSequence, 100, afterPath)
+		if err != nil {
+			return fmt.Errorf("materialize tree: %w", err)
+		}
+		for _, entry := range entries {
+			fc, err := rs.GetFile(ctx, repo, branch, entry.Path, atSequence)
+			if err != nil || fc == nil {
+				slog.Error("archive: get file error", "repo", repo, "branch", branch, "path", entry.Path, "error", err)
+				continue
+			}
+			hdr := &tar.Header{
+				Name:     entry.Path,
+				Size:     int64(len(fc.Content)),
+				Mode:     0644,
+				Typeflag: tar.TypeReg,
+			}
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+			if _, err := tw.Write(fc.Content); err != nil {
+				return err
+			}
+		}
+		if len(entries) < 100 {
+			break
+		}
+		afterPath = entries[len(entries)-1].Path
+	}
+	return nil
+}
+
 // handleArchive implements GET /repos/:name/-/archive?branch=X
 // Streams all files for the given branch as a tar archive.
 func (s *server) handleArchive(w http.ResponseWriter, r *http.Request) {
@@ -286,39 +328,8 @@ func (s *server) handleArchive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/x-tar")
-	tw := tar.NewWriter(w)
-	defer tw.Close()
-
-	afterPath := ""
-	for {
-		entries, err := s.readStore.MaterializeTree(r.Context(), repo, branch, atSequence, 100, afterPath)
-		if err != nil {
-			slog.Error("archive: materialize tree error", "repo", repo, "branch", branch, "error", err)
-			return
-		}
-		for _, entry := range entries {
-			fc, err := s.readStore.GetFile(r.Context(), repo, branch, entry.Path, atSequence)
-			if err != nil || fc == nil {
-				slog.Error("archive: get file error", "repo", repo, "branch", branch, "path", entry.Path, "error", err)
-				continue
-			}
-			hdr := &tar.Header{
-				Name:     entry.Path,
-				Size:     int64(len(fc.Content)),
-				Mode:     0644,
-				Typeflag: tar.TypeReg,
-			}
-			if err := tw.WriteHeader(hdr); err != nil {
-				return
-			}
-			if _, err := tw.Write(fc.Content); err != nil {
-				return
-			}
-		}
-		if len(entries) < 100 {
-			break
-		}
-		afterPath = entries[len(entries)-1].Path
+	if err := writeArchive(r.Context(), s.readStore, w, repo, branch, atSequence); err != nil {
+		slog.Error("archive: write error", "repo", repo, "branch", branch, "error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- BuildKit's `llb.HTTP` cache key is based on URL. Presigned archive URLs include an expiry timestamp and change on every run, causing cache misses even when source content is identical.
- Fix: compute SHA256 of the archive content in `handleArchivePresign` and return it alongside the URL as `checksum`. The ci-worker passes this to `llb.HTTP` via `llb.Checksum()` so BuildKit caches by content rather than URL.

## Changes (5 files only)

- **`internal/server/handlers_files.go`**: Extract `writeArchive(ctx, readStore, w, repo, branch, atSequence)` helper; refactor `handleArchive` to use it
- **`internal/server/handlers_archive.go`**: After generating presigned URL, stream archive through `sha256.New()` via `writeArchive`; return `{"url":"...","checksum":"sha256:<hex>"}` (empty checksum when `readStore` is nil)
- **`internal/server/handlers_archive_test.go`**: Add `TestHandleArchivePresign_ChecksumEmpty_WhenNoReadStore` and `TestHandleArchivePresign_ChecksumPresent_WhenReadStoreSet`
- **`internal/executor/executor.go`**: Add `ArchiveChecksum string` to `Config`; pass `llb.Checksum(digest.Digest(...))` to `llb.HTTP` when non-empty
- **`cmd/ci-worker/main.go`**: `getPresignedArchiveURL` returns `(url, checksum string, error)`; sets `cfg.ArchiveChecksum`

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./internal/server/... -run TestHandleArchivePresign\` — 7 tests pass
- [x] \`go test ./cmd/ci-worker/... ./cmd/ci-scheduler/... ./internal/executor/...\` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)