### PR TITLE
fix(deploy): replace auto-create session-secret step with existence check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,11 +39,12 @@ jobs:
           IMAGE=$(ko build --bare --tags latest,$(git rev-parse --short HEAD) ./cmd/docstore)
           echo "image=$IMAGE" >> $GITHUB_OUTPUT
 
-      - name: Ensure session-secret exists in Secret Manager
+      - name: Verify session-secret exists in Secret Manager
+        # The secret must be pre-created before deploying. To create it:
+        #   gcloud secrets create session-secret --replication-policy=automatic --project=dlorenc-chainguard
+        #   openssl rand -base64 32 | gcloud secrets versions add session-secret --data-file=- --project=dlorenc-chainguard
         run: |
-          gcloud secrets describe session-secret --project=dlorenc-chainguard 2>/dev/null || \
-            openssl rand -base64 32 | gcloud secrets create session-secret \
-              --data-file=- --project=dlorenc-chainguard --replication-policy=automatic
+          gcloud secrets versions access latest --secret=session-secret --project=dlorenc-chainguard > /dev/null
 
       - name: Deploy to Cloud Run
         run: |


### PR DESCRIPTION
## Summary

- The `Ensure session-secret exists` step in `deploy.yml` was failing with `Permission secretmanager.secrets.create denied` because `docstore-deployer` SA has `secretmanager.secretAccessor` but not `secretmanager.secretAdmin`.
- Removed the auto-create logic entirely; replaced with `gcloud secrets versions access latest` which fails fast with a clear error if the secret is missing.
- Added a comment documenting the one-time manual setup commands to pre-create the secret.

## Changes

Only `.github/workflows/deploy.yml` is touched.

## Test plan

- [ ] Confirm the secret `session-secret` exists in the project before next deploy
- [ ] Verify the deploy workflow runs successfully on next push to main

## Notes

If `session-secret` has not been pre-created yet, run:
```
gcloud secrets create session-secret --replication-policy=automatic --project=dlorenc-chainguard
openssl rand -base64 32 | gcloud secrets versions add session-secret --data-file=- --project=dlorenc-chainguard
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)