### PR TITLE
fix(security): block GCP metadata server; tighten ci-registry auth to repo scope

### DIFF
--- a/entrypoint-worker.sh
+++ b/entrypoint-worker.sh
@@ -43,6 +43,11 @@ cat > /etc/buildkit/buildkitd.toml << 'TOML'
   insecure = true
 TOML
 
+# Block the GCP instance metadata server before handing control to user-defined build
+# steps. Without this rule any build step can obtain a GCP service account access token
+# via the link-local metadata endpoint (169.254.169.254) without any credential.
+iptables -I OUTPUT -d 169.254.169.254 -j DROP
+
 # Start buildkitd in background (standard, non-rootless — runs natively inside Kata VM).
 # --oci-worker-net=host ensures build containers share the host network namespace so they
 # can reach dockerd at tcp://localhost:2375.

--- a/internal/registry/auth.go
+++ b/internal/registry/auth.go
@@ -14,8 +14,9 @@ import (
 //
 //   - If no Authorization: Bearer <token> header is present, returns 401.
 //   - If the token is invalid, returns 401.
-//   - If the image name extracted from the URL path does not start with the
-//     org derived from the token's repo claim, returns 403.
+//   - If the image name extracted from the URL path does not exactly match the
+//     repo claim in the token, returns 403. This prevents a token for
+//     acme/repo-a from pushing or pulling acme/repo-b cache refs.
 //   - Otherwise the request is forwarded to the inner registry handler.
 func authMiddleware(inner http.Handler, validate func(string) (*server.JobIdentity, error)) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -56,9 +57,8 @@ func authMiddleware(inner http.Handler, validate func(string) (*server.JobIdenti
 			return
 		}
 
-		// Derive the org from the repo claim: e.g. "acme/myrepo" → "acme".
-		org, _, _ := strings.Cut(identity.Repo, "/")
-		if org == "" {
+		// Validate that the repo claim contains the expected org/repo format.
+		if !strings.Contains(identity.Repo, "/") {
 			http.Error(w, "invalid token: missing org in repo claim", http.StatusForbidden)
 			return
 		}
@@ -73,10 +73,12 @@ func authMiddleware(inner http.Handler, validate func(string) (*server.JobIdenti
 			return
 		}
 
-		// Check that the image belongs to the token's org.
-		if !strings.HasPrefix(imageName, org+"/") {
-			slog.Warn("auth: forbidden", "method", r.Method, "path", r.URL.Path, "org", org, "image", imageName)
-			http.Error(w, "forbidden: image not in token org", http.StatusForbidden)
+		// Enforce repo-level scoping: the image must exactly match the token's
+		// repo claim. Org-level prefix matching is insufficient — it would allow
+		// a token for acme/repo-a to push/pull acme/repo-b cache refs.
+		if imageName != identity.Repo {
+			slog.Warn("auth: forbidden", "method", r.Method, "path", r.URL.Path, "repo", identity.Repo, "image", imageName)
+			http.Error(w, "forbidden: image does not match token repo", http.StatusForbidden)
 			return
 		}
 

--- a/internal/registry/auth_test.go
+++ b/internal/registry/auth_test.go
@@ -105,6 +105,31 @@ func TestAuthMiddleware_WrongOrg(t *testing.T) {
 	}
 }
 
+func TestAuthMiddleware_SameOrgDifferentRepo(t *testing.T) {
+	signer, err := citoken.NewLocalSigner()
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	validate := makeValidator(t, signer)
+
+	inner := &okHandler{}
+	h := authMiddleware(inner, validate)
+
+	// Token is for acme/repo-a; request accesses acme/repo-b (same org, different repo).
+	tok := makeTestToken(t, signer, "acme/repo-a")
+	req := httptest.NewRequest(http.MethodGet, "/v2/acme/repo-b/manifests/latest", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for same-org cross-repo access, got %d", rec.Code)
+	}
+	if inner.called {
+		t.Error("inner handler should not be called on cross-repo request")
+	}
+}
+
 func TestAuthMiddleware_NoToken(t *testing.T) {
 	validate := server.NewJobTokenValidator("http://unused", "ci-registry", "https://oidc.test")
 


### PR DESCRIPTION
## Summary

Closes attack surfaces #3 and #4 from issue #426.

- **Attack surface #3 (GCP metadata server):** `entrypoint-worker.sh` now runs `iptables -I OUTPUT -d 169.254.169.254 -j DROP` before starting buildkitd and dockerd. Without this rule, any build step with host networking can silently call the GCP metadata endpoint to obtain the ci-worker service account's access token — with no credential required.

- **Attack surface #4 (same-org ci-registry cache poisoning):** `internal/registry/auth.go` was checking only org-level scope (`strings.HasPrefix(imageName, org+"/")`). A token for `acme/repo-a` could therefore push arbitrary layer content to `acme/repo-b`'s cache ref, injecting attacker-controlled code into sibling-repo builds. Changed to exact repo equality (`imageName != identity.Repo`). Added `TestAuthMiddleware_SameOrgDifferentRepo` to exercise this.

## Test plan

- [ ] `go test ./internal/registry/... -run TestAuth` — all auth middleware tests including new `TestAuthMiddleware_SameOrgDifferentRepo` pass
- [ ] `go test ./... -count=1` — full suite green
- [ ] `go build ./... && go vet ./...` — clean

## Notes

- The iptables rule must run as root inside the Kata VM, which is the context `entrypoint-worker.sh` already runs in. No capability changes needed.
- The ci-registry change is a strict tightening: any existing token that was already scoped correctly (accessing its own repo's image) continues to work. Only cross-repo same-org access is now rejected.
- Potential follow-up: audit the GCP SA IAM roles held by `ci-worker@<project>.iam.gserviceaccount.com` to quantify blast radius before the iptables fix (noted in issue #426).

Fixes #426 (attack surfaces 3 and 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)