### PR TITLE
feat(secrets): repo-level secrets — phase 5 (executor wiring + log scrub)

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -196,6 +197,52 @@ func validateSecretName(kind, name string) error {
 	return nil
 }
 
+// buildSecretMap composes the BuildKit secrets map for one check session.
+// OIDC built-ins are keyed by their fixed SecretIDs; user secrets are keyed
+// by their LocalName. The reserved-prefix policy enforced by internal/secrets
+// guarantees these two keyspaces cannot collide, so a flat merge is safe and
+// no defensive overwrite logic is needed.
+//
+// Returns nil when there is nothing to attach so callers can skip wiring up
+// a secrets provider entirely.
+func buildSecretMap(oidcToken, oidcURL string, userSecrets map[string][]byte) map[string][]byte {
+	if oidcToken == "" && len(userSecrets) == 0 {
+		return nil
+	}
+	out := make(map[string][]byte, len(userSecrets)+2)
+	if oidcToken != "" {
+		out["docstore_oidc_request_token"] = []byte(oidcToken)
+		out["docstore_oidc_request_url"] = []byte(oidcURL)
+	}
+	maps.Copy(out, userSecrets)
+	return out
+}
+
+// scrubLogs returns a copy of buf with every non-empty value in secrets
+// replaced by `***`. It is a verbatim-substring backstop for accidental
+// `echo $TOKEN` style leaks; values that have been transformed in transit
+// (base64, hex, etc.) are NOT caught.
+//
+// Empty values are skipped — replacing the empty string would inject `***`
+// at every byte boundary and corrupt the buffer. Order is map-iteration order
+// (non-deterministic). With distinct user-supplied secret values that is
+// fine; a value that contains another value as a substring is the only case
+// where order is observable, and either replacement choice is acceptable
+// (both produce a buffer that no longer contains the inner value verbatim).
+func scrubLogs(buf []byte, secrets map[string][]byte) []byte {
+	if len(secrets) == 0 || len(buf) == 0 {
+		return buf
+	}
+	out := buf
+	for _, v := range secrets {
+		if len(v) == 0 {
+			continue
+		}
+		out = bytes.ReplaceAll(out, v, []byte("***"))
+	}
+	return out
+}
+
 // CheckResult is the result of executing a single check.
 type CheckResult struct {
 	Name      string `json:"name"`
@@ -266,7 +313,7 @@ func (e *Executor) Run(ctx context.Context, source string, cfg Config, triggerCt
 					}
 				}
 			}()
-			results[j] = e.runCheck(ctx, source, check, cfg.CacheRef, cfg.DockerConfigDir, cfg.ArchiveChecksum, cfg.OIDCRequestToken, cfg.OIDCRequestURL)
+			results[j] = e.runCheck(ctx, source, check, cfg.CacheRef, cfg.DockerConfigDir, cfg.ArchiveChecksum, cfg.OIDCRequestToken, cfg.OIDCRequestURL, cfg.UserSecrets)
 		})
 	}
 	wg.Wait()
@@ -284,7 +331,11 @@ func (e *Executor) Close() error {
 // archiveChecksum, when non-empty, passes llb.Checksum to BuildKit for HTTP sources.
 // oidcToken and oidcURL, when non-empty, are exposed via BuildKit secret mounts so
 // they do not bust the cache key (unlike env var injection).
-func (e *Executor) runCheck(ctx context.Context, source string, check Check, cacheRef, dockerConfigDir, archiveChecksum, oidcToken, oidcURL string) CheckResult {
+// userSecrets maps LocalName → plaintext for every repo secret resolved for this
+// job; entries are exposed to a step only if the check's Secrets allowlist
+// includes that LocalName. Like OIDC secrets these are mounted via BuildKit's
+// secrets provider and are NOT part of the cache key.
+func (e *Executor) runCheck(ctx context.Context, source string, check Check, cacheRef, dockerConfigDir, archiveChecksum, oidcToken, oidcURL string, userSecrets map[string][]byte) CheckResult {
 	isHTTP := strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://")
 	isLocal := source != "" && !isHTTP
 
@@ -346,14 +397,12 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check, cac
 	}
 
 	sessionAttachables := []session.Attachable{authprovider.NewDockerAuthProvider(ap)}
-	if oidcToken != "" {
-		// Expose OIDC credentials as BuildKit secrets so they don't bust the
-		// cache key. Steps read from /run/secrets/docstore_oidc_request_token
-		// and /run/secrets/docstore_oidc_request_url.
-		secretMap := map[string][]byte{
-			"docstore_oidc_request_token": []byte(oidcToken),
-			"docstore_oidc_request_url":   []byte(oidcURL),
-		}
+	// Compose OIDC built-in secrets and per-job user secrets into a single map
+	// for the BuildKit session. BuildKit secret mounts are excluded from the
+	// cache key by design, so adding user secrets does NOT bust the cache.
+	// The DOCSTORE_* reserved-prefix check in internal/secrets prevents key
+	// collisions between OIDC IDs and user LocalNames.
+	if secretMap := buildSecretMap(oidcToken, oidcURL, userSecrets); len(secretMap) > 0 {
 		sessionAttachables = append(sessionAttachables, secretsprovider.FromMap(secretMap))
 	}
 
@@ -461,6 +510,15 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check, cac
 					llb.AddSecret("/run/secrets/docstore_oidc_request_url", llb.SecretID("docstore_oidc_request_url"), llb.SecretOptional),
 				)
 			}
+			// Per-step user secret mounts. Each entry's LocalName is both the
+			// SecretID (looked up in the session secretMap) and the basename
+			// under /run/secrets. SecretOptional means an absent entry is a
+			// no-op rather than a step failure at LLB construction time.
+			for _, sec := range check.Secrets {
+				runOpts = append(runOpts,
+					llb.AddSecret("/run/secrets/"+sec.LocalName, llb.SecretID(sec.LocalName), llb.SecretOptional),
+				)
+			}
 			exec := state.Run(runOpts...)
 			state = exec.Root()
 			srcMount = exec.GetMount("/src")
@@ -496,8 +554,15 @@ func (e *Executor) runCheck(ctx context.Context, source string, check Check, cac
 
 	collectWg.Wait()
 
+	// Scrub user-secret values out of captured logs before stringifying.
+	// This is a backstop for `echo $TOKEN` style mistakes — it is NOT a
+	// security boundary. Anything that mutates the bytes in transit
+	// (base64, hex, gzip, etc.) will not be caught and callers should not
+	// expect it to be.
+	scrubbed := scrubLogs(logBuf.Bytes(), userSecrets)
+
 	status := "passed"
-	logs := logBuf.String()
+	logs := string(scrubbed)
 	if solveErr != nil {
 		status = "failed"
 		if logs == "" {

--- a/internal/executor/executor_secrets_phase5_test.go
+++ b/internal/executor/executor_secrets_phase5_test.go
@@ -1,0 +1,194 @@
+package executor
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestBuildSecretMapOIDCOnly: an OIDC token with no user secrets yields the
+// two built-in keys and nothing else.
+func TestBuildSecretMapOIDCOnly(t *testing.T) {
+	got := buildSecretMap("tok", "https://oidc.example", nil)
+	want := map[string][]byte{
+		"docstore_oidc_request_token": []byte("tok"),
+		"docstore_oidc_request_url":   []byte("https://oidc.example"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestBuildSecretMapUserOnly: with no OIDC token but user secrets present,
+// the map contains exactly those LocalName keys.
+func TestBuildSecretMapUserOnly(t *testing.T) {
+	user := map[string][]byte{
+		"DOCKERHUB_TOKEN": []byte("dh-secret"),
+		"SLACK_WEBHOOK":   []byte("https://hooks.slack/x"),
+	}
+	got := buildSecretMap("", "", user)
+	if !reflect.DeepEqual(got, user) {
+		t.Errorf("got %v, want %v", got, user)
+	}
+	// Defensive: built-in OIDC keys must not appear when oidcToken is empty.
+	for _, k := range []string{"docstore_oidc_request_token", "docstore_oidc_request_url"} {
+		if _, ok := got[k]; ok {
+			t.Errorf("unexpected built-in key %q present when OIDC unset", k)
+		}
+	}
+}
+
+// TestBuildSecretMapBoth: both sets coexist with no collisions.
+func TestBuildSecretMapBoth(t *testing.T) {
+	user := map[string][]byte{
+		"DOCKERHUB_TOKEN": []byte("dh-secret"),
+	}
+	got := buildSecretMap("tok", "https://oidc.example", user)
+	want := map[string][]byte{
+		"docstore_oidc_request_token": []byte("tok"),
+		"docstore_oidc_request_url":   []byte("https://oidc.example"),
+		"DOCKERHUB_TOKEN":             []byte("dh-secret"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestBuildSecretMapEmptyUserSecretsEqualsOIDCOnly: an empty (but non-nil)
+// userSecrets behaves identically to nil.
+func TestBuildSecretMapEmptyUserSecretsEqualsOIDCOnly(t *testing.T) {
+	gotNil := buildSecretMap("tok", "u", nil)
+	gotEmpty := buildSecretMap("tok", "u", map[string][]byte{})
+	if !reflect.DeepEqual(gotNil, gotEmpty) {
+		t.Errorf("nil vs empty differ: nil=%v empty=%v", gotNil, gotEmpty)
+	}
+}
+
+// TestBuildSecretMapNothingReturnsNil: with neither OIDC nor user secrets,
+// the function returns nil so callers can skip attaching a secrets provider.
+func TestBuildSecretMapNothingReturnsNil(t *testing.T) {
+	if got := buildSecretMap("", "", nil); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+	if got := buildSecretMap("", "", map[string][]byte{}); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+// TestScrubLogsEmptySecrets: nil/empty secret map returns input unchanged.
+func TestScrubLogsEmptySecrets(t *testing.T) {
+	in := []byte("hello world")
+	if got := scrubLogs(in, nil); !bytes.Equal(got, in) {
+		t.Errorf("nil secrets: got %q, want %q", got, in)
+	}
+	if got := scrubLogs(in, map[string][]byte{}); !bytes.Equal(got, in) {
+		t.Errorf("empty secrets: got %q, want %q", got, in)
+	}
+}
+
+// TestScrubLogsSingleOccurrence: a value appearing once is replaced.
+func TestScrubLogsSingleOccurrence(t *testing.T) {
+	in := []byte("token=hunter2 done")
+	got := scrubLogs(in, map[string][]byte{"FOO": []byte("hunter2")})
+	want := []byte("token=*** done")
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestScrubLogsMultipleOccurrences: every occurrence of one value is replaced.
+func TestScrubLogsMultipleOccurrences(t *testing.T) {
+	in := []byte("a hunter2 b hunter2 c hunter2")
+	got := scrubLogs(in, map[string][]byte{"FOO": []byte("hunter2")})
+	want := []byte("a *** b *** c ***")
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestScrubLogsTwoSecrets: distinct secrets are both scrubbed.
+func TestScrubLogsTwoSecrets(t *testing.T) {
+	in := []byte("user=hunter2 webhook=https://hooks.example/abc")
+	got := scrubLogs(in, map[string][]byte{
+		"PW":      []byte("hunter2"),
+		"WEBHOOK": []byte("https://hooks.example/abc"),
+	})
+	if bytes.Contains(got, []byte("hunter2")) {
+		t.Errorf("hunter2 still present in %q", got)
+	}
+	if bytes.Contains(got, []byte("hooks.example")) {
+		t.Errorf("webhook still present in %q", got)
+	}
+	if !bytes.Contains(got, []byte("***")) {
+		t.Errorf("no *** marker in %q", got)
+	}
+}
+
+// TestScrubLogsEmptyValueDoesNotCorrupt: an empty []byte in the map must be
+// skipped — replacing "" would inject *** at every byte boundary.
+func TestScrubLogsEmptyValueDoesNotCorrupt(t *testing.T) {
+	in := []byte("plain text")
+	got := scrubLogs(in, map[string][]byte{
+		"EMPTY":  nil,
+		"EMPTY2": []byte(""),
+		"REAL":   []byte("text"),
+	})
+	want := []byte("plain ***")
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	// Stronger guard: assert *** count is exactly 1 (not 11).
+	if n := strings.Count(string(got), "***"); n != 1 {
+		t.Errorf("expected exactly 1 ***, got %d in %q", n, got)
+	}
+}
+
+// TestScrubLogsBinarySecret: secrets containing NUL bytes are handled by
+// bytes.ReplaceAll like any other content.
+func TestScrubLogsBinarySecret(t *testing.T) {
+	secret := []byte{0x00, 0x01, 0x02, 'A', 'B'}
+	in := append([]byte("prefix "), secret...)
+	in = append(in, []byte(" suffix")...)
+	got := scrubLogs(in, map[string][]byte{"BIN": secret})
+	want := []byte("prefix *** suffix")
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestScrubLogsAbsentSecret: a value not present in the buffer is a no-op
+// and the buffer comes back byte-equal to the input.
+func TestScrubLogsAbsentSecret(t *testing.T) {
+	in := []byte("nothing to scrub here")
+	got := scrubLogs(in, map[string][]byte{"FOO": []byte("hunter2")})
+	if !bytes.Equal(got, in) {
+		t.Errorf("got %q, want %q", got, in)
+	}
+}
+
+// TestScrubLogsShortValue: even a single-character secret gets replaced.
+// This is intentional — the user wrote it as a secret and we honor that.
+func TestScrubLogsShortValue(t *testing.T) {
+	in := []byte("xxxxx")
+	got := scrubLogs(in, map[string][]byte{"X": []byte("x")})
+	want := []byte("***************") // 5 * len("***")
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestScrubLogsRedundantValues: when two LocalNames map to the same plaintext
+// the bytes are scrubbed once (and the second pass is a no-op). Outcome
+// matches the single-occurrence case.
+func TestScrubLogsRedundantValues(t *testing.T) {
+	in := []byte("token=hunter2 done")
+	got := scrubLogs(in, map[string][]byte{
+		"A": []byte("hunter2"),
+		"B": []byte("hunter2"),
+	})
+	want := []byte("token=*** done")
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -488,6 +488,51 @@ func TestLogCapture(t *testing.T) {
 	}
 }
 
+// TestRunWithUserSecretsSmoke verifies that a Config carrying cfg.UserSecrets
+// flows through Run without panicking and produces the expected pass result.
+// Phase 5 wires the values into the BuildKit session and per-step llb.AddSecret;
+// this test exercises that wiring against the live buildkitd. It does not
+// attempt to read the secret inside the step (that requires --mount=type=secret
+// in a real Dockerfile path) — it just guards that the secrets-provider
+// composition path doesn't break the basic happy path.
+func TestRunWithUserSecretsSmoke(t *testing.T) {
+	exec := newExecutor(t)
+
+	cfg := executor.Config{
+		Checks: []executor.Check{
+			{
+				Name:  "ci/with-secrets",
+				Image: "alpine",
+				Steps: []string{"echo no-leak"},
+				Secrets: []executor.SecretRequest{
+					{LocalName: "DOCKERHUB_TOKEN", RepoName: "DOCKERHUB_TOKEN"},
+				},
+			},
+		},
+		UserSecrets: map[string][]byte{
+			"DOCKERHUB_TOKEN": []byte("super-secret-value"),
+		},
+	}
+
+	results, err := exec.Run(t.Context(), "", cfg, ciconfig.TriggerContext{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.Status != "passed" {
+		t.Errorf("expected passed, got %s (logs: %s)", r.Status, r.Logs)
+	}
+	// Backstop: the literal plaintext must never reach the user-visible logs,
+	// even though the step here doesn't reference the secret. This guards the
+	// scrubber path in runCheck.
+	if strings.Contains(r.Logs, "super-secret-value") {
+		t.Errorf("secret plaintext leaked into logs: %s", r.Logs)
+	}
+}
+
 // TestE2ECacheWithChecksumAndSecrets verifies that BuildKit cache hits occur on
 // a second run when the source archive has the same checksum but a different URL,
 // and when OIDCRequestToken differs between runs.


### PR DESCRIPTION
## Summary

Phase 5 of the repo-level secrets feature. Branched off main after #447, #448, #450, #451 all merged.

What's in here:

- **BuildKit wiring** in `internal/executor/executor.go::runCheck`. The existing OIDC secret-mount pattern is generalized: `buildSecretMap(oidcToken, oidcURL, cfg.UserSecrets)` returns the `secretsprovider.FromMap` payload, with OIDC built-ins keyed by their fixed SecretIDs (`docstore_oidc_request_token` / `docstore_oidc_request_url`) and user secrets keyed by `LocalName`. The reserved `DOCSTORE_*` prefix policy in `internal/secrets` rules out collisions, so a flat `maps.Copy` is safe. Returns `nil` when nothing to attach, so the caller can skip wiring entirely.
- **Per-step `llb.AddSecret`** for each entry in `check.Secrets` — exposes the value at `/run/secrets/<LocalName>` inside the step container with `llb.SecretOptional`. Cache key is unaffected because BuildKit excludes secret mounts from the hash.
- **Worker-side log scrubber** `scrubLogs(buf, secrets) []byte` — `bytes.ReplaceAll` per non-empty value, replacing matches with `***`. Documented as a verbatim-substring backstop for `echo $TOKEN` style mistakes; base64/hex transformations are NOT caught and aren't expected to be. Applied at the single chokepoint in `runCheck` right before `logs := logBuf.String()`.

Both helpers extracted as named functions so the logic is unit-testable without a live buildkitd. Modern Go: `maps.Copy` for the merge.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./internal/executor/...` — 14 unit tests for the helpers + smoke test that exercises `Run` end-to-end with `cfg.UserSecrets` populated and asserts the plaintext never appears in the returned logs.

## Out of scope (still phases 6–7)

- Phase 6 — audit events on the broker (`secret.created` / `secret.updated` / `secret.deleted` / `secret.accessed`).
- Phase 7 — user-facing `docs/secrets.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)