### PR TITLE
feat(executor): replace OIDC env var injection with BuildKit secrets

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -27,7 +27,7 @@ import (
 // runner executes CI checks against a source directory.
 // *executor.Executor satisfies this interface.
 type runner interface {
-	Run(ctx context.Context, sourceDir string, cfg executor.Config, triggerCtx ciconfig.TriggerContext, extraEnv []string) ([]executor.CheckResult, error)
+	Run(ctx context.Context, sourceDir string, cfg executor.Config, triggerCtx ciconfig.TriggerContext) ([]executor.CheckResult, error)
 }
 
 // heartbeatInterval is the delay between heartbeat updates.
@@ -533,10 +533,10 @@ func runJob(
 	docstoreURL string,
 	job *model.CIJob,
 	requestToken string,
+	oidcTokenURL string,
 	jwt string,
 	logDir string,
 	triggerCtx ciconfig.TriggerContext,
-	extraEnv []string,
 	cacheRef string,
 	dockerConfigDir string,
 ) (status string, logURL *string, errMsg *string) {
@@ -586,11 +586,13 @@ func runJob(
 	pendingWg.Wait()
 
 	// 4. Execute all checks.
-	// Set cache fields if configured (populated by the caller, not from ci.yaml).
+	// Set runtime fields on cfg (not from ci.yaml).
 	cfg.CacheRef = cacheRef
 	cfg.DockerConfigDir = dockerConfigDir
 	cfg.ArchiveChecksum = archiveChecksum
-	results, err := exec.Run(ctx, archiveURL, *cfg, triggerCtx, extraEnv)
+	cfg.OIDCRequestToken = requestToken
+	cfg.OIDCRequestURL = oidcTokenURL
+	results, err := exec.Run(ctx, archiveURL, *cfg, triggerCtx)
 	if err != nil {
 		return fail(fmt.Sprintf("executor: %v", err))
 	}
@@ -749,12 +751,6 @@ func main() {
 			triggerCtx.ProposalID = *job.TriggerProposalID
 		}
 
-		// Build OIDC env vars to inject into job steps.
-		extraEnv := []string{
-			"DOCSTORE_OIDC_REQUEST_TOKEN=" + requestToken,
-			"DOCSTORE_OIDC_REQUEST_URL=" + cr.OIDCTokenURL,
-		}
-
 		// Set up BuildKit registry cache if the scheduler provided a registry.
 		var cacheRef, cacheDockerConfigDir string
 		if cr.CacheRegistry != "" {
@@ -779,7 +775,7 @@ func main() {
 		}
 
 		// Execute the job.
-		jobStatus, jobLogURL, jobErrMsg := runJob(ctx, httpClient, exec, docstoreURL, job, requestToken, jwt, logDir, triggerCtx, extraEnv, cacheRef, cacheDockerConfigDir)
+		jobStatus, jobLogURL, jobErrMsg := runJob(ctx, httpClient, exec, docstoreURL, job, requestToken, cr.OIDCTokenURL, jwt, logDir, triggerCtx, cacheRef, cacheDockerConfigDir)
 
 		// Stop heartbeat and clear log dir.
 		close(hbDone)

--- a/cmd/ci-worker/main_test.go
+++ b/cmd/ci-worker/main_test.go
@@ -30,7 +30,7 @@ type mockRunner struct {
 	err     error
 }
 
-func (m *mockRunner) Run(_ context.Context, _ string, _ executor.Config, _ ciconfig.TriggerContext, _ []string) ([]executor.CheckResult, error) {
+func (m *mockRunner) Run(_ context.Context, _ string, _ executor.Config, _ ciconfig.TriggerContext) ([]executor.CheckResult, error) {
 	return m.results, m.err
 }
 
@@ -501,7 +501,7 @@ func TestRunJob_NoCIYAML_ReturnsPassed(t *testing.T) {
 
 	status, logURL, errMsg := runJob(
 		context.Background(), srv.Client(), &mockRunner{},
-		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, nil, "", "",
+		srv.URL, testJob(), "", "", "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, "", "",
 	)
 	if status != "passed" {
 		t.Errorf("expected passed, got %q", status)
@@ -524,7 +524,7 @@ func TestRunJob_FetchConfigError_ReturnsFailed(t *testing.T) {
 
 	status, _, errMsg := runJob(
 		context.Background(), srv.Client(), &mockRunner{},
-		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, nil, "", "",
+		srv.URL, testJob(), "", "", "", t.TempDir(), ciconfig.TriggerContext{}, "", "",
 	)
 	if status != "failed" {
 		t.Errorf("expected failed, got %q", status)
@@ -544,7 +544,7 @@ func TestRunJob_ExecutorError_ReturnsFailed(t *testing.T) {
 	mockExec := &mockRunner{err: fmt.Errorf("buildkit unavailable")}
 	status, _, errMsg := runJob(
 		context.Background(), srv.Client(), mockExec,
-		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, nil, "", "",
+		srv.URL, testJob(), "", "", "", t.TempDir(), ciconfig.TriggerContext{}, "", "",
 	)
 	if status != "failed" {
 		t.Errorf("expected failed, got %q", status)
@@ -597,7 +597,7 @@ func TestRunJob_AllChecksPassed(t *testing.T) {
 
 	status, logURL, errMsg := runJob(
 		context.Background(), srv.Client(), mockExec,
-		srv.URL, testJob(), "test-request-token", "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, nil, "", "",
+		srv.URL, testJob(), "test-request-token", "", "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, "", "",
 	)
 	if status != "passed" {
 		t.Errorf("expected passed, got %q", status)
@@ -633,7 +633,7 @@ func TestRunJob_OneCheckFailed_OverallFailed(t *testing.T) {
 
 	status, _, errMsg := runJob(
 		context.Background(), srv.Client(), mockExec,
-		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, nil, "", "",
+		srv.URL, testJob(), "", "", "", t.TempDir(), ciconfig.TriggerContext{}, "", "",
 	)
 	if status != "failed" {
 		t.Errorf("expected failed, got %q", status)
@@ -677,7 +677,7 @@ func TestRunJob_LogUploadFails_StillPosts(t *testing.T) {
 
 	status, logURL, _ := runJob(
 		context.Background(), srv.Client(), mockExec,
-		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, nil, "", "",
+		srv.URL, testJob(), "", "", "", t.TempDir(), ciconfig.TriggerContext{}, "", "",
 	)
 	if status != "passed" {
 		t.Errorf("expected passed, got %q", status)
@@ -703,7 +703,7 @@ func TestRunJob_LogsWrittenToDir(t *testing.T) {
 	}}
 
 	logDir := t.TempDir()
-	runJob(context.Background(), srv.Client(), mockExec, srv.URL, testJob(), "", "", logDir, ciconfig.TriggerContext{}, nil, "", "") //nolint:errcheck
+	runJob(context.Background(), srv.Client(), mockExec, srv.URL, testJob(), "", "", "", logDir, ciconfig.TriggerContext{}, "", "") //nolint:errcheck
 
 	data, err := os.ReadFile(filepath.Join(logDir, "test.log"))
 	if err != nil {

--- a/internal/cli/ci.go
+++ b/internal/cli/ci.go
@@ -98,7 +98,7 @@ func (a *App) CIRun(checkFilter, trigger, baseBranch, buildkitAddr string) error
 	defer exec.Close()
 
 	// 8. Run all checks. executor.Run blocks until all checks complete.
-	results, err := exec.Run(context.Background(), a.Dir, cfg, triggerCtx, nil)
+	results, err := exec.Run(context.Background(), a.Dir, cfg, triggerCtx)
 	if err != nil {
 		return fmt.Errorf("executor: %w", err)
 	}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -21,6 +21,7 @@ import (
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth/authprovider"
+	"github.com/moby/buildkit/session/secrets/secretsprovider"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -47,6 +48,16 @@ type Config struct {
 	// the format "sha256:<hex>". When non-empty, passed to llb.HTTP so BuildKit
 	// verifies the downloaded archive before use. Not parsed from ci.yaml.
 	ArchiveChecksum string `json:"-" yaml:"-"`
+
+	// OIDCRequestToken and OIDCRequestURL are the per-job OIDC credentials.
+	// When set, they are exposed to check steps via BuildKit secret mounts at
+	// /run/secrets/docstore_oidc_request_token and
+	// /run/secrets/docstore_oidc_request_url respectively.
+	// Secrets are NOT part of the BuildKit cache key, so using secret mounts
+	// avoids busting the cache on every run (unlike env var injection).
+	// Not parsed from ci.yaml; populated by the CI worker at runtime.
+	OIDCRequestToken string `json:"-" yaml:"-"`
+	OIDCRequestURL   string `json:"-" yaml:"-"`
 }
 
 // Check is a single CI check configuration.
@@ -85,12 +96,9 @@ func New(buildkitAddr string) (*Executor, error) {
 //   - a local filesystem path — BuildKit uploads it via llb.Local (used by ds ci run)
 //   - "" — uses an empty scratch state (useful in tests that do not read source files)
 //
-// extraEnv is an optional list of additional KEY=VALUE environment variables to
-// inject into every check step (e.g. DOCSTORE_OIDC_REQUEST_TOKEN=...).
-//
 // Checks whose if: condition evaluates to false are skipped (omitted from results).
 // It returns once all checks have resolved.
-func (e *Executor) Run(ctx context.Context, source string, cfg Config, triggerCtx ciconfig.TriggerContext, extraEnv []string) ([]CheckResult, error) {
+func (e *Executor) Run(ctx context.Context, source string, cfg Config, triggerCtx ciconfig.TriggerContext) ([]CheckResult, error) {
 	// Pre-filter: evaluate if: conditions before launching goroutines.
 	type indexedCheck struct {
 		idx   int
@@ -130,7 +138,7 @@ func (e *Executor) Run(ctx context.Context, source string, cfg Config, triggerCt
 					}
 				}
 			}()
-			results[j] = e.runCheck(ctx, source, check, cfg.CacheRef, cfg.DockerConfigDir, cfg.ArchiveChecksum, extraEnv)
+			results[j] = e.runCheck(ctx, source, check, cfg.CacheRef, cfg.DockerConfigDir, cfg.ArchiveChecksum, cfg.OIDCRequestToken, cfg.OIDCRequestURL)
 		})
 	}
 	wg.Wait()
@@ -146,8 +154,9 @@ func (e *Executor) Close() error {
 // cacheRef, when non-empty, enables BuildKit registry cache export/import.
 // dockerConfigDir, when non-empty, overrides the Docker config directory for auth.
 // archiveChecksum, when non-empty, passes llb.Checksum to BuildKit for HTTP sources.
-// extraEnv is injected as additional environment variables into every step.
-func (e *Executor) runCheck(ctx context.Context, source string, check Check, cacheRef, dockerConfigDir, archiveChecksum string, extraEnv []string) CheckResult {
+// oidcToken and oidcURL, when non-empty, are exposed via BuildKit secret mounts so
+// they do not bust the cache key (unlike env var injection).
+func (e *Executor) runCheck(ctx context.Context, source string, check Check, cacheRef, dockerConfigDir, archiveChecksum, oidcToken, oidcURL string) CheckResult {
 	isHTTP := strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://")
 	isLocal := source != "" && !isHTTP
 
@@ -202,11 +211,21 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check, cac
 		ap.AuthConfigProvider = authprovider.LoadAuthConfig(dockerCfg)
 	}
 
+	sessionAttachables := []session.Attachable{authprovider.NewDockerAuthProvider(ap)}
+	if oidcToken != "" {
+		// Expose OIDC credentials as BuildKit secrets so they don't bust the
+		// cache key. Steps read from /run/secrets/docstore_oidc_request_token
+		// and /run/secrets/docstore_oidc_request_url.
+		secretMap := map[string][]byte{
+			"docstore_oidc_request_token": []byte(oidcToken),
+			"docstore_oidc_request_url":   []byte(oidcURL),
+		}
+		sessionAttachables = append(sessionAttachables, secretsprovider.FromMap(secretMap))
+	}
+
 	solveOpt := client.SolveOpt{
 		FrontendAttrs: map[string]string{},
-		Session: []session.Attachable{
-			authprovider.NewDockerAuthProvider(ap),
-		},
+		Session:       sessionAttachables,
 	}
 	if cacheRef != "" {
 		solveOpt.CacheExports = []client.CacheOptionsEntry{{
@@ -260,15 +279,8 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check, cac
 		// Inject DOCKER_HOST so docker:cli checks can reach the dockerd running
 		// in the Kata VM. Build containers run with --oci-worker-net=host so they
 		// share the host network namespace and can reach dockerd via TCP.
+		// DOCKER_HOST is cache-stable (same value every run) so env var is fine here.
 		envOpts = append(envOpts, llb.AddEnv("DOCKER_HOST", "tcp://localhost:2375"))
-
-		// Inject caller-supplied extra environment variables (e.g. OIDC tokens).
-		for _, kv := range extraEnv {
-			k, v, _ := strings.Cut(kv, "=")
-			if k != "" {
-				envOpts = append(envOpts, llb.AddEnv(k, v))
-			}
-		}
 
 		// Build the source mount based on the source type:
 		//   HTTP(S) URL → BuildKit fetches the tar directly; busybox extracts it to /src.
@@ -309,6 +321,12 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check, cac
 				llb.AddMount("/usr/local/cargo/registry", llb.Scratch(), llb.AsPersistentCacheDir("cargo-registry", llb.CacheMountShared)),
 			}
 			runOpts = append(runOpts, envOpts...)
+			if oidcToken != "" {
+				runOpts = append(runOpts,
+					llb.AddSecret("/run/secrets/docstore_oidc_request_token", llb.SecretID("docstore_oidc_request_token"), llb.SecretOptional),
+					llb.AddSecret("/run/secrets/docstore_oidc_request_url", llb.SecretID("docstore_oidc_request_url"), llb.SecretOptional),
+				)
+			}
 			exec := state.Run(runOpts...)
 			state = exec.Root()
 			srcMount = exec.GetMount("/src")

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -49,7 +49,7 @@ func TestPass(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), "", cfg, ciconfig.TriggerContext{}, nil)
+	results, err := exec.Run(context.Background(), "", cfg, ciconfig.TriggerContext{})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestFail(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), "", cfg, ciconfig.TriggerContext{}, nil)
+	results, err := exec.Run(context.Background(), "", cfg, ciconfig.TriggerContext{})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestMultiCheck(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), "", cfg, ciconfig.TriggerContext{}, nil)
+	results, err := exec.Run(context.Background(), "", cfg, ciconfig.TriggerContext{})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestIfConditionSkipsCheck(t *testing.T) {
 	}
 
 	// Trigger type is "proposal", so the push-only check must be skipped.
-	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "proposal"}, nil)
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "proposal"})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestIfConditionRunsCheck(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push"}, nil)
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push"})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -206,7 +206,7 @@ func TestIfConditionMixedChecks(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push"}, nil)
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push"})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -246,7 +246,7 @@ func TestIfConditionBranchFilter(t *testing.T) {
 	}
 
 	// feature branch — should be skipped.
-	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push", Branch: "feature"}, nil)
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push", Branch: "feature"})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -255,7 +255,7 @@ func TestIfConditionBranchFilter(t *testing.T) {
 	}
 
 	// main branch — should run.
-	results, err = exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push", Branch: "main"}, nil)
+	results, err = exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push", Branch: "main"})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -285,7 +285,7 @@ func TestIfConditionAndExpression(t *testing.T) {
 	}
 
 	// push to main — should run.
-	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push", Branch: "main"}, nil)
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push", Branch: "main"})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -294,7 +294,7 @@ func TestIfConditionAndExpression(t *testing.T) {
 	}
 
 	// push to feature — should be skipped (branch condition false).
-	results, err = exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push", Branch: "feature"}, nil)
+	results, err = exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "push", Branch: "feature"})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -303,7 +303,7 @@ func TestIfConditionAndExpression(t *testing.T) {
 	}
 
 	// proposal to main — should be skipped (type condition false).
-	results, err = exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "proposal", Branch: "main"}, nil)
+	results, err = exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "proposal", Branch: "main"})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -330,7 +330,7 @@ func TestIfConditionOrExpression(t *testing.T) {
 	}
 
 	for _, triggerType := range []string{"push", "proposal"} {
-		results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: triggerType}, nil)
+		results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: triggerType})
 		if err != nil {
 			t.Fatalf("Run(%s): %v", triggerType, err)
 		}
@@ -340,7 +340,7 @@ func TestIfConditionOrExpression(t *testing.T) {
 	}
 
 	// schedule — neither condition matches, should be skipped.
-	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "schedule"}, nil)
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "schedule"})
 	if err != nil {
 		t.Fatalf("Run(schedule): %v", err)
 	}
@@ -362,7 +362,7 @@ func TestIfConditionAllSkipped(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "schedule"}, nil)
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{Type: "schedule"})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -391,7 +391,7 @@ func TestLocalPathSource(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{}, nil)
+	results, err := exec.Run(context.Background(), dir, cfg, ciconfig.TriggerContext{})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -424,7 +424,7 @@ func TestPathTraversalRejected(t *testing.T) {
 		"foo/../../bar",
 	}
 	for _, path := range badPaths {
-		results, err := exec.Run(context.Background(), path, cfg, ciconfig.TriggerContext{}, nil)
+		results, err := exec.Run(context.Background(), path, cfg, ciconfig.TriggerContext{})
 		if err != nil {
 			t.Fatalf("Run(%q): unexpected error: %v", path, err)
 		}
@@ -458,7 +458,7 @@ func TestLogCapture(t *testing.T) {
 		},
 	}
 
-	results, err := exec.Run(context.Background(), "", cfg, ciconfig.TriggerContext{}, nil)
+	results, err := exec.Run(context.Background(), "", cfg, ciconfig.TriggerContext{})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}


### PR DESCRIPTION
## Summary

OIDC credentials were injected as \`llb.AddEnv()\` causing BuildKit cache misses on every run (fresh token = different cache key). Replace with BuildKit secret mounts which are NOT part of the cache key.

## Changes (5 files)

- **\`internal/executor/executor.go\`**: Add \`OIDCRequestToken\`/\`OIDCRequestURL\` to \`Config\`; remove \`extraEnv []string\` from \`Run()\`/\`runCheck()\`; add \`secretsprovider.FromMap()\` to session; mount secrets at \`/run/secrets/docstore_oidc_request_token\` and \`/run/secrets/docstore_oidc_request_url\`
- **\`cmd/ci-worker/main.go\`**: Remove \`extraEnv\` from \`runner\` interface and \`runJob()\`; add \`oidcTokenURL\` param to \`runJob()\`; set \`cfg.OIDCRequestToken\`/\`cfg.OIDCRequestURL\`
- **\`internal/cli/ci.go\`**: Remove \`nil\` extraEnv arg from \`exec.Run()\`
- **\`internal/executor/executor_test.go\`**: Update \`Run()\` calls
- **\`cmd/ci-worker/main_test.go\`**: Update \`mockRunner\` and \`runJob()\` calls

## Breaking change

Steps that read \`\$DOCSTORE_OIDC_REQUEST_TOKEN\` must now read from \`/run/secrets/docstore_oidc_request_token\`. Issue #418 will add opt-in per-step env injection.

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./cmd/ci-worker/... ./internal/executor/... ./internal/cli/...\` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)