### PR TITLE
fix(deploy): update Cloud Run config for OAuth migration (#439)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,8 +47,8 @@ jobs:
             --region=us-central1 \
             --service-account=docstore-server@dlorenc-chainguard.iam.gserviceaccount.com \
             --add-cloudsql-instances=dlorenc-chainguard:us-central1:docstore-mvp \
-            --update-secrets=DATABASE_URL=docstore-db-url:latest,IAP_CLIENT_SECRET=iap-oauth-client-secret:latest,ARCHIVE_HMAC_SECRET=archive-hmac-secret:latest \
-            --set-env-vars=ARCHIVE_BASE_URL=https://docstore-efuj4cj54a-uc.a.run.app,OIDC_JWKS_URL=https://oidc.docstore.dev/.well-known/jwks.json,OIDC_AUDIENCE=docstore,OIDC_ISSUER=https://oidc.docstore.dev,LOG_STORE=gcs,LOG_BUCKET=docstore-ci-logs \
+            --update-secrets=DATABASE_URL=docstore-db-url:latest,OAUTH_CLIENT_SECRET=iap-oauth-client-secret:latest,SESSION_SECRET=session-secret:latest,ARCHIVE_HMAC_SECRET=archive-hmac-secret:latest \
+            --set-env-vars=OAUTH_CLIENT_ID=320310132788-md94jtp0d9fdcdlq2quma4mcpr0ul1qr.apps.googleusercontent.com,ARCHIVE_BASE_URL=https://docstore-efuj4cj54a-uc.a.run.app,OIDC_JWKS_URL=https://oidc.docstore.dev/.well-known/jwks.json,OIDC_AUDIENCE=docstore,OIDC_ISSUER=https://oidc.docstore.dev,LOG_STORE=gcs,LOG_BUCKET=docstore-ci-logs \
             --ingress=internal-and-cloud-load-balancing \
             --min-instances=1 \
             --max-instances=1 \
@@ -57,7 +57,7 @@ jobs:
             --network=default \
             --subnet=default \
             --vpc-egress=private-ranges-only \
-            --args=--bootstrap-admin=dlorenc@chainguard.dev,--iap-client-id=320310132788-md94jtp0d9fdcdlq2quma4mcpr0ul1qr.apps.googleusercontent.com
+            --args=--bootstrap-admin=dlorenc@chainguard.dev
 
       - name: Grant CI workers access to docstore internal URL
         run: |


### PR DESCRIPTION
## Summary

- Renames `IAP_CLIENT_SECRET` → `OAUTH_CLIENT_SECRET` in `--update-secrets`, reusing the existing `iap-oauth-client-secret` Secret Manager secret (contains the same OAuth client secret value)
- Adds `SESSION_SECRET=session-secret:latest` to `--update-secrets` (requires a `session-secret` secret to be created in Secret Manager before deploying)
- Moves the OAuth client ID to `OAUTH_CLIENT_ID` in `--set-env-vars` (non-sensitive, was previously passed as `--iap-client-id` flag)
- Removes `--iap-client-id` from `--args` (server now reads `OAUTH_CLIENT_ID` env var directly)

Fixes the Cloud Run revision startup failure introduced by PR #439 (replace IAP with direct Google OAuth).

## Pre-deploy action required

The `session-secret` Secret Manager secret must exist before this deploys:

```bash
# Generate a random 32-byte secret and store it base64-encoded
openssl rand 32 | base64 | tr -d '\n' | \
  gcloud secrets create session-secret --data-file=- --project=dlorenc-chainguard --replication-policy=automatic
```

If it already exists, add a new version with the same command replacing `create` with `versions add`.

## Test plan

- [ ] All unit/integration tests pass (pre-existing `TestDockerSmoke` failure requires authenticated GCloud credentials locally — not caused by this change)
- [ ] Cloud Run revision starts successfully after deploy
- [ ] OAuth login flow works end-to-end at https://docstore.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)