### PR TITLE
feat(ci): implement job permissions system (#428)

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -902,10 +902,11 @@ type CIJob struct {
 	LogURL            *string    `json:"log_url,omitempty"`
 	ErrorMessage      *string    `json:"error_message,omitempty"`
 	CreatedAt         time.Time  `json:"created_at"`
-	TriggerType       string  `json:"trigger_type,omitempty"`
-	TriggerBranch     string  `json:"trigger_branch,omitempty"`
-	TriggerBaseBranch string  `json:"trigger_base_branch,omitempty"`
-	TriggerProposalID *string `json:"trigger_proposal_id,omitempty"`
+	TriggerType       string   `json:"trigger_type,omitempty"`
+	TriggerBranch     string   `json:"trigger_branch,omitempty"`
+	TriggerBaseBranch string   `json:"trigger_base_branch,omitempty"`
+	TriggerProposalID *string  `json:"trigger_proposal_id,omitempty"`
+	Permissions       []string `json:"permissions,omitempty"`
 }
 
 // ListCIJobsResponse is the response for GET .../ci-jobs

--- a/cmd/ci-oidc/main.go
+++ b/cmd/ci-oidc/main.go
@@ -158,6 +158,7 @@ func (s *server) handleToken(w http.ResponseWriter, r *http.Request) {
 		TriggeredBy: "",
 		JobID:       job.ID,
 		Sequence:    job.Sequence,
+		Permissions: job.Permissions,
 	}
 
 	// 7. Issue JWT.

--- a/cmd/ci-scheduler/main.go
+++ b/cmd/ci-scheduler/main.go
@@ -48,7 +48,7 @@ import (
 // ---------------------------------------------------------------------------
 
 type ciJobStore interface {
-	InsertCIJob(ctx context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerBaseBranch, triggerProposalID string) (*model.CIJob, error)
+	InsertCIJob(ctx context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerBaseBranch, triggerProposalID string, permissions []string) (*model.CIJob, error)
 	GetCIJob(ctx context.Context, id string) (*model.CIJob, error)
 	ClaimCIJob(ctx context.Context, podName, podIP string) (*model.CIJob, error)
 	StoreRequestToken(ctx context.Context, jobID string, hashedToken string, exp time.Time) error
@@ -214,6 +214,31 @@ func (s *scheduler) fetchOpenProposalForBranch(ctx context.Context, repo, branch
 	return proposals[0], nil
 }
 
+// fetchPermissions extracts the effective permissions from the ci.yaml at the
+// given repo/branch/sequence. Returns the default set (["checks"]) on any error
+// or if no ci.yaml / permissions block is present.
+func (s *scheduler) fetchPermissions(ctx context.Context, repo, branch string, sequence int64) []string {
+	cfg, err := s.fetchCIConfig(ctx, repo, branch, sequence)
+	if err != nil || cfg == nil {
+		return []string{"checks"}
+	}
+	return cfg.EffectivePermissions()
+}
+
+// fetchPermissionsForBaseBranch fetches the effective permissions from the
+// target (base) branch's ci.yaml. This is used for proposal and
+// proposal_synchronized jobs to enforce the security invariant: a proposal
+// cannot escalate its own permissions by adding a permissions block to its
+// source branch.
+func (s *scheduler) fetchPermissionsForBaseBranch(ctx context.Context, repo, baseBranch string) []string {
+	headSeq, err := s.fetchBranchHead(ctx, repo, baseBranch)
+	if err != nil {
+		slog.Warn("permissions: could not fetch base branch head, using default", "repo", repo, "base_branch", baseBranch, "error", err)
+		return []string{"checks"}
+	}
+	return s.fetchPermissions(ctx, repo, baseBranch, headSeq)
+}
+
 // handleWebhook handles POST /webhook — receives CloudEvents from docstore outbox.
 func (s *scheduler) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
@@ -278,7 +303,8 @@ func (s *scheduler) handleCommitCreated(w http.ResponseWriter, r *http.Request, 
 	}
 
 	if cfg == nil || cfg.MatchesPush(data.Branch) {
-		job, err := s.store.InsertCIJob(r.Context(), data.Repo, data.Branch, data.Sequence, "push", data.Branch, "", "")
+		perms := s.fetchPermissions(r.Context(), data.Repo, data.Branch, data.Sequence)
+		job, err := s.store.InsertCIJob(r.Context(), data.Repo, data.Branch, data.Sequence, "push", data.Branch, "", "", perms)
 		if err != nil {
 			slog.Error("insert ci job failed", "repo", data.Repo, "branch", data.Branch, "error", err)
 			http.Error(w, "internal error", http.StatusInternalServerError)
@@ -300,7 +326,9 @@ func (s *scheduler) handleCommitCreated(w http.ResponseWriter, r *http.Request, 
 			proposalCfgMatch = cfg.MatchesProposal(proposal.BaseBranch)
 		}
 		if proposalCfgMatch {
-			job, err := s.store.InsertCIJob(r.Context(), data.Repo, data.Branch, data.Sequence, "proposal_synchronized", data.Branch, proposal.BaseBranch, proposal.ID)
+			// Security: use base branch permissions for proposal jobs.
+			perms := s.fetchPermissionsForBaseBranch(r.Context(), data.Repo, proposal.BaseBranch)
+			job, err := s.store.InsertCIJob(r.Context(), data.Repo, data.Branch, data.Sequence, "proposal_synchronized", data.Branch, proposal.BaseBranch, proposal.ID, perms)
 			if err != nil {
 				slog.Error("insert proposal_synchronized ci job failed", "repo", data.Repo, "branch", data.Branch, "proposal_id", proposal.ID, "error", err)
 				http.Error(w, "internal error", http.StatusInternalServerError)
@@ -348,7 +376,9 @@ func (s *scheduler) handleProposalOpened(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	job, err := s.store.InsertCIJob(r.Context(), data.Repo, data.Branch, sequence, "proposal", data.Branch, data.BaseBranch, data.ProposalID)
+	// Security: use base branch permissions for proposal jobs.
+	perms := s.fetchPermissionsForBaseBranch(r.Context(), data.Repo, data.BaseBranch)
+	job, err := s.store.InsertCIJob(r.Context(), data.Repo, data.Branch, sequence, "proposal", data.Branch, data.BaseBranch, data.ProposalID, perms)
 	if err != nil {
 		slog.Error("insert proposal ci job failed", "repo", data.Repo, "branch", data.Branch, "proposal_id", data.ProposalID, "error", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -668,6 +698,7 @@ func (s *scheduler) runScheduledJobs(ctx context.Context, t time.Time) {
 		if cfg == nil || cfg.On == nil || len(cfg.On.Schedule) == 0 {
 			continue
 		}
+		perms := s.fetchPermissions(ctx, repo, "main", headSeq)
 		for _, entry := range cfg.On.Schedule {
 			sched, err := cron.ParseStandard(entry.Cron)
 			if err != nil {
@@ -677,7 +708,7 @@ func (s *scheduler) runScheduledJobs(ctx context.Context, t time.Time) {
 			// Check if the cron fires at this minute: the next fire time after
 			// (now - 1 minute) must equal now.
 			if sched.Next(now.Add(-time.Minute)).Equal(now) {
-				job, err := s.store.InsertCIJob(ctx, repo, "main", headSeq, "schedule", "main", "", "")
+				job, err := s.store.InsertCIJob(ctx, repo, "main", headSeq, "schedule", "main", "", "", perms)
 				if err != nil {
 					slog.Error("schedule runner: insert ci job failed", "repo", repo, "cron", entry.Cron, "error", err)
 					continue

--- a/cmd/ci-scheduler/main_test.go
+++ b/cmd/ci-scheduler/main_test.go
@@ -44,7 +44,7 @@ type stubStore struct {
 	proposalListErr error
 }
 
-func (s *stubStore) InsertCIJob(_ context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerBaseBranch, triggerProposalID string) (*model.CIJob, error) {
+func (s *stubStore) InsertCIJob(_ context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerBaseBranch, triggerProposalID string, permissions []string) (*model.CIJob, error) {
 	j := &model.CIJob{
 		ID:                "test-uuid",
 		Repo:              repo,
@@ -54,6 +54,7 @@ func (s *stubStore) InsertCIJob(_ context.Context, repo, branch string, sequence
 		TriggerType:       triggerType,
 		TriggerBranch:     triggerBranch,
 		TriggerBaseBranch: triggerBaseBranch,
+		Permissions:       permissions,
 	}
 	if triggerProposalID != "" {
 		j.TriggerProposalID = &triggerProposalID
@@ -681,7 +682,7 @@ type countingStore struct {
 	reapErr   error
 }
 
-func (s *countingStore) InsertCIJob(_ context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerBaseBranch, triggerProposalID string) (*model.CIJob, error) {
+func (s *countingStore) InsertCIJob(_ context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerBaseBranch, triggerProposalID string, _ []string) (*model.CIJob, error) {
 	return &model.CIJob{ID: "test-uuid", Repo: repo, Branch: branch, Sequence: sequence, Status: "queued", TriggerType: triggerType}, nil
 }
 

--- a/internal/ciconfig/ciconfig.go
+++ b/internal/ciconfig/ciconfig.go
@@ -6,10 +6,53 @@ package ciconfig
 import "github.com/gobwas/glob"
 
 // CIConfig is the top-level structure of .docstore/ci.yaml.
-// Only the 'on:' block is parsed here; execution-related fields (checks, jobs)
-// are handled separately by the executor package.
+// Only the 'on:' and 'permissions:' blocks are parsed here; execution-related
+// fields (checks, jobs) are handled separately by the executor package.
 type CIConfig struct {
-	On *TriggerConfig `yaml:"on"`
+	On          *TriggerConfig `yaml:"on"`
+	Permissions *Permissions   `yaml:"permissions"`
+}
+
+// Permissions declares the elevated API permissions a CI job is granted.
+// All values are the literal string "write" when present; absent keys are not
+// granted. Default (no permissions block): only checks: write is effective.
+type Permissions struct {
+	Contents  string `yaml:"contents"`  // commit, branch, merge, rebase, purge
+	Checks    string `yaml:"checks"`    // check run reporting (default)
+	Proposals string `yaml:"proposals"` // create proposals, post reviews/comments
+	Issues    string `yaml:"issues"`    // create/close/comment on issues
+	Releases  string `yaml:"releases"`  // create/delete releases
+	CI        string `yaml:"ci"`        // trigger CI runs
+}
+
+// EffectivePermissions returns the list of permission names granted by this
+// config. If no Permissions block is declared, only "checks" is returned.
+// When a Permissions block is present, only explicitly declared "write"
+// permissions are included.
+func (cfg *CIConfig) EffectivePermissions() []string {
+	if cfg.Permissions == nil {
+		return []string{"checks"}
+	}
+	var perms []string
+	if cfg.Permissions.Checks == "write" {
+		perms = append(perms, "checks")
+	}
+	if cfg.Permissions.Contents == "write" {
+		perms = append(perms, "contents")
+	}
+	if cfg.Permissions.Proposals == "write" {
+		perms = append(perms, "proposals")
+	}
+	if cfg.Permissions.Issues == "write" {
+		perms = append(perms, "issues")
+	}
+	if cfg.Permissions.Releases == "write" {
+		perms = append(perms, "releases")
+	}
+	if cfg.Permissions.CI == "write" {
+		perms = append(perms, "ci")
+	}
+	return perms
 }
 
 // ScheduleEntry holds a single cron-based schedule trigger.

--- a/internal/ciconfig/ciconfig_test.go
+++ b/internal/ciconfig/ciconfig_test.go
@@ -1,6 +1,9 @@
 package ciconfig
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestMatchesPush(t *testing.T) {
 	tests := []struct {
@@ -199,6 +202,65 @@ func TestMatchesProposal(t *testing.T) {
 			got := tt.cfg.MatchesProposal(tt.baseBranch)
 			if got != tt.want {
 				t.Errorf("MatchesProposal(%q) = %v, want %v", tt.baseBranch, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectivePermissions(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  CIConfig
+		want []string
+	}{
+		{
+			name: "no permissions block returns default checks",
+			cfg:  CIConfig{Permissions: nil},
+			want: []string{"checks"},
+		},
+		{
+			name: "empty permissions block returns nothing",
+			cfg:  CIConfig{Permissions: &Permissions{}},
+			want: nil,
+		},
+		{
+			name: "checks write only",
+			cfg:  CIConfig{Permissions: &Permissions{Checks: "write"}},
+			want: []string{"checks"},
+		},
+		{
+			name: "contents write only",
+			cfg:  CIConfig{Permissions: &Permissions{Contents: "write"}},
+			want: []string{"contents"},
+		},
+		{
+			name: "checks and contents",
+			cfg:  CIConfig{Permissions: &Permissions{Checks: "write", Contents: "write"}},
+			want: []string{"checks", "contents"},
+		},
+		{
+			name: "all permissions",
+			cfg: CIConfig{Permissions: &Permissions{
+				Checks:    "write",
+				Contents:  "write",
+				Proposals: "write",
+				Issues:    "write",
+				Releases:  "write",
+				CI:        "write",
+			}},
+			want: []string{"checks", "contents", "proposals", "issues", "releases", "ci"},
+		},
+		{
+			name: "non-write values are ignored",
+			cfg:  CIConfig{Permissions: &Permissions{Checks: "read", Contents: "write"}},
+			want: []string{"contents"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.EffectivePermissions()
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("EffectivePermissions() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/citoken/citoken.go
+++ b/internal/citoken/citoken.go
@@ -45,6 +45,7 @@ type JobClaims struct {
 	TriggeredBy string
 	JobID       string
 	Sequence    int64
+	Permissions []string // effective permissions granted to this job
 }
 
 // GenerateRequestToken returns a (plaintext, hashedForStorage) pair.
@@ -74,6 +75,10 @@ func IssueJWT(ctx context.Context, signer Signer, claims JobClaims) (string, err
 	now := time.Now()
 	jti := uuid.New().String()
 
+	perms := claims.Permissions
+	if len(perms) == 0 {
+		perms = []string{"checks"}
+	}
 	c := map[string]any{
 		"iss":          claims.Issuer,
 		"sub":          claims.Subject,
@@ -89,6 +94,7 @@ func IssueJWT(ctx context.Context, signer Signer, claims JobClaims) (string, err
 		"triggered_by": claims.TriggeredBy,
 		"job_id":       claims.JobID,
 		"sequence":     claims.Sequence,
+		"permissions":  perms,
 	}
 
 	return signer.Sign(ctx, c)

--- a/internal/db/ci_jobs.go
+++ b/internal/db/ci_jobs.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lib/pq"
+
 	"github.com/dlorenc/docstore/internal/model"
 )
 
@@ -17,7 +19,7 @@ var ErrTokenInvalid = errors.New("request token invalid or expired")
 // ciJobColumns is the ordered list of columns returned by SELECT * on ci_jobs.
 const ciJobColumns = `id, repo, branch, sequence, status, claimed_at, last_heartbeat_at,
 	worker_pod, worker_pod_ip, log_url, error_message, created_at, trigger_type, trigger_branch, trigger_base_branch, trigger_proposal_id,
-	request_token, request_token_exp`
+	request_token, request_token_exp, permissions`
 
 // scanCIJob scans a single ci_jobs row into a model.CIJob.
 func scanCIJob(row interface {
@@ -38,17 +40,21 @@ func scanCIJob(row interface {
 	// the public api.CIJob wire type; scan them into discard variables.
 	var requestToken sql.NullString
 	var requestTokenExp sql.NullTime
+	var permissions pq.StringArray
 	if err := row.Scan(
 		&j.ID, &j.Repo, &j.Branch, &j.Sequence, &j.Status,
 		&claimedAt, &lastHeartbeatAt, &workerPod, &workerPodIP,
 		&logURL, &errorMessage, &j.CreatedAt,
 		&triggerType, &triggerBranch, &triggerBaseBranch, &triggerProposalID,
-		&requestToken, &requestTokenExp,
+		&requestToken, &requestTokenExp, &permissions,
 	); err != nil {
 		return nil, err
 	}
 	_ = requestToken
 	_ = requestTokenExp
+	if len(permissions) > 0 {
+		j.Permissions = []string(permissions)
+	}
 	if claimedAt.Valid {
 		j.ClaimedAt = &claimedAt.Time
 	}
@@ -120,7 +126,9 @@ func (s *Store) LookupRequestToken(ctx context.Context, hashedToken string) (*mo
 // triggerBranch is the branch that caused the trigger (may be empty for some trigger types).
 // triggerBaseBranch is the base branch for proposal-triggered jobs (empty string for others).
 // triggerProposalID is the proposal ID for proposal-triggered jobs (empty string for others).
-func (s *Store) InsertCIJob(ctx context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerBaseBranch, triggerProposalID string) (*model.CIJob, error) {
+// permissions is the list of permission names granted to the job (e.g. "checks", "contents").
+// A nil or empty permissions slice defaults to {"checks"} at the DB level.
+func (s *Store) InsertCIJob(ctx context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerBaseBranch, triggerProposalID string, permissions []string) (*model.CIJob, error) {
 	var proposalID any
 	if triggerProposalID != "" {
 		proposalID = triggerProposalID
@@ -129,10 +137,13 @@ func (s *Store) InsertCIJob(ctx context.Context, repo, branch string, sequence i
 	if triggerBaseBranch != "" {
 		baseBranch = triggerBaseBranch
 	}
+	if len(permissions) == 0 {
+		permissions = []string{"checks"}
+	}
 	row := s.db.QueryRowContext(ctx,
-		`INSERT INTO ci_jobs (repo, branch, sequence, trigger_type, trigger_branch, trigger_base_branch, trigger_proposal_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING `+ciJobColumns,
-		repo, branch, sequence, triggerType, triggerBranch, baseBranch, proposalID,
+		`INSERT INTO ci_jobs (repo, branch, sequence, trigger_type, trigger_branch, trigger_base_branch, trigger_proposal_id, permissions)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING `+ciJobColumns,
+		repo, branch, sequence, triggerType, triggerBranch, baseBranch, proposalID, pq.Array(permissions),
 	)
 	j, err := scanCIJob(row)
 	if err != nil {

--- a/internal/db/ci_jobs_test.go
+++ b/internal/db/ci_jobs_test.go
@@ -21,7 +21,7 @@ func TestInsertCIJob(t *testing.T) {
 	s, _ := newCIJobStore(t)
 	ctx := context.Background()
 
-	j, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "")
+	j, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "", nil)
 	if err != nil {
 		t.Fatalf("InsertCIJob: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestInsertCIJob_ProposalTrigger(t *testing.T) {
 	ctx := context.Background()
 
 	proposalID := "prop-42"
-	j, err := s.InsertCIJob(ctx, "org/repo", "feat", 3, "proposal", "feat", "main", proposalID)
+	j, err := s.InsertCIJob(ctx, "org/repo", "feat", 3, "proposal", "feat", "main", proposalID, nil)
 	if err != nil {
 		t.Fatalf("InsertCIJob: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestGetCIJob(t *testing.T) {
 	s, _ := newCIJobStore(t)
 	ctx := context.Background()
 
-	inserted, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "")
+	inserted, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "", nil)
 	if err != nil {
 		t.Fatalf("InsertCIJob: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestClaimCIJob(t *testing.T) {
 	s, _ := newCIJobStore(t)
 	ctx := context.Background()
 
-	inserted, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "")
+	inserted, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "", nil)
 	if err != nil {
 		t.Fatalf("InsertCIJob: %v", err)
 	}
@@ -153,10 +153,10 @@ func TestClaimCIJob_OnePodOneClaim(t *testing.T) {
 	ctx := context.Background()
 
 	// Insert two queued jobs.
-	if _, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", ""); err != nil {
+	if _, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "", nil); err != nil {
 		t.Fatalf("InsertCIJob 1: %v", err)
 	}
-	if _, err := s.InsertCIJob(ctx, "org/repo", "main", 2, "push", "main", "", ""); err != nil {
+	if _, err := s.InsertCIJob(ctx, "org/repo", "main", 2, "push", "main", "", "", nil); err != nil {
 		t.Fatalf("InsertCIJob 2: %v", err)
 	}
 
@@ -201,7 +201,7 @@ func TestClaimCIJob_SkipLocked(t *testing.T) {
 	s, _ := newCIJobStore(t)
 	ctx := context.Background()
 
-	if _, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", ""); err != nil {
+	if _, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "", nil); err != nil {
 		t.Fatalf("InsertCIJob: %v", err)
 	}
 
@@ -228,7 +228,7 @@ func TestHeartbeatCIJob(t *testing.T) {
 	s, d := newCIJobStore(t)
 	ctx := context.Background()
 
-	inserted, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "")
+	inserted, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "", nil)
 	if err != nil {
 		t.Fatalf("InsertCIJob: %v", err)
 	}
@@ -258,7 +258,7 @@ func TestCompleteCIJob_Passed(t *testing.T) {
 	s, _ := newCIJobStore(t)
 	ctx := context.Background()
 
-	inserted, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "")
+	inserted, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "", nil)
 	if err != nil {
 		t.Fatalf("InsertCIJob: %v", err)
 	}
@@ -288,7 +288,7 @@ func TestCompleteCIJob_Failed(t *testing.T) {
 	s, _ := newCIJobStore(t)
 	ctx := context.Background()
 
-	inserted, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "")
+	inserted, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "", nil)
 	if err != nil {
 		t.Fatalf("InsertCIJob: %v", err)
 	}
@@ -317,7 +317,7 @@ func TestReapStaleCIJobs(t *testing.T) {
 	ctx := context.Background()
 
 	// Insert a job and claim it.
-	inserted, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "")
+	inserted, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "", nil)
 	if err != nil {
 		t.Fatalf("InsertCIJob: %v", err)
 	}
@@ -370,7 +370,7 @@ func TestReapStaleCIJobs_FreshJobNotReaped(t *testing.T) {
 	ctx := context.Background()
 
 	// Claim a fresh job (heartbeat just now via claimed_at).
-	if _, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", ""); err != nil {
+	if _, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "", nil); err != nil {
 		t.Fatalf("InsertCIJob: %v", err)
 	}
 	if _, err := s.ClaimCIJob(ctx, "pod-a", "1.1.1.1"); err != nil {
@@ -391,7 +391,7 @@ func TestReapStaleCIJobs_HeartbeatKeepsJobAlive(t *testing.T) {
 	s, d := newCIJobStore(t)
 	ctx := context.Background()
 
-	inserted, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "")
+	inserted, err := s.InsertCIJob(ctx, "org/repo", "main", 1, "push", "main", "", "", nil)
 	if err != nil {
 		t.Fatalf("InsertCIJob: %v", err)
 	}

--- a/internal/db/ci_oidc_test.go
+++ b/internal/db/ci_oidc_test.go
@@ -12,7 +12,7 @@ func TestStoreAndLookupRequestToken(t *testing.T) {
 	ctx := context.Background()
 
 	// Insert a job and claim it so its status becomes 'claimed'.
-	inserted, err := s.InsertCIJob(ctx, "org/repo", "feat", 5, "push", "feat", "", "")
+	inserted, err := s.InsertCIJob(ctx, "org/repo", "feat", 5, "push", "feat", "", "", nil)
 	if err != nil {
 		t.Fatalf("InsertCIJob: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestLookupRequestToken_Expired(t *testing.T) {
 	s, _ := newCIJobStore(t)
 	ctx := context.Background()
 
-	inserted, err := s.InsertCIJob(ctx, "org/repo", "feat", 5, "push", "feat", "", "")
+	inserted, err := s.InsertCIJob(ctx, "org/repo", "feat", 5, "push", "feat", "", "", nil)
 	if err != nil {
 		t.Fatalf("InsertCIJob: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestLookupRequestToken_WrongStatus(t *testing.T) {
 	ctx := context.Background()
 
 	// Insert a job but do NOT claim it — it stays 'queued'.
-	inserted, err := s.InsertCIJob(ctx, "org/repo", "feat", 5, "push", "feat", "", "")
+	inserted, err := s.InsertCIJob(ctx, "org/repo", "feat", 5, "push", "feat", "", "", nil)
 	if err != nil {
 		t.Fatalf("InsertCIJob: %v", err)
 	}

--- a/internal/db/migrations/000019_ci_jobs_permissions.down.sql
+++ b/internal/db/migrations/000019_ci_jobs_permissions.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ci_jobs
+    DROP COLUMN permissions;

--- a/internal/db/migrations/000019_ci_jobs_permissions.up.sql
+++ b/internal/db/migrations/000019_ci_jobs_permissions.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ci_jobs
+    ADD COLUMN permissions TEXT[] NOT NULL DEFAULT '{}';

--- a/internal/server/handlers_ci.go
+++ b/internal/server/handlers_ci.go
@@ -128,7 +128,7 @@ func (s *server) handleTriggerCIRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	job, err := s.commitStore.InsertCIJob(r.Context(), repo, req.Branch, branchInfo.HeadSequence, "manual", req.Branch, "", "")
+	job, err := s.commitStore.InsertCIJob(r.Context(), repo, req.Branch, branchInfo.HeadSequence, "manual", req.Branch, "", "", nil)
 	if err != nil {
 		slog.Error("internal error", "op", "trigger_ci_run", "repo", repo, "branch", req.Branch, "error", err)
 		writeAPIError(w, ErrCodeInternalError, http.StatusInternalServerError, "insert ci job failed")

--- a/internal/server/handlers_oidc_scope_test.go
+++ b/internal/server/handlers_oidc_scope_test.go
@@ -314,3 +314,177 @@ func TestHandleReview_RepoNotFound(t *testing.T) {
 		t.Fatalf("expected 404 for non-existent repo in handleReview, got %d; body: %s", rec.Code, rec.Body.String())
 	}
 }
+
+// ---------------------------------------------------------------------------
+// jobEndpointAllowed unit tests
+// ---------------------------------------------------------------------------
+
+func TestJobEndpointAllowed_DefaultChecksPermission(t *testing.T) {
+	// "check" is always allowed regardless of the permissions slice.
+	if !jobEndpointAllowed("check", nil) {
+		t.Error("check should be allowed with nil permissions")
+	}
+	if !jobEndpointAllowed("check", []string{}) {
+		t.Error("check should be allowed with empty permissions")
+	}
+	if !jobEndpointAllowed("check", []string{"contents"}) {
+		t.Error("check should be allowed with any permissions")
+	}
+}
+
+func TestJobEndpointAllowed_ContentsPermission(t *testing.T) {
+	contentsEndpoints := []string{"commit", "merge", "rebase", "purge", "branch", "branch/main", "branch/feat/foo"}
+	for _, ep := range contentsEndpoints {
+		if jobEndpointAllowed(ep, nil) {
+			t.Errorf("%q should be denied without contents permission", ep)
+		}
+		if jobEndpointAllowed(ep, []string{"checks"}) {
+			t.Errorf("%q should be denied with only checks permission", ep)
+		}
+		if !jobEndpointAllowed(ep, []string{"contents"}) {
+			t.Errorf("%q should be allowed with contents permission", ep)
+		}
+	}
+}
+
+func TestJobEndpointAllowed_ProposalsPermission(t *testing.T) {
+	proposalEndpoints := []string{"review", "comment", "comment/abc123", "proposals", "proposals/my-id", "proposals/my-id/close"}
+	for _, ep := range proposalEndpoints {
+		if jobEndpointAllowed(ep, nil) {
+			t.Errorf("%q should be denied without proposals permission", ep)
+		}
+		if !jobEndpointAllowed(ep, []string{"proposals"}) {
+			t.Errorf("%q should be allowed with proposals permission", ep)
+		}
+	}
+}
+
+func TestJobEndpointAllowed_IssuesPermission(t *testing.T) {
+	issueEndpoints := []string{"issues", "issues/1", "issues/1/close", "issues/1/comments"}
+	for _, ep := range issueEndpoints {
+		if jobEndpointAllowed(ep, nil) {
+			t.Errorf("%q should be denied without issues permission", ep)
+		}
+		if !jobEndpointAllowed(ep, []string{"issues"}) {
+			t.Errorf("%q should be allowed with issues permission", ep)
+		}
+	}
+}
+
+func TestJobEndpointAllowed_ReleasesPermission(t *testing.T) {
+	releaseEndpoints := []string{"releases", "releases/v1.0"}
+	for _, ep := range releaseEndpoints {
+		if jobEndpointAllowed(ep, nil) {
+			t.Errorf("%q should be denied without releases permission", ep)
+		}
+		if !jobEndpointAllowed(ep, []string{"releases"}) {
+			t.Errorf("%q should be allowed with releases permission", ep)
+		}
+	}
+}
+
+func TestJobEndpointAllowed_CIPermission(t *testing.T) {
+	if jobEndpointAllowed("ci/run", nil) {
+		t.Error("ci/run should be denied without ci permission")
+	}
+	if !jobEndpointAllowed("ci/run", []string{"ci"}) {
+		t.Error("ci/run should be allowed with ci permission")
+	}
+}
+
+func TestJobEndpointAllowed_UnknownEndpointDenied(t *testing.T) {
+	unknownEndpoints := []string{"", "admin", "roles", "chain", "tree"}
+	for _, ep := range unknownEndpoints {
+		if jobEndpointAllowed(ep, []string{"checks", "contents", "proposals", "issues", "releases", "ci"}) {
+			t.Errorf("%q should be denied even with all permissions", ep)
+		}
+	}
+}
+
+// TestOIDC_ContentsPermissionAllowsCommit verifies that a job with
+// "contents" permission in its JWT can POST /-/commit to its own repo.
+func TestOIDC_ContentsPermissionAllowsCommit(t *testing.T) {
+	// Use a mock that recognizes the repo but we send empty files so
+	// handleCommit returns 400 (before touching the service layer).
+	// The key assertion is that the permissions gate does NOT return 403.
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return &model.Repo{Name: name}, nil
+		},
+	}
+	handler, key := buildOIDCServer(t, ms)
+
+	// Build a token with permissions: ["checks", "contents"]
+	tok := makeJobJWTWithPermissions(t, key, "acme/myrepo", "main", []string{"checks", "contents"})
+	body, _ := json.Marshal(map[string]any{
+		"branch":  "main",
+		"message": "test commit",
+		"files":   []any{}, // empty files → 400 from handler (not 403 from gate)
+	})
+	req := httptest.NewRequest(http.MethodPost, "/repos/acme/myrepo/-/commit", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("expected commit to pass the permissions gate, got 403; body: %s", rec.Body.String())
+	}
+}
+
+// TestOIDC_NoContentsPermissionDeniesCommit verifies that a job without
+// "contents" permission cannot POST /-/commit even to its own repo.
+func TestOIDC_NoContentsPermissionDeniesCommit(t *testing.T) {
+	ms := &mockStore{
+		getRepoFn: func(_ context.Context, name string) (*model.Repo, error) {
+			return &model.Repo{Name: name}, nil
+		},
+	}
+	handler, key := buildOIDCServer(t, ms)
+
+	// Token has only the default "checks" permission (no contents).
+	tok := makeJobJWTWithPermissions(t, key, "acme/myrepo", "main", []string{"checks"})
+	body, _ := json.Marshal(map[string]any{
+		"branch":  "main",
+		"message": "test commit",
+		"files":   []any{},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/repos/acme/myrepo/-/commit", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for commit without contents permission, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// makeJobJWTWithPermissions creates a signed RS256 JWT with the given permissions claim.
+func makeJobJWTWithPermissions(t *testing.T, key *rsa.PrivateKey, repo, branch string, permissions []string) string {
+	t.Helper()
+	const kid = "oidc-test-key"
+	const issuer = "https://oidc.docstore.dev"
+	const audience = "docstore"
+	headerJSON, _ := json.Marshal(map[string]string{"alg": "RS256", "kid": kid, "typ": "JWT"})
+	payloadJSON, _ := json.Marshal(map[string]any{
+		"iss":         issuer,
+		"sub":         "repo:" + repo + ":branch:" + branch + ":check:",
+		"aud":         audience,
+		"exp":         time.Now().Add(time.Hour).Unix(),
+		"iat":         time.Now().Unix(),
+		"job_id":      "job-perm-test",
+		"repo":        repo,
+		"branch":      branch,
+		"permissions": permissions,
+	})
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	signingInput := headerB64 + "." + payloadB64
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+	if err != nil {
+		t.Fatalf("sign JWT: %v", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig)
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -371,10 +371,11 @@ const jobIdentityKey contextKey = "jobIdentity"
 
 // JobIdentity holds the identity of a CI job extracted from a validated OIDC token.
 type JobIdentity struct {
-	JobID   string
-	Repo    string
-	Branch  string
-	Subject string
+	JobID       string
+	Repo        string
+	Branch      string
+	Subject     string
+	Permissions []string // effective permissions granted to this job
 }
 
 // JobIdentityFromContext returns the job identity stored in the context by
@@ -487,13 +488,14 @@ func validateJobOIDCToken(tokenString string, fetchKey func(kid string) (crypto.
 		return nil, fmt.Errorf("decode payload: %w", err)
 	}
 	var claims struct {
-		Iss    string  `json:"iss"`
-		Sub    string  `json:"sub"`
-		Aud    any     `json:"aud"` // string or []interface{}
-		Exp    float64 `json:"exp"`
-		JobID  string  `json:"job_id"`
-		Repo   string  `json:"repo"`
-		Branch string  `json:"branch"`
+		Iss         string  `json:"iss"`
+		Sub         string  `json:"sub"`
+		Aud         any     `json:"aud"` // string or []interface{}
+		Exp         float64 `json:"exp"`
+		JobID       string  `json:"job_id"`
+		Repo        string  `json:"repo"`
+		Branch      string  `json:"branch"`
+		Permissions []string `json:"permissions"`
 	}
 	if err := json.Unmarshal(payloadJSON, &claims); err != nil {
 		return nil, fmt.Errorf("parse payload: %w", err)
@@ -519,10 +521,11 @@ func validateJobOIDCToken(tokenString string, fetchKey func(kid string) (crypto.
 	}
 
 	return &JobIdentity{
-		JobID:   claims.JobID,
-		Repo:    claims.Repo,
-		Branch:  claims.Branch,
-		Subject: claims.Sub,
+		JobID:       claims.JobID,
+		Repo:        claims.Repo,
+		Branch:      claims.Branch,
+		Subject:     claims.Sub,
+		Permissions: claims.Permissions,
 	}, nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -155,7 +155,7 @@ type WriteStore interface {
 	ListCIJobs(ctx context.Context, repo string, branch, status *string, limit int) ([]model.CIJob, error)
 
 	// CI job management
-	InsertCIJob(ctx context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerBaseBranch, triggerProposalID string) (*model.CIJob, error)
+	InsertCIJob(ctx context.Context, repo, branch string, sequence int64, triggerType, triggerBranch, triggerBaseBranch, triggerProposalID string, permissions []string) (*model.CIJob, error)
 }
 
 // CommitStore is an alias for backward compatibility with tests.
@@ -292,6 +292,54 @@ func newServer(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broke
 		s.readStore = rs
 	}
 	return s.buildHandler(devIdentity, bootstrapAdmin, writeStore)
+}
+
+// jobRequiredPermission returns the permission name required to call the given
+// endpoint via an OIDC job token. An empty string means the endpoint is not
+// reachable via a job token (deny by default).
+func jobRequiredPermission(endpoint string) string {
+	switch {
+	case endpoint == "check":
+		return "checks"
+	case endpoint == "commit" || endpoint == "merge" || endpoint == "rebase" || endpoint == "purge":
+		return "contents"
+	case endpoint == "branch" || strings.HasPrefix(endpoint, "branch/"):
+		return "contents"
+	case endpoint == "review":
+		return "proposals"
+	case endpoint == "comment" || strings.HasPrefix(endpoint, "comment/"):
+		return "proposals"
+	case endpoint == "proposals" || strings.HasPrefix(endpoint, "proposals/"):
+		return "proposals"
+	case endpoint == "issues" || strings.HasPrefix(endpoint, "issues/"):
+		return "issues"
+	case endpoint == "releases" || strings.HasPrefix(endpoint, "releases/"):
+		return "releases"
+	case endpoint == "ci/run":
+		return "ci"
+	default:
+		return ""
+	}
+}
+
+// jobEndpointAllowed reports whether a job with the given permissions is
+// allowed to call the endpoint. "checks" is always granted regardless of
+// the permissions slice (default permission). All other permissions must be
+// explicitly listed.
+func jobEndpointAllowed(endpoint string, permissions []string) bool {
+	required := jobRequiredPermission(endpoint)
+	if required == "" {
+		return false
+	}
+	if required == "checks" {
+		return true
+	}
+	for _, p := range permissions {
+		if p == required {
+			return true
+		}
+	}
+	return false
 }
 
 // buildHandler wires up all routes and middleware for the given server.
@@ -455,11 +503,12 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 						writeAPIError(w, ErrCodeForbidden, http.StatusForbidden, "forbidden: job may only write to its own repo")
 						return
 					}
-					// Allowlist: OIDC JWT job tokens may only call POST /-/check on
-					// their own repo. All other write endpoints are denied until a
-					// permissions system is in place.
-					if endpoint != "check" {
-						slog.Warn("job token endpoint not in allowlist", "job_repo", jobID.Repo, "endpoint", endpoint, "path", r.URL.Path)
+					// Permissions gate: check that the endpoint is permitted by
+					// the job's declared permissions. "checks" is always the
+					// default; additional endpoints are unlocked by the
+					// permissions block in .docstore/ci.yaml.
+					if !jobEndpointAllowed(endpoint, jobID.Permissions) {
+						slog.Warn("job token endpoint not permitted", "job_repo", jobID.Repo, "endpoint", endpoint, "path", r.URL.Path, "permissions", jobID.Permissions)
 						writeAPIError(w, ErrCodeForbidden, http.StatusForbidden, "forbidden: job token not permitted for this endpoint")
 						return
 					}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -543,7 +543,7 @@ func (m *mockStore) ListCIJobs(ctx context.Context, repo string, branch, status 
 	return []model.CIJob{}, nil
 }
 
-func (m *mockStore) InsertCIJob(_ context.Context, _, _ string, _ int64, _, _, _, _ string) (*model.CIJob, error) {
+func (m *mockStore) InsertCIJob(_ context.Context, _, _ string, _ int64, _, _, _, _ string, _ []string) (*model.CIJob, error) {
 	return &model.CIJob{ID: "test-job-id"}, nil
 }
 


### PR DESCRIPTION
## Summary

Implements the CI job permissions system described in issue #428.

- **ciconfig**: adds `permissions:` block parsing to `.docstore/ci.yaml` with `EffectivePermissions()` helper
- **DB**: migration `000019` adds `permissions TEXT[]` column to `ci_jobs`
- **ci-scheduler**: extracts permissions at dispatch time using the hybrid source model (base branch for proposals/proposal_synchronized, own branch for push/schedule); passes permissions to `InsertCIJob`
- **citoken**: adds `Permissions []string` to `JobClaims`; `IssueJWT` embeds a `permissions` claim in the JWT
- **ci-oidc**: reads `job.Permissions` and passes through to `JobClaims` when issuing tokens
- **server middleware**: adds `Permissions []string` to `JobIdentity`; `validateJobOIDCToken` extracts the `permissions` claim from the JWT payload
- **server buildHandler**: replaces the hard-coded `if endpoint != "check"` allowlist with `jobEndpointAllowed()` / `jobRequiredPermission()` — a stateless permission lookup using the already-validated `JobIdentity`

## Security model

Proposal and `proposal_synchronized` jobs fetch permissions from the **base branch** (target) ci.yaml, not the source branch. A PR that adds `permissions: contents: write` to its own branch does not receive `contents` access until that change is reviewed and merged. The `InsertCIJob` DB write stores the resolved permissions at dispatch time; they are fixed for the job's lifetime.

## Endpoint-to-permission mapping

| Permission | Endpoints |
|---|---|
| `checks: write` (default) | `POST /-/check` |
| `contents: write` | `POST /-/commit`, `branch`, `merge`, `rebase`, `purge`; all `branch/…` sub-paths |
| `proposals: write` | `POST /-/review`, `comment`, `proposals`, `proposals/…` |
| `issues: write` | `POST /-/issues`, `issues/…` |
| `releases: write` | `POST/DELETE /-/releases`, `releases/…` |
| `ci: write` | `POST /-/ci/run` |

## Test plan

- [x] `TestEffectivePermissions` — ciconfig permissions parsing (no block / empty / all fields)
- [x] `TestJobEndpointAllowed_*` — unit tests for the permission gate function
- [x] `TestOIDC_ContentsPermissionAllowsCommit` — JWT with `contents` passes gate for commit
- [x] `TestOIDC_NoContentsPermissionDeniesCommit` — JWT without `contents` blocked at gate
- [x] All existing OIDC scope tests still pass (cross-repo, non-check endpoint denied, etc.)
- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./internal/ciconfig/... ./internal/citoken/... ./cmd/ci-scheduler/... ./cmd/ci-oidc/...` all pass
- [x] `go test ./internal/server/ -run "Test[^DI]"` all pass (Integration/Docker tests require external infra)

## Notes for follow-up

- Manual CI trigger (`POST /-/ci/run`) currently uses `nil` permissions (defaults to `["checks"]`). If manual triggers should inherit the branch's permissions, that can be wired up separately.
- The `contents: write` permission covers all branch mutation endpoints. A future split (e.g., separate `branches: write`) was noted as an open question in #428 and left out of scope here.

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)