### PR TITLE
fix(security): prevent cross-repo check result spoofing via OIDC job tokens

### DIFF
--- a/internal/server/handlers_oidc_scope_test.go
+++ b/internal/server/handlers_oidc_scope_test.go
@@ -1,0 +1,288 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	dbpkg "github.com/dlorenc/docstore/internal/db"
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// makeJobJWTFull creates a signed RS256 JWT for a CI job with configurable repo/branch.
+func makeJobJWTFull(t *testing.T, key *rsa.PrivateKey, kid, issuer, audience, jobID, repo, branch string, exp time.Time) string {
+	t.Helper()
+	headerJSON, _ := json.Marshal(map[string]string{"alg": "RS256", "kid": kid, "typ": "JWT"})
+	payloadJSON, _ := json.Marshal(map[string]any{
+		"iss":    issuer,
+		"sub":    "repo:" + repo + ":branch:" + branch + ":check:",
+		"aud":    audience,
+		"exp":    exp.Unix(),
+		"iat":    time.Now().Unix(),
+		"job_id": jobID,
+		"repo":   repo,
+		"branch": branch,
+	})
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	signingInput := headerB64 + "." + payloadB64
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+	if err != nil {
+		t.Fatalf("sign JWT: %v", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// buildOIDCServer constructs a server with OIDC enabled using a static in-memory key.
+// Returns the http.Handler and the RSA key so callers can mint test tokens.
+func buildOIDCServer(t *testing.T, ms WriteStore) (http.Handler, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	const kid = "oidc-test-key"
+	const issuer = "https://oidc.docstore.dev"
+	const audience = "docstore"
+
+	// Pre-populate the key cache with our test key to avoid HTTP fetching.
+	kc := &keyCache{
+		keys:      map[string]crypto.PublicKey{kid: &key.PublicKey},
+		fetchedAt: time.Now(),
+		ttl:       time.Hour,
+	}
+	s := &server{
+		commitStore:  ms,
+		oidcKeyCache: kc,
+		oidcAudience: audience,
+		oidcIssuer:   issuer,
+	}
+	// Use devIdentity so IAP is bypassed for non-OIDC paths in the same test server.
+	handler := s.buildHandler("dev@example.com", "", ms)
+	return handler, key
+}
+
+// oidcToken is a convenience wrapper for tests in this file.
+func oidcToken(t *testing.T, key *rsa.PrivateKey, repo, branch string) string {
+	t.Helper()
+	const kid = "oidc-test-key"
+	const issuer = "https://oidc.docstore.dev"
+	const audience = "docstore"
+	return makeJobJWTFull(t, key, kid, issuer, audience, "job-test-001", repo, branch, time.Now().Add(time.Hour))
+}
+
+// ---------------------------------------------------------------------------
+// OIDC JWT repo scope enforcement tests
+// ---------------------------------------------------------------------------
+
+// TestOIDC_CheckRejectsWrongRepo verifies that a job token for acme/myrepo
+// cannot POST a check result to victim/other (the cross-repo spoofing vector).
+func TestOIDC_CheckRejectsWrongRepo(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return &model.Repo{Name: name}, nil
+		},
+	}
+	handler, key := buildOIDCServer(t, ms)
+
+	// Job token claims acme/myrepo but we POST to victim/other.
+	tok := oidcToken(t, key, "acme/myrepo", "main")
+	body, _ := json.Marshal(map[string]any{
+		"branch":     "main",
+		"check_name": "ci",
+		"status":     "passed",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/repos/victim/other/-/check", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for cross-repo check spoofing, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestOIDC_CheckAllowsOwnRepo verifies that a valid job token may POST a check
+// result to its own repo's endpoint.
+func TestOIDC_CheckAllowsOwnRepo(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return &model.Repo{Name: name}, nil
+		},
+		createCheckRunFn: func(_ context.Context, repo, branch, checkName string, status model.CheckRunStatus, reporter string, logURL *string, atSeq *int64, attempt int16, metadata json.RawMessage) (*model.CheckRun, error) {
+			return &model.CheckRun{ID: "cr-1", Sequence: 1}, nil
+		},
+	}
+	handler, key := buildOIDCServer(t, ms)
+
+	tok := oidcToken(t, key, "acme/myrepo", "main")
+	body, _ := json.Marshal(map[string]any{
+		"branch":     "main",
+		"check_name": "ci",
+		"status":     "passed",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/repos/acme/myrepo/-/check", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for own-repo check, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestOIDC_WriteToNonRepoPathDenied verifies that a job token cannot POST to
+// non-repo-scoped write endpoints like POST /repos (create repo) or POST /orgs.
+func TestOIDC_WriteToNonRepoPathDenied(t *testing.T) {
+	ms := &mockStore{}
+	handler, key := buildOIDCServer(t, ms)
+
+	tok := oidcToken(t, key, "acme/myrepo", "main")
+
+	writePaths := []string{
+		"/repos",
+		"/orgs",
+	}
+	for _, path := range writePaths {
+		body, _ := json.Marshal(map[string]any{"name": "test"})
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("POST %s: expected 403 for job token on non-repo path, got %d; body: %s", path, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+// TestOIDC_GetAcrossReposAllowed verifies that a job token may issue GET requests
+// to paths outside its own repo. Read operations are not restricted by repo scope.
+func TestOIDC_GetAcrossReposAllowed(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return &model.Repo{Name: name}, nil
+		},
+	}
+	handler, key := buildOIDCServer(t, ms)
+
+	// Token is for acme/myrepo, but we read from victim/other.
+	tok := oidcToken(t, key, "acme/myrepo", "main")
+	req := httptest.NewRequest(http.MethodGet, "/repos/victim/other", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// GET should succeed regardless of repo mismatch.
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("GET on different repo should not return 403 for OIDC token, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestOIDC_CrossRepoCommitDenied verifies that the repo scope enforcement covers
+// endpoints other than /check (commit is another write endpoint).
+func TestOIDC_CrossRepoCommitDenied(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return &model.Repo{Name: name}, nil
+		},
+	}
+	handler, key := buildOIDCServer(t, ms)
+
+	tok := oidcToken(t, key, "acme/myrepo", "main")
+	body, _ := json.Marshal(map[string]any{
+		"branch":  "feature/x",
+		"message": "oops",
+		"files":   []any{},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/repos/victim/other/-/commit", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for cross-repo commit, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestOIDC_CrossRepoDeleteDenied verifies that a job token cannot DELETE a repo it
+// does not own. The bare /repos/:name DELETE path must also be repo-scoped.
+func TestOIDC_CrossRepoDeleteDenied(t *testing.T) {
+	ms := &mockStore{}
+	handler, key := buildOIDCServer(t, ms)
+
+	tok := oidcToken(t, key, "acme/myrepo", "main")
+	req := httptest.NewRequest(http.MethodDelete, "/repos/victim/other", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for cross-repo DELETE /repos/victim/other, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// validateRepo in handleCheck / handleReview
+// ---------------------------------------------------------------------------
+
+// TestHandleCheck_RepoNotFound verifies that handleCheck returns 404 when the
+// repo does not exist (validateRepo added per handler checklist).
+func TestHandleCheck_RepoNotFound(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return nil, dbpkg.ErrRepoNotFound
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	body, _ := json.Marshal(map[string]any{
+		"branch":     "main",
+		"check_name": "ci",
+		"status":     "passed",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/repos/noorg/norepo/-/check", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for non-existent repo in handleCheck, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleReview_RepoNotFound verifies that handleReview returns 404 when the
+// repo does not exist (validateRepo added per handler checklist).
+func TestHandleReview_RepoNotFound(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return nil, dbpkg.ErrRepoNotFound
+		},
+	}
+	srv := New(ms, nil, devID, devID)
+	body, _ := json.Marshal(map[string]any{
+		"branch": "main",
+		"status": "approved",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/repos/noorg/norepo/-/review", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for non-existent repo in handleReview, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/server/handlers_proposals.go
+++ b/internal/server/handlers_proposals.go
@@ -23,6 +23,9 @@ import (
 // handleReview implements POST /repos/:name/review
 func (s *server) handleReview(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
 	reviewer := IdentityFromContext(r.Context())
 
 	var req model.CreateReviewRequest
@@ -62,6 +65,9 @@ func (s *server) handleReview(w http.ResponseWriter, r *http.Request) {
 // handleCheck implements POST /repos/:name/check
 func (s *server) handleCheck(w http.ResponseWriter, r *http.Request) {
 	repo := r.PathValue("name")
+	if !s.validateRepo(w, r, repo) {
+		return
+	}
 	reporter := IdentityFromContext(r.Context())
 	// If the request was authenticated via a job OIDC token, prefer the job
 	// subject as the reporter so check runs record the precise job identity.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -424,6 +424,24 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 					writeAPIError(w, ErrCodeUnauthorized, http.StatusUnauthorized, "unauthenticated")
 					return
 				}
+				// SECURITY: Enforce that OIDC-authenticated jobs can only write to
+				// their own repo. Read-only requests (GET, HEAD) may access any
+				// accessible path. Write operations on repo-scoped paths must match
+				// the job token's repo claim. Write operations on non-repo-scoped
+				// paths (e.g. POST /repos, POST /orgs) are not permitted for job tokens.
+				if r.Method != http.MethodGet && r.Method != http.MethodHead {
+					urlRepo, _, ok := parseRepoPath(r.URL.Path)
+					if !ok || urlRepo == "" {
+						slog.Warn("job token non-repo write denied", "job_repo", jobID.Repo, "path", r.URL.Path, "method", r.Method)
+						writeAPIError(w, ErrCodeForbidden, http.StatusForbidden, "forbidden: job token not permitted for this endpoint")
+						return
+					}
+					if jobID.Repo != urlRepo {
+						slog.Warn("job token repo mismatch", "job_repo", jobID.Repo, "url_repo", urlRepo, "path", r.URL.Path)
+						writeAPIError(w, ErrCodeForbidden, http.StatusForbidden, "forbidden: job may only write to its own repo")
+						return
+					}
+				}
 				identity := "ci-job:" + jobID.JobID
 				if rl := requestLogFromContext(r.Context()); rl != nil {
 					rl.identity = identity


### PR DESCRIPTION
## Summary

- **Primary fix**: OIDC JWT routing in `server.go` now enforces that write operations match the job token's repo claim. A CI job for `acme/myrepo` can no longer POST to `/repos/victim-org/other-repo/-/check` (or any other write endpoint) for a different repo.
- **Non-repo write block**: Write operations on non-repo-scoped paths (`POST /repos`, `POST /orgs`, etc.) are now rejected for OIDC job tokens entirely.
- **validateRepo fixes**: `handleCheck` and `handleReview` were both missing the mandatory `validateRepo` call per the handler checklist. Added to both — non-existent repos now return 404 instead of reaching the DB layer.

## Root Cause

In `buildHandler`, the OIDC JWT path authenticated the token but then immediately called `inner.ServeHTTP` with no repo-scope check. The `inner` mux includes every write endpoint. A valid job token for any repo could therefore:
- Submit fake check results for any other repo (`POST /repos/victim/-/check`)
- Commit to any repo (`POST /repos/victim/-/commit`)
- Merge/delete branches in any repo
- Delete repos (`DELETE /repos/victim`)
- Create orgs/repos (`POST /orgs`, `POST /repos`)

The fix adds the scope check in one place (the OIDC JWT handler in `buildHandler`) before routing to `inner`, providing blanket protection for all inner routes.

## Test plan

- `TestOIDC_CheckRejectsWrongRepo` — job token for `acme/myrepo` → 403 on `victim/other/-/check`
- `TestOIDC_CheckAllowsOwnRepo` — job token for `acme/myrepo` → 201 on `acme/myrepo/-/check`
- `TestOIDC_WriteToNonRepoPathDenied` — job token → 403 on `POST /repos` and `POST /orgs`
- `TestOIDC_GetAcrossReposAllowed` — job token → GET on different repo is not blocked
- `TestOIDC_CrossRepoCommitDenied` — job token → 403 on commit to different repo
- `TestOIDC_CrossRepoDeleteDenied` — job token → 403 on DELETE of different repo
- `TestHandleCheck_RepoNotFound` — `handleCheck` returns 404 for non-existent repo
- `TestHandleReview_RepoNotFound` — `handleReview` returns 404 for non-existent repo

All existing tests continue to pass.

## Opportunities not implemented (noted for follow-up)

- `handlePurge` is also missing `validateRepo` — low risk after this fix since OIDC jobs can only reach their own repo, but could be cleaned up for consistency.
- The RBAC middleware is still entirely bypassed for OIDC JWT requests. For now, repo-scope enforcement provides the security boundary; if finer-grained RBAC for CI jobs is desired, a follow-up could add role checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)