### PR TITLE
ci: bump checkout and setup-go to Node.js 24 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run tests
@@ -23,8 +23,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run go vet
@@ -33,8 +33,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Build docstore
@@ -43,15 +43,15 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build Docker image
         run: docker build -t docstore:ci .
 
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run integration tests

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,8 +15,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - uses: ko-build/setup-ko@v0.7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,9 +12,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -71,9 +71,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deploy]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -142,9 +142,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deploy]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deploy, build-and-deploy-ci-scheduler]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: google-github-actions/auth@v2
         with:
@@ -230,9 +230,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deploy, build-and-deploy-ci-scheduler]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
## Summary

GitHub is deprecating Node.js 20 on hosted runners. Node.js 24 will become the default on **2026-06-02**, and Node.js 20 will be removed on **2026-09-16** (see the [changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The current CI emits warnings for `actions/checkout@v4` and `actions/setup-go@v5`, which both run on Node.js 20.

This PR bumps each to its latest major release, which run on Node.js 24:

- `actions/checkout`: `v4` → `v6` (v6.0.2)
- `actions/setup-go`: `v5` → `v6` (v6.4.0)

Verified the major-version tags (`@v6`) resolve to releases whose `action.yml` declares `using: node24`. No other usage changes — both bumps are drop-in for the inputs the workflows already pass.

Files touched: `.github/workflows/{ci,deploy,deploy-docs}.yml`.

## Test plan

- [ ] CI runs cleanly with no Node.js 20 deprecation warnings.
- [ ] All existing jobs (test, lint, build, docker, integration, deploy variants) pass on the new actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)