### PR TITLE
feat(secrets): repo-level secrets — phase 1 (design + encryptor + store + CLI)

### DIFF
--- a/cmd/ds/main.go
+++ b/cmd/ds/main.go
@@ -51,6 +51,11 @@ commands:
   comment --path <path> --body <body> [--branch <name>]  Add an inline file comment
   comments [--path <path>] [--branch <name>]      List inline file comments
   import-git <path> [--mode squash|replay]        Import a git repo into docstore main
+  secrets list                                    List repo secrets (metadata only)
+  secrets set <NAME> -                            Set a secret; reads value from stdin
+  secrets set <NAME> --from-file=<path>           Set a secret from a file
+  secrets set <NAME> ... [--description=<text>]   Optional description for the secret
+  secrets unset <NAME>                            Delete a secret
   tui                                             Launch the terminal UI
   purge --older-than <Nd> [--dry-run]             Purge old merged/abandoned branches
 
@@ -417,6 +422,9 @@ func main() {
 			}
 		}
 		err = app.ImportGit(repoPath, mode)
+
+	case "secrets":
+		err = runSecrets(app, args)
 
 	case "tui":
 		err = app.TUI()
@@ -1262,4 +1270,110 @@ func main() {
 		fmt.Fprintf(os.Stderr, "error: %s\n", err)
 		os.Exit(1)
 	}
+}
+
+// secretsUsage is the help text for the `ds secrets` family.
+const secretsUsage = `usage:
+  ds secrets list
+  ds secrets set <NAME> -                       Read value from stdin
+  ds secrets set <NAME> --from-file=<path>      Read value from a file
+  ds secrets set <NAME> ... [--description=<text>]
+  ds secrets unset <NAME>
+
+Note: --value=... is intentionally not supported. Plaintext must not appear in
+argv (shell history, ps listings).`
+
+// runSecrets parses and dispatches `ds secrets <subcommand>`. It returns an
+// error for runtime failures; usage problems print to stderr and call
+// os.Exit(2) to keep the rest of main() untouched.
+func runSecrets(app *cli.App, args []string) error {
+	if len(args) < 2 {
+		fmt.Fprintln(os.Stderr, secretsUsage)
+		os.Exit(2)
+	}
+	switch args[1] {
+	case "list":
+		return app.SecretsList()
+	case "set":
+		return runSecretsSet(app, args[2:])
+	case "unset":
+		if len(args) != 3 {
+			fmt.Fprintln(os.Stderr, "usage: ds secrets unset <NAME>")
+			os.Exit(2)
+		}
+		return app.SecretsUnset(args[2])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown secrets subcommand: %s\n", args[1])
+		fmt.Fprintln(os.Stderr, secretsUsage)
+		os.Exit(2)
+	}
+	return nil
+}
+
+// runSecretsSet parses `ds secrets set <NAME> [...]` and calls SecretsSet.
+// rest is the slice after "secrets set", i.e. starting with NAME.
+func runSecretsSet(app *cli.App, rest []string) error {
+	if len(rest) < 1 {
+		fmt.Fprintln(os.Stderr, "usage: ds secrets set <NAME> [-|--from-file=<path>] [--description=<text>]")
+		os.Exit(2)
+	}
+	name := rest[0]
+	var (
+		fromFile    string
+		fromStdin   bool
+		description string
+	)
+	for i := 1; i < len(rest); i++ {
+		arg := rest[i]
+		switch {
+		case arg == "-":
+			fromStdin = true
+		case arg == "--from-file":
+			if i+1 >= len(rest) {
+				fmt.Fprintln(os.Stderr, "error: --from-file requires a path")
+				os.Exit(2)
+			}
+			fromFile = rest[i+1]
+			i++
+		case strings.HasPrefix(arg, "--from-file="):
+			fromFile = strings.TrimPrefix(arg, "--from-file=")
+		case arg == "--description":
+			if i+1 >= len(rest) {
+				fmt.Fprintln(os.Stderr, "error: --description requires text")
+				os.Exit(2)
+			}
+			description = rest[i+1]
+			i++
+		case strings.HasPrefix(arg, "--description="):
+			description = strings.TrimPrefix(arg, "--description=")
+		case arg == "--value" || strings.HasPrefix(arg, "--value="):
+			fmt.Fprintln(os.Stderr, "error: --value is not supported (plaintext must not appear in argv)")
+			fmt.Fprintln(os.Stderr, secretsUsage)
+			os.Exit(2)
+		default:
+			fmt.Fprintf(os.Stderr, "unknown argument: %s\n", arg)
+			fmt.Fprintln(os.Stderr, secretsUsage)
+			os.Exit(2)
+		}
+	}
+	if fromStdin && fromFile != "" {
+		fmt.Fprintln(os.Stderr, "error: cannot combine '-' with --from-file")
+		os.Exit(2)
+	}
+	if !fromStdin && fromFile == "" {
+		fmt.Fprintln(os.Stderr, "error: must specify '-' (stdin) or --from-file=<path>")
+		fmt.Fprintln(os.Stderr, secretsUsage)
+		os.Exit(2)
+	}
+
+	var reader = os.Stdin
+	if fromFile != "" {
+		f, err := os.Open(fromFile)
+		if err != nil {
+			return fmt.Errorf("opening secret file: %w", err)
+		}
+		defer f.Close()
+		reader = f
+	}
+	return app.SecretsSet(name, reader, description)
 }

--- a/docs/secrets-design.md
+++ b/docs/secrets-design.md
@@ -1,0 +1,229 @@
+# Repo-level secrets — design
+
+Status: draft, awaiting implementation.
+Owner: TBD.
+
+## Goal
+
+Allow repo admins to store opaque key/value secrets that CI jobs read at
+runtime through BuildKit secret mounts (`/run/secrets/<NAME>`). Plaintext
+must never return from any read API, never appear in logs / events /
+webhooks, and never be passed to CI runs from untrusted contexts (proposals
+opened by non-members).
+
+## Non-goals (v1)
+
+- Org-level secrets shared across an org's repos.
+- Per-environment / per-stage secrets (prod vs. staging within one repo).
+- Per-branch secrets.
+- Bring-your-own-key (BYOK).
+- Approval workflows for secret access.
+- Automatic rotation hooks.
+
+All extensions, not blockers.
+
+## Threat model
+
+1. DB-only compromise must NOT yield plaintext (envelope encryption with KMS).
+2. Plaintext exits the system **only** as the request body of
+   `PUT /-/secrets/{name}` from an authenticated admin, and as a BuildKit
+   secret mount inside a step's container at run time.
+3. CI jobs from external-fork proposals get **no** secrets.
+4. Per-secret data encryption key (DEK) so a single DEK leak doesn't
+   compromise the rest.
+5. Secrets are **not** part of the per-branch commit hash chain in
+   `internal/db/store.go:35`. Editing a secret does not produce a commit.
+
+## Data model
+
+```sql
+CREATE TABLE repo_secrets (
+    id            TEXT PRIMARY KEY,                  -- ULID
+    repo          TEXT NOT NULL,                     -- "org/name"
+    name          TEXT NOT NULL,                     -- e.g. DOCKERHUB_TOKEN
+    description   TEXT NOT NULL DEFAULT '',
+    ciphertext    BYTEA NOT NULL,                    -- AES-256-GCM(plaintext, DEK)
+    nonce         BYTEA NOT NULL,                    -- 12-byte GCM nonce
+    encrypted_dek BYTEA NOT NULL,                    -- KMS.Encrypt(DEK)
+    kms_key_name  TEXT NOT NULL,                     -- KMS resource path used
+    size_bytes    INT NOT NULL,                      -- length of plaintext
+    created_by    TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL,
+    updated_by    TEXT,
+    updated_at    TIMESTAMPTZ,
+    last_used_at  TIMESTAMPTZ,
+    UNIQUE(repo, name)
+);
+CREATE INDEX repo_secrets_by_repo ON repo_secrets(repo);
+```
+
+### Envelope encryption
+
+Standard pattern:
+
+- DEK = 32 random bytes per secret, generated server-side.
+- `ciphertext` = AES-256-GCM(plaintext, DEK, nonce).
+- `encrypted_dek` = KMS.Encrypt(DEK), using a single repo-secrets KMS key
+  (separate from the JWT signing key in `internal/citoken/citoken.go`).
+- One KMS API call per write/read.
+- KEK rotation is transparent — KMS Decrypt accepts old key versions.
+
+### Constraints
+
+- Name pattern: `[A-Z][A-Z0-9_]{0,63}` (POSIX env-var shape).
+- Reserved prefix `DOCSTORE_*` is forbidden at write time — used by built-in
+  secrets like `docstore_oidc_request_token`.
+- Value size cap: 32 KiB. Larger blobs belong in object storage with a
+  presigned URL, not in this table.
+
+## API surface
+
+```
+GET    /repos/{owner}/{name}/-/secrets             list metadata only
+PUT    /repos/{owner}/{name}/-/secrets/{secname}   create or update
+DELETE /repos/{owner}/{name}/-/secrets/{secname}   delete
+```
+
+`PUT` body: `{ "value": "<plaintext>", "description": "..." }`. Response
+echoes metadata only.
+
+`GET` response — names, sizes, timestamps, who created/updated, `last_used_at`.
+Never the value. There is no read-value endpoint at all; CI access goes
+through the scheduler service path described below.
+
+## RBAC
+
+| Action              | Required role           |
+|---------------------|-------------------------|
+| List metadata       | repo `reader`+          |
+| Create / update     | repo `admin`            |
+| Delete              | repo `admin`            |
+| Read plaintext (CI) | scheduler-service auth  |
+
+Uses the existing `RoleType` enum (`api/types.go:38–45`); no new role.
+
+## CLI
+
+```
+ds secrets list
+ds secrets set DOCKERHUB_TOKEN -            # reads stdin
+ds secrets set DOCKERHUB_TOKEN --from-file=tok.txt
+ds secrets set DOCKERHUB_TOKEN --description "..."
+ds secrets unset DOCKERHUB_TOKEN
+```
+
+No `--value=` flag — refuse to take plaintext from argv to keep it out of
+shell history and `ps` listings.
+
+## CI integration
+
+### `.docstore/ci.yaml` extension
+
+```yaml
+checks:
+  build:
+    image: cgr.dev/chainguard/go
+    commands: ["./scripts/release.sh"]
+    secrets:
+      - DOCKERHUB_TOKEN
+      - SLACK_WEBHOOK_URL: "{{ secrets.SLACK_INCOMING }}"   # optional rename
+```
+
+`secrets:` is a per-step **allowlist**. A step sees only what it asks for.
+Parser in `internal/ciconfig/` rejects unknown names at config-load time so
+the user gets the error before scheduling.
+
+### Gating policy
+
+| Trigger                                       | Secrets injected? |
+|-----------------------------------------------|-------------------|
+| Post-submit on internal branch                | yes               |
+| Proposal opened by org member                 | yes               |
+| Proposal opened by non-member contributor     | no                |
+| Manual rerun by `writer`/`maintainer`/`admin` | yes               |
+| Probe / dry-run                               | no                |
+
+Encoded in the scheduler. Not user-configurable in v1. Mirrors GitHub's
+PR-from-fork rule.
+
+### Plaintext lifetime
+
+```
+KMS.Decrypt → scheduler RAM → authenticated RPC to worker
+            → BuildKit secretsprovider.FromMap
+            → /run/secrets/<NAME> mount inside step container
+            → discarded at step end
+```
+
+Never written to disk on the docstore side. The existing executor already
+has the right hook (`internal/executor/executor.go:226–334`) — extend
+`secretMap` and `llb.AddSecret` with user-defined names alongside
+`docstore_oidc_request_token`.
+
+### Log scrubbing
+
+Worker-side wrapper around step output: Aho–Corasick over the small set of
+injected secret values, replacing matches with `***`. Backstop for
+`echo $TOKEN` mistakes — not a security boundary.
+
+## Events / audit
+
+Emit on the existing broker — names only, never values:
+
+- `secret.created` { repo, name, id, size_bytes, actor }
+- `secret.updated` { repo, name, id, size_bytes, actor }
+- `secret.deleted` { repo, name, id, actor }
+- `secret.accessed` { repo, name, id, job_id, sequence, branch }
+
+The last one fires when the scheduler attaches a secret to a CI run. Wire
+through HMAC-signed webhooks (`docs/cryptographic-verifiability.md:159`),
+so SIEM integration is free.
+
+## Operational concerns
+
+- **KEK rotation**: handled by GCP KMS automatic rotation; no docstore
+  code change.
+- **Per-secret rotation**: `ds secrets set` with a new value; `updated_at`
+  bumps.
+- **Backup**: standard Postgres dump. A restored DB without KMS access
+  stays sealed — the desired property.
+- **Repo rename**: `UPDATE repo_secrets SET repo=$1 WHERE repo=$2` in the
+  same transaction as the rename.
+- **Hard delete** on `DELETE`. Past CI runs that already consumed the
+  value live in their step exec record — out of docstore's scope.
+- **Dev mode**: add `LocalEncryptor` mirroring the `LocalSigner` pattern
+  in `internal/citoken/citoken.go:103`. Persists an AES key to
+  `~/.docstore/dev-encryption-key`. Server prints a banner: "DEV MODE —
+  secrets sealed by local key, NOT KMS".
+
+## Implementation phases
+
+Each phase is independently shippable.
+
+1. **`internal/secrets/`** — service interface (`Encryptor`, `Service`),
+   KMS encryptor, local encryptor, schema migration, unit tests against a
+   stub encryptor and integration tests against the real Postgres
+   testcontainer.
+2. **REST handlers** — `internal/server/handlers_secrets.go` plus RBAC
+   tests.
+3. **CLI** — `ds secrets {list,set,unset}` subcommands.
+4. **ciconfig parser** — `secrets:` per check; reject unknown names.
+5. **Scheduler integration** — gating policy + batch decrypt + job-spec
+   wiring.
+6. **Executor wiring** — extend `secretMap` / `llb.AddSecret`; worker-side
+   scrubber.
+7. **Event types** plumbed through the broker.
+8. **`docs/secrets.md`** — user model, threat model, rotation, dev mode.
+
+## Open trade-offs
+
+- **One KEK per server vs. per repo.** v1: one KEK. Per-repo KEK gives
+  stronger blast-radius isolation if a single repo's IAM is compromised,
+  at the cost of N KMS keys to manage. Worth revisiting at scale.
+- **Audit-event hash chain.** v1: events flow through the broker but are
+  not in the per-branch `commit_hash` chain. Putting them in a separate
+  `secret_events` chain (same SHA-256 pattern) gives tamper-evident audit
+  cheaply. Probably worth doing in v1.
+- **Symmetric vs. asymmetric KMS.** Use symmetric KMS (Cloud KMS
+  `ENCRYPT_DECRYPT`). The existing citoken key is asymmetric (signing);
+  these are different keys for different purposes.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -17,9 +17,11 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 	"time"
 	"unicode/utf8"
 
@@ -3453,4 +3455,160 @@ func (a *App) IssueTie(number int64, refType, refID string) error {
 	}
 	fmt.Fprintf(a.Out, "Tied %s %s to issue #%d\n", refType, refID, number)
 	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Repo-level secrets
+// ---------------------------------------------------------------------------
+
+// SecretMetadata is the JSON shape returned by the secrets list/set endpoints.
+// Plaintext is never returned by any read path; this struct intentionally has
+// no Value field.
+type SecretMetadata struct {
+	ID          string     `json:"id"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	SizeBytes   int        `json:"size_bytes"`
+	CreatedBy   string     `json:"created_by"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedBy   *string    `json:"updated_by,omitempty"`
+	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
+	LastUsedAt  *time.Time `json:"last_used_at,omitempty"`
+}
+
+// secretNamePattern enforces the POSIX env-var shape from the design doc:
+// uppercase letter followed by up to 63 uppercase letters, digits, or
+// underscores.
+var secretNamePattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]{0,63}$`)
+
+// maxSecretValueBytes caps secret payloads at 32 KiB. Larger values belong in
+// object storage, not in the secrets table.
+const maxSecretValueBytes = 32 * 1024
+
+// reservedSecretPrefix is forbidden at write time; reserved for built-in
+// secrets injected by docstore (e.g. docstore_oidc_request_token in its
+// uppercased form).
+const reservedSecretPrefix = "DOCSTORE_"
+
+// validateSecretName checks the name pattern and reserved-prefix rule. It
+// never includes the value in any error message.
+func validateSecretName(name string) error {
+	if !secretNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid secret name %q: must match [A-Z][A-Z0-9_]{0,63}", name)
+	}
+	if strings.HasPrefix(name, reservedSecretPrefix) {
+		return fmt.Errorf("invalid secret name %q: %s prefix is reserved", name, reservedSecretPrefix)
+	}
+	return nil
+}
+
+// SecretsList prints repo secret metadata (never plaintext values) as a
+// tab-separated table.
+func (a *App) SecretsList() error {
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	resp, err := a.httpGet(cfg, repoBase(cfg)+"/secrets")
+	if err != nil {
+		return fmt.Errorf("listing secrets: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return a.readError(resp)
+	}
+	var secrets []SecretMetadata
+	if err := json.NewDecoder(resp.Body).Decode(&secrets); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	tw := tabwriter.NewWriter(a.Out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tSIZE\tUPDATED\tLAST_USED\tDESCRIPTION")
+	for _, s := range secrets {
+		updated := s.CreatedAt.Format(time.RFC3339)
+		if s.UpdatedAt != nil {
+			updated = s.UpdatedAt.Format(time.RFC3339)
+		}
+		lastUsed := "-"
+		if s.LastUsedAt != nil {
+			lastUsed = s.LastUsedAt.Format(time.RFC3339)
+		}
+		fmt.Fprintf(tw, "%s\t%d\t%s\t%s\t%s\n",
+			s.Name, s.SizeBytes, updated, lastUsed, s.Description)
+	}
+	return tw.Flush()
+}
+
+// SecretsSet sets the named secret to the contents of valueReader. The caller
+// is responsible for sourcing valueReader (stdin or a file). description may
+// be empty. Errors never include the secret value.
+func (a *App) SecretsSet(name string, valueReader io.Reader, description string) error {
+	if err := validateSecretName(name); err != nil {
+		return err
+	}
+	if valueReader == nil {
+		return fmt.Errorf("secret value reader is required")
+	}
+	// Read at most maxSecretValueBytes+1 so we can detect oversized values
+	// without buffering arbitrarily large input.
+	limited := io.LimitReader(valueReader, int64(maxSecretValueBytes)+1)
+	value, err := io.ReadAll(limited)
+	if err != nil {
+		return fmt.Errorf("reading secret value: %w", err)
+	}
+	if len(value) == 0 {
+		return fmt.Errorf("secret value is empty")
+	}
+	if len(value) > maxSecretValueBytes {
+		return fmt.Errorf("secret value exceeds maximum size of %d bytes", maxSecretValueBytes)
+	}
+
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+
+	body := struct {
+		Value       string `json:"value"`
+		Description string `json:"description,omitempty"`
+	}{
+		Value:       string(value),
+		Description: description,
+	}
+	resp, err := a.doPUTJSON(repoBase(cfg)+"/secrets/"+name, body)
+	if err != nil {
+		// Wrap network-level errors generically; never echo the value.
+		return fmt.Errorf("setting secret %s: %w", name, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return a.readError(resp)
+	}
+	fmt.Fprintf(a.Out, "Set %s (%d bytes)\n", name, len(value))
+	return nil
+}
+
+// SecretsUnset deletes the named secret.
+func (a *App) SecretsUnset(name string) error {
+	if err := validateSecretName(name); err != nil {
+		return err
+	}
+	cfg, err := a.loadConfig()
+	if err != nil {
+		return err
+	}
+	resp, err := a.doDELETE(repoBase(cfg) + "/secrets/" + name)
+	if err != nil {
+		return fmt.Errorf("unsetting secret %s: %w", name, err)
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusNoContent, http.StatusOK:
+		fmt.Fprintf(a.Out, "Unset %s\n", name)
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf("secret %s not found", name)
+	default:
+		return a.readError(resp)
+	}
 }

--- a/internal/cli/secrets_test.go
+++ b/internal/cli/secrets_test.go
@@ -1,0 +1,391 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// secretSetBody mirrors the JSON shape sent by SecretsSet. Defined in the test
+// to keep the wire-shape assertion explicit and decoupled from the production
+// anonymous struct.
+type secretSetBody struct {
+	Value       string `json:"value"`
+	Description string `json:"description,omitempty"`
+}
+
+// initSecretsWorkspace prepares an App with a usable workspace pointing at the
+// given remote.
+func initSecretsWorkspace(t *testing.T, app *App, remote string) {
+	t.Helper()
+	initWorkspace(t, app, remote, "main", "alice")
+}
+
+func TestSecretsList(t *testing.T) {
+	created := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	updated := time.Date(2026, 4, 15, 12, 30, 0, 0, time.UTC)
+	lastUsed := time.Date(2026, 5, 1, 9, 15, 0, 0, time.UTC)
+	updatedBy := "bob"
+
+	body := []SecretMetadata{
+		{
+			ID:          "01H...A",
+			Name:        "DOCKERHUB_TOKEN",
+			Description: "Docker Hub publish token",
+			SizeBytes:   42,
+			CreatedBy:   "alice",
+			CreatedAt:   created,
+			UpdatedBy:   &updatedBy,
+			UpdatedAt:   &updated,
+			LastUsedAt:  &lastUsed,
+		},
+		{
+			ID:          "01H...B",
+			Name:        "SLACK_WEBHOOK_URL",
+			Description: "",
+			SizeBytes:   88,
+			CreatedBy:   "alice",
+			CreatedAt:   created,
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/repos/default/default/-/secrets" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(body)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initSecretsWorkspace(t, app, srv.URL)
+
+	if err := app.SecretsList(); err != nil {
+		t.Fatalf("SecretsList: %v", err)
+	}
+	got := out.String()
+
+	wantSubstrings := []string{
+		"NAME", "SIZE", "UPDATED", "LAST_USED", "DESCRIPTION",
+		"DOCKERHUB_TOKEN", "42", updated.Format(time.RFC3339),
+		lastUsed.Format(time.RFC3339), "Docker Hub publish token",
+		"SLACK_WEBHOOK_URL", "88",
+	}
+	for _, s := range wantSubstrings {
+		if !strings.Contains(got, s) {
+			t.Errorf("output missing %q\n%s", s, got)
+		}
+	}
+
+	// SLACK_WEBHOOK_URL has no UpdatedAt: should fall back to CreatedAt.
+	if !strings.Contains(got, created.Format(time.RFC3339)) {
+		t.Errorf("expected created timestamp fallback in output:\n%s", got)
+	}
+	// SLACK_WEBHOOK_URL has no LastUsedAt: should print "-".
+	if !strings.Contains(got, "-") {
+		t.Errorf("expected '-' for missing LAST_USED:\n%s", got)
+	}
+}
+
+func TestSecretsList_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"not authorized"}`))
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initSecretsWorkspace(t, app, srv.URL)
+
+	err := app.SecretsList()
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not authorized") {
+		t.Errorf("expected server error surfaced, got: %v", err)
+	}
+}
+
+func TestSecretsSet_PutsCorrectBody(t *testing.T) {
+	const secretValue = "super-secret-value"
+	var (
+		gotMethod string
+		gotPath   string
+		gotBody   secretSetBody
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initSecretsWorkspace(t, app, srv.URL)
+
+	err := app.SecretsSet("DOCKERHUB_TOKEN", strings.NewReader(secretValue), "publish")
+	if err != nil {
+		t.Fatalf("SecretsSet: %v", err)
+	}
+	if gotMethod != "PUT" {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if gotPath != "/repos/default/default/-/secrets/DOCKERHUB_TOKEN" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotBody.Value != secretValue {
+		t.Errorf("value = %q, want %q", gotBody.Value, secretValue)
+	}
+	if gotBody.Description != "publish" {
+		t.Errorf("description = %q, want %q", gotBody.Description, "publish")
+	}
+	if !strings.Contains(out.String(), "Set DOCKERHUB_TOKEN") {
+		t.Errorf("expected success message, got: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "18 bytes") {
+		t.Errorf("expected size in output, got: %s", out.String())
+	}
+}
+
+func TestSecretsSet_OmitsEmptyDescription(t *testing.T) {
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initSecretsWorkspace(t, app, srv.URL)
+
+	if err := app.SecretsSet("FOO", strings.NewReader("bar"), ""); err != nil {
+		t.Fatalf("SecretsSet: %v", err)
+	}
+	if strings.Contains(string(rawBody), "description") {
+		t.Errorf("expected description omitted from JSON, got: %s", string(rawBody))
+	}
+}
+
+func TestSecretsSet_RejectsBadNames(t *testing.T) {
+	cases := []struct {
+		name    string
+		secret  string
+		wantSub string
+	}{
+		{"lowercase", "my_token", "must match"},
+		{"leading_digit", "1FOO", "must match"},
+		{"with_hyphen", "FOO-BAR", "must match"},
+		{"too_long", strings.Repeat("A", 65), "must match"},
+		{"reserved_prefix", "DOCSTORE_TOKEN", "reserved"},
+		{"empty", "", "must match"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var called bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusCreated)
+			}))
+			defer srv.Close()
+
+			app, _ := newTestApp(t, srv)
+			initSecretsWorkspace(t, app, srv.URL)
+
+			err := app.SecretsSet(tc.secret, strings.NewReader("value"), "")
+			if err == nil {
+				t.Fatalf("expected error for name %q", tc.secret)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q missing %q", err.Error(), tc.wantSub)
+			}
+			if called {
+				t.Errorf("server should not be called for invalid name %q", tc.secret)
+			}
+		})
+	}
+}
+
+func TestSecretsSet_RejectsOversize(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initSecretsWorkspace(t, app, srv.URL)
+
+	big := bytes.Repeat([]byte("A"), maxSecretValueBytes+1)
+	err := app.SecretsSet("FOO", bytes.NewReader(big), "")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Errorf("expected size error, got: %v", err)
+	}
+	if called {
+		t.Errorf("server should not be called for oversized value")
+	}
+}
+
+func TestSecretsSet_AcceptsExactMaxSize(t *testing.T) {
+	var receivedLen int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var b secretSetBody
+		_ = json.NewDecoder(r.Body).Decode(&b)
+		receivedLen = len(b.Value)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initSecretsWorkspace(t, app, srv.URL)
+
+	big := bytes.Repeat([]byte("A"), maxSecretValueBytes)
+	if err := app.SecretsSet("FOO", bytes.NewReader(big), ""); err != nil {
+		t.Fatalf("SecretsSet: %v", err)
+	}
+	if receivedLen != maxSecretValueBytes {
+		t.Errorf("server got %d bytes, want %d", receivedLen, maxSecretValueBytes)
+	}
+}
+
+func TestSecretsSet_RejectsEmpty(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initSecretsWorkspace(t, app, srv.URL)
+
+	if err := app.SecretsSet("FOO", strings.NewReader(""), ""); err == nil {
+		t.Fatalf("expected empty-value error")
+	}
+	if called {
+		t.Errorf("server should not be called for empty value")
+	}
+}
+
+func TestSecretsSet_ServerErrorDoesNotLeakValue(t *testing.T) {
+	const secretValue = "super-secret-value"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"kms unavailable"}`))
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initSecretsWorkspace(t, app, srv.URL)
+
+	err := app.SecretsSet("FOO", strings.NewReader(secretValue), "desc")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if strings.Contains(err.Error(), secretValue) {
+		t.Errorf("error must not include secret value: %v", err)
+	}
+	if !strings.Contains(err.Error(), "kms unavailable") {
+		t.Errorf("expected server error surfaced, got: %v", err)
+	}
+}
+
+func TestSecretsUnset(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	app, out := newTestApp(t, srv)
+	initSecretsWorkspace(t, app, srv.URL)
+
+	if err := app.SecretsUnset("DOCKERHUB_TOKEN"); err != nil {
+		t.Fatalf("SecretsUnset: %v", err)
+	}
+	if gotMethod != "DELETE" {
+		t.Errorf("method = %q, want DELETE", gotMethod)
+	}
+	if gotPath != "/repos/default/default/-/secrets/DOCKERHUB_TOKEN" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if !strings.Contains(out.String(), "Unset DOCKERHUB_TOKEN") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+}
+
+func TestSecretsUnset_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initSecretsWorkspace(t, app, srv.URL)
+
+	err := app.SecretsUnset("MISSING")
+	if err == nil {
+		t.Fatalf("expected error for 404")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected friendly not-found message, got: %v", err)
+	}
+}
+
+func TestSecretsUnset_RejectsBadName(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initSecretsWorkspace(t, app, srv.URL)
+
+	if err := app.SecretsUnset("bad-name"); err == nil {
+		t.Fatalf("expected validation error")
+	}
+	if called {
+		t.Errorf("server should not be called for invalid name")
+	}
+}
+
+func TestSecretsUnset_ServerErrorMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden: admin role required"}`))
+	}))
+	defer srv.Close()
+
+	app, _ := newTestApp(t, srv)
+	initSecretsWorkspace(t, app, srv.URL)
+
+	err := app.SecretsUnset("FOO")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "admin role required") {
+		t.Errorf("expected server error surfaced, got: %v", err)
+	}
+}

--- a/internal/db/migrations/000020_repo_secrets.down.sql
+++ b/internal/db/migrations/000020_repo_secrets.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE repo_secrets;

--- a/internal/db/migrations/000020_repo_secrets.up.sql
+++ b/internal/db/migrations/000020_repo_secrets.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE repo_secrets (
+    id            TEXT PRIMARY KEY,
+    repo          TEXT NOT NULL,
+    name          TEXT NOT NULL,
+    description   TEXT NOT NULL DEFAULT '',
+    ciphertext    BYTEA NOT NULL,
+    nonce         BYTEA NOT NULL,
+    encrypted_dek BYTEA NOT NULL,
+    kms_key_name  TEXT NOT NULL,
+    size_bytes    INT NOT NULL,
+    created_by    TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL,
+    updated_by    TEXT,
+    updated_at    TIMESTAMPTZ,
+    last_used_at  TIMESTAMPTZ,
+    UNIQUE (repo, name)
+);
+
+CREATE INDEX repo_secrets_by_repo ON repo_secrets (repo);

--- a/internal/db/secrets_store.go
+++ b/internal/db/secrets_store.go
@@ -1,0 +1,196 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ErrSecretNotFound is returned by repo-secret operations when no row matches
+// the given (repo, name) tuple.
+var ErrSecretNotFound = errors.New("repo secret not found")
+
+// RepoSecret is a sealed secret keyed by (repo, name). Ciphertext, Nonce, and
+// EncryptedDEK are produced by the encryptor service; the store treats them
+// as opaque bytes.
+type RepoSecret struct {
+	ID           string
+	Repo         string
+	Name         string
+	Description  string
+	Ciphertext   []byte
+	Nonce        []byte
+	EncryptedDEK []byte
+	KMSKeyName   string
+	SizeBytes    int
+	CreatedBy    string
+	CreatedAt    time.Time
+	UpdatedBy    *string
+	UpdatedAt    *time.Time
+	LastUsedAt   *time.Time
+}
+
+// repoSecretColumns is the ordered list of columns returned by SELECT * on
+// repo_secrets.
+const repoSecretColumns = `id, repo, name, description, ciphertext, nonce, encrypted_dek,
+	kms_key_name, size_bytes, created_by, created_at, updated_by, updated_at, last_used_at`
+
+// scanRepoSecret scans a single repo_secrets row into a RepoSecret.
+func scanRepoSecret(row interface {
+	Scan(...any) error
+}) (RepoSecret, error) {
+	var rs RepoSecret
+	var updatedBy sql.NullString
+	var updatedAt sql.NullTime
+	var lastUsedAt sql.NullTime
+	if err := row.Scan(
+		&rs.ID, &rs.Repo, &rs.Name, &rs.Description,
+		&rs.Ciphertext, &rs.Nonce, &rs.EncryptedDEK,
+		&rs.KMSKeyName, &rs.SizeBytes,
+		&rs.CreatedBy, &rs.CreatedAt,
+		&updatedBy, &updatedAt, &lastUsedAt,
+	); err != nil {
+		return RepoSecret{}, err
+	}
+	if updatedBy.Valid {
+		rs.UpdatedBy = &updatedBy.String
+	}
+	if updatedAt.Valid {
+		rs.UpdatedAt = &updatedAt.Time
+	}
+	if lastUsedAt.Valid {
+		rs.LastUsedAt = &lastUsedAt.Time
+	}
+	return rs, nil
+}
+
+// SetRepoSecret inserts or updates a repo secret keyed by (repo, name).
+//
+// On insert: id, created_by, and created_at are taken from the input (or
+// generated when missing) and written verbatim. On update by (repo, name):
+// the existing id, created_by, and created_at are preserved, last_used_at
+// is left untouched, and updated_by/updated_at are bumped to the caller's
+// identity / now(). The remaining sealed fields and metadata are replaced
+// with the new values.
+//
+// Returns the row as written.
+func (s *Store) SetRepoSecret(ctx context.Context, in RepoSecret) (RepoSecret, error) {
+	if in.ID == "" {
+		in.ID = uuid.New().String()
+	}
+	if in.CreatedAt.IsZero() {
+		in.CreatedAt = time.Now().UTC()
+	} else {
+		in.CreatedAt = in.CreatedAt.UTC()
+	}
+	now := time.Now().UTC()
+
+	row := s.db.QueryRowContext(ctx,
+		`INSERT INTO repo_secrets (
+			id, repo, name, description, ciphertext, nonce, encrypted_dek,
+			kms_key_name, size_bytes, created_by, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		ON CONFLICT (repo, name) DO UPDATE SET
+			description   = EXCLUDED.description,
+			ciphertext    = EXCLUDED.ciphertext,
+			nonce         = EXCLUDED.nonce,
+			encrypted_dek = EXCLUDED.encrypted_dek,
+			kms_key_name  = EXCLUDED.kms_key_name,
+			size_bytes    = EXCLUDED.size_bytes,
+			updated_by    = $12,
+			updated_at    = $13
+		RETURNING `+repoSecretColumns,
+		in.ID, in.Repo, in.Name, in.Description,
+		in.Ciphertext, in.Nonce, in.EncryptedDEK,
+		in.KMSKeyName, in.SizeBytes,
+		in.CreatedBy, in.CreatedAt,
+		in.CreatedBy, now,
+	)
+	rs, err := scanRepoSecret(row)
+	if err != nil {
+		return RepoSecret{}, fmt.Errorf("set repo secret: %w", err)
+	}
+	return rs, nil
+}
+
+// GetRepoSecret returns the repo secret keyed by (repo, name). Returns
+// ErrSecretNotFound if no such row exists.
+func (s *Store) GetRepoSecret(ctx context.Context, repo, name string) (RepoSecret, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+repoSecretColumns+` FROM repo_secrets WHERE repo = $1 AND name = $2`,
+		repo, name,
+	)
+	rs, err := scanRepoSecret(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return RepoSecret{}, ErrSecretNotFound
+		}
+		return RepoSecret{}, fmt.Errorf("get repo secret: %w", err)
+	}
+	return rs, nil
+}
+
+// ListRepoSecrets returns all repo secrets for a repo, ordered by name ASC.
+// Sealed fields are populated; callers that only need metadata should
+// project away ciphertext/nonce/encrypted_dek themselves.
+func (s *Store) ListRepoSecrets(ctx context.Context, repo string) ([]RepoSecret, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+repoSecretColumns+` FROM repo_secrets WHERE repo = $1 ORDER BY name ASC`,
+		repo,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list repo secrets: %w", err)
+	}
+	defer rows.Close()
+
+	var secrets []RepoSecret
+	for rows.Next() {
+		rs, err := scanRepoSecret(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list repo secrets: scan: %w", err)
+		}
+		secrets = append(secrets, rs)
+	}
+	if secrets == nil {
+		secrets = []RepoSecret{}
+	}
+	return secrets, rows.Err()
+}
+
+// DeleteRepoSecret removes the repo secret keyed by (repo, name). Returns
+// ErrSecretNotFound if no row was deleted.
+func (s *Store) DeleteRepoSecret(ctx context.Context, repo, name string) error {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM repo_secrets WHERE repo = $1 AND name = $2`,
+		repo, name,
+	)
+	if err != nil {
+		return fmt.Errorf("delete repo secret: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("delete repo secret: rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrSecretNotFound
+	}
+	return nil
+}
+
+// TouchRepoSecretLastUsed sets last_used_at = now() for (repo, name). It is
+// idempotent and does not return an error if the row is missing — callers
+// have already observed the row via GetRepoSecret before touching it.
+func (s *Store) TouchRepoSecretLastUsed(ctx context.Context, repo, name string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE repo_secrets SET last_used_at = now() WHERE repo = $1 AND name = $2`,
+		repo, name,
+	)
+	if err != nil {
+		return fmt.Errorf("touch repo secret last used: %w", err)
+	}
+	return nil
+}

--- a/internal/db/secrets_store_test.go
+++ b/internal/db/secrets_store_test.go
@@ -1,0 +1,298 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dlorenc/docstore/internal/testutil"
+	"github.com/google/uuid"
+)
+
+// newRepoSecret returns a RepoSecret pre-populated with deterministic-looking
+// sealed bytes so that tests can compare round-tripped values.
+func newRepoSecret(repo, name string) RepoSecret {
+	return RepoSecret{
+		ID:           uuid.New().String(),
+		Repo:         repo,
+		Name:         name,
+		Description:  "test secret " + name,
+		Ciphertext:   []byte("sealed:" + name),
+		Nonce:        bytes.Repeat([]byte{0xab}, 12),
+		EncryptedDEK: []byte("kms-wrapped-dek:" + name),
+		KMSKeyName:   "projects/p/locations/l/keyRings/r/cryptoKeys/repo-secrets",
+		SizeBytes:    len("plaintext-" + name),
+		CreatedBy:    "alice@example.com",
+		CreatedAt:    time.Now().UTC().Truncate(time.Microsecond),
+	}
+}
+
+func assertSealedFieldsEqual(t *testing.T, got, want RepoSecret) {
+	t.Helper()
+	if got.Repo != want.Repo {
+		t.Errorf("repo: got %q want %q", got.Repo, want.Repo)
+	}
+	if got.Name != want.Name {
+		t.Errorf("name: got %q want %q", got.Name, want.Name)
+	}
+	if got.Description != want.Description {
+		t.Errorf("description: got %q want %q", got.Description, want.Description)
+	}
+	if !bytes.Equal(got.Ciphertext, want.Ciphertext) {
+		t.Errorf("ciphertext: got %x want %x", got.Ciphertext, want.Ciphertext)
+	}
+	if !bytes.Equal(got.Nonce, want.Nonce) {
+		t.Errorf("nonce: got %x want %x", got.Nonce, want.Nonce)
+	}
+	if !bytes.Equal(got.EncryptedDEK, want.EncryptedDEK) {
+		t.Errorf("encrypted_dek: got %x want %x", got.EncryptedDEK, want.EncryptedDEK)
+	}
+	if got.KMSKeyName != want.KMSKeyName {
+		t.Errorf("kms_key_name: got %q want %q", got.KMSKeyName, want.KMSKeyName)
+	}
+	if got.SizeBytes != want.SizeBytes {
+		t.Errorf("size_bytes: got %d want %d", got.SizeBytes, want.SizeBytes)
+	}
+}
+
+func TestRepoSecret_SetGetRoundtrip(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	in := newRepoSecret("acme/widgets", "DOCKERHUB_TOKEN")
+
+	written, err := s.SetRepoSecret(ctx, in)
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if written.ID != in.ID {
+		t.Errorf("id: got %q want %q", written.ID, in.ID)
+	}
+	if written.CreatedBy != in.CreatedBy {
+		t.Errorf("created_by: got %q want %q", written.CreatedBy, in.CreatedBy)
+	}
+	if !written.CreatedAt.Equal(in.CreatedAt) {
+		t.Errorf("created_at: got %v want %v", written.CreatedAt, in.CreatedAt)
+	}
+	if written.UpdatedBy != nil {
+		t.Errorf("updated_by: got %v want nil", *written.UpdatedBy)
+	}
+	if written.UpdatedAt != nil {
+		t.Errorf("updated_at: got %v want nil", *written.UpdatedAt)
+	}
+	if written.LastUsedAt != nil {
+		t.Errorf("last_used_at: got %v want nil", *written.LastUsedAt)
+	}
+	assertSealedFieldsEqual(t, written, in)
+
+	got, err := s.GetRepoSecret(ctx, in.Repo, in.Name)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.ID != in.ID {
+		t.Errorf("id roundtrip: got %q want %q", got.ID, in.ID)
+	}
+	if !got.CreatedAt.Equal(in.CreatedAt) {
+		t.Errorf("created_at roundtrip: got %v want %v", got.CreatedAt, in.CreatedAt)
+	}
+	assertSealedFieldsEqual(t, got, in)
+}
+
+func TestRepoSecret_SetTwiceUpdates(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	first := newRepoSecret("acme/widgets", "DOCKERHUB_TOKEN")
+	written1, err := s.SetRepoSecret(ctx, first)
+	if err != nil {
+		t.Fatalf("first set: %v", err)
+	}
+
+	// Second write with same (repo, name) but a different caller-supplied id,
+	// CreatedBy, sealed payload, and description. The store must preserve the
+	// original id/created_by/created_at and bump updated_by/updated_at.
+	second := newRepoSecret("acme/widgets", "DOCKERHUB_TOKEN")
+	second.CreatedBy = "bob@example.com"
+	second.Description = "rotated"
+	second.Ciphertext = []byte("sealed:rotated")
+	second.EncryptedDEK = []byte("kms-wrapped-dek:rotated")
+	second.SizeBytes = 99
+
+	beforeUpdate := time.Now().UTC().Add(-time.Second)
+	written2, err := s.SetRepoSecret(ctx, second)
+	if err != nil {
+		t.Fatalf("second set: %v", err)
+	}
+
+	if written2.ID != written1.ID {
+		t.Errorf("id changed on update: got %q want %q", written2.ID, written1.ID)
+	}
+	if written2.CreatedBy != written1.CreatedBy {
+		t.Errorf("created_by changed on update: got %q want %q", written2.CreatedBy, written1.CreatedBy)
+	}
+	if !written2.CreatedAt.Equal(written1.CreatedAt) {
+		t.Errorf("created_at changed on update: got %v want %v", written2.CreatedAt, written1.CreatedAt)
+	}
+	if written2.UpdatedBy == nil || *written2.UpdatedBy != second.CreatedBy {
+		t.Errorf("updated_by: got %v want %q", written2.UpdatedBy, second.CreatedBy)
+	}
+	if written2.UpdatedAt == nil {
+		t.Fatal("updated_at: got nil, want non-nil")
+	}
+	if written2.UpdatedAt.Before(beforeUpdate) {
+		t.Errorf("updated_at: got %v, expected >= %v", *written2.UpdatedAt, beforeUpdate)
+	}
+	if written2.Description != "rotated" {
+		t.Errorf("description not updated: %q", written2.Description)
+	}
+	if !bytes.Equal(written2.Ciphertext, []byte("sealed:rotated")) {
+		t.Errorf("ciphertext not updated: %x", written2.Ciphertext)
+	}
+	if !bytes.Equal(written2.EncryptedDEK, []byte("kms-wrapped-dek:rotated")) {
+		t.Errorf("encrypted_dek not updated: %x", written2.EncryptedDEK)
+	}
+	if written2.SizeBytes != 99 {
+		t.Errorf("size_bytes not updated: %d", written2.SizeBytes)
+	}
+
+	// Confirm only one row exists for (repo, name).
+	var count int
+	if err := d.QueryRow(`SELECT COUNT(*) FROM repo_secrets WHERE repo = $1 AND name = $2`,
+		first.Repo, first.Name).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 row, got %d", count)
+	}
+}
+
+func TestRepoSecret_ListByRepo(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	want := []string{"AAA_TOKEN", "BBB_TOKEN", "ZZZ_TOKEN"}
+	// Insert in non-sorted order to confirm List orders by name.
+	for _, name := range []string{want[2], want[0], want[1]} {
+		if _, err := s.SetRepoSecret(ctx, newRepoSecret("acme/widgets", name)); err != nil {
+			t.Fatalf("set %s: %v", name, err)
+		}
+	}
+	// Insert a row in another repo that must not appear.
+	if _, err := s.SetRepoSecret(ctx, newRepoSecret("other/repo", "OTHER_TOKEN")); err != nil {
+		t.Fatalf("set other repo: %v", err)
+	}
+
+	got, err := s.ListRepoSecrets(ctx, "acme/widgets")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d secrets, want %d", len(got), len(want))
+	}
+	for i, name := range want {
+		if got[i].Name != name {
+			t.Errorf("position %d: got %q, want %q", i, got[i].Name, name)
+		}
+		if got[i].Repo != "acme/widgets" {
+			t.Errorf("position %d: cross-repo leak, repo=%q", i, got[i].Repo)
+		}
+		if len(got[i].Ciphertext) == 0 {
+			t.Errorf("position %d: ciphertext was projected away", i)
+		}
+	}
+
+	// Listing an empty repo returns an empty (non-nil) slice.
+	empty, err := s.ListRepoSecrets(ctx, "no/such")
+	if err != nil {
+		t.Fatalf("list empty: %v", err)
+	}
+	if empty == nil {
+		t.Error("list of empty repo: got nil, want []")
+	}
+	if len(empty) != 0 {
+		t.Errorf("list of empty repo: got %d rows", len(empty))
+	}
+}
+
+func TestRepoSecret_Delete(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	in := newRepoSecret("acme/widgets", "DOCKERHUB_TOKEN")
+	if _, err := s.SetRepoSecret(ctx, in); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	if err := s.DeleteRepoSecret(ctx, in.Repo, in.Name); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	if _, err := s.GetRepoSecret(ctx, in.Repo, in.Name); !errors.Is(err, ErrSecretNotFound) {
+		t.Errorf("get after delete: got %v, want ErrSecretNotFound", err)
+	}
+
+	if err := s.DeleteRepoSecret(ctx, in.Repo, in.Name); !errors.Is(err, ErrSecretNotFound) {
+		t.Errorf("delete missing: got %v, want ErrSecretNotFound", err)
+	}
+
+	if err := s.DeleteRepoSecret(ctx, "no/such", "NOPE"); !errors.Is(err, ErrSecretNotFound) {
+		t.Errorf("delete unknown repo: got %v, want ErrSecretNotFound", err)
+	}
+}
+
+func TestRepoSecret_TouchLastUsed(t *testing.T) {
+	t.Parallel()
+	d := testutil.TestDBFromShared(t, sharedAdminDSN, RunMigrations)
+	s := NewStore(d)
+	ctx := context.Background()
+
+	in := newRepoSecret("acme/widgets", "DOCKERHUB_TOKEN")
+	if _, err := s.SetRepoSecret(ctx, in); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	beforeTouch := time.Now().UTC().Add(-time.Second)
+	if err := s.TouchRepoSecretLastUsed(ctx, in.Repo, in.Name); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+
+	got, err := s.GetRepoSecret(ctx, in.Repo, in.Name)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.LastUsedAt == nil {
+		t.Fatal("last_used_at: got nil after touch")
+	}
+	if got.LastUsedAt.Before(beforeTouch) {
+		t.Errorf("last_used_at: got %v, expected >= %v", *got.LastUsedAt, beforeTouch)
+	}
+
+	// Touching again advances the timestamp.
+	first := *got.LastUsedAt
+	time.Sleep(10 * time.Millisecond)
+	if err := s.TouchRepoSecretLastUsed(ctx, in.Repo, in.Name); err != nil {
+		t.Fatalf("touch second: %v", err)
+	}
+	got2, err := s.GetRepoSecret(ctx, in.Repo, in.Name)
+	if err != nil {
+		t.Fatalf("get second: %v", err)
+	}
+	if got2.LastUsedAt == nil || !got2.LastUsedAt.After(first) {
+		t.Errorf("last_used_at not advanced: first=%v second=%v", first, got2.LastUsedAt)
+	}
+
+	// Touching a missing row is a no-op, not an error.
+	if err := s.TouchRepoSecretLastUsed(ctx, "no/such", "NOPE"); err != nil {
+		t.Errorf("touch missing: got %v, want nil", err)
+	}
+}

--- a/internal/secrets/encryptor.go
+++ b/internal/secrets/encryptor.go
@@ -1,0 +1,39 @@
+// Package secrets implements envelope encryption for repo-scoped secrets.
+// It provides the Encryptor abstraction with two implementations: a KMS-backed
+// encryptor for production and an in-process AES key for local development.
+//
+// Per docs/secrets-design.md, the storage shape is (ciphertext, nonce,
+// encrypted_dek, kms_key_name): plaintext is sealed under a per-secret DEK,
+// and the DEK is wrapped under a long-lived KEK (Cloud KMS in production,
+// a file-backed AES key in dev). Plaintext bytes never leave this package
+// alive once Encrypt returns.
+package secrets
+
+import "context"
+
+// Sealed is the result of Encrypt — what callers persist verbatim. EncryptedDEK
+// is the wrapped DEK; KMSKeyName names the KEK used so callers know which
+// key/version to ask for on Decrypt and so we can rotate cleanly.
+type Sealed struct {
+	Ciphertext   []byte
+	Nonce        []byte
+	EncryptedDEK []byte
+	KMSKeyName   string
+}
+
+// Encryptor wraps envelope encryption. Implementations are KMS-backed for
+// production and a local in-process key for dev.
+type Encryptor interface {
+	// Encrypt seals plaintext. Generates a fresh DEK + nonce internally;
+	// callers do NOT pass them.
+	Encrypt(ctx context.Context, plaintext []byte) (Sealed, error)
+
+	// Decrypt reverses Encrypt. Implementations must accept any KMSKeyName
+	// they own (so KEK rotation is transparent). They must reject names
+	// they do not own.
+	Decrypt(ctx context.Context, sealed Sealed) ([]byte, error)
+
+	// KeyName returns the canonical KMS key name new ciphertext is sealed
+	// under. Diagnostic; not part of the security boundary.
+	KeyName() string
+}

--- a/internal/secrets/encryptor_test.go
+++ b/internal/secrets/encryptor_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
@@ -189,6 +190,7 @@ func TestLocalEncryptor_KeyNameUsesBasename(t *testing.T) {
 // and returns nonce||ct as the wrapped bytes — close enough to the real
 // thing to exercise our request/response handling without touching GCP.
 type fakeKMSClient struct {
+	mu         sync.Mutex
 	gcm        cipher.AEAD
 	expectName string
 	encryptErr error
@@ -215,6 +217,8 @@ func newFakeKMSClient(t *testing.T, expectName string) *fakeKMSClient {
 }
 
 func (f *fakeKMSClient) Encrypt(_ context.Context, req *kmspb.EncryptRequest, _ ...gax.CallOption) (*kmspb.EncryptResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.encryptN++
 	if f.encryptErr != nil {
 		return nil, f.encryptErr
@@ -232,6 +236,8 @@ func (f *fakeKMSClient) Encrypt(_ context.Context, req *kmspb.EncryptRequest, _ 
 }
 
 func (f *fakeKMSClient) Decrypt(_ context.Context, req *kmspb.DecryptRequest, _ ...gax.CallOption) (*kmspb.DecryptResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.decryptN++
 	if f.decryptErr != nil {
 		return nil, f.decryptErr

--- a/internal/secrets/encryptor_test.go
+++ b/internal/secrets/encryptor_test.go
@@ -1,0 +1,406 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
+	"github.com/googleapis/gax-go/v2"
+)
+
+// --- LocalEncryptor ---------------------------------------------------------
+
+func newLocalEncryptorForTest(t *testing.T) *LocalEncryptor {
+	t.Helper()
+	keyPath := filepath.Join(t.TempDir(), "dev-encryption-key")
+	enc, err := NewLocalEncryptor(keyPath)
+	if err != nil {
+		t.Fatalf("NewLocalEncryptor: %v", err)
+	}
+	return enc
+}
+
+func TestLocalEncryptor_Roundtrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	enc := newLocalEncryptorForTest(t)
+
+	cases := map[string][]byte{
+		"small": []byte("hunter2"),
+		"empty": {},
+		"32KiB": bytes.Repeat([]byte{0xab}, 32*1024),
+	}
+
+	for name, pt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			sealed, err := enc.Encrypt(ctx, pt)
+			if err != nil {
+				t.Fatalf("Encrypt: %v", err)
+			}
+			if sealed.KMSKeyName != enc.KeyName() {
+				t.Errorf("KMSKeyName = %q, want %q", sealed.KMSKeyName, enc.KeyName())
+			}
+			got, err := enc.Decrypt(ctx, sealed)
+			if err != nil {
+				t.Fatalf("Decrypt: %v", err)
+			}
+			if !bytes.Equal(got, pt) {
+				t.Errorf("plaintext mismatch: got %d bytes, want %d", len(got), len(pt))
+			}
+		})
+	}
+}
+
+func TestLocalEncryptor_FreshDEKEachCall(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	enc := newLocalEncryptorForTest(t)
+
+	pt := []byte("same plaintext both times")
+	a, err := enc.Encrypt(ctx, pt)
+	if err != nil {
+		t.Fatalf("Encrypt a: %v", err)
+	}
+	b, err := enc.Encrypt(ctx, pt)
+	if err != nil {
+		t.Fatalf("Encrypt b: %v", err)
+	}
+
+	if bytes.Equal(a.Ciphertext, b.Ciphertext) {
+		t.Error("ciphertexts should differ across Encrypt calls (fresh nonce)")
+	}
+	if bytes.Equal(a.Nonce, b.Nonce) {
+		t.Error("nonces should differ across Encrypt calls")
+	}
+	if bytes.Equal(a.EncryptedDEK, b.EncryptedDEK) {
+		t.Error("encrypted DEKs should differ across Encrypt calls (fresh DEK)")
+	}
+}
+
+func TestLocalEncryptor_TamperDetected(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	enc := newLocalEncryptorForTest(t)
+
+	pt := []byte("don't-mess-with-me")
+	sealed, err := enc.Encrypt(ctx, pt)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	// Each subtest flips one byte in a different field.
+	tests := []struct {
+		name  string
+		field func(*Sealed)
+	}{
+		{"ciphertext", func(s *Sealed) { s.Ciphertext[0] ^= 0x01 }},
+		{"nonce", func(s *Sealed) { s.Nonce[0] ^= 0x01 }},
+		{"encrypted_dek", func(s *Sealed) { s.EncryptedDEK[0] ^= 0x01 }},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			bad := Sealed{
+				Ciphertext:   bytes.Clone(sealed.Ciphertext),
+				Nonce:        bytes.Clone(sealed.Nonce),
+				EncryptedDEK: bytes.Clone(sealed.EncryptedDEK),
+				KMSKeyName:   sealed.KMSKeyName,
+			}
+			tc.field(&bad)
+			if _, err := enc.Decrypt(ctx, bad); err == nil {
+				t.Errorf("Decrypt of tampered %s should fail", tc.name)
+			}
+		})
+	}
+}
+
+func TestLocalEncryptor_Persistence(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	keyPath := filepath.Join(t.TempDir(), "dev-encryption-key")
+
+	first, err := NewLocalEncryptor(keyPath)
+	if err != nil {
+		t.Fatalf("NewLocalEncryptor first: %v", err)
+	}
+	pt := []byte("persistent-plaintext")
+	sealed, err := first.Encrypt(ctx, pt)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	// Fresh instance reading the same key file must Decrypt the prior Sealed.
+	second, err := NewLocalEncryptor(keyPath)
+	if err != nil {
+		t.Fatalf("NewLocalEncryptor second: %v", err)
+	}
+	got, err := second.Decrypt(ctx, sealed)
+	if err != nil {
+		t.Fatalf("Decrypt across instances: %v", err)
+	}
+	if !bytes.Equal(got, pt) {
+		t.Errorf("decrypted plaintext = %q, want %q", got, pt)
+	}
+	if first.KeyName() != second.KeyName() {
+		t.Errorf("KeyName mismatch: first=%q second=%q", first.KeyName(), second.KeyName())
+	}
+}
+
+func TestLocalEncryptor_RejectsForeignKeyName(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	enc := newLocalEncryptorForTest(t)
+
+	sealed, err := enc.Encrypt(ctx, []byte("x"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	sealed.KMSKeyName = "local:somebody-elses-key"
+	if _, err := enc.Decrypt(ctx, sealed); err == nil {
+		t.Error("Decrypt should reject a Sealed with a foreign key name")
+	}
+}
+
+func TestLocalEncryptor_KeyNameUsesBasename(t *testing.T) {
+	t.Parallel()
+	keyPath := filepath.Join(t.TempDir(), "my-key-file")
+	enc, err := NewLocalEncryptor(keyPath)
+	if err != nil {
+		t.Fatalf("NewLocalEncryptor: %v", err)
+	}
+	const want = "local:my-key-file"
+	if got := enc.KeyName(); got != want {
+		t.Errorf("KeyName = %q, want %q", got, want)
+	}
+}
+
+// --- KMSEncryptor (with fake client) ---------------------------------------
+
+// fakeKMSClient is a deterministic, in-memory stand-in for the Cloud KMS
+// client. It "wraps" a DEK by AES-GCM-sealing it under a process-local KEK
+// and returns nonce||ct as the wrapped bytes — close enough to the real
+// thing to exercise our request/response handling without touching GCP.
+type fakeKMSClient struct {
+	gcm        cipher.AEAD
+	expectName string
+	encryptErr error
+	decryptErr error
+	encryptN   int
+	decryptN   int
+}
+
+func newFakeKMSClient(t *testing.T, expectName string) *fakeKMSClient {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("aes: %v", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("gcm: %v", err)
+	}
+	return &fakeKMSClient{gcm: gcm, expectName: expectName}
+}
+
+func (f *fakeKMSClient) Encrypt(_ context.Context, req *kmspb.EncryptRequest, _ ...gax.CallOption) (*kmspb.EncryptResponse, error) {
+	f.encryptN++
+	if f.encryptErr != nil {
+		return nil, f.encryptErr
+	}
+	if req.GetName() != f.expectName {
+		return nil, errors.New("fake kms: unexpected key name")
+	}
+	nonce := make([]byte, f.gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	out := append([]byte{}, nonce...)
+	out = f.gcm.Seal(out, nonce, req.GetPlaintext(), nil)
+	return &kmspb.EncryptResponse{Name: req.GetName(), Ciphertext: out}, nil
+}
+
+func (f *fakeKMSClient) Decrypt(_ context.Context, req *kmspb.DecryptRequest, _ ...gax.CallOption) (*kmspb.DecryptResponse, error) {
+	f.decryptN++
+	if f.decryptErr != nil {
+		return nil, f.decryptErr
+	}
+	if req.GetName() != f.expectName {
+		return nil, errors.New("fake kms: unexpected key name")
+	}
+	ns := f.gcm.NonceSize()
+	wrapped := req.GetCiphertext()
+	if len(wrapped) < ns+f.gcm.Overhead() {
+		return nil, errors.New("fake kms: ciphertext too short")
+	}
+	pt, err := f.gcm.Open(nil, wrapped[:ns], wrapped[ns:], nil)
+	if err != nil {
+		return nil, err
+	}
+	return &kmspb.DecryptResponse{Plaintext: pt}, nil
+}
+
+const testKMSKey = "projects/p/locations/l/keyRings/r/cryptoKeys/k"
+
+func TestKMSEncryptor_Roundtrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fake := newFakeKMSClient(t, testKMSKey)
+	enc := newKMSEncryptorWithClient(fake, testKMSKey)
+
+	cases := map[string][]byte{
+		"small": []byte("kms-roundtrip"),
+		"empty": {},
+		"32KiB": bytes.Repeat([]byte{0x55}, 32*1024),
+	}
+	for name, pt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			sealed, err := enc.Encrypt(ctx, pt)
+			if err != nil {
+				t.Fatalf("Encrypt: %v", err)
+			}
+			if sealed.KMSKeyName != testKMSKey {
+				t.Errorf("KMSKeyName = %q, want %q", sealed.KMSKeyName, testKMSKey)
+			}
+			got, err := enc.Decrypt(ctx, sealed)
+			if err != nil {
+				t.Fatalf("Decrypt: %v", err)
+			}
+			if !bytes.Equal(got, pt) {
+				t.Errorf("roundtrip mismatch: got %d bytes, want %d", len(got), len(pt))
+			}
+		})
+	}
+}
+
+func TestKMSEncryptor_FreshDEK(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fake := newFakeKMSClient(t, testKMSKey)
+	enc := newKMSEncryptorWithClient(fake, testKMSKey)
+
+	pt := []byte("same plaintext")
+	a, err := enc.Encrypt(ctx, pt)
+	if err != nil {
+		t.Fatalf("Encrypt a: %v", err)
+	}
+	b, err := enc.Encrypt(ctx, pt)
+	if err != nil {
+		t.Fatalf("Encrypt b: %v", err)
+	}
+	if bytes.Equal(a.Ciphertext, b.Ciphertext) {
+		t.Error("ciphertexts should differ")
+	}
+	if bytes.Equal(a.EncryptedDEK, b.EncryptedDEK) {
+		t.Error("encrypted DEKs should differ")
+	}
+	if fake.encryptN != 2 {
+		t.Errorf("expected 2 KMS Encrypt calls, got %d", fake.encryptN)
+	}
+}
+
+func TestKMSEncryptor_EncryptErrorPropagates(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fake := newFakeKMSClient(t, testKMSKey)
+	wantErr := errors.New("kms unavailable")
+	fake.encryptErr = wantErr
+
+	enc := newKMSEncryptorWithClient(fake, testKMSKey)
+	if _, err := enc.Encrypt(ctx, []byte("x")); err == nil {
+		t.Fatal("Encrypt: expected error, got nil")
+	} else if !errors.Is(err, wantErr) {
+		t.Errorf("Encrypt error = %v, want chain containing %v", err, wantErr)
+	}
+}
+
+func TestKMSEncryptor_DecryptErrorPropagates(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fake := newFakeKMSClient(t, testKMSKey)
+	enc := newKMSEncryptorWithClient(fake, testKMSKey)
+
+	sealed, err := enc.Encrypt(ctx, []byte("x"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	wantErr := errors.New("kms decrypt boom")
+	fake.decryptErr = wantErr
+	if _, err := enc.Decrypt(ctx, sealed); err == nil {
+		t.Fatal("Decrypt: expected error, got nil")
+	} else if !errors.Is(err, wantErr) {
+		t.Errorf("Decrypt error = %v, want chain containing %v", err, wantErr)
+	}
+}
+
+func TestKMSEncryptor_RejectsForeignKeyName(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fake := newFakeKMSClient(t, testKMSKey)
+	enc := newKMSEncryptorWithClient(fake, testKMSKey)
+
+	sealed, err := enc.Encrypt(ctx, []byte("x"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	sealed.KMSKeyName = "projects/other/locations/l/keyRings/r/cryptoKeys/other"
+	if _, err := enc.Decrypt(ctx, sealed); err == nil {
+		t.Error("Decrypt should reject foreign KMSKeyName before calling KMS")
+	}
+	if fake.decryptN != 0 {
+		t.Errorf("KMS Decrypt should not have been called; got %d calls", fake.decryptN)
+	}
+}
+
+func TestKMSEncryptor_TamperDetected(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fake := newFakeKMSClient(t, testKMSKey)
+	enc := newKMSEncryptorWithClient(fake, testKMSKey)
+
+	sealed, err := enc.Encrypt(ctx, []byte("don't-mess"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	tests := []struct {
+		name  string
+		field func(*Sealed)
+	}{
+		{"ciphertext", func(s *Sealed) { s.Ciphertext[0] ^= 0x01 }},
+		{"nonce", func(s *Sealed) { s.Nonce[0] ^= 0x01 }},
+		{"encrypted_dek", func(s *Sealed) { s.EncryptedDEK[0] ^= 0x01 }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			bad := Sealed{
+				Ciphertext:   bytes.Clone(sealed.Ciphertext),
+				Nonce:        bytes.Clone(sealed.Nonce),
+				EncryptedDEK: bytes.Clone(sealed.EncryptedDEK),
+				KMSKeyName:   sealed.KMSKeyName,
+			}
+			tc.field(&bad)
+			if _, err := enc.Decrypt(ctx, bad); err == nil {
+				t.Errorf("Decrypt of tampered %s should fail", tc.name)
+			}
+		})
+	}
+}
+
+// Compile-time assertions that both implementations satisfy the interface.
+var (
+	_ Encryptor = (*LocalEncryptor)(nil)
+	_ Encryptor = (*KMSEncryptor)(nil)
+)

--- a/internal/secrets/kms.go
+++ b/internal/secrets/kms.go
@@ -1,0 +1,139 @@
+package secrets
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"fmt"
+
+	kms "cloud.google.com/go/kms/apiv1"
+	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
+	"github.com/googleapis/gax-go/v2"
+)
+
+// kmsClient is the minimal subset of *kms.KeyManagementClient that
+// KMSEncryptor uses. Tests inject a fake; production wires in the real client
+// via NewKMSEncryptor.
+type kmsClient interface {
+	Encrypt(ctx context.Context, req *kmspb.EncryptRequest, opts ...gax.CallOption) (*kmspb.EncryptResponse, error)
+	Decrypt(ctx context.Context, req *kmspb.DecryptRequest, opts ...gax.CallOption) (*kmspb.DecryptResponse, error)
+}
+
+// KMSEncryptor seals secrets under a Cloud KMS symmetric ENCRYPT_DECRYPT key.
+// The KMS key wraps a per-secret DEK; plaintext bytes are encrypted locally
+// with AES-256-GCM under the DEK so KMS only sees the (small, fixed-size) DEK.
+type KMSEncryptor struct {
+	client      kmsClient
+	keyResource string
+}
+
+// NewKMSEncryptor constructs a KMSEncryptor by opening a default KMS client.
+// keyResource is the canonical KMS key path
+// (projects/.../locations/.../keyRings/.../cryptoKeys/...). Cloud KMS routes
+// Decrypt requests to the appropriate key version automatically, which is
+// what makes KEK rotation transparent to callers.
+func NewKMSEncryptor(ctx context.Context, keyResource string) (*KMSEncryptor, error) {
+	if keyResource == "" {
+		return nil, errors.New("kms encryptor: empty key resource")
+	}
+	c, err := kms.NewKeyManagementClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("kms encryptor: new client: %w", err)
+	}
+	return &KMSEncryptor{client: c, keyResource: keyResource}, nil
+}
+
+// newKMSEncryptorWithClient is the test seam — exported only within the
+// package so we can inject a fake kmsClient without leaking the interface
+// to the rest of the codebase.
+func newKMSEncryptorWithClient(client kmsClient, keyResource string) *KMSEncryptor {
+	return &KMSEncryptor{client: client, keyResource: keyResource}
+}
+
+// KeyName returns the KMS key resource path. Diagnostic only.
+func (e *KMSEncryptor) KeyName() string { return e.keyResource }
+
+// Encrypt generates a fresh DEK, AES-GCM-seals the plaintext under the DEK
+// locally, then asks KMS to wrap the DEK. One KMS API call per write.
+//
+// Any KMS error is treated as terminal — we do not retry inside the
+// encryptor; the caller decides whether a transient failure deserves a retry.
+func (e *KMSEncryptor) Encrypt(ctx context.Context, plaintext []byte) (Sealed, error) {
+	dek := make([]byte, 32)
+	if _, err := rand.Read(dek); err != nil {
+		return Sealed{}, fmt.Errorf("kms encrypt: generate dek: %w", err)
+	}
+	defer zero(dek)
+
+	dekBlock, err := aes.NewCipher(dek)
+	if err != nil {
+		return Sealed{}, fmt.Errorf("kms encrypt: dek cipher: %w", err)
+	}
+	dekGCM, err := cipher.NewGCM(dekBlock)
+	if err != nil {
+		return Sealed{}, fmt.Errorf("kms encrypt: dek gcm: %w", err)
+	}
+	nonce := make([]byte, dekGCM.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return Sealed{}, fmt.Errorf("kms encrypt: nonce: %w", err)
+	}
+	ct := dekGCM.Seal(nil, nonce, plaintext, nil)
+
+	resp, err := e.client.Encrypt(ctx, &kmspb.EncryptRequest{
+		Name:      e.keyResource,
+		Plaintext: dek,
+	})
+	if err != nil {
+		return Sealed{}, fmt.Errorf("kms encrypt: wrap dek: %w", err)
+	}
+
+	return Sealed{
+		Ciphertext:   ct,
+		Nonce:        nonce,
+		EncryptedDEK: resp.GetCiphertext(),
+		KMSKeyName:   e.keyResource,
+	}, nil
+}
+
+// Decrypt asks KMS to unwrap the DEK, then AES-GCM-Opens the ciphertext.
+// We always send the configured keyResource as Name. Cloud KMS' Decrypt
+// accepts the key (not key version) and figures out the version itself,
+// which is how KEK rotation stays transparent.
+//
+// We refuse Sealed values whose KMSKeyName does not match this encryptor's
+// keyResource so a misconfigured deployment fails loud rather than feeding
+// the wrong ciphertext to KMS and getting a generic decryption error.
+func (e *KMSEncryptor) Decrypt(ctx context.Context, sealed Sealed) ([]byte, error) {
+	if sealed.KMSKeyName != e.keyResource {
+		return nil, fmt.Errorf("kms decrypt: key name %q not owned by this encryptor (%q)", sealed.KMSKeyName, e.keyResource)
+	}
+
+	resp, err := e.client.Decrypt(ctx, &kmspb.DecryptRequest{
+		Name:       e.keyResource,
+		Ciphertext: sealed.EncryptedDEK,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kms decrypt: unwrap dek: %w", err)
+	}
+	dek := resp.GetPlaintext()
+	defer zero(dek)
+
+	dekBlock, err := aes.NewCipher(dek)
+	if err != nil {
+		return nil, fmt.Errorf("kms decrypt: dek cipher: %w", err)
+	}
+	dekGCM, err := cipher.NewGCM(dekBlock)
+	if err != nil {
+		return nil, fmt.Errorf("kms decrypt: dek gcm: %w", err)
+	}
+	if len(sealed.Nonce) != dekGCM.NonceSize() {
+		return nil, fmt.Errorf("kms decrypt: nonce size: want %d, got %d", dekGCM.NonceSize(), len(sealed.Nonce))
+	}
+	pt, err := dekGCM.Open(nil, sealed.Nonce, sealed.Ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("kms decrypt: open: %w", err)
+	}
+	return pt, nil
+}

--- a/internal/secrets/local.go
+++ b/internal/secrets/local.go
@@ -1,0 +1,201 @@
+package secrets
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// localKeyName is the canonical prefix returned by LocalEncryptor.KeyName.
+// "local:" makes it visually impossible to confuse with a real KMS resource
+// path in the DB or in logs.
+const localKeyPrefix = "local:"
+
+// LocalEncryptor is an in-process AES-256-GCM Encryptor. The KEK is persisted
+// to a file on disk (mode 0600) so successive process invocations can decrypt
+// data sealed by earlier ones. It mirrors the LocalSigner pattern in
+// internal/citoken/citoken.go and is intended ONLY for local development —
+// the server prints a banner when it starts with this implementation.
+type LocalEncryptor struct {
+	keyPath string
+	kekGCM  cipher.AEAD
+	keyName string
+}
+
+// NewLocalEncryptor returns a LocalEncryptor backed by the AES-256 key at
+// keyPath. If the file does not exist a fresh 32-byte key is generated and
+// written with mode 0600 (and the parent directory is created with 0700 if
+// missing). If the file exists it must be exactly 32 bytes.
+func NewLocalEncryptor(keyPath string) (*LocalEncryptor, error) {
+	if keyPath == "" {
+		return nil, errors.New("local encryptor: empty key path")
+	}
+
+	key, err := loadOrCreateKEK(keyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("local encryptor: aes cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("local encryptor: gcm: %w", err)
+	}
+
+	return &LocalEncryptor{
+		keyPath: keyPath,
+		kekGCM:  gcm,
+		// Use the file's basename so the stored kms_key_name is stable across
+		// machines/users with different home directories. The full path would
+		// leak operator-local detail into the DB.
+		keyName: localKeyPrefix + filepath.Base(keyPath),
+	}, nil
+}
+
+// loadOrCreateKEK reads the AES-256 key at path, or creates one if missing.
+func loadOrCreateKEK(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if len(data) != 32 {
+			return nil, fmt.Errorf("local encryptor: key file %q: want 32 bytes, got %d", path, len(data))
+		}
+		return data, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("local encryptor: read key file: %w", err)
+	}
+
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if mkErr := os.MkdirAll(dir, 0o700); mkErr != nil {
+			return nil, fmt.Errorf("local encryptor: create key dir: %w", mkErr)
+		}
+	}
+
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("local encryptor: generate key: %w", err)
+	}
+	if err := os.WriteFile(path, key, 0o600); err != nil {
+		return nil, fmt.Errorf("local encryptor: write key file: %w", err)
+	}
+	return key, nil
+}
+
+// KeyName returns "local:<basename>" — see NewLocalEncryptor.
+func (e *LocalEncryptor) KeyName() string { return e.keyName }
+
+// Encrypt generates a fresh DEK and nonce, AES-GCM-seals the plaintext under
+// the DEK, then wraps the DEK under the file-backed KEK. The 32 KiB plaintext
+// cap is enforced upstream — not here, so this layer stays opinion-free about
+// size.
+func (e *LocalEncryptor) Encrypt(_ context.Context, plaintext []byte) (Sealed, error) {
+	dek := make([]byte, 32)
+	if _, err := rand.Read(dek); err != nil {
+		return Sealed{}, fmt.Errorf("local encrypt: generate dek: %w", err)
+	}
+	dekBlock, err := aes.NewCipher(dek)
+	if err != nil {
+		return Sealed{}, fmt.Errorf("local encrypt: dek cipher: %w", err)
+	}
+	dekGCM, err := cipher.NewGCM(dekBlock)
+	if err != nil {
+		return Sealed{}, fmt.Errorf("local encrypt: dek gcm: %w", err)
+	}
+
+	nonce := make([]byte, dekGCM.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return Sealed{}, fmt.Errorf("local encrypt: nonce: %w", err)
+	}
+	// nil dst, nil aad — the Sealed struct fields fully describe the ciphertext.
+	ct := dekGCM.Seal(nil, nonce, plaintext, nil)
+
+	wrapped, err := e.wrapDEK(dek)
+	if err != nil {
+		return Sealed{}, err
+	}
+
+	return Sealed{
+		Ciphertext:   ct,
+		Nonce:        nonce,
+		EncryptedDEK: wrapped,
+		KMSKeyName:   e.keyName,
+	}, nil
+}
+
+// Decrypt unwraps the DEK and AES-GCM-Opens the ciphertext.
+func (e *LocalEncryptor) Decrypt(_ context.Context, sealed Sealed) ([]byte, error) {
+	if sealed.KMSKeyName != e.keyName {
+		// Refusing names we do not own makes operator misconfiguration loud
+		// instead of producing a confusing GCM-tag-mismatch error deeper down.
+		return nil, fmt.Errorf("local decrypt: key name %q not owned by this encryptor (%q)", sealed.KMSKeyName, e.keyName)
+	}
+
+	dek, err := e.unwrapDEK(sealed.EncryptedDEK)
+	if err != nil {
+		return nil, err
+	}
+	defer zero(dek)
+
+	dekBlock, err := aes.NewCipher(dek)
+	if err != nil {
+		return nil, fmt.Errorf("local decrypt: dek cipher: %w", err)
+	}
+	dekGCM, err := cipher.NewGCM(dekBlock)
+	if err != nil {
+		return nil, fmt.Errorf("local decrypt: dek gcm: %w", err)
+	}
+	if len(sealed.Nonce) != dekGCM.NonceSize() {
+		return nil, fmt.Errorf("local decrypt: nonce size: want %d, got %d", dekGCM.NonceSize(), len(sealed.Nonce))
+	}
+	pt, err := dekGCM.Open(nil, sealed.Nonce, sealed.Ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("local decrypt: open: %w", err)
+	}
+	return pt, nil
+}
+
+// wrapDEK seals the DEK under the KEK with a fresh per-call nonce. The
+// on-disk format is `nonce_kek (12B) || ciphertext_dek_with_tag` so the
+// EncryptedDEK byte string carries everything needed for unwrap. We pick
+// this self-contained format (rather than a separate "dek_nonce" column)
+// to keep the schema in docs/secrets-design.md unchanged for the dev path.
+func (e *LocalEncryptor) wrapDEK(dek []byte) ([]byte, error) {
+	nonce := make([]byte, e.kekGCM.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("local encrypt: kek nonce: %w", err)
+	}
+	out := make([]byte, 0, len(nonce)+len(dek)+e.kekGCM.Overhead())
+	out = append(out, nonce...)
+	out = e.kekGCM.Seal(out, nonce, dek, nil)
+	return out, nil
+}
+
+// unwrapDEK reverses wrapDEK.
+func (e *LocalEncryptor) unwrapDEK(wrapped []byte) ([]byte, error) {
+	ns := e.kekGCM.NonceSize()
+	if len(wrapped) < ns+e.kekGCM.Overhead() {
+		return nil, fmt.Errorf("local decrypt: encrypted dek too short: %d bytes", len(wrapped))
+	}
+	nonce, ct := wrapped[:ns], wrapped[ns:]
+	dek, err := e.kekGCM.Open(nil, nonce, ct, nil)
+	if err != nil {
+		return nil, fmt.Errorf("local decrypt: unwrap dek: %w", err)
+	}
+	return dek, nil
+}
+
+// zero overwrites the slice with zeros. Best-effort hygiene — Go's GC may
+// have already copied the bytes, but we wipe what we can reach.
+func zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of the repo-level secrets feature. Lays the foundation without exposing anything user-visible yet — the REST handlers and CI integration land in follow-up PRs.

What's in here:

- **Design doc** at `docs/secrets-design.md`. Captures the v1 plan: AES-256-GCM envelope encryption with KMS-wrapped DEKs, admin-only write API, no read-value endpoint, BuildKit secret-mount delivery to CI, gating against fork PRs, audit events on the existing broker. Lists v1 non-goals and open trade-offs explicitly.
- **`internal/secrets/`** — `Encryptor` interface + `KMSEncryptor` (Cloud KMS symmetric `ENCRYPT_DECRYPT`) + `LocalEncryptor` (file-backed AES key for dev). Mirrors the `LocalSigner` / KMS pattern in `internal/citoken`. No new third-party deps.
- **`repo_secrets` table** (migration `000020`) and `*Store` CRUD: `SetRepoSecret` (upsert by repo+name), `Get`, `List`, `Delete`, `TouchLastUsed`. Encryptor-agnostic — sealed bytes flow through.
- **`ds secrets {list,set,unset}`** CLI. Plaintext only on stdin / `--from-file=`; `--value=` is refused. Validates name shape (`^[A-Z][A-Z0-9_]{0,63}$`, no `DOCSTORE_` prefix) and 32 KiB size cap before any HTTP call.

The four pieces are atomic per-commit, each independently buildable, so review can be incremental.

## Threat model recap

1. DB-only compromise must NOT yield plaintext (envelope encryption with KMS).
2. Plaintext exits the system **only** as the request body of `PUT /-/secrets/{name}` from an authenticated admin, and as a BuildKit secret mount inside a step's container at run time.
3. CI jobs from external-fork proposals get **no** secrets.
4. Per-secret DEK so a single DEK leak doesn't compromise the rest.
5. Secrets are **not** in the per-branch commit hash chain — editing a secret does not produce a commit.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/secrets/... ./internal/db/... ./internal/cli/... ./cmd/ds/...`
- [x] `go test ./internal/secrets/... -count=1` — local + KMS-fake roundtrips, tamper detection, persistence, fresh-DEK-per-call, foreign-key-name rejection.
- [x] `go test ./internal/db/... -count=1 -run RepoSecret` — full lifecycle against the existing Postgres testcontainer.
- [x] `go test ./internal/cli/... -count=1 -run Secrets` — `httptest.NewServer` fakes for all three subcommands plus negative tests (bad names, oversize values, server-error scrubbing).

Pre-existing `TestImportGit*` failures on this branch are unrelated — they reproduce on `main` and are caused by local `gpgsign=true` in the developer's gitconfig hitting an unusable signing key when the test creates fixture commits.

## Out of scope (follow-up PRs)

- Phase 2 — REST handlers (`/repos/{owner}/{name}/-/secrets`) plus RBAC enforcement.
- Phase 3 — `.docstore/ci.yaml` `secrets:` schema and parser.
- Phase 4 — scheduler gating policy + batch decrypt.
- Phase 5 — executor wiring (`secretMap` / `llb.AddSecret`) + worker-side log scrubber.
- Phase 6 — audit events on the broker.
- Phase 7 — user-facing `docs/secrets.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)