### PR TITLE
fix(scheduler): enforce one-claim-per-pod to prevent SA token abuse

### DIFF
--- a/internal/db/ci_jobs.go
+++ b/internal/db/ci_jobs.go
@@ -166,6 +166,7 @@ func (s *Store) ClaimCIJob(ctx context.Context, podName, podIP string) (*model.C
 		WHERE id = (
 			SELECT id FROM ci_jobs
 			WHERE status = 'queued'
+			  AND NOT EXISTS (SELECT 1 FROM ci_jobs c2 WHERE c2.worker_pod = $1 AND c2.status = 'claimed')
 			ORDER BY created_at
 			FOR UPDATE SKIP LOCKED
 			LIMIT 1

--- a/internal/db/ci_jobs_test.go
+++ b/internal/db/ci_jobs_test.go
@@ -145,6 +145,40 @@ func TestClaimCIJob(t *testing.T) {
 	}
 }
 
+// TestClaimCIJob_OnePodOneClaim verifies that a pod which already holds a
+// claimed job cannot claim a second job, preventing SA-token-based queue drain.
+func TestClaimCIJob_OnePodOneClaim(t *testing.T) {
+	t.Parallel()
+	s, _ := newCIJobStore(t)
+	ctx := context.Background()
+
+	// Insert two queued jobs.
+	if _, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", ""); err != nil {
+		t.Fatalf("InsertCIJob 1: %v", err)
+	}
+	if _, err := s.InsertCIJob(ctx, "org/repo", "main", 2, "push", "main", "", ""); err != nil {
+		t.Fatalf("InsertCIJob 2: %v", err)
+	}
+
+	// First claim from the pod should succeed.
+	first, err := s.ClaimCIJob(ctx, "worker-pod-1", "10.0.0.1")
+	if err != nil {
+		t.Fatalf("first ClaimCIJob: %v", err)
+	}
+	if first == nil {
+		t.Fatal("expected first claim to succeed")
+	}
+
+	// Second claim from the same pod must return nil — the pod already owns one.
+	second, err := s.ClaimCIJob(ctx, "worker-pod-1", "10.0.0.1")
+	if err != nil {
+		t.Fatalf("second ClaimCIJob: %v", err)
+	}
+	if second != nil {
+		t.Errorf("expected second claim from same pod to return nil, got job %q", second.ID)
+	}
+}
+
 func TestClaimCIJob_NoQueued(t *testing.T) {
 	t.Parallel()
 	s, _ := newCIJobStore(t)


### PR DESCRIPTION
## Summary

- Adds `AND NOT EXISTS (SELECT 1 FROM ci_jobs c2 WHERE c2.worker_pod = $1 AND c2.status = 'claimed')` to the inner `SELECT` in `ClaimCIJob` (`internal/db/ci_jobs.go`)
- A pod that already holds a `claimed` job now receives `nil` from a second `/claim` call, so a compromised build step cannot use the pod's K8s SA token to drain the queue and steal other tenants' `request_token`s
- Adds `TestClaimCIJob_OnePodOneClaim`: inserts two queued jobs, verifies the first claim from `worker-pod-1` succeeds and the second returns `nil`

## Pre-existing test failures

The full `go test ./...` run shows connection-reset failures in several packages (`internal/db`, `cmd/docstore`, etc.) caused by the test container running out of connections under high parallelism. These failures predate this change and are unrelated — `go test ./internal/db/... -count=1` passes cleanly (all 80+ tests).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/db/... -count=1` — all pass including new `TestClaimCIJob_OnePodOneClaim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)