### PR TITLE
fix(ci-worker): docker run support and GCS log persistence

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
             --service-account=docstore-server@dlorenc-chainguard.iam.gserviceaccount.com \
             --add-cloudsql-instances=dlorenc-chainguard:us-central1:docstore-mvp \
             --update-secrets=DATABASE_URL=docstore-db-url:latest,IAP_CLIENT_SECRET=iap-oauth-client-secret:latest,ARCHIVE_HMAC_SECRET=archive-hmac-secret:latest \
-            --set-env-vars=ARCHIVE_BASE_URL=https://docstore-efuj4cj54a-uc.a.run.app,OIDC_JWKS_URL=https://oidc.docstore.dev/.well-known/jwks.json,OIDC_AUDIENCE=docstore,OIDC_ISSUER=https://oidc.docstore.dev \
+            --set-env-vars=ARCHIVE_BASE_URL=https://docstore-efuj4cj54a-uc.a.run.app,OIDC_JWKS_URL=https://oidc.docstore.dev/.well-known/jwks.json,OIDC_AUDIENCE=docstore,OIDC_ISSUER=https://oidc.docstore.dev,LOG_STORE=gcs,LOG_BUCKET=docstore-ci-logs \
             --ingress=internal-and-cloud-load-balancing \
             --min-instances=1 \
             --max-instances=1 \
@@ -66,6 +66,13 @@ jobs:
             --project=dlorenc-chainguard \
             --member=allUsers \
             --role=roles/run.invoker || true
+
+      - name: Grant docstore server write access to CI log bucket
+        run: |
+          gcloud storage buckets add-iam-policy-binding gs://docstore-ci-logs \
+            --member=serviceAccount:docstore-server@dlorenc-chainguard.iam.gserviceaccount.com \
+            --role=roles/storage.objectAdmin \
+            --project=dlorenc-chainguard || true
 
   build-and-deploy-ci-scheduler:
     runs-on: ubuntu-latest

--- a/Dockerfile.ci-worker
+++ b/Dockerfile.ci-worker
@@ -17,6 +17,7 @@ COPY --from=docker-bins /usr/local/bin/docker /usr/local/bin/docker
 COPY --from=docker-bins /usr/local/bin/dockerd /usr/local/bin/dockerd
 COPY --from=docker-bins /usr/local/bin/docker-proxy /usr/local/bin/docker-proxy
 COPY --from=docker-bins /usr/local/bin/containerd /usr/local/bin/containerd
+COPY --from=docker-bins /usr/local/bin/containerd-shim-runc-v2 /usr/local/bin/containerd-shim-runc-v2
 COPY --from=buildkit /usr/bin/buildkitd /usr/bin/buildkitd
 COPY --from=build /ci-worker /usr/bin/ci-worker
 COPY entrypoint-worker.sh /entrypoint-worker.sh


### PR DESCRIPTION
## Summary

Two fixes discovered during end-to-end testing of the CI docker build step.

- **`containerd-shim-runc-v2` missing from ci-worker image**: `docker run` inside a build step was failing with `containerd-shim-runc-v2: file does not exist`. The Dockerfile copied `containerd`, `dockerd`, `docker-proxy`, and `docker` from `docker:27-dind` but omitted the shim binary that bridges containerd and runc. One-line fix.

- **GCS-backed CI log storage**: the docstore server was defaulting to `LOG_STORE=local`, writing CI check logs to the Cloud Run ephemeral filesystem. Logs disappeared after each request, making CI failures undebuggable. Wires up `LOG_STORE=gcs` and `LOG_BUCKET=docstore-ci-logs` in the deploy workflow, and grants the `docstore-server` SA `roles/storage.objectAdmin` on the bucket.

## Pre-requisite

The GCS bucket must exist before deploying:
```bash
gcloud storage buckets create gs://docstore-ci-logs \
  --project=dlorenc-chainguard \
  --location=us-central1 \
  --uniform-bucket-level-access
```

## Test plan

- [ ] Deploy triggers and ci-worker image rebuilds with the shim present
- [ ] Push a commit to `default/test` with a `docker run` step — check passes
- [ ] CI check logs appear as `gs://` URLs instead of `file://` URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)