### PR TITLE
fix(buildkit): add buildkitd.toml with insecure registry config for ci-registry

### DIFF
--- a/entrypoint-worker.sh
+++ b/entrypoint-worker.sh
@@ -33,11 +33,21 @@ else
   echo "loop-ext4 mounted at /var/lib/buildkit on $LOOP" >&2
 fi
 
+# Write buildkitd config so the ci-registry service (plain HTTP) is treated as insecure.
+# Without this, BuildKit attempts HTTPS for cache import/export auth challenges even though
+# ci-registry.docstore-ci.svc.cluster.local runs on plain HTTP.
+mkdir -p /etc/buildkit
+cat > /etc/buildkit/buildkitd.toml << 'TOML'
+[registry."ci-registry.docstore-ci.svc.cluster.local"]
+  http = true
+  insecure = true
+TOML
+
 # Start buildkitd in background (standard, non-rootless — runs natively inside Kata VM).
 # --oci-worker-net=host ensures build containers share the host network namespace so they
 # can reach dockerd at tcp://localhost:2375.
 # overlayfs snapshotter now works because /var/lib/buildkit is ext4 (supports upper dirs).
-buildkitd --addr tcp://localhost:1234 --oci-worker-net=host --oci-worker-snapshotter=overlayfs &
+buildkitd --addr tcp://localhost:1234 --oci-worker-net=host --oci-worker-snapshotter=overlayfs --config /etc/buildkit/buildkitd.toml &
 
 # Start dockerd in background.
 # -H tcp://127.0.0.1:2375 exposes dockerd over TCP so build containers running with


### PR DESCRIPTION
## Summary

- Creates `/etc/buildkit/buildkitd.toml` in `entrypoint-worker.sh` before starting buildkitd
- Configures `ci-registry.docstore-ci.svc.cluster.local` as an insecure HTTP registry (`http = true`, `insecure = true`)
- Passes `--config /etc/buildkit/buildkitd.toml` to the buildkitd start command

## Problem

Production buildkitd was starting with no `--config` flag and no `buildkitd.toml`. Without an explicit registry entry, BuildKit attempts HTTPS for cache import/export auth challenges even though `ci-registry.docstore-ci.svc.cluster.local` runs on plain HTTP. This caused cache import/export to fail silently in production.

The local E2E test works because `testutil/testbuildkit.go` already writes a `buildkitd.toml` with explicit insecure entries for the test registry hosts.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `go vet ./...` passes
- The fix mirrors exactly what the E2E test helper does for the test registry

## Notes

- PR #421 (TestE2ECacheWithChecksumAndSecrets) was already merged
- PR #422 (host-gateway fix) was closed as superseded by the `HostGatewayIP()` helper in #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)