### PR TITLE
fix(executor): pass CacheImports in inner gateway SolveRequest to enable registry cache hits

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -352,9 +352,19 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check, cac
 			return nil, fmt.Errorf("marshal: %w", err)
 		}
 
-		return c.Solve(ctx, gwclient.SolveRequest{
+		req := gwclient.SolveRequest{
 			Definition: def.ToPB(),
-		})
+		}
+		if cacheRef != "" {
+			req.CacheImports = []gwclient.CacheOptionsEntry{{
+				Type: "registry",
+				Attrs: map[string]string{
+					"ref":               cacheRef,
+					"registry.insecure": "true",
+				},
+			}}
+		}
+		return c.Solve(ctx, req)
 	}, ch)
 
 	collectWg.Wait()

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -50,13 +51,13 @@ func New(blobHandler BlobHandler, store ManifestStore, jwksURL, audience, issuer
 
 const blobUnknownBody = `{"errors":[{"code":"BLOB_UNKNOWN","message":"Unknown blob"}]}` + "\n"
 
-// blobHeadMiddleware intercepts HEAD /v2/{repo}/blobs/{digest} requests and
-// serves them directly using BlobHandler.Stat, returning the correct
-// 404 BLOB_UNKNOWN when a blob is absent rather than delegating to
+// blobHeadMiddleware intercepts HEAD and GET /v2/{repo}/blobs/{digest} requests
+// and serves them directly using BlobHandler, returning the correct 404
+// BLOB_UNKNOWN when a blob is absent rather than delegating to
 // go-containerregistry's blob handler which returns 500 for missing blobs.
 func blobHeadMiddleware(blobHandler BlobHandler, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodHead {
+		if r.Method != http.MethodHead && r.Method != http.MethodGet {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -74,19 +75,47 @@ func blobHeadMiddleware(blobHandler BlobHandler, next http.Handler) http.Handler
 			return
 		}
 
+		if r.Method == http.MethodHead {
+			size, err := blobHandler.Stat(r.Context(), repo, h)
+			if errors.Is(err, errNotFound) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				io.WriteString(w, blobUnknownBody) //nolint:errcheck
+				return
+			}
+			if err != nil {
+				http.Error(w, fmt.Sprintf("stat blob: %v", err), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+			w.Header().Set("Docker-Content-Digest", dgst)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// GET: stat for size then stream the blob.
 		size, err := blobHandler.Stat(r.Context(), repo, h)
 		if errors.Is(err, errNotFound) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
+			io.WriteString(w, blobUnknownBody) //nolint:errcheck
 			return
 		}
 		if err != nil {
 			http.Error(w, fmt.Sprintf("stat blob: %v", err), http.StatusInternalServerError)
 			return
 		}
+		rc, err := blobHandler.Get(r.Context(), repo, h)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("get blob: %v", err), http.StatusInternalServerError)
+			return
+		}
+		defer rc.Close()
+		w.Header().Set("Content-Type", "application/octet-stream")
 		w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 		w.Header().Set("Docker-Content-Digest", dgst)
 		w.WriteHeader(http.StatusOK)
+		io.Copy(w, rc) //nolint:errcheck
 	})
 }
 
@@ -179,6 +208,7 @@ func serveManifest(store ManifestStore, repo, ref string, w http.ResponseWriter,
 		content, mediaType, err := store.Get(r.Context(), repo, ref)
 		if err != nil {
 			if errors.Is(err, errNotFound) {
+				slog.Info("manifest not found", "method", r.Method, "repo", repo, "ref", ref)
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusNotFound)
 				if r.Method == http.MethodGet {
@@ -190,6 +220,7 @@ func serveManifest(store ManifestStore, repo, ref string, w http.ResponseWriter,
 			return
 		}
 		d := digest.FromBytes(content)
+		slog.Info("manifest served", "method", r.Method, "repo", repo, "ref", ref, "digest", d.String(), "media_type", mediaType)
 		w.Header().Set("Content-Type", mediaType)
 		w.Header().Set("Docker-Content-Digest", d.String())
 		w.Header().Set("Content-Length", strconv.Itoa(len(content)))
@@ -210,6 +241,7 @@ func serveManifest(store ManifestStore, repo, ref string, w http.ResponseWriter,
 			return
 		}
 		d := digest.FromBytes(body)
+		slog.Info("manifest stored", "method", r.Method, "repo", repo, "ref", ref, "digest", d.String(), "media_type", mediaType)
 		w.Header().Set("Docker-Content-Digest", d.String())
 		w.Header().Set("Location", "/v2/"+repo+"/manifests/"+d.String())
 		w.WriteHeader(http.StatusCreated)


### PR DESCRIPTION
## Root cause

When using BuildKit's gateway API (`client.Build`), the outer `SolveOpt.CacheImports` gets encoded as `frontendAttrs["cache-imports"]`. This encoding is only consumed by Dockerfile-style frontends (via dockerui). For raw LLB solves via `gwclient.SolveRequest`, BuildKit only looks at the `CacheImports` field of the inner request directly.

The executor's inner `c.Solve()` call was not setting `CacheImports`, so buildkitd never contacted the registry for cache import — every run built from scratch even though the cache was fully populated in GCS.

Diagnosed by:
1. Adding manifest request logging to the registry (`manifest served`/`manifest stored`)
2. Confirming zero registry requests during the import window across both registry pods
3. Tracing through BuildKit v0.29.0 source: `grpcclient.Solve` propagates `cache-imports` via `FrontendOpt`, but `llbBridgeForwarder.Solve` only reads `req.CacheImports` (not FrontendOpt) when building from LLB

## Fixes

- **executor**: set `CacheImports` explicitly in the `gwclient.SolveRequest` passed to the inner gateway Solve
- **registry**: extend `blobHeadMiddleware` to also handle GET blob requests, returning `404 BLOB_UNKNOWN` for missing blobs instead of delegating to go-containerregistry which returns `500 INTERNAL_SERVER_ERROR`
- **registry**: add structured logging for manifest operations to make cache import/export activity visible

## Result

```
"vertex":"importing cache manifest from ci-registry.docstore-ci.svc.cluster.local/default/default:buildkit","duration_ms":30291
"vertex":"test: go test ./...","cached":true,"duration_ms":358
```

`go test ./...` went from ~18s (cold) to ~358ms (cached) on the second run.

## Test plan

- [x] Run 1 (cold): clears cache, exports to registry, `go test` ~18s
- [x] Run 2 (warm): imports from registry, `go test` cached ~358ms (`cached: true`)
- [x] `go test ./...` passes (including registry unit tests)
- [x] `go build ./...` and `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)