### PR TITLE
fix(deploy): add DOCSTORE_SECRETS_KMS_KEY to Cloud Run secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
             --region=us-central1 \
             --service-account=docstore-server@dlorenc-chainguard.iam.gserviceaccount.com \
             --add-cloudsql-instances=dlorenc-chainguard:us-central1:docstore-mvp \
-            --update-secrets=DATABASE_URL=docstore-db-url:latest,OAUTH_CLIENT_ID=oauth-client-id:latest,OAUTH_CLIENT_SECRET=oauth-client-secret:latest,SESSION_SECRET=session-secret:latest,ARCHIVE_HMAC_SECRET=archive-hmac-secret:latest \
+            --update-secrets=DATABASE_URL=docstore-db-url:latest,OAUTH_CLIENT_ID=oauth-client-id:latest,OAUTH_CLIENT_SECRET=oauth-client-secret:latest,SESSION_SECRET=session-secret:latest,ARCHIVE_HMAC_SECRET=archive-hmac-secret:latest,DOCSTORE_SECRETS_KMS_KEY=docstore-secrets-kms-key:latest \
             --set-env-vars=ARCHIVE_BASE_URL=https://docstore-efuj4cj54a-uc.a.run.app,OIDC_JWKS_URL=https://oidc.docstore.dev/.well-known/jwks.json,OIDC_AUDIENCE=docstore,OIDC_ISSUER=https://oidc.docstore.dev,LOG_STORE=gcs,LOG_BUCKET=docstore-ci-logs \
             --ingress=internal-and-cloud-load-balancing \
             --min-instances=1 \


### PR DESCRIPTION
## Summary

- Fixes production Cloud Run container failing to start after PR #448 (repo-level secrets phase 2)
- `main.go` requires `DOCSTORE_SECRETS_KMS_KEY` in non-dev mode or exits with error; this was not wired up in deploy.yml
- Adds `DOCSTORE_SECRETS_KMS_KEY=docstore-secrets-kms-key:latest` to the `--update-secrets` flag in the `gcloud run deploy` step

## One-time setup required

Before this deploy succeeds, the `docstore-secrets-kms-key` secret must be created in Secret Manager with the KMS key resource name as its value:

```bash
# Create the secret
gcloud secrets create docstore-secrets-kms-key \
  --replication-policy=automatic \
  --project=dlorenc-chainguard

# Populate it with the KMS key resource name
echo -n "projects/dlorenc-chainguard/locations/us-central1/keyRings/<ring>/cryptoKeys/<key>" | \
  gcloud secrets versions add docstore-secrets-kms-key \
    --data-file=- --project=dlorenc-chainguard
```

Replace `<ring>` and `<key>` with the actual KMS key ring and key names.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `go vet ./...` passes (verified locally)
- [ ] One-time KMS secret setup performed in production project
- [ ] Deploy workflow succeeds end-to-end after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)