### PR TITLE
refactor: remove stale IAP references after OAuth migration (#438)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ export DATABASE_URL="postgres://docstore:docstore@localhost:5432/docstore?sslmod
 
 ### 2. Run the server in dev mode
 
-`DEV_IDENTITY` bypasses IAP authentication (required for local dev).
+`DEV_IDENTITY` bypasses OAuth authentication (required for local dev).
 `DEV_UI` makes the server read HTML templates from `internal/ui/templates/` on
 disk instead of the embedded copies, so template changes take effect on the next
 request without recompiling.
@@ -52,16 +52,16 @@ Air watches `*.go` files and rebuilds+restarts the server automatically.
 Template/CSS/JS edits take effect immediately without restart because `DEV_UI`
 reads them from disk at request time.
 
-### Note: production uses IAP
+### Note: production uses direct Google OAuth
 
 In production, the Cloud Run service sits behind a Global HTTPS Load Balancer
-with Google Cloud Identity-Aware Proxy (IAP) at `https://docstore.dev`. IAP
-handles authentication by injecting `X-Goog-IAP-JWT-Assertion` headers, which
-the app's `IAPMiddleware` validates. Direct requests to `*.run.app` are blocked
-(ingress is `internal-and-cloud-load-balancing`).
+at `https://docstore.dev`. Authentication is handled directly by the server via
+Google OAuth 2.0 — the server validates Google ID tokens from session cookies
+set by its own OAuth callback (`/auth/callback`). Direct requests to `*.run.app`
+are blocked (ingress is `internal-and-cloud-load-balancing`).
 
 `DEV_IDENTITY` / `--dev-identity` is **only for local development** — it bypasses
-IAP entirely and must never be set in production.
+OAuth entirely and must never be set in production.
 
 ### 4. Visual iteration with Playwright MCP
 
@@ -86,7 +86,7 @@ Go code changes trigger an air rebuild; template/CSS changes are instant.
 | Variable | Purpose |
 |---|---|
 | `DATABASE_URL` | Postgres DSN (required) |
-| `DEV_IDENTITY` | Bypass IAP — use this email as the caller identity |
+| `DEV_IDENTITY` | Bypass OAuth — use this email as the caller identity |
 | `DEV_UI` | Read templates from disk instead of embedded binary |
 | `PORT` | HTTP listen port (default: `8080`) |
 | `LOG_FORMAT` | `text` for human-readable logs (default: JSON) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ export DATABASE_URL="postgres://localhost/docstore?sslmode=disable"
 go run ./cmd/docstore --dev-identity you@example.com
 ```
 
-The server runs on port 8080. With `--dev-identity`, IAP JWT validation is bypassed and every request is treated as the given identity. **This flag is for local development only and must never be used in production.** Production is deployed at `https://docstore.dev` behind Google Cloud IAP, which handles authentication via `X-Goog-IAP-JWT-Assertion` headers.
+The server runs on port 8080. With `--dev-identity`, OAuth JWT validation is bypassed and every request is treated as the given identity. **This flag is for local development only and must never be used in production.** Production is deployed at `https://docstore.dev` with direct Google OAuth 2.0 authentication.
 
 ## Project structure
 

--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,18 @@
 BINARY := docstore
 BUILD_DIR := bin
 DEFAULT_REMOTE ?= https://docstore.dev
-# IAP OAuth client ID for docstore.dev (public — Desktop app clients are distributed openly).
-IAP_CLIENT_ID ?= 320310132788-md94jtp0d9fdcdlq2quma4mcpr0ul1qr.apps.googleusercontent.com
-# IAP OAuth client secret — do NOT commit. Set via env var or GitHub Actions secret.
-# Local builds: make build-ds IAP_CLIENT_SECRET=<secret>
-# CI builds: injected from the IAP_OAUTH_CLIENT_SECRET Actions secret.
-IAP_CLIENT_SECRET ?=
+# OAuth client ID for docstore.dev (public — Desktop app clients are distributed openly).
+OAUTH_CLIENT_ID ?= 320310132788-md94jtp0d9fdcdlq2quma4mcpr0ul1qr.apps.googleusercontent.com
+# OAuth client secret — do NOT commit. Set via env var or GitHub Actions secret.
+# Local builds: make build-ds OAUTH_CLIENT_SECRET=<secret>
+# CI builds: injected from the OAUTH_CLIENT_SECRET Actions secret.
+OAUTH_CLIENT_SECRET ?=
 
 build:
 	go build -o $(BUILD_DIR)/$(BINARY) ./cmd/docstore
 
 build-ds:
-	go build -ldflags "-X main.defaultRemote=$(DEFAULT_REMOTE) -X main.defaultIAPClientID=$(IAP_CLIENT_ID) -X main.defaultIAPClientSecret=$(IAP_CLIENT_SECRET)" -o $(BUILD_DIR)/ds ./cmd/ds
+	go build -ldflags "-X main.defaultRemote=$(DEFAULT_REMOTE) -X main.defaultOAuthClientID=$(OAUTH_CLIENT_ID) -X main.defaultOAuthClientSecret=$(OAUTH_CLIENT_SECRET)" -o $(BUILD_DIR)/ds ./cmd/ds
 
 test:
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ DocStore is a server-side version control system for structured documents, built
 | [docs/concepts.md](docs/concepts.md) | Branching model, content addressing, how it differs from git |
 | [docs/cli-reference.md](docs/cli-reference.md) | All `ds` commands with flags and examples |
 | [docs/api-reference.md](docs/api-reference.md) | Full REST API |
-| [docs/deployment.md](docs/deployment.md) | Cloud Run + Cloud SQL + GKE setup, Global HTTPS LB + IAP |
+| [docs/deployment.md](docs/deployment.md) | Cloud Run + Cloud SQL + GKE setup, Global HTTPS LB + Google OAuth |
 | [docs/ci.md](docs/ci.md) | CI system: ci-scheduler, ci-worker, `.docstore/ci.yaml` DSL |
 | [docs/policy.md](docs/policy.md) | RBAC roles, OPA policy engine, OWNERS files |
 | [docs/events.md](docs/events.md) | Event types, SSE streaming, webhook subscriptions |
@@ -26,7 +26,7 @@ DocStore is a server-side version control system for structured documents, built
 
 ## Production
 
-The hosted instance is live at **https://docstore.dev**, deployed on Cloud Run behind a Global HTTPS Load Balancer with Google Cloud IAP. Any Google account can sign in — IAP handles authentication and injects the user's identity into the app.
+The hosted instance is live at **https://docstore.dev**, deployed on Cloud Run behind a Global HTTPS Load Balancer. Any Google account can sign in — the server handles authentication directly via Google OAuth 2.0.
 
 ## Quickstart
 
@@ -223,7 +223,7 @@ ds init https://docstore.example.com/repos/acme/myrepo --author bob@example.com
 ## Architecture at a glance
 
 ```
-ds CLI  ──►  https://docstore.dev (Global HTTPS LB + Cloud IAP)
+ds CLI  ──►  https://docstore.dev (Global HTTPS LB + Google OAuth)
                       │
              Cloud Run (docstore server)  ──►  Cloud SQL (PostgreSQL)
                       │
@@ -233,4 +233,4 @@ ds CLI  ──►  https://docstore.dev (Global HTTPS LB + Cloud IAP)
                                      ── BuildKit / LLB ──►  check results
 ```
 
-The server is a single stateless binary (`cmd/docstore`) deployed on Cloud Run, fronted by a Global HTTPS Load Balancer with Google Cloud IAP for authentication. All state is in PostgreSQL. The CI system is a separate pair of GKE workloads: `ci-scheduler` receives webhook events and queues jobs; `ci-worker` pods claim and execute jobs inside Kata Container microVMs.
+The server is a single stateless binary (`cmd/docstore`) deployed on Cloud Run, fronted by a Global HTTPS Load Balancer. Authentication is handled directly by the server via Google OAuth 2.0. All state is in PostgreSQL. The CI system is a separate pair of GKE workloads: `ci-scheduler` receives webhook events and queues jobs; `ci-worker` pods claim and execute jobs inside Kata Container microVMs.

--- a/api/types.go
+++ b/api/types.go
@@ -715,7 +715,7 @@ type CreateSubscriptionRequest struct {
 	Backend string `json:"backend"`
 	// Config is backend-specific: {"url":"https://...","secret":"..."}
 	Config json.RawMessage `json:"config"`
-	// CreatedBy is populated by the server from the IAP identity; not set by clients.
+	// CreatedBy is populated by the server from the authenticated identity; not set by clients.
 	CreatedBy string `json:"-"`
 }
 

--- a/cmd/ci-worker/main.go
+++ b/cmd/ci-worker/main.go
@@ -223,7 +223,7 @@ func heartbeat(ctx context.Context, schedulerURL, jobID, requestToken string, do
 // getPresignedArchiveURL calls POST /repos/{repo}/-/archive/presign with the
 // request_token and returns the presigned URL and checksum for BuildKit to fetch
 // the archive. checksum is "sha256:<hex>" when the server computed it, or ""
-// if the server did not provide one. This endpoint bypasses IAP and uses the
+// if the server did not provide one. This endpoint bypasses OAuth and uses the
 // request_token for authentication.
 func getPresignedArchiveURL(ctx context.Context, docstoreURL, repo, requestToken string) (url, checksum string, err error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)

--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -16,14 +16,13 @@ import (
 // If empty, ds init requires an explicit remote URL.
 var defaultRemote string
 
-// defaultIAPClientID and defaultIAPClientSecret are the compiled-in OAuth
+// defaultOAuthClientID and defaultOAuthClientSecret are the compiled-in OAuth
 // client credentials for the hosted docstore.dev instance, injected via
-// -ldflags. Used as fallback when /.well-known/ds-config is not reachable
-// (e.g. when the server is behind IAP and the endpoint is blocked).
+// -ldflags. Used as fallback when /.well-known/ds-config is not reachable.
 // Desktop app OAuth secrets are semi-public by nature (shipped in every CLI
 // binary), so embedding them here is intentional and standard practice.
-var defaultIAPClientID string
-var defaultIAPClientSecret string
+var defaultOAuthClientID string
+var defaultOAuthClientSecret string
 
 const usage = `usage: ds <command> [args]
 
@@ -1239,7 +1238,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, "error: no server URL provided and no default compiled in")
 			os.Exit(1)
 		}
-		err = app.Login(serverURL, defaultIAPClientID, defaultIAPClientSecret)
+		err = app.Login(serverURL, defaultOAuthClientID, defaultOAuthClientSecret)
 
 	case "logout":
 		serverURL := defaultRemote

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-All endpoints (except `GET /healthz`) require authentication. In production, the server validates the GCP IAP JWT from the `X-Goog-IAP-JWT-Assertion` header. In dev/test, set the `DEV_IDENTITY` env var on the server to bypass JWT validation.
+All endpoints (except `GET /healthz`) require authentication. In production, the server validates Google ID tokens — either from a session cookie (browser) or `Authorization: Bearer <id_token>` (CLI/API). In dev/test, set the `DEV_IDENTITY` env var on the server to bypass JWT validation.
 
 Repo-scoped endpoints use the `/-/` separator to allow org/repo names to contain slashes without ambiguity:
 
@@ -346,7 +346,7 @@ List reviews for a branch.
 
 Report a CI check result.
 
-**Auth:** IAP JWT (human users) or job OIDC JWT (`Authorization: Bearer {jwt}`, issued by `oidc.docstore.dev`).
+**Auth:** Google ID token (human users) or job OIDC JWT (`Authorization: Bearer {jwt}`, issued by `oidc.docstore.dev`).
 
 **Body:**
 ```json
@@ -420,7 +420,7 @@ Download the repo tree as a `.tar.gz`.
 - `branch` — Branch name (default `main`).
 - `at` — Sequence number.
 
-Requires authentication (IAP JWT or job OIDC JWT). For CI workers, use the presigned URL variant instead.
+Requires authentication (Google ID token or job OIDC JWT). For CI workers, use the presigned URL variant instead.
 
 ### `GET /repos/{name}/-/archive` (presigned — no auth required)
 

--- a/docs/ci-architecture.md
+++ b/docs/ci-architecture.md
@@ -159,7 +159,7 @@ Deliveries are HMAC-SHA256 signed using `WEBHOOK_SECRET`. The scheduler verifies
 | `com.docstore.commit.created` | `proposal_synchronized` | Additionally, if the pushed branch has an open proposal and `on.proposal` is configured |
 | `com.docstore.proposal.opened` | `proposal` | If `on.proposal.base_branches` matches the proposal's base branch |
 | *(cron runner)* | `schedule` | If the current minute matches a `on.schedule[].cron` expression |
-| `POST /repos/:name/-/ci/run` on docstore (IAP-protected, writer+) | `manual` | Always |
+| `POST /repos/:name/-/ci/run` on docstore (auth-protected, writer+) | `manual` | Always |
 
 The `proposal_synchronized` trigger is synthetic — ci-scheduler detects it by querying `GET /repos/:name/-/proposals?state=open&branch=<branch>` after receiving a `commit.created` event. No separate event is emitted by docstore.
 
@@ -195,7 +195,7 @@ These map directly to the `event.*` fields available in `if:` expressions (see [
 
 ### Manual trigger
 
-The manual trigger endpoint moved to the main docstore server (IAP-protected, requires writer role):
+The manual trigger endpoint is on the main docstore server (requires writer role):
 
 ```bash
 curl -X POST https://docstore.dev/repos/acme/myrepo/-/ci/run \

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -40,7 +40,7 @@ A lightweight HTTP service that:
 - Parses `com.docstore.commit.created` events and inserts a row into `ci_jobs`.
 - Serves job status at `GET /run/{id}`.
 - Proxies live logs at `GET /run/{id}/logs/{check}` — either reverse-proxying to the worker pod (while the job is claimed) or redirecting to the GCS log URL (after completion).
-- Manual CI triggers are handled by the main docstore server at `POST /repos/:name/-/ci/run` (IAP-protected, writer+ RBAC).
+- Manual CI triggers are handled by the main docstore server at `POST /repos/:name/-/ci/run` (writer+ RBAC).
 - Runs a stale-job reaper every 30 seconds to reclaim jobs that have missed their heartbeat.
 - Serves `POST /claim` — validates K8s projected SA tokens with pod provenance checks, claims the next queued job, and returns a `request_token`.
 - Serves `POST /jobs/{id}/heartbeat` — request_token authenticated; updates the job heartbeat.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -57,7 +57,7 @@ A release pins a specific sequence number under a human-readable name (e.g. `v1.
 | | Git | DocStore |
 |---|---|---|
 | Storage | Local `.git/` object store | PostgreSQL (server-side) |
-| Auth | SSH keys / HTTPS tokens | GCP IAP (JWT) |
+| Auth | SSH keys / HTTPS tokens | Google OAuth (JWT) |
 | Access control | Repository-level (GitHub) | Per-repo RBAC with 4 roles |
 | Merge gating | Branch protection rules | OPA Rego policies + OWNERS |
 | CI | External (GitHub Actions) | Built-in (`ci.yaml` + BuildKit) |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -43,7 +43,7 @@ This configures Workload Identity for the GKE cluster, creates the `docstore-ci`
 |---|---|---|---|
 | `DATABASE_URL` | yes | — | PostgreSQL DSN (`postgres://user:pass@host/db`) |
 | `PORT` | no | `8080` | HTTP listen port |
-| `DEV_IDENTITY` | no | — | Bypass IAP JWT validation (dev only) |
+| `DEV_IDENTITY` | no | — | Bypass OAuth JWT validation (dev only) |
 | `BOOTSTRAP_ADMIN` | no | — | Identity with admin access to repos with no admin yet |
 | `LOG_FORMAT` | no | `json` | Log format: `json` or `text` |
 | `LOG_LEVEL` | no | `info` | Log level: `debug`, `info`, `warn`, `error` |
@@ -98,17 +98,18 @@ gcloud run deploy docstore \
 
 The compiled-in default remote URL for `ds` is `https://docstore.dev` (set in `Makefile` as `DEFAULT_REMOTE`).
 
-## Authentication (Cloud IAP)
+## Authentication (Direct Google OAuth)
 
-Production traffic reaches the server exclusively through a Global HTTPS Load Balancer at `https://docstore.dev`. Google Cloud Identity-Aware Proxy (IAP) is enabled on the backend service — any Google account can sign in; no allowlist is required (`allAuthenticatedUsers` has `roles/iap.httpsResourceAccessor`).
+Production traffic reaches the server exclusively through a Global HTTPS Load Balancer at `https://docstore.dev`. Authentication is handled directly by the server using Google OAuth 2.0 — any Google account can sign in.
 
 ### How it works
 
 1. The client (browser or `ds` CLI) sends a request to `https://docstore.dev`.
 2. The Global HTTPS LB terminates TLS using the managed certificate `docstore-cert`.
-3. IAP validates the user's Google session and injects an `X-Goog-IAP-JWT-Assertion` header signed by Google.
-4. The request is forwarded to Cloud Run via the serverless NEG `docstore-neg`.
-5. The server's `IAPMiddleware` validates the JWT (RS256, keys from `https://www.gstatic.com/iap/verify/public_key-jwk`) and extracts the `email` claim as the caller's identity.
+3. The request is forwarded to Cloud Run via the serverless NEG `docstore-neg`.
+4. For browser clients: unauthenticated requests are redirected to `/auth/login`, which initiates the OAuth 2.0 authorization code flow. After Google authenticates the user, `/auth/callback` receives the code, exchanges it for a Google ID token, and sets a signed session cookie.
+5. For the CLI (`ds login`): the CLI performs the OAuth 2.0 authorization code flow locally (loopback redirect) and stores the Google ID token, which is sent as `Authorization: Bearer <id_token>` on subsequent requests.
+6. The server's `GoogleAuthMiddleware` validates the ID token (RS256, keys from `https://www.googleapis.com/oauth2/v3/certs`) and extracts the `email` claim as the caller's identity.
 
 Cloud Run ingress is set to `internal-and-cloud-load-balancing`, so direct requests to `*.run.app` are blocked. All traffic must go through the load balancer.
 
@@ -130,7 +131,7 @@ gcloud compute network-endpoint-groups create docstore-neg \
   --cloud-run-service=docstore \
   --project=dlorenc-chainguard
 
-# Backend service with IAP enabled
+# Backend service (no IAP — auth is handled by the server directly)
 gcloud compute backend-services create docstore-backend \
   --global \
   --protocol=HTTPS \
@@ -140,19 +141,6 @@ gcloud compute backend-services add-backend docstore-backend \
   --global \
   --network-endpoint-group=docstore-neg \
   --network-endpoint-group-region=us-central1 \
-  --project=dlorenc-chainguard
-
-# Enable IAP on the backend service
-gcloud iap web enable --resource-type=backend-services \
-  --service=docstore-backend \
-  --project=dlorenc-chainguard
-
-# Grant all Google accounts access via IAP
-gcloud iap web add-iam-policy-binding \
-  --resource-type=backend-services \
-  --service=docstore-backend \
-  --member=allAuthenticatedUsers \
-  --role=roles/iap.httpsResourceAccessor \
   --project=dlorenc-chainguard
 
 # URL map, managed SSL cert, HTTPS proxy, and forwarding rule
@@ -385,7 +373,7 @@ The deploy workflow (`deploy.yml`) also builds and deploys both CI binaries afte
    echo -n 'your-secret' | gcloud secrets versions add ci-runner-webhook-secret \
      --data-file=- --project=dlorenc-chainguard
    ```
-4. Provision the Global HTTPS LB + IAP infrastructure (see "One-time infrastructure" commands in the Authentication section above). This only needs to be done once per project.
+4. Provision the Global HTTPS LB infrastructure (see "One-time infrastructure" commands in the Authentication section above). This only needs to be done once per project.
 5. Create the OIDC KMS resources and secrets (see "One-time OIDC setup prerequisites" above):
    - KMS keyring and signing key
    - `ci-oidc-kms-key-version` secret in Secret Manager
@@ -420,20 +408,4 @@ The event broker persists all events to the `event_log` PostgreSQL table and use
 
 ### CLI authentication (ds login)
 
-After enabling IAP, add the Desktop app OAuth client to IAP's programmatic access allowlist so `ds login` works:
-
-```bash
-cat > /tmp/iap-settings.yaml << 'YAML'
-access_settings:
-  oauth_settings:
-    programmatic_clients:
-      - <DESKTOP_APP_CLIENT_ID>
-YAML
-
-gcloud iap settings set /tmp/iap-settings.yaml \
-  --project=<PROJECT> \
-  --resource-type=backend-services \
-  --service=<BACKEND_SERVICE_NAME>
-```
-
-This allows ID tokens with the Desktop app client's audience to pass through IAP. Without this step, IAP rejects CLI tokens with "Invalid JWT audience".
+`ds login` performs the Google OAuth 2.0 authorization code flow using the compiled-in Desktop app client credentials (`OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` in the Makefile). The server accepts the resulting Google ID token as a `Bearer` token. No additional IAP configuration is required — the server validates the token directly.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ go run ./cmd/docstore --dev-identity you@example.com
 DEV_IDENTITY=you@example.com DATABASE_URL=... go run ./cmd/docstore
 ```
 
-With `--dev-identity` set, the server skips IAP JWT validation and treats every request as that identity. **This is for local development only** — do not set this flag in production. Production uses Google Cloud IAP at `https://docstore.dev`.
+With `--dev-identity` set, the server skips OAuth JWT validation and treats every request as that identity. **This is for local development only** — do not set this flag in production. Production uses direct Google OAuth at `https://docstore.dev`.
 
 The server listens on port 8080 by default (`PORT` env var overrides it).
 

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -2,15 +2,15 @@
 
 DocStore has three layers of access control:
 
-1. **IAP authentication** — validates GCP Identity-Aware Proxy JWTs to establish identity.
+1. **Google OAuth authentication** — validates Google ID tokens to establish identity.
 2. **RBAC** — per-repo role assignments that gate which HTTP methods each identity can call.
 3. **OPA policy engine** — Rego-based merge gates that can require reviews, CI checks, and OWNERS approval.
 
-## Authentication (IAP)
+## Authentication (Google OAuth)
 
-The server validates the `X-Goog-IAP-JWT-Assertion` header on every request (except `GET /healthz`). The JWT is RS256-signed by Google. Public keys are fetched from `https://www.gstatic.com/iap/verify/public_key-jwk` and cached for 1 hour. The identity is extracted from the `email` claim.
+The server validates Google ID tokens on every request (except `GET /healthz`). For browser sessions, the server issues a signed cookie after completing the OAuth 2.0 authorization code flow (`/auth/login` → `/auth/callback`). For the CLI, `ds login` stores a Google ID token that is sent as a `Bearer` token. Tokens are RS256-signed by Google; public keys are fetched from `https://www.googleapis.com/oauth2/v3/certs` and cached. The identity is extracted from the `email` claim.
 
-**Local dev only:** Set `DEV_IDENTITY=you@example.com` (or `--dev-identity`) on the server to bypass JWT validation. All requests are treated as that identity. This must never be set in production — production uses real IAP JWTs at `https://docstore.dev`.
+**Local dev only:** Set `DEV_IDENTITY=you@example.com` (or `--dev-identity`) on the server to bypass JWT validation. All requests are treated as that identity. This must never be set in production — production uses real Google OAuth at `https://docstore.dev`.
 
 ## RBAC roles
 

--- a/docs/proposals-and-ci-triggers.md
+++ b/docs/proposals-and-ci-triggers.md
@@ -152,7 +152,7 @@ on:
     base_branches: [main]       # trigger when a proposal targeting main is opened
   schedule:
     - cron: '0 2 * * *'         # nightly at 2 AM UTC
-  # manual: trigger via POST /repos/:name/-/ci/run on docstore (IAP-protected, writer+) — no config needed, always enabled
+  # manual: trigger via POST /repos/:name/-/ci/run on docstore (requires writer role) — no config needed, always enabled
 
 checks:
   - name: ci/test
@@ -219,7 +219,7 @@ on:
 
 #### `manual`
 
-Always enabled. Trigger a run via the docstore server (IAP-protected, requires writer role):
+Always enabled. Trigger a run via the docstore server (requires writer role):
 
 ```bash
 curl -X POST https://docstore.dev/repos/acme/myrepo/-/ci/run \

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -29,7 +29,7 @@ if err != nil {
 |---|---|
 | `WithBearerToken(token string)` | Sets `Authorization: Bearer <token>` on every request. |
 | `WithIdentity(identity string)` | Sets `X-DocStore-Identity` header (dev mode only — server must have `DEV_IDENTITY` set). |
-| `WithHTTPClient(h *http.Client)` | Replaces the default `http.DefaultClient`. Use for custom timeouts, proxies, or an IAP-authenticated transport. |
+| `WithHTTPClient(h *http.Client)` | Replaces the default `http.DefaultClient`. Use for custom timeouts, proxies, or a custom transport. |
 | `WithUserAgent(ua string)` | Overrides the `User-Agent` header (default: `docstore-go-sdk/0.1`). |
 
 ## Repo-scoped operations

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -196,8 +196,8 @@ type dsServerConfig struct {
 
 // Login authenticates with the given server and stores the credentials.
 // It first tries to discover OAuth client credentials via /.well-known/ds-config.
-// If that fails (e.g. the endpoint is behind IAP itself), it falls back to the
-// compiled-in fallbackClientID and fallbackClientSecret.
+// If that fails, it falls back to the compiled-in fallbackClientID and
+// fallbackClientSecret.
 func (a *App) Login(serverURL, fallbackClientID, fallbackClientSecret string) error {
 	serverURL = strings.TrimRight(serverURL, "/")
 
@@ -214,6 +214,7 @@ func (a *App) Login(serverURL, fallbackClientID, fallbackClientSecret string) er
 				fmt.Fprintln(a.Out, "Server does not require authentication")
 				return nil
 			}
+			// "iap" is kept for backward compatibility with older server configs.
 			if (cfg.Auth.Type == "oauth" || cfg.Auth.Type == "iap") && cfg.Auth.ClientID != "" {
 				clientID = cfg.Auth.ClientID
 				if cfg.Auth.ClientSecret != "" {

--- a/internal/server/dsconfig_test.go
+++ b/internal/server/dsconfig_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/dlorenc/docstore/internal/server"
 )
 
-func TestDSConfigEndpoint_NoIAP(t *testing.T) {
-	// Server without IAP client ID configured.
+func TestDSConfigEndpoint_NoOAuth(t *testing.T) {
+	// Server without OAuth client ID configured.
 	h := server.NewWithReadStore(nil, nil, "dev@example.com", "")
 	req := httptest.NewRequest("GET", "/.well-known/ds-config", nil)
 	w := httptest.NewRecorder()

--- a/internal/server/handlers_archive_test.go
+++ b/internal/server/handlers_archive_test.go
@@ -277,7 +277,7 @@ func TestHandleArchivePresign_ChecksumWithReadStore(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestHandlePresignedArchive_MissingSig(t *testing.T) {
-	// Without sig param, the request is passed through to IAP and the inner mux.
+	// Without sig param, the request is passed through to the auth handler and inner mux.
 	// In the inner mux, "archive" with GET goes to handleArchive, which needs
 	// a read store. Without one configured, it returns 503.
 	// The key test: no sig → does NOT call handlePresignedArchive directly.
@@ -287,7 +287,7 @@ func TestHandlePresignedArchive_MissingSig(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/repos/org/myrepo/-/archive?branch=main", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
-	// Without sig, goes through IAP → inner mux → handleArchive → 503 (no read store)
+	// Without sig, goes through auth handler → inner mux → handleArchive → 503 (no read store)
 	// or 404 (repo not found via validateRepo with mockStore returning ErrRepoNotFound).
 	// Either way, it's not 403 (which would come from handlePresignedArchive's HMAC check).
 	if rec.Code == http.StatusForbidden {

--- a/internal/server/handlers_check_logs_test.go
+++ b/internal/server/handlers_check_logs_test.go
@@ -219,7 +219,7 @@ func TestHandleCheckLogs_MethodNotAllowed(t *testing.T) {
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
-	// GET requests fall through to the IAP + inner mux, which won't match check/ci_build/logs.
+	// GET requests fall through to the auth + inner mux, which won't match check/ci_build/logs.
 	// We just verify it's not a 200.
 	if rec.Code == http.StatusOK {
 		t.Fatalf("expected non-200 for GET, got 200")

--- a/internal/server/handlers_ci_request_token.go
+++ b/internal/server/handlers_ci_request_token.go
@@ -16,7 +16,7 @@ import (
 // handleCIConfig implements GET /repos/:repo/-/ci/config.
 // Authenticated via request_token (Authorization: Bearer <plaintext>).
 // Returns the .docstore/ci.yaml file at the job's branch and sequence as a
-// JSON FileResponse, using the same wire format as the IAP-gated file endpoint.
+// JSON FileResponse, using the same wire format as the authenticated file endpoint.
 func (s *server) handleCIConfig(w http.ResponseWriter, r *http.Request) {
 	if s.jobTokenStore == nil || s.readStore == nil {
 		writeError(w, http.StatusServiceUnavailable, "ci config not available")
@@ -67,7 +67,7 @@ func (s *server) handleCIConfig(w http.ResponseWriter, r *http.Request) {
 
 // handleCICheck implements POST /repos/:repo/-/check via request_token authentication.
 // This is the worker-facing check-run endpoint, authenticated via request_token.
-// It mirrors handleCheck but bypasses IAP/RBAC and derives identity from the token.
+// It mirrors handleCheck but bypasses auth/RBAC and derives identity from the token.
 func (s *server) handleCICheck(w http.ResponseWriter, r *http.Request) {
 	if s.jobTokenStore == nil || s.commitStore == nil {
 		writeError(w, http.StatusServiceUnavailable, "ci check not available")

--- a/internal/server/handlers_oidc_scope_test.go
+++ b/internal/server/handlers_oidc_scope_test.go
@@ -67,7 +67,7 @@ func buildOIDCServer(t *testing.T, ms WriteStore) (http.Handler, *rsa.PrivateKey
 		oidcAudience: audience,
 		oidcIssuer:   issuer,
 	}
-	// Use devIdentity so IAP is bypassed for non-OIDC paths in the same test server.
+	// Use devIdentity so OAuth is bypassed for non-OIDC paths in the same test server.
 	handler := s.buildHandler("dev@example.com", "", ms)
 	return handler, key
 }

--- a/internal/server/handlers_orgs.go
+++ b/internal/server/handlers_orgs.go
@@ -370,7 +370,7 @@ func (s *server) handleListInvites(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleAcceptInvite implements POST /orgs/{org}/invites/{token}/accept
-// The IAP identity must match the invite email.
+// The authenticated identity must match the invite email.
 func (s *server) handleAcceptInvite(w http.ResponseWriter, r *http.Request) {
 	org := r.PathValue("org")
 	token := r.PathValue("token")

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -228,14 +228,14 @@ func (m *mockRoleStore) HasAdmin(ctx context.Context, repo string) (bool, error)
 }
 
 // rbacTestServer creates a server with a fixed identity in context (simulating
-// post-IAP) and the given role store + bootstrap admin. Returns the mux handler
+// post-auth) and the given role store + bootstrap admin. Returns the mux handler
 // and a recorder factory.
 func rbacTestServer(store RoleStore, bootstrapAdmin, identity string) http.Handler {
 	inner := http.NewServeMux()
 	inner.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	// Inject identity into context (normally done by IAPMiddleware).
+	// Inject identity into context (normally done by GoogleAuthMiddleware).
 	identityInjector := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := context.WithValue(r.Context(), identityKey, identity)
@@ -744,7 +744,7 @@ func TestGoogleAuthMiddleware_InvalidIssuer(t *testing.T) {
 		map[string]any{
 			"email": "alice@example.com",
 			"exp":   time.Now().Add(time.Hour).Unix(),
-			"iss":   "https://cloud.google.com/iap", // IAP issuer, not direct Google
+			"iss":   "https://cloud.google.com/iap", // wrong issuer (IAP issuer, not accounts.google.com)
 			"aud":   testClientID,
 		},
 	)
@@ -760,7 +760,7 @@ func TestGoogleAuthMiddleware_InvalidIssuer(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("expected 401 for IAP issuer, got %d", rec.Code)
+		t.Fatalf("expected 401 for wrong issuer, got %d", rec.Code)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -436,11 +436,11 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 	if writeStore != nil {
 		routed = RBACMiddleware(writeStore, bootstrapAdmin)(inner)
 	}
-	iapHandler := GoogleAuthMiddleware(devIdentity, s.oauthClientID, s.sessionSecret)(routed)
+	authHandler := GoogleAuthMiddleware(devIdentity, s.oauthClientID, s.sessionSecret)(routed)
 
 	// Wrap the auth handler: intercept presign, HMAC-signed archive, and job
 	// OIDC token requests before Google ID token validation. Everything else falls through
-	// to iapHandler.
+	// to authHandler.
 	// Using "/" (not "/repos/") avoids the Go mux trailing-slash redirect that
 	// would turn POST /repos into a 307 → POST /repos/.
 	outer.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -488,7 +488,7 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 		// Job OIDC token auth: if a Bearer token is present and OIDC is configured,
 		// validate it as a job OIDC JWT. On success, inject job identity into context
 		// and route directly to the inner mux (bypassing Google auth and RBAC).
-		// On failure, return 401. If no Bearer token, fall through to iapHandler.
+		// On failure, return 401. If no Bearer token, fall through to authHandler.
 		if s.oidcKeyCache != nil {
 			auth := r.Header.Get("Authorization")
 			if tok := strings.TrimPrefix(auth, "Bearer "); tok != "" && tok != auth {
@@ -537,7 +537,7 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 			}
 		}
 
-		iapHandler.ServeHTTP(w, r)
+		authHandler.ServeHTTP(w, r)
 	}))
 	return RequestLogger(outer)
 }
@@ -734,7 +734,7 @@ func (s *server) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, stateCookie)
 
 	conf := s.oauthConfig(r)
-	authURL := conf.AuthCodeURL(state, oauth2.AccessTypeOffline)
+	authURL := conf.AuthCodeURL(state, oauth2.AccessTypeOnline)
 	http.Redirect(w, r, authURL, http.StatusFound)
 }
 

--- a/sdk/go/docstore/client.go
+++ b/sdk/go/docstore/client.go
@@ -48,14 +48,14 @@ func WithBearerToken(token string) ClientOption {
 }
 
 // WithIdentity sets the X-DocStore-Identity header on every request. The
-// server only honours this header in dev mode (no IAP); use it for local
+// server only honours this header in dev mode (no OAuth); use it for local
 // development and tests.
 func WithIdentity(identity string) ClientOption {
 	return func(c *Client) { c.identity = identity }
 }
 
 // WithHTTPClient replaces the *http.Client used for all requests. Use it to
-// inject timeouts, proxies, or an IAP-authenticated transport.
+// inject timeouts, proxies, or a custom transport.
 func WithHTTPClient(h *http.Client) ClientOption {
 	return func(c *Client) {
 		if h != nil {

--- a/sdk/go/docstore/doc.go
+++ b/sdk/go/docstore/doc.go
@@ -28,16 +28,12 @@
 //
 // # Authentication
 //
-// WithBearerToken sets Authorization: Bearer <token>. This is forward-
-// compatible with the API-token feature tracked in issue #101 of the server
-// repo; today the server validates GCP IAP JWTs via the
-// X-Goog-IAP-JWT-Assertion header, which is typically terminated by a
-// reverse proxy. When calling the server directly (for example from within
-// the same VPC behind IAP), provide an IAP-authenticated *http.Client via
-// WithHTTPClient.
+// WithBearerToken sets Authorization: Bearer <token>. The server validates
+// Google ID tokens issued to the configured OAuth client. This is the standard
+// authentication path used by the ds CLI after `ds login`.
 //
 // WithIdentity sets the X-DocStore-Identity header, which the server
-// honours when running in dev mode (no IAP). Use it for local development
+// honours when running in dev mode (no OAuth). Use it for local development
 // and test fixtures.
 //
 // # Errors


### PR DESCRIPTION
## Summary

- Renames `iapHandler` → `authHandler` in `server.go:439` and updates 3 related comments
- Changes `oauth2.AccessTypeOffline` → `oauth2.AccessTypeOnline` in `server.go` (refresh token is never used)
- Renames `defaultIAPClientID`/`defaultIAPClientSecret` → `defaultOAuthClientID`/`defaultOAuthClientSecret` in `cmd/ds/main.go` and updates the Makefile variables and ldflags accordingly
- Updates stale IAP comments in `middleware_test.go`, `handlers_orgs.go`, `internal/cli/auth.go`, `handlers_ci_request_token.go`, `cmd/ci-worker/main.go`, SDK, API types, and test files
- Updates all docs files (`deployment.md`, `policy.md`, `getting-started.md`, `concepts.md`, `api-reference.md`, `sdk.md`, `ci-architecture.md`, `ci.md`, `proposals-and-ci-triggers.md`) to remove IAP references
- Updates `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` passes (all non-Docker tests)
- [ ] `TestDockerSmoke` timed out — this is a pre-existing Docker integration test requiring a running Docker daemon, unrelated to this change

## Notes

- `internal/cli/auth.go` keeps the `cfg.Auth.Type == "iap"` condition for backward compatibility with older server configs; a comment explains this
- The stale `gcloud iap` commands in `deployment.md`'s "One-time infrastructure" block have been removed since IAP is no longer used

🤖 Generated with [Claude Code](https://claude.com/claude-code)