### PR TITLE
feat(k8sproof): tighten CI worker token validation

### DIFF
--- a/internal/k8sproof/k8sproof.go
+++ b/internal/k8sproof/k8sproof.go
@@ -3,16 +3,22 @@
 //
 // The validation chain is:
 //  1. TokenReview — token must be valid and issued for the ci-worker service account
-//  2. Pod freshness — pod.creationTimestamp must be < maxAge ago
-//  3. Owner chain — pod → batch/v1 Job → keda.sh/v1alpha1 ScaledJob named "ci-worker"
+//  2. Pod name and UID extracted from token extra claims
+//  3. Pod fetched; UID cross-checked against token claim
+//  4. Pod freshness — pod.creationTimestamp must be < maxAge ago
+//  5. Pod phase — pod must be in Running phase
+//  6. Container image digest — every container image must reference a digest (@sha256:)
+//  7. Owner chain — pod → batch/v1 Job → keda.sh/v1alpha1 ScaledJob named "ci-worker"
 package k8sproof
 
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	authv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -71,25 +77,48 @@ func (p *PodClaimer) ValidateToken(ctx context.Context, token string) (podName, 
 			result.Status.User.Username, expectedServiceAccount)
 	}
 
-	// 2. Extract pod name from extra claims.
+	// 2. Extract pod name and UID from extra claims.
 	podNames := result.Status.User.Extra["authentication.kubernetes.io/pod-name"]
 	if len(podNames) == 0 {
 		return "", "", fmt.Errorf("pod name not present in token extra claims")
 	}
 	podName = string(podNames[0])
 
-	// 3. Fetch the pod and check freshness.
+	podUIDs := result.Status.User.Extra["authentication.kubernetes.io/pod-uid"]
+	if len(podUIDs) == 0 {
+		return "", "", fmt.Errorf("pod UID not present in token extra claims")
+	}
+	tokenPodUID := string(podUIDs[0])
+
+	// 3. Fetch the pod and cross-check the UID.
 	pod, err := p.client.CoreV1().Pods(p.namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
 		return "", "", fmt.Errorf("fetch pod %q: %w", podName, err)
 	}
+	if string(pod.UID) != tokenPodUID {
+		return "", "", fmt.Errorf("pod UID mismatch: token claims %q, pod has %q", tokenPodUID, pod.UID)
+	}
+
+	// 4. Check pod freshness.
 	podAge := time.Since(pod.CreationTimestamp.Time)
 	if podAge > p.maxAge {
 		return "", "", fmt.Errorf("pod %q is too old (%s > %s)", podName, podAge.Round(time.Second), p.maxAge)
 	}
 	podIP = pod.Status.PodIP
 
-	// 4. Pod must be owned by a batch/v1 Job.
+	// 5. Pod must be in Running phase.
+	if pod.Status.Phase != corev1.PodRunning {
+		return "", "", fmt.Errorf("pod %q is not running (phase: %s)", podName, pod.Status.Phase)
+	}
+
+	// 6. Every container image must be digest-pinned.
+	for _, c := range pod.Spec.Containers {
+		if !strings.Contains(c.Image, "@sha256:") {
+			return "", "", fmt.Errorf("container %q image %q is not digest-pinned (missing @sha256:)", c.Name, c.Image)
+		}
+	}
+
+	// 7. Pod must be owned by a batch/v1 Job.
 	var jobName string
 	for _, ref := range pod.OwnerReferences {
 		if ref.APIVersion == "batch/v1" && ref.Kind == "Job" {
@@ -101,7 +130,7 @@ func (p *PodClaimer) ValidateToken(ctx context.Context, token string) (podName, 
 		return "", "", fmt.Errorf("pod %q has no batch/v1 Job owner", podName)
 	}
 
-	// 5. That Job must be owned by the ci-worker KEDA ScaledJob.
+	// 8. That Job must be owned by the ci-worker KEDA ScaledJob.
 	job, err := p.client.BatchV1().Jobs(p.namespace).Get(ctx, jobName, metav1.GetOptions{})
 	if err != nil {
 		return "", "", fmt.Errorf("fetch job %q: %w", jobName, err)

--- a/internal/k8sproof/k8sproof_test.go
+++ b/internal/k8sproof/k8sproof_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 
@@ -22,7 +23,7 @@ const (
 )
 
 // tokenReviewReactor returns a fake reactor for TokenReview creates.
-func tokenReviewReactor(authenticated bool, username, podName string) k8stesting.ReactionFunc {
+func tokenReviewReactor(authenticated bool, username, podName, podUID string) k8stesting.ReactionFunc {
 	return func(action k8stesting.Action) (bool, runtime.Object, error) {
 		result := &authv1.TokenReview{
 			Status: authv1.TokenReviewStatus{
@@ -31,6 +32,7 @@ func tokenReviewReactor(authenticated bool, username, podName string) k8stesting
 					Username: username,
 					Extra: map[string]authv1.ExtraValue{
 						"authentication.kubernetes.io/pod-name": {podName},
+						"authentication.kubernetes.io/pod-uid":  {podUID},
 					},
 				},
 			},
@@ -42,17 +44,18 @@ func tokenReviewReactor(authenticated bool, username, podName string) k8stesting
 	}
 }
 
-// validTokenReviewReactor returns a reactor for a valid ci-worker token for the given podName.
-func validTokenReviewReactor(podName string) k8stesting.ReactionFunc {
-	return tokenReviewReactor(true, "system:serviceaccount:docstore-ci:ci-worker", podName)
+// validTokenReviewReactor returns a reactor for a valid ci-worker token for the given podName and podUID.
+func validTokenReviewReactor(podName, podUID string) k8stesting.ReactionFunc {
+	return tokenReviewReactor(true, "system:serviceaccount:docstore-ci:ci-worker", podName, podUID)
 }
 
 // freshPod returns a pod with a fresh creationTimestamp owned by the given job.
-func freshPod(podName, jobName string) *corev1.Pod {
+func freshPod(podName, jobName string, podUID types.UID) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              podName,
 			Namespace:         ns,
+			UID:               podUID,
 			CreationTimestamp: metav1.NewTime(time.Now()),
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -62,8 +65,17 @@ func freshPod(podName, jobName string) *corev1.Pod {
 				},
 			},
 		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "ci-worker",
+					Image: "us-central1-docker.pkg.dev/example/images/ci-worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				},
+			},
+		},
 		Status: corev1.PodStatus{
 			PodIP: "10.0.0.1",
+			Phase: corev1.PodRunning,
 		},
 	}
 }
@@ -88,12 +100,13 @@ func jobOwnedByScaledJob(jobName, scaledJobName string) *batchv1.Job {
 func TestValidateToken_HappyPath(t *testing.T) {
 	podName := "ci-worker-abc"
 	jobName := "ci-worker-job-1"
+	podUID := types.UID("test-pod-uid")
 
 	client := k8sfake.NewClientset(
-		freshPod(podName, jobName),
+		freshPod(podName, jobName, podUID),
 		jobOwnedByScaledJob(jobName, "ci-worker"),
 	)
-	client.PrependReactor("create", "tokenreviews", validTokenReviewReactor(podName))
+	client.PrependReactor("create", "tokenreviews", validTokenReviewReactor(podName, string(podUID)))
 
 	claimer := k8sproof.New(client, ns)
 	gotPod, gotIP, err := claimer.ValidateToken(context.Background(), saToken)
@@ -111,7 +124,7 @@ func TestValidateToken_HappyPath(t *testing.T) {
 func TestValidateToken_BadToken(t *testing.T) {
 	client := k8sfake.NewClientset()
 	client.PrependReactor("create", "tokenreviews",
-		tokenReviewReactor(false, "", ""))
+		tokenReviewReactor(false, "", "", ""))
 
 	claimer := k8sproof.New(client, ns)
 	_, _, err := claimer.ValidateToken(context.Background(), "bad-token")
@@ -124,7 +137,7 @@ func TestValidateToken_WrongSA(t *testing.T) {
 	podName := "some-pod"
 	client := k8sfake.NewClientset()
 	client.PrependReactor("create", "tokenreviews",
-		tokenReviewReactor(true, "system:serviceaccount:other-ns:other-sa", podName))
+		tokenReviewReactor(true, "system:serviceaccount:other-ns:other-sa", podName, "test-pod-uid"))
 
 	claimer := k8sproof.New(client, ns)
 	_, _, err := claimer.ValidateToken(context.Background(), saToken)
@@ -136,21 +149,34 @@ func TestValidateToken_WrongSA(t *testing.T) {
 func TestValidateToken_StalePod(t *testing.T) {
 	podName := "ci-worker-stale"
 	jobName := "ci-worker-job-2"
+	podUID := types.UID("test-pod-uid")
 
 	stalePod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              podName,
 			Namespace:         ns,
+			UID:               podUID,
 			CreationTimestamp: metav1.NewTime(time.Now().Add(-5 * time.Hour)),
 			OwnerReferences: []metav1.OwnerReference{
 				{APIVersion: "batch/v1", Kind: "Job", Name: jobName},
 			},
 		},
-		Status: corev1.PodStatus{PodIP: "10.0.0.2"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "ci-worker",
+					Image: "us-central1-docker.pkg.dev/example/images/ci-worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.0.0.2",
+			Phase: corev1.PodRunning,
+		},
 	}
 
 	client := k8sfake.NewClientset(stalePod, jobOwnedByScaledJob(jobName, "ci-worker"))
-	client.PrependReactor("create", "tokenreviews", validTokenReviewReactor(podName))
+	client.PrependReactor("create", "tokenreviews", validTokenReviewReactor(podName, string(podUID)))
 
 	claimer := k8sproof.New(client, ns)
 	_, _, err := claimer.ValidateToken(context.Background(), saToken)
@@ -161,18 +187,32 @@ func TestValidateToken_StalePod(t *testing.T) {
 
 func TestValidateToken_MissingJobOwner(t *testing.T) {
 	podName := "ci-worker-nojob"
-	// Pod has no ownerReferences — should fail at check 4.
+	podUID := types.UID("test-pod-uid")
+
+	// Pod has no ownerReferences — should fail at the Job owner check.
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              podName,
 			Namespace:         ns,
+			UID:               podUID,
 			CreationTimestamp: metav1.NewTime(time.Now()),
 		},
-		Status: corev1.PodStatus{PodIP: "10.0.0.3"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "ci-worker",
+					Image: "us-central1-docker.pkg.dev/example/images/ci-worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP:  "10.0.0.3",
+			Phase:  corev1.PodRunning,
+		},
 	}
 
 	client := k8sfake.NewClientset(pod)
-	client.PrependReactor("create", "tokenreviews", validTokenReviewReactor(podName))
+	client.PrependReactor("create", "tokenreviews", validTokenReviewReactor(podName, string(podUID)))
 
 	claimer := k8sproof.New(client, ns)
 	_, _, err := claimer.ValidateToken(context.Background(), saToken)
@@ -184,16 +224,114 @@ func TestValidateToken_MissingJobOwner(t *testing.T) {
 func TestValidateToken_WrongScaledJobName(t *testing.T) {
 	podName := "ci-worker-wrongsj"
 	jobName := "ci-worker-job-3"
+	podUID := types.UID("test-pod-uid")
 
 	client := k8sfake.NewClientset(
-		freshPod(podName, jobName),
+		freshPod(podName, jobName, podUID),
 		jobOwnedByScaledJob(jobName, "some-other-scaled-job"),
 	)
-	client.PrependReactor("create", "tokenreviews", validTokenReviewReactor(podName))
+	client.PrependReactor("create", "tokenreviews", validTokenReviewReactor(podName, string(podUID)))
 
 	claimer := k8sproof.New(client, ns)
 	_, _, err := claimer.ValidateToken(context.Background(), saToken)
 	if err == nil {
 		t.Fatal("expected error for wrong ScaledJob name, got nil")
+	}
+}
+
+func TestValidateToken_PodUIDMismatch(t *testing.T) {
+	podName := "ci-worker-uid-mismatch"
+	jobName := "ci-worker-job-4"
+	podUID := types.UID("uid-different")
+
+	client := k8sfake.NewClientset(
+		freshPod(podName, jobName, podUID),
+		jobOwnedByScaledJob(jobName, "ci-worker"),
+	)
+	// Token claims a different UID than the pod actually has.
+	client.PrependReactor("create", "tokenreviews", validTokenReviewReactor(podName, "uid-from-token"))
+
+	claimer := k8sproof.New(client, ns)
+	_, _, err := claimer.ValidateToken(context.Background(), saToken)
+	if err == nil {
+		t.Fatal("expected error for pod UID mismatch, got nil")
+	}
+}
+
+func TestValidateToken_PodNotRunning(t *testing.T) {
+	podName := "ci-worker-pending"
+	jobName := "ci-worker-job-5"
+	podUID := types.UID("test-pod-uid")
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              podName,
+			Namespace:         ns,
+			UID:               podUID,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+			OwnerReferences: []metav1.OwnerReference{
+				{APIVersion: "batch/v1", Kind: "Job", Name: jobName},
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "ci-worker",
+					Image: "us-central1-docker.pkg.dev/example/images/ci-worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.0.0.4",
+			Phase: corev1.PodPending,
+		},
+	}
+
+	client := k8sfake.NewClientset(pod, jobOwnedByScaledJob(jobName, "ci-worker"))
+	client.PrependReactor("create", "tokenreviews", validTokenReviewReactor(podName, string(podUID)))
+
+	claimer := k8sproof.New(client, ns)
+	_, _, err := claimer.ValidateToken(context.Background(), saToken)
+	if err == nil {
+		t.Fatal("expected error for pod not running, got nil")
+	}
+}
+
+func TestValidateToken_ImageNotDigestPinned(t *testing.T) {
+	podName := "ci-worker-notpinned"
+	jobName := "ci-worker-job-6"
+	podUID := types.UID("test-pod-uid")
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              podName,
+			Namespace:         ns,
+			UID:               podUID,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+			OwnerReferences: []metav1.OwnerReference{
+				{APIVersion: "batch/v1", Kind: "Job", Name: jobName},
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "ci-worker",
+					Image: "us-central1-docker.pkg.dev/example/images/ci-worker:latest",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.0.0.5",
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	client := k8sfake.NewClientset(pod, jobOwnedByScaledJob(jobName, "ci-worker"))
+	client.PrependReactor("create", "tokenreviews", validTokenReviewReactor(podName, string(podUID)))
+
+	claimer := k8sproof.New(client, ns)
+	_, _, err := claimer.ValidateToken(context.Background(), saToken)
+	if err == nil {
+		t.Fatal("expected error for image not digest-pinned, got nil")
 	}
 }


### PR DESCRIPTION
## Summary

- **Pod UID cross-check**: extract `authentication.kubernetes.io/pod-uid` from TokenReview extra claims and verify it matches the fetched pod's actual UID. Prevents token-replay attacks where a token stolen from a deleted pod is presented against a recycled pod with the same name.
- **Pod phase check**: reject claims from pods not in `Running` phase. A completed, failed, or pending pod cannot claim a job.
- **Container image digest check**: reject claims from any pod whose containers do not reference a digest-pinned image (`@sha256:`). Ensures pods were deployed via the normal pipeline kubectl patch rather than a floating tag.

Adds three new tests covering each failure case, and updates existing test helpers (`freshPod`, `tokenReviewReactor`) to carry UID and phase through the full happy path.

## Test plan

- [ ] `go test ./internal/k8sproof/... -count=1 -v` — all 9 tests pass
- [ ] `go vet ./internal/k8sproof/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)