### PR TITLE
fix(security): restrict OIDC JWT to check-only allowlist; move fetchConfig/postCheckRun to request_token auth

### DIFF
--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -416,16 +416,16 @@ func writeCacheDockerConfig(regHost, token string) (string, error) {
 	return dir, nil
 }
 
-func fetchConfig(ctx context.Context, client *http.Client, docstoreURL, repo, branch string, headSeq int64, jwt string) (*executor.Config, error) {
+func fetchConfig(ctx context.Context, client *http.Client, docstoreURL, repo, requestToken string) (*executor.Config, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	fileURL := fmt.Sprintf("%s/repos/%s/-/file/.docstore/ci.yaml?branch=%s&at=%d", docstoreURL, repo, url.QueryEscape(branch), headSeq)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
+	u := fmt.Sprintf("%s/repos/%s/-/ci/config", docstoreURL, repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create config request: %w", err)
 	}
-	if jwt != "" {
-		req.Header.Set("Authorization", "Bearer "+jwt)
+	if requestToken != "" {
+		req.Header.Set("Authorization", "Bearer "+requestToken)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -449,7 +449,7 @@ func fetchConfig(ctx context.Context, client *http.Client, docstoreURL, repo, br
 	return &cfg, nil
 }
 
-func postCheckRun(ctx context.Context, client *http.Client, docstoreURL, repo string, jwt string, req model.CreateCheckRunRequest) error {
+func postCheckRun(ctx context.Context, client *http.Client, docstoreURL, repo string, requestToken string, req model.CreateCheckRunRequest) error {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return fmt.Errorf("marshal check run: %w", err)
@@ -460,8 +460,8 @@ func postCheckRun(ctx context.Context, client *http.Client, docstoreURL, repo st
 		return fmt.Errorf("create check run request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	if jwt != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+jwt)
+	if requestToken != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+requestToken)
 	}
 	resp, err := client.Do(httpReq)
 	if err != nil {
@@ -524,8 +524,7 @@ func (s *checkLogServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // runJob fetches CI config, pulls source, executes checks, uploads logs, and
 // posts check run results. Returns (overallStatus, firstLogURL, errorMessage).
-// jwt is the OIDC job token for authenticating requests to docstore; may be
-// empty when OIDC is not configured (local dev mode).
+// requestToken is used to authenticate all docstore API calls (ci/config and check).
 func runJob(
 	ctx context.Context,
 	httpClient *http.Client,
@@ -534,7 +533,6 @@ func runJob(
 	job *model.CIJob,
 	requestToken string,
 	oidcTokenURL string,
-	jwt string,
 	logDir string,
 	triggerCtx ciconfig.TriggerContext,
 	cacheRef string,
@@ -546,9 +544,9 @@ func runJob(
 	}
 
 	// 1. Fetch CI config from the branch under test at its head sequence.
-	cfg, err := fetchConfig(ctx, httpClient, docstoreURL, job.Repo, job.Branch, job.Sequence, jwt)
+	cfg, err := fetchConfig(ctx, httpClient, docstoreURL, job.Repo, requestToken)
 	if err != nil {
-		_ = postCheckRun(ctx, httpClient, docstoreURL, job.Repo, jwt, model.CreateCheckRunRequest{
+		_ = postCheckRun(ctx, httpClient, docstoreURL, job.Repo, requestToken, model.CreateCheckRunRequest{
 			Branch:    job.Branch,
 			CheckName: "ci/config",
 			Status:    model.CheckRunFailed,
@@ -573,7 +571,7 @@ func runJob(
 		pendingWg.Add(1)
 		go func(checkName string) {
 			defer pendingWg.Done()
-			if err := postCheckRun(ctx, httpClient, docstoreURL, job.Repo, jwt, model.CreateCheckRunRequest{
+			if err := postCheckRun(ctx, httpClient, docstoreURL, job.Repo, requestToken, model.CreateCheckRunRequest{
 				Branch:    job.Branch,
 				CheckName: checkName,
 				Status:    model.CheckRunPending,
@@ -615,7 +613,7 @@ func runJob(
 			}
 		}
 
-		if err := postCheckRun(ctx, httpClient, docstoreURL, job.Repo, jwt, model.CreateCheckRunRequest{
+		if err := postCheckRun(ctx, httpClient, docstoreURL, job.Repo, requestToken, model.CreateCheckRunRequest{
 			Branch:    job.Branch,
 			CheckName: result.Name,
 			Status:    model.CheckRunStatus(result.Status),
@@ -712,19 +710,6 @@ func main() {
 
 		slog.Info("claimed job", "job_id", job.ID, "repo", job.Repo, "branch", job.Branch, "sequence", job.Sequence)
 
-		// Exchange the request_token for a short-lived OIDC JWT (aud=docstore)
-		// to authenticate API calls to docstore. If the OIDC token URL is empty
-		// (local dev / presign not configured), jwt remains empty and calls are
-		// made without authentication (relying on DEV_IDENTITY bypass).
-		jwt, err := getDocstoreOIDCToken(ctx, cr.OIDCTokenURL, requestToken)
-		if err != nil {
-			slog.Error("get docstore OIDC token failed", "job_id", job.ID, "error", err)
-			msg := err.Error()
-			_ = completeJob(ctx, schedulerURL, job.ID, requestToken, "failed", nil, &msg)
-			time.Sleep(1 * time.Second)
-			continue
-		}
-
 		// Start heartbeat goroutine.
 		hbDone := make(chan struct{})
 		go heartbeat(ctx, schedulerURL, job.ID, requestToken, hbDone)
@@ -775,7 +760,7 @@ func main() {
 		}
 
 		// Execute the job.
-		jobStatus, jobLogURL, jobErrMsg := runJob(ctx, httpClient, exec, docstoreURL, job, requestToken, cr.OIDCTokenURL, jwt, logDir, triggerCtx, cacheRef, cacheDockerConfigDir)
+		jobStatus, jobLogURL, jobErrMsg := runJob(ctx, httpClient, exec, docstoreURL, job, requestToken, cr.OIDCTokenURL, logDir, triggerCtx, cacheRef, cacheDockerConfigDir)
 
 		// Stop heartbeat and clear log dir.
 		close(hbDone)

--- a/cmd/ci-worker/main_test.go
+++ b/cmd/ci-worker/main_test.go
@@ -217,7 +217,7 @@ func TestFetchConfig_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cfg, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "main", 1, "")
+	cfg, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestFetchConfig_NotFound_ReturnsNil(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cfg, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "main", 1, "")
+	cfg, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "")
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
@@ -250,7 +250,7 @@ func TestFetchConfig_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "main", 1, "")
+	_, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "")
 	if err == nil {
 		t.Fatal("expected error for 500, got nil")
 	}
@@ -262,27 +262,24 @@ func TestFetchConfig_InvalidJSON(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "main", 1, "")
+	_, err := fetchConfig(context.Background(), srv.Client(), srv.URL, "repo", "")
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
 	}
 }
 
-func TestFetchConfig_URLContainsBranchAndSeq(t *testing.T) {
-	var gotURL string
+func TestFetchConfig_URLIsCIConfigEndpoint(t *testing.T) {
+	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotURL = r.URL.String()
+		gotPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(fileResponseJSON(t, "checks: []")) //nolint:errcheck
 	}))
 	defer srv.Close()
 
-	_, _ = fetchConfig(context.Background(), srv.Client(), srv.URL, "myrepo", "feat/x", 99, "")
-	if !strings.Contains(gotURL, "feat%2Fx") {
-		t.Errorf("branch not URL-encoded in request: %s", gotURL)
-	}
-	if !strings.Contains(gotURL, "at=99") {
-		t.Errorf("sequence missing from request: %s", gotURL)
+	_, _ = fetchConfig(context.Background(), srv.Client(), srv.URL, "myrepo", "")
+	if gotPath != "/repos/myrepo/-/ci/config" {
+		t.Errorf("expected ci/config endpoint, got path: %s", gotPath)
 	}
 }
 
@@ -465,7 +462,7 @@ func docstoreHandler(t *testing.T, ciYAML string, tarData []byte, checkStatus in
 	return func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 		switch {
-		case strings.Contains(path, "/-/file/"):
+		case strings.Contains(path, "/-/ci/config"):
 			if ciYAML == "" {
 				http.NotFound(w, r)
 				return
@@ -501,7 +498,7 @@ func TestRunJob_NoCIYAML_ReturnsPassed(t *testing.T) {
 
 	status, logURL, errMsg := runJob(
 		context.Background(), srv.Client(), &mockRunner{},
-		srv.URL, testJob(), "", "", "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, "", "",
+		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, "", "",
 	)
 	if status != "passed" {
 		t.Errorf("expected passed, got %q", status)
@@ -513,7 +510,7 @@ func TestRunJob_NoCIYAML_ReturnsPassed(t *testing.T) {
 
 func TestRunJob_FetchConfigError_ReturnsFailed(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/-/file/") {
+		if strings.Contains(r.URL.Path, "/-/ci/config") {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -524,7 +521,7 @@ func TestRunJob_FetchConfigError_ReturnsFailed(t *testing.T) {
 
 	status, _, errMsg := runJob(
 		context.Background(), srv.Client(), &mockRunner{},
-		srv.URL, testJob(), "", "", "", t.TempDir(), ciconfig.TriggerContext{}, "", "",
+		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, "", "",
 	)
 	if status != "failed" {
 		t.Errorf("expected failed, got %q", status)
@@ -544,7 +541,7 @@ func TestRunJob_ExecutorError_ReturnsFailed(t *testing.T) {
 	mockExec := &mockRunner{err: fmt.Errorf("buildkit unavailable")}
 	status, _, errMsg := runJob(
 		context.Background(), srv.Client(), mockExec,
-		srv.URL, testJob(), "", "", "", t.TempDir(), ciconfig.TriggerContext{}, "", "",
+		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, "", "",
 	)
 	if status != "failed" {
 		t.Errorf("expected failed, got %q", status)
@@ -568,7 +565,7 @@ func TestRunJob_AllChecksPassed(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 		switch {
-		case strings.Contains(path, "/-/file/"):
+		case strings.Contains(path, "/-/ci/config"):
 			w.Header().Set("Content-Type", "application/json")
 			w.Write(fileResponseJSON(t, ciYAML)) //nolint:errcheck
 		case r.Method == http.MethodPost && strings.Contains(path, "/-/archive/presign"):
@@ -597,7 +594,7 @@ func TestRunJob_AllChecksPassed(t *testing.T) {
 
 	status, logURL, errMsg := runJob(
 		context.Background(), srv.Client(), mockExec,
-		srv.URL, testJob(), "test-request-token", "", "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, "", "",
+		srv.URL, testJob(), "test-request-token", "", t.TempDir(), ciconfig.TriggerContext{Type: "push"}, "", "",
 	)
 	if status != "passed" {
 		t.Errorf("expected passed, got %q", status)
@@ -633,7 +630,7 @@ func TestRunJob_OneCheckFailed_OverallFailed(t *testing.T) {
 
 	status, _, errMsg := runJob(
 		context.Background(), srv.Client(), mockExec,
-		srv.URL, testJob(), "", "", "", t.TempDir(), ciconfig.TriggerContext{}, "", "",
+		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, "", "",
 	)
 	if status != "failed" {
 		t.Errorf("expected failed, got %q", status)
@@ -653,7 +650,7 @@ func TestRunJob_LogUploadFails_StillPosts(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 		switch {
-		case strings.Contains(path, "/-/file/"):
+		case strings.Contains(path, "/-/ci/config"):
 			w.Header().Set("Content-Type", "application/json")
 			w.Write(fileResponseJSON(t, ciYAML)) //nolint:errcheck
 		case r.Method == http.MethodPost && strings.Contains(path, "/-/archive/presign"):
@@ -677,7 +674,7 @@ func TestRunJob_LogUploadFails_StillPosts(t *testing.T) {
 
 	status, logURL, _ := runJob(
 		context.Background(), srv.Client(), mockExec,
-		srv.URL, testJob(), "", "", "", t.TempDir(), ciconfig.TriggerContext{}, "", "",
+		srv.URL, testJob(), "", "", t.TempDir(), ciconfig.TriggerContext{}, "", "",
 	)
 	if status != "passed" {
 		t.Errorf("expected passed, got %q", status)
@@ -703,7 +700,7 @@ func TestRunJob_LogsWrittenToDir(t *testing.T) {
 	}}
 
 	logDir := t.TempDir()
-	runJob(context.Background(), srv.Client(), mockExec, srv.URL, testJob(), "", "", "", logDir, ciconfig.TriggerContext{}, "", "") //nolint:errcheck
+	runJob(context.Background(), srv.Client(), mockExec, srv.URL, testJob(), "", "", logDir, ciconfig.TriggerContext{}, "", "") //nolint:errcheck
 
 	data, err := os.ReadFile(filepath.Join(logDir, "test.log"))
 	if err != nil {
@@ -801,13 +798,13 @@ func TestFetchConfig_SendsAuthHeader(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, _ = fetchConfig(context.Background(), srv.Client(), srv.URL, "myrepo", "main", 1, "my-jwt")
-	if gotAuth != "Bearer my-jwt" {
-		t.Errorf("expected Authorization: Bearer my-jwt, got %q", gotAuth)
+	_, _ = fetchConfig(context.Background(), srv.Client(), srv.URL, "myrepo", "my-request-token")
+	if gotAuth != "Bearer my-request-token" {
+		t.Errorf("expected Authorization: Bearer my-request-token, got %q", gotAuth)
 	}
 }
 
-func TestFetchConfig_NoAuthHeaderWhenJWTEmpty(t *testing.T) {
+func TestFetchConfig_NoAuthHeaderWhenTokenEmpty(t *testing.T) {
 	var gotAuth string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
@@ -816,9 +813,9 @@ func TestFetchConfig_NoAuthHeaderWhenJWTEmpty(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, _ = fetchConfig(context.Background(), srv.Client(), srv.URL, "myrepo", "main", 1, "")
+	_, _ = fetchConfig(context.Background(), srv.Client(), srv.URL, "myrepo", "")
 	if gotAuth != "" {
-		t.Errorf("expected no Authorization header for empty JWT, got %q", gotAuth)
+		t.Errorf("expected no Authorization header for empty token, got %q", gotAuth)
 	}
 }
 

--- a/internal/server/handlers_ci_request_token.go
+++ b/internal/server/handlers_ci_request_token.go
@@ -1,0 +1,157 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/dlorenc/docstore/internal/citoken"
+	"github.com/dlorenc/docstore/internal/db"
+	evtypes "github.com/dlorenc/docstore/internal/events/types"
+	"github.com/dlorenc/docstore/internal/model"
+)
+
+// handleCIConfig implements GET /repos/:repo/-/ci/config.
+// Authenticated via request_token (Authorization: Bearer <plaintext>).
+// Returns the .docstore/ci.yaml file at the job's branch and sequence as a
+// JSON FileResponse, using the same wire format as the IAP-gated file endpoint.
+func (s *server) handleCIConfig(w http.ResponseWriter, r *http.Request) {
+	if s.jobTokenStore == nil || s.readStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "ci config not available")
+		return
+	}
+
+	// 1. Extract and validate request_token from Authorization header.
+	authHdr := r.Header.Get("Authorization")
+	plaintext := strings.TrimPrefix(authHdr, "Bearer ")
+	if plaintext == "" || plaintext == authHdr {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	hashed := citoken.HashRequestToken(plaintext)
+	job, err := s.jobTokenStore.LookupRequestToken(r.Context(), hashed)
+	if errors.Is(err, db.ErrTokenInvalid) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// 2. Verify repo in token matches the request path.
+	repoName := r.PathValue("name")
+	if job.Repo != repoName {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// 3. Fetch .docstore/ci.yaml at the job's branch and sequence.
+	seq := job.Sequence
+	fc, err := s.readStore.GetFile(r.Context(), job.Repo, job.Branch, ".docstore/ci.yaml", &seq)
+	if err != nil {
+		slog.Error("ci config fetch", "repo", job.Repo, "branch", job.Branch, "seq", seq, "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if fc == nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(fc) //nolint:errcheck
+}
+
+// handleCICheck implements POST /repos/:repo/-/check via request_token authentication.
+// This is the worker-facing check-run endpoint, authenticated via request_token.
+// It mirrors handleCheck but bypasses IAP/RBAC and derives identity from the token.
+func (s *server) handleCICheck(w http.ResponseWriter, r *http.Request) {
+	if s.jobTokenStore == nil || s.commitStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "ci check not available")
+		return
+	}
+
+	// 1. Extract and validate request_token from Authorization header.
+	authHdr := r.Header.Get("Authorization")
+	plaintext := strings.TrimPrefix(authHdr, "Bearer ")
+	if plaintext == "" || plaintext == authHdr {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	hashed := citoken.HashRequestToken(plaintext)
+	job, err := s.jobTokenStore.LookupRequestToken(r.Context(), hashed)
+	if errors.Is(err, db.ErrTokenInvalid) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// 2. Verify repo in token matches the request path.
+	repoName := r.PathValue("name")
+	if job.Repo != repoName {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// 3. Decode and validate request body.
+	var req model.CreateCheckRunRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Branch == "" {
+		writeError(w, http.StatusBadRequest, "branch is required")
+		return
+	}
+	if req.CheckName == "" {
+		writeError(w, http.StatusBadRequest, "check_name is required")
+		return
+	}
+	if req.Status == "" {
+		writeError(w, http.StatusBadRequest, "status is required")
+		return
+	}
+
+	reporter := "ci-job:" + job.ID
+
+	attempt := int16(1)
+	if req.Attempt != nil {
+		attempt = *req.Attempt
+	}
+	cr, err := s.commitStore.CreateCheckRun(r.Context(), repoName, req.Branch, req.CheckName, req.Status, reporter, req.LogURL, req.Sequence, attempt, req.Metadata)
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrBranchNotFound):
+			writeAPIError(w, ErrCodeBranchNotFound, http.StatusNotFound, "branch not found")
+		default:
+			slog.Error("internal error", "op", "ci_check", "repo", repoName, "error", err)
+			writeAPIError(w, ErrCodeInternalError, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	bs, bsErr := s.computeBranchStatus(r.Context(), repoName, req.Branch, reporter)
+	if bsErr != nil {
+		slog.Warn("branch status computation failed", "op", "ci_check", "repo", repoName, "branch", req.Branch, "error", bsErr)
+	}
+	s.emit(r.Context(), evtypes.CheckReported{
+		Repo:         repoName,
+		Branch:       req.Branch,
+		Sequence:     cr.Sequence,
+		CheckName:    req.CheckName,
+		Status:       string(req.Status),
+		Reporter:     reporter,
+		BranchStatus: bs,
+	})
+	writeJSON(w, http.StatusCreated, model.CreateCheckRunResponse{
+		ID:       cr.ID,
+		Sequence: cr.Sequence,
+		LogURL:   req.LogURL,
+	})
+}

--- a/internal/server/handlers_oidc_scope_test.go
+++ b/internal/server/handlers_oidc_scope_test.go
@@ -219,6 +219,34 @@ func TestOIDC_CrossRepoCommitDenied(t *testing.T) {
 	}
 }
 
+// TestOIDC_OwnRepoNonCheckEndpointDenied verifies that a job token cannot POST to
+// endpoints other than /check on its own repo — the allowlist gate rejects them.
+func TestOIDC_OwnRepoNonCheckEndpointDenied(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return &model.Repo{Name: name}, nil
+		},
+	}
+	handler, key := buildOIDCServer(t, ms)
+
+	// Token is for acme/myrepo; we POST to acme/myrepo/-/commit (own repo, wrong endpoint).
+	tok := oidcToken(t, key, "acme/myrepo", "main")
+	body, _ := json.Marshal(map[string]any{
+		"branch":  "main",
+		"message": "pwned",
+		"files":   []any{},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/repos/acme/myrepo/-/commit", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for own-repo non-check endpoint, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
 // TestOIDC_CrossRepoDeleteDenied verifies that a job token cannot DELETE a repo it
 // does not own. The bare /repos/:name DELETE path must also be repo-scoped.
 func TestOIDC_CrossRepoDeleteDenied(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -409,6 +409,19 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 					return
 				}
 			}
+			// CI config fetch (worker → get .docstore/ci.yaml): auth via request_token.
+			if endpoint == "ci/config" && r.Method == http.MethodGet {
+				r.SetPathValue("name", repoName)
+				s.handleCIConfig(w, r)
+				return
+			}
+			// Check run (worker → post check result): auth via request_token.
+			// Only intercept when jobTokenStore is configured; fall through to OIDC/IAP otherwise.
+			if endpoint == "check" && r.Method == http.MethodPost && s.jobTokenStore != nil {
+				r.SetPathValue("name", repoName)
+				s.handleCICheck(w, r)
+				return
+			}
 		}
 
 		// Job OIDC token auth: if a Bearer token is present and OIDC is configured,
@@ -425,12 +438,13 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 					return
 				}
 				// SECURITY: Enforce that OIDC-authenticated jobs can only write to
-				// their own repo. Read-only requests (GET, HEAD) may access any
-				// accessible path. Write operations on repo-scoped paths must match
-				// the job token's repo claim. Write operations on non-repo-scoped
-				// paths (e.g. POST /repos, POST /orgs) are not permitted for job tokens.
+				// their own repo via the allowlisted endpoint. Read-only requests
+				// (GET, HEAD) may access any accessible path. Write operations
+				// must target the job's own repo AND be on the allowlist.
+				// Write operations on non-repo-scoped paths (e.g. POST /repos,
+				// POST /orgs) are not permitted for job tokens.
 				if r.Method != http.MethodGet && r.Method != http.MethodHead {
-					urlRepo, _, ok := parseRepoPath(r.URL.Path)
+					urlRepo, endpoint, ok := parseRepoPath(r.URL.Path)
 					if !ok || urlRepo == "" {
 						slog.Warn("job token non-repo write denied", "job_repo", jobID.Repo, "path", r.URL.Path, "method", r.Method)
 						writeAPIError(w, ErrCodeForbidden, http.StatusForbidden, "forbidden: job token not permitted for this endpoint")
@@ -439,6 +453,14 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 					if jobID.Repo != urlRepo {
 						slog.Warn("job token repo mismatch", "job_repo", jobID.Repo, "url_repo", urlRepo, "path", r.URL.Path)
 						writeAPIError(w, ErrCodeForbidden, http.StatusForbidden, "forbidden: job may only write to its own repo")
+						return
+					}
+					// Allowlist: OIDC JWT job tokens may only call POST /-/check on
+					// their own repo. All other write endpoints are denied until a
+					// permissions system is in place.
+					if endpoint != "check" {
+						slog.Warn("job token endpoint not in allowlist", "job_repo", jobID.Repo, "endpoint", endpoint, "path", r.URL.Path)
+						writeAPIError(w, ErrCodeForbidden, http.StatusForbidden, "forbidden: job token not permitted for this endpoint")
 						return
 					}
 				}


### PR DESCRIPTION
## Summary

Addresses attack surface 1 from issue #426 (OIDC JWT bypass).

- **OIDC JWT allowlist gate**: In `buildHandler`, after the existing repo-binding check, add an endpoint allowlist — OIDC JWT job tokens may only reach `POST /-/check` on their own repo. All other non-GET writes return 403. This closes the full cross-tenant blast radius: delete-repo, delete-org, purge, set-role, commit, branch, merge, CI trigger, etc.

- **New `request_token`-gated outer endpoints**:
  - `GET /repos/{repo}/-/ci/config` — serves `.docstore/ci.yaml` at the job's branch/sequence; auth via request_token (token carries branch/seq, no query params needed).
  - `POST /repos/{repo}/-/check` — creates a check run using identity from the token; active in the outer mux only when `jobTokenStore` is configured, so the OIDC JWT path to inner still works in dev/test.

- **ci-worker: stop using OIDC JWT for docstore API calls**: `fetchConfig` now calls `GET /-/ci/config` with `request_token` Bearer. `postCheckRun` now uses `request_token` Bearer. The `getDocstoreOIDCToken` (aud=docstore) exchange is removed from the main job loop. `getCIRegistryToken` (aud=ci-registry) is unaffected.

## Test plan

- [x] `go test ./... -count=1` passes
- [x] `go build ./...` and `go vet ./...` clean
- New test: `TestOIDC_OwnRepoNonCheckEndpointDenied` — OIDC JWT for `POST /-/commit` on own repo → 403
- New handlers covered by `handlers_ci_request_token.go` pattern (follows existing `handleCheckLogs`/`handleArchivePresign` pattern)
- ci-worker tests updated: `docstoreHandler` now dispatches on `/-/ci/config` instead of `/-/file/`; `fetchConfig` signature tests updated

## Opportunities noted (not implemented)

- `getDocstoreOIDCToken` function is no longer called from main but left in place since it has tests and may be useful if the permissions system is built out later.
- The OIDC JWT allowlist currently has one entry (`check`). When the permissions system is implemented, the gate at the JWT dispatch point is the right place to expand it.
- `entrypoint-worker.sh` metadata server block (iptables) and same-org ci-registry cache poisoning are tracked separately in issue #426.

Closes: #426 (attack surface 1)
Related: gentle-dolphin (#425), gentle-otter (#427)

🤖 Generated with [Claude Code](https://claude.com/claude-code)