### PR TITLE
feat(auth): replace IAP with direct Google OAuth (#438)

### DIFF
--- a/cmd/docstore/main.go
+++ b/cmd/docstore/main.go
@@ -28,10 +28,11 @@ import (
 )
 
 func main() {
-	devIdentity := flag.String("dev-identity", "", "bypass IAP JWT validation and use this identity (local dev/testing only)")
+	devIdentity := flag.String("dev-identity", "", "bypass Google ID token validation and use this identity (local dev/testing only)")
 	bootstrapAdmin := flag.String("bootstrap-admin", "", "identity granted admin access to repos with no admin assigned yet")
-	iapClientID := flag.String("iap-client-id", "", "IAP OAuth client ID advertised via /.well-known/ds-config (overrides IAP_CLIENT_ID env var)")
-	iapClientSecret := flag.String("iap-client-secret", "", "IAP OAuth client secret advertised via /.well-known/ds-config (overrides IAP_CLIENT_SECRET env var)")
+	oauthClientID := flag.String("oauth-client-id", "", "Google OAuth 2.0 client ID advertised via /.well-known/ds-config (overrides OAUTH_CLIENT_ID env var)")
+	oauthClientSecret := flag.String("oauth-client-secret", "", "Google OAuth 2.0 client secret for the web OAuth callback handler (overrides OAUTH_CLIENT_SECRET env var)")
+	sessionSecretB64 := flag.String("session-secret", "", "base64-encoded HMAC secret for signing session cookies (overrides SESSION_SECRET env var)")
 	flag.Parse()
 
 	// Set up structured logger based on LOG_FORMAT and LOG_LEVEL env vars.
@@ -53,22 +54,25 @@ func main() {
 	logger := slog.New(handler)
 	slog.SetDefault(logger)
 
-	// Also accept DEV_IDENTITY and BOOTSTRAP_ADMIN env vars for container-based testing.
+	// Also accept env vars for container-based configuration.
 	if *devIdentity == "" {
 		*devIdentity = os.Getenv("DEV_IDENTITY")
 	}
 	if *bootstrapAdmin == "" {
 		*bootstrapAdmin = os.Getenv("BOOTSTRAP_ADMIN")
 	}
-	if *iapClientID == "" {
-		*iapClientID = os.Getenv("IAP_CLIENT_ID")
+	if *oauthClientID == "" {
+		*oauthClientID = os.Getenv("OAUTH_CLIENT_ID")
 	}
-	if *iapClientSecret == "" {
-		*iapClientSecret = os.Getenv("IAP_CLIENT_SECRET")
+	if *oauthClientSecret == "" {
+		*oauthClientSecret = os.Getenv("OAUTH_CLIENT_SECRET")
+	}
+	if *sessionSecretB64 == "" {
+		*sessionSecretB64 = os.Getenv("SESSION_SECRET")
 	}
 
 	if *devIdentity != "" {
-		logger.Warn("IAP JWT validation disabled", "dev_identity", *devIdentity)
+		logger.Warn("Google ID token validation disabled", "dev_identity", *devIdentity)
 	}
 	if *bootstrapAdmin != "" {
 		logger.Info("bootstrap admin configured", "identity", *bootstrapAdmin)
@@ -192,6 +196,19 @@ func main() {
 		logger.Warn("OIDC_JWKS_URL not set — job OIDC token authentication disabled")
 	}
 
+	// Decode session secret for signing web UI session cookies.
+	// SESSION_SECRET: base64-encoded raw HMAC secret bytes.
+	var sessionSecret []byte
+	if *sessionSecretB64 != "" {
+		sessionSecret, err = base64.StdEncoding.DecodeString(*sessionSecretB64)
+		if err != nil {
+			logger.Error("invalid SESSION_SECRET", "error", err)
+			os.Exit(1)
+		}
+	} else {
+		logger.Warn("SESSION_SECRET not set — web UI session cookie auth disabled")
+	}
+
 	// Initialize log store for CI check log uploads.
 	ls, err := logstore.NewFromEnv(context.Background())
 	if err != nil {
@@ -201,9 +218,9 @@ func main() {
 
 	jobStore := db.NewStore(database)
 	srv := server.NewWithOIDC(commitStore, database, bs, broker,
-		*devIdentity, *bootstrapAdmin, *iapClientID, *iapClientSecret,
+		*devIdentity, *bootstrapAdmin, *oauthClientID, *oauthClientSecret,
 		jobStore, archiveHMACSecret, archiveBaseURL,
-		oidcJWKSURL, oidcAudience, oidcIssuer, ls)
+		oidcJWKSURL, oidcAudience, oidcIssuer, ls, sessionSecret)
 
 	// Start the auto-merge worker. It subscribes to check.reported and
 	// review.submitted events and merges branches with auto_merge=true.

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -22,9 +22,9 @@ import (
 )
 
 // Token holds OAuth2 credentials cached for a server URL.
-// IAP requires an OIDC ID token (IDToken), not the OAuth access token.
+// The server validates the Google ID token (IDToken) directly.
 type Token struct {
-	IDToken      string    `json:"id_token"`      // OIDC JWT — what IAP validates
+	IDToken      string    `json:"id_token"`      // Google OIDC ID token — what the server validates
 	AccessToken  string    `json:"access_token"`  // kept for reference / future use
 	RefreshToken string    `json:"refresh_token"`
 	Expiry       time.Time `json:"expiry"`
@@ -145,10 +145,10 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		t.mu.Unlock()
 	}
 
-	// IAP requires the OIDC ID token, not the OAuth access token.
+	// The server validates the Google OIDC ID token directly.
 	bearer := tok.IDToken
 	if bearer == "" {
-		bearer = tok.AccessToken // fallback for non-IAP servers
+		bearer = tok.AccessToken // fallback when no ID token available
 	}
 	reqCopy := req.Clone(req.Context())
 	reqCopy.Header.Set("Authorization", "Bearer "+bearer)
@@ -214,9 +214,11 @@ func (a *App) Login(serverURL, fallbackClientID, fallbackClientSecret string) er
 				fmt.Fprintln(a.Out, "Server does not require authentication")
 				return nil
 			}
-			if cfg.Auth.Type == "iap" && cfg.Auth.ClientID != "" {
+			if (cfg.Auth.Type == "oauth" || cfg.Auth.Type == "iap") && cfg.Auth.ClientID != "" {
 				clientID = cfg.Auth.ClientID
-				clientSecret = cfg.Auth.ClientSecret
+				if cfg.Auth.ClientSecret != "" {
+					clientSecret = cfg.Auth.ClientSecret
+				}
 			}
 		}
 	} else if resp != nil {
@@ -232,7 +234,7 @@ func (a *App) Login(serverURL, fallbackClientID, fallbackClientSecret string) er
 		return fmt.Errorf("oauth flow: %w", err)
 	}
 
-	// Extract the OIDC ID token — this is what IAP requires as the Bearer token.
+	// Extract the Google OIDC ID token — sent as the Bearer token to the server.
 	email := ""
 	idToken, _ := oauthTok.Extra("id_token").(string)
 	if idToken != "" {

--- a/internal/server/dsconfig_test.go
+++ b/internal/server/dsconfig_test.go
@@ -32,8 +32,8 @@ func TestDSConfigEndpoint_NoIAP(t *testing.T) {
 	}
 }
 
-func TestDSConfigEndpoint_WithIAP(t *testing.T) {
-	// Server with IAP client ID configured.
+func TestDSConfigEndpoint_WithOAuth(t *testing.T) {
+	// Server with OAuth client ID configured.
 	h := server.NewWithBroker(nil, nil, nil, nil, "dev@example.com", "", "test-client-id", "test-secret")
 	req := httptest.NewRequest("GET", "/.well-known/ds-config", nil)
 	w := httptest.NewRecorder()
@@ -50,46 +50,21 @@ func TestDSConfigEndpoint_WithIAP(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected auth object, got %T", got["auth"])
 	}
-	if auth["type"] != "iap" {
-		t.Errorf("expected type=iap, got %v", auth["type"])
+	if auth["type"] != "oauth" {
+		t.Errorf("expected type=oauth, got %v", auth["type"])
 	}
 	if auth["client_id"] != "test-client-id" {
 		t.Errorf("expected client_id=test-client-id, got %v", auth["client_id"])
 	}
-	if auth["client_secret"] != "test-secret" {
-		t.Errorf("expected client_secret=test-secret, got %v", auth["client_secret"])
-	}
-}
-
-func TestDSConfigEndpoint_WithIAPNoSecret(t *testing.T) {
-	// Server with IAP client ID but no client secret.
-	h := server.NewWithBroker(nil, nil, nil, nil, "dev@example.com", "", "test-client-id", "")
-	req := httptest.NewRequest("GET", "/.well-known/ds-config", nil)
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Code)
-	}
-	var got map[string]any
-	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	auth, ok := got["auth"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected auth object, got %T", got["auth"])
-	}
-	if auth["type"] != "iap" {
-		t.Errorf("expected type=iap, got %v", auth["type"])
-	}
+	// client_secret is not advertised in ds-config (it's a server-side secret).
 	if _, has := auth["client_secret"]; has {
-		t.Errorf("expected no client_secret field when secret is empty")
+		t.Errorf("expected no client_secret field in ds-config")
 	}
 }
 
 func TestDSConfigEndpoint_Unauthenticated(t *testing.T) {
-	// Endpoint must be accessible without auth (no IAP token required).
-	// Use a server without dev identity — real IAP mode — and verify 200 (not 401).
+	// Endpoint must be accessible without auth (no token required).
+	// Use a server without dev identity — real auth mode — and verify 200 (not 401).
 	h := server.NewWithBroker(nil, nil, nil, nil, "", "", "some-client-id", "")
 	req := httptest.NewRequest("GET", "/.well-known/ds-config", nil)
 	w := httptest.NewRecorder()

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -546,16 +546,16 @@ func TestIntegrationRebase_FullFlow(t *testing.T) {
 	}
 }
 
-// TestHTTP_AuthRequired verifies that write endpoints return 401 when no IAP JWT
+// TestHTTP_AuthRequired verifies that write endpoints return 401 when no Bearer token
 // is present and the server is not in dev mode.
 func TestHTTP_AuthRequired(t *testing.T) {
 	t.Parallel()
-	// No devIdentity → real IAP auth enforced.
+	// No devIdentity → real Google ID token auth enforced.
 	handler := server.New(nil, nil, "", "")
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	// POST /repos/default/default/-/commit without X-Goog-IAP-JWT-Assertion must return 401.
+	// POST /repos/default/default/-/commit without Authorization: Bearer must return 401.
 	resp, err := http.Post(srv.URL+"/repos/default/default/-/commit", "application/json",
 		strings.NewReader(`{"branch":"main","message":"m","files":[{"path":"a.txt","content":"YQ=="}]}`))
 	if err != nil {

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -6,6 +6,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/hmac"
 	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
@@ -29,7 +30,7 @@ const identityKey contextKey = "identity"
 const roleKey contextKey = "role"
 
 // IdentityFromContext returns the authenticated identity stored in the context
-// by the IAP middleware. Returns empty string if not set.
+// by the auth middleware. Returns empty string if not set.
 func IdentityFromContext(ctx context.Context) string {
 	v, _ := ctx.Value(identityKey).(string)
 	return v
@@ -45,7 +46,7 @@ func RoleFromContext(ctx context.Context) model.RoleType {
 // --- Request logger ---
 
 // requestLog is a mutable capture placed in context by RequestLogger so that
-// inner middleware (IAPMiddleware) can write the authenticated identity back
+// inner middleware (GoogleAuthMiddleware) can write the authenticated identity back
 // for use in the access log.
 type requestLog struct {
 	identity string
@@ -99,7 +100,7 @@ func repoFromPath(path string) string {
 
 // RequestLogger returns an HTTP middleware that logs one structured line per
 // request on completion. It uses a requestLog capture in the context so that
-// IAPMiddleware can write back the authenticated identity.
+// GoogleAuthMiddleware can write back the authenticated identity.
 func RequestLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
@@ -142,7 +143,7 @@ type RoleStore interface {
 }
 
 // RBACMiddleware returns an HTTP middleware that enforces role-based access
-// control for repo-scoped routes. It must run after IAPMiddleware so that
+// control for repo-scoped routes. It must run after GoogleAuthMiddleware so that
 // the identity is already in context.
 //
 // bootstrapAdmin, if non-empty, is granted full admin access for any repo
@@ -389,7 +390,7 @@ func JobIdentityFromContext(ctx context.Context) *JobIdentity {
 // JobTokenMiddleware validates a CI job OIDC JWT (issued by oidc.docstore.dev)
 // and extracts the job context. If the token is valid, it sets the identity
 // in context so the request proceeds. If invalid, returns 401.
-// If no Authorization header is present, falls through (allows IAP to handle it).
+// If no Authorization header is present, falls through (allows GoogleAuthMiddleware to handle it).
 func JobTokenMiddleware(jwksURL, audience, issuer string) func(http.Handler) http.Handler {
 	cache := newKeyCacheForURL(jwksURL)
 	return newJobTokenMiddlewareWithKeyFetcher(cache.get, audience, issuer)
@@ -545,18 +546,21 @@ func jwtAudienceContains(aud any, target string) bool {
 	return false
 }
 
-// IAPMiddleware returns an HTTP middleware that validates GCP IAP JWTs from the
-// X-Goog-IAP-JWT-Assertion header. If devIdentity is non-empty, JWT validation is
-// skipped and devIdentity is used directly (for local dev/testing).
-func IAPMiddleware(devIdentity string) func(http.Handler) http.Handler {
-	cache := newKeyCache()
-	return newMiddleware(devIdentity, cache.get)
+// GoogleAuthMiddleware returns an HTTP middleware that validates Google ID tokens
+// from the Authorization: Bearer header, or a signed session cookie for web UI
+// requests. If devIdentity is non-empty, all validation is skipped and devIdentity
+// is used directly (for local dev/testing).
+//
+// clientID is the OAuth 2.0 client ID used to validate the audience claim of
+// Google ID tokens. sessionSecret is the HMAC key for signing session cookies;
+// nil disables session cookie auth.
+func GoogleAuthMiddleware(devIdentity, clientID string, sessionSecret []byte) func(http.Handler) http.Handler {
+	cache := newKeyCacheForURL(googleJWKURL)
+	return newGoogleAuthMiddleware(devIdentity, clientID, sessionSecret, cache.get)
 }
 
-
-// newMiddleware is the testable core of IAPMiddleware. fetchKey is called with a
-// key ID and returns the corresponding RSA public key.
-func newMiddleware(devIdentity string, fetchKey func(kid string) (crypto.PublicKey, error)) func(http.Handler) http.Handler {
+// newGoogleAuthMiddleware is the testable core of GoogleAuthMiddleware.
+func newGoogleAuthMiddleware(devIdentity, clientID string, sessionSecret []byte, fetchKey func(kid string) (crypto.PublicKey, error)) func(http.Handler) http.Handler {
 	if devIdentity != "" {
 		return func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -570,29 +574,51 @@ func newMiddleware(devIdentity string, fetchKey func(kid string) (crypto.PublicK
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			token := r.Header.Get("X-Goog-IAP-JWT-Assertion")
-			if token == "" {
-				slog.Warn("auth failed", "reason", "missing_token", "path", r.URL.Path)
-				writeAPIError(w, ErrCodeUnauthorized, http.StatusUnauthorized, "unauthenticated")
+			// Try Bearer token first (CLI and direct API use).
+			auth := r.Header.Get("Authorization")
+			if bearerToken := strings.TrimPrefix(auth, "Bearer "); bearerToken != "" && bearerToken != auth {
+				email, err := validateGoogleIDToken(bearerToken, fetchKey, clientID)
+				if err != nil {
+					slog.Warn("auth failed", "reason", "invalid_id_token", "path", r.URL.Path, "error", err)
+					writeAPIError(w, ErrCodeUnauthorized, http.StatusUnauthorized, "unauthenticated")
+					return
+				}
+				if rl := requestLogFromContext(r.Context()); rl != nil {
+					rl.identity = email
+				}
+				ctx := context.WithValue(r.Context(), identityKey, email)
+				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
-			email, err := validateIAPJWT(token, fetchKey)
-			if err != nil {
-				slog.Warn("auth failed", "reason", "invalid_jwt", "path", r.URL.Path, "error", err)
-				writeAPIError(w, ErrCodeUnauthorized, http.StatusUnauthorized, "unauthenticated")
+
+			// Try session cookie (web UI use).
+			if len(sessionSecret) > 0 {
+				if email := sessionEmailFromRequest(r, sessionSecret); email != "" {
+					if rl := requestLogFromContext(r.Context()); rl != nil {
+						rl.identity = email
+					}
+					ctx := context.WithValue(r.Context(), identityKey, email)
+					next.ServeHTTP(w, r.WithContext(ctx))
+					return
+				}
+			}
+
+			// No valid auth. Redirect web UI paths to login; return 401 for API paths.
+			if strings.HasPrefix(r.URL.Path, "/ui/") {
+				loginURL := "/auth/login?redirect=" + r.URL.RequestURI()
+				http.Redirect(w, r, loginURL, http.StatusFound)
 				return
 			}
-			if rl := requestLogFromContext(r.Context()); rl != nil {
-				rl.identity = email
-			}
-			ctx := context.WithValue(r.Context(), identityKey, email)
-			next.ServeHTTP(w, r.WithContext(ctx))
+
+			slog.Warn("auth failed", "reason", "missing_token", "path", r.URL.Path)
+			writeAPIError(w, ErrCodeUnauthorized, http.StatusUnauthorized, "unauthenticated")
 		})
 	}
 }
 
-// validateIAPJWT parses and validates an IAP JWT (RS256 or ES256), returning the email claim.
-func validateIAPJWT(tokenString string, fetchKey func(kid string) (crypto.PublicKey, error)) (string, error) {
+// validateGoogleIDToken parses and validates a Google ID token (RS256 or ES256),
+// returning the email claim. The clientID is matched against the audience claim.
+func validateGoogleIDToken(tokenString string, fetchKey func(kid string) (crypto.PublicKey, error), clientID string) (string, error) {
 	parts := strings.SplitN(tokenString, ".", 3)
 	if len(parts) != 3 {
 		return "", fmt.Errorf("invalid JWT format")
@@ -664,6 +690,8 @@ func validateIAPJWT(tokenString string, fetchKey func(kid string) (crypto.Public
 	var claims struct {
 		Email string  `json:"email"`
 		Exp   float64 `json:"exp"`
+		Iss   string  `json:"iss"`
+		Aud   any     `json:"aud"` // string or []interface{}
 	}
 	if err := json.Unmarshal(payloadJSON, &claims); err != nil {
 		return "", fmt.Errorf("parse payload: %w", err)
@@ -674,29 +702,97 @@ func validateIAPJWT(tokenString string, fetchKey func(kid string) (crypto.Public
 		return "", fmt.Errorf("token expired")
 	}
 
+	// Validate issuer — Google ID tokens use either form.
+	if claims.Iss != "accounts.google.com" && claims.Iss != "https://accounts.google.com" {
+		return "", fmt.Errorf("invalid issuer: %q", claims.Iss)
+	}
+
+	// Validate audience against the configured OAuth client ID (if provided).
+	if clientID != "" && !jwtAudienceContains(claims.Aud, clientID) {
+		return "", fmt.Errorf("invalid audience")
+	}
+
 	if claims.Email == "" {
 		return "", fmt.Errorf("missing email claim")
 	}
 	return claims.Email, nil
 }
 
+// --- Session cookie management ---
+
+const sessionCookieName = "ds_session"
+
+// createSessionCookie creates a signed HMAC session cookie for the given email.
+// The cookie value format is: base64url(json) + "." + base64url(hmac_sha256).
+func createSessionCookie(email string, expiry time.Time, secret []byte, secure bool) *http.Cookie {
+	payload, _ := json.Marshal(map[string]any{
+		"email": email,
+		"exp":   expiry.Unix(),
+	})
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payload)
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(payloadB64))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    payloadB64 + "." + sig,
+		Path:     "/",
+		Expires:  expiry,
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
+// sessionEmailFromRequest validates the session cookie in r and returns the email.
+// Returns "" if the cookie is missing, malformed, or expired.
+func sessionEmailFromRequest(r *http.Request, secret []byte) string {
+	cookie, err := r.Cookie(sessionCookieName)
+	if err != nil {
+		return ""
+	}
+	dot := strings.LastIndex(cookie.Value, ".")
+	if dot < 0 {
+		return ""
+	}
+	payloadB64 := cookie.Value[:dot]
+	sigB64 := cookie.Value[dot+1:]
+
+	// Verify HMAC.
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(payloadB64))
+	expectedSig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(sigB64), []byte(expectedSig)) {
+		return ""
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(payloadB64)
+	if err != nil {
+		return ""
+	}
+	var claims struct {
+		Email string  `json:"email"`
+		Exp   float64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	if time.Now().Unix() > int64(claims.Exp) {
+		return ""
+	}
+	return claims.Email
+}
+
 // --- JWK key cache ---
 
-const iapJWKURL = "https://www.gstatic.com/iap/verify/public_key-jwk"
+const googleJWKURL = "https://www.googleapis.com/oauth2/v3/certs"
 
 type keyCache struct {
-	url       string // JWKS URL to fetch; defaults to iapJWKURL if empty
+	url       string // JWKS URL to fetch; defaults to googleJWKURL if empty
 	mu        sync.RWMutex
 	keys      map[string]crypto.PublicKey
 	fetchedAt time.Time
 	ttl       time.Duration
-}
-
-func newKeyCache() *keyCache {
-	return &keyCache{
-		url: iapJWKURL,
-		ttl: time.Hour,
-	}
 }
 
 // newKeyCacheForURL returns a keyCache that fetches JWKS from the given URL.
@@ -742,7 +838,7 @@ func (c *keyCache) get(kid string) (crypto.PublicKey, error) {
 func (c *keyCache) refresh() error {
 	url := c.url
 	if url == "" {
-		url = iapJWKURL
+		url = googleJWKURL
 	}
 	resp, err := http.Get(url) //nolint:noctx
 	if err != nil {

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -31,7 +32,8 @@ func generateTestKey(t *testing.T) *rsa.PrivateKey {
 }
 
 // makeTestJWT returns a signed RS256 JWT with the given claims.
-func makeTestJWT(t *testing.T, key *rsa.PrivateKey, kid, email string, exp time.Time) string {
+// clientID is used as the audience claim (matches Google ID token format).
+func makeTestJWT(t *testing.T, key *rsa.PrivateKey, kid, email, clientID string, exp time.Time) string {
 	t.Helper()
 
 	headerJSON, _ := json.Marshal(map[string]string{"alg": "RS256", "kid": kid, "typ": "JWT"})
@@ -39,7 +41,8 @@ func makeTestJWT(t *testing.T, key *rsa.PrivateKey, kid, email string, exp time.
 		"email": email,
 		"exp":   exp.Unix(),
 		"iat":   time.Now().Unix(),
-		"iss":   "https://cloud.google.com/iap",
+		"iss":   "accounts.google.com",
+		"aud":   clientID,
 	})
 
 	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
@@ -76,16 +79,18 @@ func (c *identityCapture) handler() http.HandlerFunc {
 	}
 }
 
-func TestIAPMiddleware_ValidJWT(t *testing.T) {
+const testClientID = "test-client-id"
+
+func TestGoogleAuthMiddleware_ValidJWT(t *testing.T) {
 	key := generateTestKey(t)
 	kid := "test-key-1"
-	mw := newMiddleware("", staticKeyFetcher(kid, &key.PublicKey))
+	mw := newGoogleAuthMiddleware("", testClientID, nil, staticKeyFetcher(kid, &key.PublicKey))
 	cap := &identityCapture{}
 	handler := mw(cap.handler())
 
-	token := makeTestJWT(t, key, kid, "alice@example.com", time.Now().Add(time.Hour))
+	token := makeTestJWT(t, key, kid, "alice@example.com", testClientID, time.Now().Add(time.Hour))
 	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
-	req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -94,15 +99,15 @@ func TestIAPMiddleware_ValidJWT(t *testing.T) {
 	}
 }
 
-func TestIAPMiddleware_MissingHeader(t *testing.T) {
-	mw := newMiddleware("", func(kid string) (crypto.PublicKey, error) {
+func TestGoogleAuthMiddleware_MissingToken(t *testing.T) {
+	mw := newGoogleAuthMiddleware("", testClientID, nil, func(kid string) (crypto.PublicKey, error) {
 		return nil, fmt.Errorf("should not be called")
 	})
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/something", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -119,19 +124,19 @@ func TestIAPMiddleware_MissingHeader(t *testing.T) {
 	}
 }
 
-func TestIAPMiddleware_InvalidSignature(t *testing.T) {
+func TestGoogleAuthMiddleware_InvalidSignature(t *testing.T) {
 	signingKey := generateTestKey(t)
 	verifyKey := generateTestKey(t) // different key — signature will not match
 	kid := "test-key-1"
 
-	mw := newMiddleware("", staticKeyFetcher(kid, &verifyKey.PublicKey))
+	mw := newGoogleAuthMiddleware("", testClientID, nil, staticKeyFetcher(kid, &verifyKey.PublicKey))
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	token := makeTestJWT(t, signingKey, kid, "alice@example.com", time.Now().Add(time.Hour))
+	token := makeTestJWT(t, signingKey, kid, "alice@example.com", testClientID, time.Now().Add(time.Hour))
 	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
-	req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -140,17 +145,17 @@ func TestIAPMiddleware_InvalidSignature(t *testing.T) {
 	}
 }
 
-func TestIAPMiddleware_ExpiredToken(t *testing.T) {
+func TestGoogleAuthMiddleware_ExpiredToken(t *testing.T) {
 	key := generateTestKey(t)
 	kid := "test-key-1"
-	mw := newMiddleware("", staticKeyFetcher(kid, &key.PublicKey))
+	mw := newGoogleAuthMiddleware("", testClientID, nil, staticKeyFetcher(kid, &key.PublicKey))
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	token := makeTestJWT(t, key, kid, "alice@example.com", time.Now().Add(-time.Hour))
+	token := makeTestJWT(t, key, kid, "alice@example.com", testClientID, time.Now().Add(-time.Hour))
 	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
-	req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -159,9 +164,9 @@ func TestIAPMiddleware_ExpiredToken(t *testing.T) {
 	}
 }
 
-func TestIAPMiddleware_DevMode(t *testing.T) {
-	// Dev mode: no key fetcher needed, no JWT header needed.
-	mw := newMiddleware("alice@example.com", nil)
+func TestGoogleAuthMiddleware_DevMode(t *testing.T) {
+	// Dev mode: no key fetcher needed, no token header needed.
+	mw := newGoogleAuthMiddleware("alice@example.com", "", nil, nil)
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -175,18 +180,18 @@ func TestIAPMiddleware_DevMode(t *testing.T) {
 	}
 }
 
-func TestIAPMiddleware_IdentityInContext(t *testing.T) {
+func TestGoogleAuthMiddleware_IdentityInContext(t *testing.T) {
 	key := generateTestKey(t)
 	kid := "test-key-1"
 	const email = "alice@example.com"
 
-	mw := newMiddleware("", staticKeyFetcher(kid, &key.PublicKey))
+	mw := newGoogleAuthMiddleware("", testClientID, nil, staticKeyFetcher(kid, &key.PublicKey))
 	cap := &identityCapture{}
 	handler := mw(cap.handler())
 
-	token := makeTestJWT(t, key, kid, email, time.Now().Add(time.Hour))
+	token := makeTestJWT(t, key, kid, email, testClientID, time.Now().Add(time.Hour))
 	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
-	req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -444,8 +449,8 @@ func buildJWT(t *testing.T, key *rsa.PrivateKey, header, payload map[string]any)
 	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig)
 }
 
-func TestIAPMiddleware_MalformedToken(t *testing.T) {
-	mw := newMiddleware("", func(kid string) (crypto.PublicKey, error) {
+func TestGoogleAuthMiddleware_MalformedToken(t *testing.T) {
+	mw := newGoogleAuthMiddleware("", testClientID, nil, func(kid string) (crypto.PublicKey, error) {
 		return nil, fmt.Errorf("should not be reached")
 	})
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -454,7 +459,7 @@ func TestIAPMiddleware_MalformedToken(t *testing.T) {
 
 	for _, token := range []string{"notajwt", "only.two"} {
 		req := httptest.NewRequest(http.MethodGet, "/tree", nil)
-		req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+		req.Header.Set("Authorization", "Bearer "+token)
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 		if rec.Code != http.StatusUnauthorized {
@@ -463,21 +468,21 @@ func TestIAPMiddleware_MalformedToken(t *testing.T) {
 	}
 }
 
-func TestIAPMiddleware_WrongAlgorithm(t *testing.T) {
+func TestGoogleAuthMiddleware_WrongAlgorithm(t *testing.T) {
 	key := generateTestKey(t)
 	kid := "test-key-1"
 	token := buildJWT(t, key,
 		map[string]any{"alg": "HS256", "kid": kid, "typ": "JWT"},
-		map[string]any{"email": "alice@example.com", "exp": time.Now().Add(time.Hour).Unix()},
+		map[string]any{"email": "alice@example.com", "exp": time.Now().Add(time.Hour).Unix(), "iss": "accounts.google.com", "aud": testClientID},
 	)
 
-	mw := newMiddleware("", staticKeyFetcher(kid, &key.PublicKey))
+	mw := newGoogleAuthMiddleware("", testClientID, nil, staticKeyFetcher(kid, &key.PublicKey))
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
-	req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -486,14 +491,14 @@ func TestIAPMiddleware_WrongAlgorithm(t *testing.T) {
 	}
 }
 
-func TestIAPMiddleware_MissingKid(t *testing.T) {
+func TestGoogleAuthMiddleware_MissingKid(t *testing.T) {
 	key := generateTestKey(t)
 	token := buildJWT(t, key,
 		map[string]any{"alg": "RS256", "typ": "JWT"}, // no kid
-		map[string]any{"email": "alice@example.com", "exp": time.Now().Add(time.Hour).Unix()},
+		map[string]any{"email": "alice@example.com", "exp": time.Now().Add(time.Hour).Unix(), "iss": "accounts.google.com", "aud": testClientID},
 	)
 
-	mw := newMiddleware("", func(kid string) (crypto.PublicKey, error) {
+	mw := newGoogleAuthMiddleware("", testClientID, nil, func(kid string) (crypto.PublicKey, error) {
 		return nil, fmt.Errorf("should not be reached")
 	})
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -501,7 +506,7 @@ func TestIAPMiddleware_MissingKid(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
-	req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -510,19 +515,19 @@ func TestIAPMiddleware_MissingKid(t *testing.T) {
 	}
 }
 
-func TestIAPMiddleware_UnknownKid(t *testing.T) {
+func TestGoogleAuthMiddleware_UnknownKid(t *testing.T) {
 	key := generateTestKey(t)
 
-	mw := newMiddleware("", func(kid string) (crypto.PublicKey, error) {
+	mw := newGoogleAuthMiddleware("", testClientID, nil, func(kid string) (crypto.PublicKey, error) {
 		return nil, fmt.Errorf("key %q not found", kid)
 	})
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	token := makeTestJWT(t, key, "unknown-kid", "alice@example.com", time.Now().Add(time.Hour))
+	token := makeTestJWT(t, key, "unknown-kid", "alice@example.com", testClientID, time.Now().Add(time.Hour))
 	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
-	req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -531,21 +536,21 @@ func TestIAPMiddleware_UnknownKid(t *testing.T) {
 	}
 }
 
-func TestIAPMiddleware_MissingEmailClaim(t *testing.T) {
+func TestGoogleAuthMiddleware_MissingEmailClaim(t *testing.T) {
 	key := generateTestKey(t)
 	kid := "test-key-1"
 	token := buildJWT(t, key,
 		map[string]any{"alg": "RS256", "kid": kid, "typ": "JWT"},
-		map[string]any{"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix()}, // no email
+		map[string]any{"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(), "iss": "accounts.google.com", "aud": testClientID}, // no email
 	)
 
-	mw := newMiddleware("", staticKeyFetcher(kid, &key.PublicKey))
+	mw := newGoogleAuthMiddleware("", testClientID, nil, staticKeyFetcher(kid, &key.PublicKey))
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
-	req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -554,21 +559,21 @@ func TestIAPMiddleware_MissingEmailClaim(t *testing.T) {
 	}
 }
 
-func TestIAPMiddleware_EmptyEmailClaim(t *testing.T) {
+func TestGoogleAuthMiddleware_EmptyEmailClaim(t *testing.T) {
 	key := generateTestKey(t)
 	kid := "test-key-1"
 	token := buildJWT(t, key,
 		map[string]any{"alg": "RS256", "kid": kid, "typ": "JWT"},
-		map[string]any{"email": "", "exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix()},
+		map[string]any{"email": "", "exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(), "iss": "accounts.google.com", "aud": testClientID},
 	)
 
-	mw := newMiddleware("", staticKeyFetcher(kid, &key.PublicKey))
+	mw := newGoogleAuthMiddleware("", testClientID, nil, staticKeyFetcher(kid, &key.PublicKey))
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
-	req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -577,22 +582,22 @@ func TestIAPMiddleware_EmptyEmailClaim(t *testing.T) {
 	}
 }
 
-func TestIAPMiddleware_MissingExpClaim(t *testing.T) {
+func TestGoogleAuthMiddleware_MissingExpClaim(t *testing.T) {
 	// A JWT with no exp defaults to zero (epoch), which is in the past.
 	key := generateTestKey(t)
 	kid := "test-key-1"
 	token := buildJWT(t, key,
 		map[string]any{"alg": "RS256", "kid": kid, "typ": "JWT"},
-		map[string]any{"email": "alice@example.com", "iat": time.Now().Unix()}, // no exp
+		map[string]any{"email": "alice@example.com", "iat": time.Now().Unix(), "iss": "accounts.google.com", "aud": testClientID}, // no exp
 	)
 
-	mw := newMiddleware("", staticKeyFetcher(kid, &key.PublicKey))
+	mw := newGoogleAuthMiddleware("", testClientID, nil, staticKeyFetcher(kid, &key.PublicKey))
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
-	req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -602,7 +607,7 @@ func TestIAPMiddleware_MissingExpClaim(t *testing.T) {
 	}
 }
 
-func TestIAPMiddleware_FutureIatIsAccepted(t *testing.T) {
+func TestGoogleAuthMiddleware_FutureIatIsAccepted(t *testing.T) {
 	// A token with future iat is still valid: the implementation checks only exp.
 	key := generateTestKey(t)
 	kid := "test-key-1"
@@ -612,21 +617,150 @@ func TestIAPMiddleware_FutureIatIsAccepted(t *testing.T) {
 			"email": "alice@example.com",
 			"exp":   time.Now().Add(time.Hour).Unix(),
 			"iat":   time.Now().Add(time.Hour).Unix(), // future iat
+			"iss":   "accounts.google.com",
+			"aud":   testClientID,
 		},
 	)
 
-	mw := newMiddleware("", staticKeyFetcher(kid, &key.PublicKey))
+	mw := newGoogleAuthMiddleware("", testClientID, nil, staticKeyFetcher(kid, &key.PublicKey))
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
-	req.Header.Set("X-Goog-IAP-JWT-Assertion", token)
+	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200 for future iat with valid exp, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session cookie tests
+// ---------------------------------------------------------------------------
+
+func TestSessionCookie_ValidCookie(t *testing.T) {
+	secret := []byte("test-session-secret-32bytes!!!!!")
+	email := "alice@example.com"
+	expiry := time.Now().Add(time.Hour)
+
+	cookie := createSessionCookie(email, expiry, secret, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
+	req.AddCookie(cookie)
+
+	got := sessionEmailFromRequest(req, secret)
+	if got != email {
+		t.Errorf("expected %q, got %q", email, got)
+	}
+}
+
+func TestSessionCookie_ExpiredCookie(t *testing.T) {
+	secret := []byte("test-session-secret-32bytes!!!!!")
+	email := "alice@example.com"
+	expiry := time.Now().Add(-time.Hour)
+
+	cookie := createSessionCookie(email, expiry, secret, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
+	req.AddCookie(cookie)
+
+	got := sessionEmailFromRequest(req, secret)
+	if got != "" {
+		t.Errorf("expected empty string for expired cookie, got %q", got)
+	}
+}
+
+func TestSessionCookie_TamperedCookie(t *testing.T) {
+	secret := []byte("test-session-secret-32bytes!!!!!")
+	email := "alice@example.com"
+	expiry := time.Now().Add(time.Hour)
+
+	cookie := createSessionCookie(email, expiry, secret, false)
+	cookie.Value = cookie.Value + "tampered"
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
+	req.AddCookie(cookie)
+
+	got := sessionEmailFromRequest(req, secret)
+	if got != "" {
+		t.Errorf("expected empty string for tampered cookie, got %q", got)
+	}
+}
+
+func TestGoogleAuthMiddleware_SessionCookieAuth(t *testing.T) {
+	secret := []byte("test-session-secret-32bytes!!!!!")
+	email := "alice@example.com"
+
+	mw := newGoogleAuthMiddleware("", testClientID, secret, func(kid string) (crypto.PublicKey, error) {
+		t.Error("key fetcher should not be called for session cookie auth")
+		return nil, fmt.Errorf("should not be reached")
+	})
+	cap := &identityCapture{}
+	handler := mw(cap.handler())
+
+	cookie := createSessionCookie(email, time.Now().Add(time.Hour), secret, false)
+	req := httptest.NewRequest(http.MethodGet, "/ui/repos", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if cap.identity != email {
+		t.Errorf("expected identity %q, got %q", email, cap.identity)
+	}
+}
+
+func TestGoogleAuthMiddleware_UIPathRedirectsToLogin(t *testing.T) {
+	mw := newGoogleAuthMiddleware("", testClientID, nil, func(kid string) (crypto.PublicKey, error) {
+		return nil, fmt.Errorf("should not be reached")
+	})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/repos", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("expected 302 redirect for /ui/ path, got %d", rec.Code)
+	}
+	loc := rec.Header().Get("Location")
+	if !strings.HasPrefix(loc, "/auth/login") {
+		t.Errorf("expected redirect to /auth/login, got %q", loc)
+	}
+}
+
+func TestGoogleAuthMiddleware_InvalidIssuer(t *testing.T) {
+	key := generateTestKey(t)
+	kid := "test-key-1"
+	token := buildJWT(t, key,
+		map[string]any{"alg": "RS256", "kid": kid, "typ": "JWT"},
+		map[string]any{
+			"email": "alice@example.com",
+			"exp":   time.Now().Add(time.Hour).Unix(),
+			"iss":   "https://cloud.google.com/iap", // IAP issuer, not direct Google
+			"aud":   testClientID,
+		},
+	)
+
+	mw := newGoogleAuthMiddleware("", testClientID, nil, staticKeyFetcher(kid, &key.PublicKey))
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/tree", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for IAP issuer, got %d", rec.Code)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,14 +2,20 @@ package server
 
 import (
 	"context"
+	cryptorand "crypto/rand"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 
 	"github.com/dlorenc/docstore/internal/blob"
 	"github.com/dlorenc/docstore/internal/db"
@@ -181,28 +187,28 @@ func NewWithReadStore(ws WriteStore, rs ReadStore, devIdentity, bootstrapAdmin s
 	return s.buildHandler(devIdentity, bootstrapAdmin, ws)
 }
 
-
 // New returns an http.Handler with all routes registered.
-// devIdentity, if non-empty, bypasses IAP JWT validation (for local dev/testing).
+// devIdentity, if non-empty, bypasses Google ID token validation (for local dev/testing).
 // bootstrapAdmin, if non-empty, has admin access to any repo with no existing admin.
 // writeStore provides write operations; pass nil if only read/health endpoints are needed.
 // database provides read operations; pass nil if only write/health endpoints are needed.
 func New(writeStore WriteStore, database *sql.DB, devIdentity, bootstrapAdmin string) http.Handler {
-	return newServer(writeStore, database, nil, nil, devIdentity, bootstrapAdmin, "", "")
+	return newServer(writeStore, database, nil, nil, devIdentity, bootstrapAdmin, "", "", nil)
 }
 
 // NewWithBlobStore is like New but also wires a BlobStore into the read store
 // so that files stored externally can be fetched by the file endpoint.
 func NewWithBlobStore(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, devIdentity, bootstrapAdmin string) http.Handler {
-	return newServer(writeStore, database, bs, nil, devIdentity, bootstrapAdmin, "", "")
+	return newServer(writeStore, database, bs, nil, devIdentity, bootstrapAdmin, "", "", nil)
 }
 
 // NewWithBroker is like NewWithBlobStore but also wires an event Broker.
 // Use this in production so mutation handlers can emit events.
-// iapClientID and iapClientSecret are optional; when set they are advertised
-// via the /.well-known/ds-config endpoint so the CLI can perform the OAuth flow.
-func NewWithBroker(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker, devIdentity, bootstrapAdmin, iapClientID, iapClientSecret string) http.Handler {
-	return newServer(writeStore, database, bs, broker, devIdentity, bootstrapAdmin, iapClientID, iapClientSecret)
+// oauthClientID is optional; when set it is advertised via /.well-known/ds-config
+// so the CLI can perform the appropriate OAuth flow.
+// oauthClientSecret is used by the server-side OAuth callback handler.
+func NewWithBroker(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker, devIdentity, bootstrapAdmin, oauthClientID, oauthClientSecret string) http.Handler {
+	return newServer(writeStore, database, bs, broker, devIdentity, bootstrapAdmin, oauthClientID, oauthClientSecret, nil)
 }
 
 // NewWithPresign is like NewWithBroker but also enables presigned archive URLs.
@@ -210,35 +216,38 @@ func NewWithBroker(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, b
 // public server base URL used when constructing presigned URLs.
 // If archiveHMACSecret is nil, presigned archive URLs are disabled.
 func NewWithPresign(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker,
-	devIdentity, bootstrapAdmin, iapClientID, iapClientSecret string,
+	devIdentity, bootstrapAdmin, oauthClientID, oauthClientSecret string,
 	jobStore jobTokenStore, archiveHMACSecret []byte, archiveBaseURL string) http.Handler {
 	return NewWithOIDC(writeStore, database, bs, broker,
-		devIdentity, bootstrapAdmin, iapClientID, iapClientSecret,
+		devIdentity, bootstrapAdmin, oauthClientID, oauthClientSecret,
 		jobStore, archiveHMACSecret, archiveBaseURL,
-		"", "", "", nil)
+		"", "", "", nil, nil)
 }
 
 // NewWithOIDC is like NewWithPresign but also enables OIDC job token authentication
-// for worker-facing endpoints. Workers presenting a valid job OIDC JWT bypass IAP
-// and RBAC and are routed directly to the inner handler with their job identity.
+// for worker-facing endpoints. Workers presenting a valid job OIDC JWT bypass Google
+// ID token validation and RBAC and are routed directly to the inner handler with
+// their job identity.
 //
 // oidcJWKSURL is the JWKS endpoint of the OIDC issuer (e.g. https://oidc.docstore.dev/.well-known/jwks.json).
 // oidcAudience is the expected audience claim (e.g. "docstore").
 // oidcIssuer is the expected issuer claim (e.g. "https://oidc.docstore.dev").
 // If oidcJWKSURL is empty, OIDC job token auth is disabled.
 // ls is the LogStore used by POST /repos/:repo/-/check/:name/logs; if nil the endpoint returns 503.
+// sessionSecret is the HMAC key for signing session cookies; nil disables web UI session auth.
 func NewWithOIDC(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker,
-	devIdentity, bootstrapAdmin, iapClientID, iapClientSecret string,
+	devIdentity, bootstrapAdmin, oauthClientID, oauthClientSecret string,
 	jobStore jobTokenStore, archiveHMACSecret []byte, archiveBaseURL string,
-	oidcJWKSURL, oidcAudience, oidcIssuer string, ls logstore.LogStore) http.Handler {
+	oidcJWKSURL, oidcAudience, oidcIssuer string, ls logstore.LogStore, sessionSecret []byte) http.Handler {
 	pc := policy.NewCache()
 	s := &server{
 		commitStore:       writeStore,
 		policyCache:       pc,
 		broker:            broker,
 		globalAdmin:       bootstrapAdmin,
-		iapClientID:       iapClientID,
-		iapClientSecret:   iapClientSecret,
+		oauthClientID:     oauthClientID,
+		oauthClientSecret: oauthClientSecret,
+		sessionSecret:     sessionSecret,
 		archiveHMACSecret: archiveHMACSecret,
 		archiveBaseURL:    archiveBaseURL,
 		jobTokenStore:     jobStore,
@@ -267,15 +276,16 @@ func NewWithOIDC(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, bro
 	return s.buildHandler(devIdentity, bootstrapAdmin, writeStore)
 }
 
-func newServer(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker, devIdentity, bootstrapAdmin, iapClientID, iapClientSecret string) http.Handler {
+func newServer(writeStore WriteStore, database *sql.DB, bs blob.BlobStore, broker *events.Broker, devIdentity, bootstrapAdmin, oauthClientID, oauthClientSecret string, sessionSecret []byte) http.Handler {
 	pc := policy.NewCache()
 	s := &server{
-		commitStore:     writeStore,
-		policyCache:     pc,
-		broker:          broker,
-		globalAdmin:     bootstrapAdmin,
-		iapClientID:     iapClientID,
-		iapClientSecret: iapClientSecret,
+		commitStore:       writeStore,
+		policyCache:       pc,
+		broker:            broker,
+		globalAdmin:       bootstrapAdmin,
+		oauthClientID:     oauthClientID,
+		oauthClientSecret: oauthClientSecret,
+		sessionSecret:     sessionSecret,
 	}
 	if writeStore != nil {
 		var emitter service.EventEmitter
@@ -346,12 +356,15 @@ func jobEndpointAllowed(endpoint string, permissions []string) bool {
 // Extracted so tests can construct a server with injected dependencies and still
 // get the full middleware stack.
 func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore WriteStore) http.Handler {
-	// Health check and well-known config are exempt from auth.
+	// Health check, well-known config, and OAuth endpoints are exempt from auth.
 	outer := http.NewServeMux()
 	outer.HandleFunc("GET /healthz", handleHealth)
 	outer.HandleFunc("GET /.well-known/ds-config", s.handleDSConfig)
+	outer.HandleFunc("GET /auth/login", s.handleAuthLogin)
+	outer.HandleFunc("GET /auth/callback", s.handleAuthCallback)
+	outer.HandleFunc("GET /auth/logout", s.handleAuthLogout)
 
-	// All other routes require IAP authentication.
+	// All other routes require authentication.
 	inner := http.NewServeMux()
 
 	// Org management endpoints
@@ -383,7 +396,7 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 	//   GET  /repos/acme/myrepo          (bare: GET/DELETE a repo)
 	inner.Handle("/repos/", http.HandlerFunc(s.handleReposPrefix))
 
-	// Minimal read-only web UI. Registered on `inner` so it shares IAP + RBAC
+	// Minimal read-only web UI. Registered on `inner` so it shares Google auth + RBAC
 	// middleware. Only wires up when both a read store and write store are
 	// present — read-only mode still works for browsing, but we need the write
 	// store for repo/org listings.
@@ -417,16 +430,16 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 	// Global SSE stream (admin only).
 	inner.HandleFunc("GET /events", s.handleSSEGlobalEvents)
 
-	// Chain: IAPMiddleware → RBACMiddleware (when store present) → routes.
-	// IAP must run first to set identity in context before RBAC reads it.
+	// Chain: GoogleAuthMiddleware → RBACMiddleware (when store present) → routes.
+	// Auth must run first to set identity in context before RBAC reads it.
 	var routed http.Handler = inner
 	if writeStore != nil {
 		routed = RBACMiddleware(writeStore, bootstrapAdmin)(inner)
 	}
-	iapHandler := IAPMiddleware(devIdentity)(routed)
+	iapHandler := GoogleAuthMiddleware(devIdentity, s.oauthClientID, s.sessionSecret)(routed)
 
-	// Wrap the IAP handler: intercept presign, HMAC-signed archive, and job
-	// OIDC token requests before IAP validation. Everything else falls through
+	// Wrap the auth handler: intercept presign, HMAC-signed archive, and job
+	// OIDC token requests before Google ID token validation. Everything else falls through
 	// to iapHandler.
 	// Using "/" (not "/repos/") avoids the Go mux trailing-slash redirect that
 	// would turn POST /repos into a 307 → POST /repos/.
@@ -464,7 +477,7 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 				return
 			}
 			// Check run (worker → post check result): auth via request_token.
-			// Only intercept when jobTokenStore is configured; fall through to OIDC/IAP otherwise.
+			// Only intercept when jobTokenStore is configured; fall through to OIDC/Google auth otherwise.
 			if endpoint == "check" && r.Method == http.MethodPost && s.jobTokenStore != nil {
 				r.SetPathValue("name", repoName)
 				s.handleCICheck(w, r)
@@ -474,7 +487,7 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 
 		// Job OIDC token auth: if a Bearer token is present and OIDC is configured,
 		// validate it as a job OIDC JWT. On success, inject job identity into context
-		// and route directly to the inner mux (bypassing IAP and RBAC).
+		// and route directly to the inner mux (bypassing Google auth and RBAC).
 		// On failure, return 401. If no Bearer token, fall through to iapHandler.
 		if s.oidcKeyCache != nil {
 			auth := r.Header.Get("Authorization")
@@ -546,10 +559,16 @@ type server struct {
 	// globalAdmin is the identity that may manage global resources like
 	// event subscriptions. Corresponds to the --bootstrap-admin flag.
 	globalAdmin string
-	// iapClientID and iapClientSecret are advertised via /.well-known/ds-config
-	// so CLI tools can perform the IAP OAuth flow.
-	iapClientID     string
-	iapClientSecret string
+	// oauthClientID is the Google OAuth 2.0 client ID. Advertised via
+	// /.well-known/ds-config so CLI tools can perform the OAuth flow.
+	// Also used to validate the audience claim of Google ID tokens.
+	oauthClientID string
+	// oauthClientSecret is the Google OAuth 2.0 client secret used by
+	// the server-side /auth/callback handler to exchange authorization codes.
+	oauthClientSecret string
+	// sessionSecret is the HMAC key for signing session cookies.
+	// nil disables session cookie auth for the web UI.
+	sessionSecret []byte
 	// archiveHMACSecret is the raw HMAC key for presigned archive URLs.
 	// nil means the feature is disabled.
 	archiveHMACSecret []byte
@@ -572,18 +591,14 @@ type server struct {
 // It advertises the server's authentication configuration so CLI tools can
 // perform the appropriate OAuth flow.
 func (s *server) handleDSConfig(w http.ResponseWriter, r *http.Request) {
-	if s.iapClientID == "" {
+	if s.oauthClientID == "" {
 		writeJSON(w, http.StatusOK, map[string]any{"auth": map[string]string{"type": "none"}})
 		return
 	}
-	auth := map[string]any{
-		"type":      "iap",
-		"client_id": s.iapClientID,
-	}
-	if s.iapClientSecret != "" {
-		auth["client_secret"] = s.iapClientSecret
-	}
-	writeJSON(w, http.StatusOK, map[string]any{"auth": auth})
+	writeJSON(w, http.StatusOK, map[string]any{"auth": map[string]any{
+		"type":      "oauth",
+		"client_id": s.oauthClientID,
+	}})
 }
 
 func (s *server) handleCommit(w http.ResponseWriter, r *http.Request) {
@@ -680,6 +695,153 @@ func (s *server) requireRepoReadAccess(w http.ResponseWriter, r *http.Request, r
 
 func handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// --- OAuth2 web authentication handlers ---
+
+// oauthStateCookieName is the cookie used to carry the CSRF state during OAuth.
+const oauthStateCookieName = "ds_oauth_state"
+
+// handleAuthLogin redirects the browser to Google's OAuth consent page.
+func (s *server) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
+	if s.oauthClientID == "" || s.oauthClientSecret == "" || len(s.sessionSecret) == 0 {
+		http.Error(w, "OAuth not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	redirect := r.URL.Query().Get("redirect")
+	if redirect == "" {
+		redirect = "/ui/"
+	}
+
+	stateBytes := make([]byte, 16)
+	if _, err := cryptorand.Read(stateBytes); err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	state := base64.RawURLEncoding.EncodeToString(stateBytes)
+
+	// Store state and post-auth redirect in a short-lived cookie.
+	stateCookie := &http.Cookie{
+		Name:     oauthStateCookieName,
+		Value:    state + "|" + redirect,
+		Path:     "/auth/",
+		MaxAge:   300, // 5 minutes
+		HttpOnly: true,
+		Secure:   r.TLS != nil,
+		SameSite: http.SameSiteLaxMode,
+	}
+	http.SetCookie(w, stateCookie)
+
+	conf := s.oauthConfig(r)
+	authURL := conf.AuthCodeURL(state, oauth2.AccessTypeOffline)
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+// handleAuthCallback handles the OAuth2 authorization code callback from Google.
+func (s *server) handleAuthCallback(w http.ResponseWriter, r *http.Request) {
+	if s.oauthClientID == "" || s.oauthClientSecret == "" || len(s.sessionSecret) == 0 {
+		http.Error(w, "OAuth not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Validate state from cookie.
+	stateCookie, err := r.Cookie(oauthStateCookieName)
+	if err != nil {
+		http.Error(w, "missing state cookie", http.StatusBadRequest)
+		return
+	}
+	parts := strings.SplitN(stateCookie.Value, "|", 2)
+	if len(parts) != 2 {
+		http.Error(w, "malformed state cookie", http.StatusBadRequest)
+		return
+	}
+	expectedState, redirect := parts[0], parts[1]
+
+	if r.URL.Query().Get("state") != expectedState {
+		http.Error(w, "state mismatch", http.StatusBadRequest)
+		return
+	}
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		http.Error(w, "missing authorization code", http.StatusBadRequest)
+		return
+	}
+
+	// Exchange code for tokens.
+	conf := s.oauthConfig(r)
+	tok, err := conf.Exchange(r.Context(), code)
+	if err != nil {
+		slog.Warn("oauth exchange failed", "error", err)
+		http.Error(w, "token exchange failed", http.StatusInternalServerError)
+		return
+	}
+
+	idToken, _ := tok.Extra("id_token").(string)
+	if idToken == "" {
+		http.Error(w, "no id_token in response", http.StatusInternalServerError)
+		return
+	}
+
+	// Validate the ID token and extract email.
+	cache := newKeyCacheForURL(googleJWKURL)
+	email, err := validateGoogleIDToken(idToken, cache.get, s.oauthClientID)
+	if err != nil {
+		slog.Warn("oauth id_token invalid", "error", err)
+		http.Error(w, "invalid id token", http.StatusUnauthorized)
+		return
+	}
+
+	// Clear the state cookie.
+	http.SetCookie(w, &http.Cookie{
+		Name:     oauthStateCookieName,
+		Value:    "",
+		Path:     "/auth/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   r.TLS != nil,
+	})
+
+	// Set session cookie (valid for 24 hours).
+	expiry := time.Now().Add(24 * time.Hour)
+	sessionCookie := createSessionCookie(email, expiry, s.sessionSecret, r.TLS != nil)
+	http.SetCookie(w, sessionCookie)
+
+	if redirect == "" {
+		redirect = "/ui/"
+	}
+	http.Redirect(w, r, redirect, http.StatusFound)
+}
+
+// handleAuthLogout clears the session cookie and redirects to the home page.
+func (s *server) handleAuthLogout(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   r.TLS != nil,
+	})
+	http.Redirect(w, r, "/ui/", http.StatusFound)
+}
+
+// oauthConfig returns an oauth2.Config for the server's OAuth client.
+// The redirect URL uses the request's scheme and host.
+func (s *server) oauthConfig(r *http.Request) *oauth2.Config {
+	scheme := "https"
+	if r.TLS == nil {
+		scheme = "http"
+	}
+	redirectURL := fmt.Sprintf("%s://%s/auth/callback", scheme, r.Host)
+	return &oauth2.Config{
+		ClientID:     s.oauthClientID,
+		ClientSecret: s.oauthClientSecret,
+		RedirectURL:  redirectURL,
+		Scopes:       []string{"openid", "email"},
+		Endpoint:     google.Endpoint,
+	}
 }
 
 func notImplemented(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -548,7 +548,7 @@ func (m *mockStore) InsertCIJob(_ context.Context, _, _ string, _ int64, _, _, _
 }
 
 func TestHealthEndpoint(t *testing.T) {
-	// /healthz is exempt from IAP auth, so devIdentity="" is fine here.
+	// /healthz is exempt from auth, so devIdentity="" is fine here.
 	srv := New(nil, nil, "", "")
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)


### PR DESCRIPTION
## Summary

Implements issue #438 — replaces GCP Identity-Aware Proxy authentication with direct Google ID token validation in the application.

- **Replace `IAPMiddleware`** with `GoogleAuthMiddleware` that validates `Authorization: Bearer <google-id-token>` directly using Google's JWKS endpoint (`accounts.google.com/oauth2/v3/certs`), with issuer and audience claim validation
- **Add OAuth2 web flow** for the browser/web UI: `/auth/login` → Google OAuth consent → `/auth/callback` (exchanges code, sets HMAC-signed session cookie) → `/auth/logout`
- **Update `/.well-known/ds-config`** to return `type: "oauth"` (was `"iap"`); no longer includes `client_secret`
- **Rename flags/env vars**: `--iap-client-id` → `--oauth-client-id`, `IAP_CLIENT_ID` → `OAUTH_CLIENT_ID`, etc.; add `--session-secret` / `SESSION_SECRET` for cookie signing
- **CLI**: handles `auth.type == "oauth"` from ds-config (same desktop OAuth flow, same ID token bearer pattern)

## What stays the same

- All RBAC logic (identity is still an email string)
- CI worker OIDC job token auth (`JobTokenMiddleware`) — unchanged
- `--bootstrap-admin` flag — unchanged
- `DEV_IDENTITY` bypass for local dev — unchanged
- Database schema — unchanged

## Test plan

- All existing middleware tests renamed and updated for new header/issuer
- New tests: session cookie (valid, expired, tampered), UI path redirect to login, invalid issuer rejection
- ds-config tests updated to assert `type: "oauth"`
- `TestDockerSmoke` was already failing on `main` (GCloud credentials required for image pull) — pre-existing, unrelated to this change

## Notes for next steps / opportunities

- The deploy/ directory has no IAP/LB config (only k8s CI worker files) — GCP Load Balancer and IAP terraform/deployment config would need to be removed separately
- `DEV_IDENTITY` can optionally be removed since local OAuth now works natively, but keeping it preserves the fast dev loop
- Consider PKCE support for the CLI OAuth flow (currently uses client secret)

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)