### PR TITLE
feat(ui): repo secrets metadata page (read-only)

### DIFF
--- a/cmd/ui-preview/main.go
+++ b/cmd/ui-preview/main.go
@@ -424,7 +424,7 @@ func (e *notFoundErr) Error() string { return "branch not found" }
 // ---------------------------------------------------------------------------
 
 func main() {
-	h, err := ui.NewHandler(fakeRead{}, fakeWrite{}, nil, fakeAssemble, nil)
+	h, err := ui.NewHandler(fakeRead{}, fakeWrite{}, nil, nil, fakeAssemble, nil)
 	if err != nil {
 		log.Fatalf("ui init: %v", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -417,9 +417,9 @@ func (s *server) buildHandler(devIdentity, bootstrapAdmin string, writeStore Wri
 		var uiHandler *ui.Handler
 		var err error
 		if os.Getenv("DEV_UI") != "" {
-			uiHandler, err = ui.NewHandlerDev(s.readStore, writeStore, s.svc, assemble, IdentityFromContext)
+			uiHandler, err = ui.NewHandlerDev(s.readStore, writeStore, s.svc, s.secrets, assemble, IdentityFromContext)
 		} else {
-			uiHandler, err = ui.NewHandler(s.readStore, writeStore, s.svc, assemble, IdentityFromContext)
+			uiHandler, err = ui.NewHandler(s.readStore, writeStore, s.svc, s.secrets, assemble, IdentityFromContext)
 		}
 		if err != nil {
 			slog.Error("ui init failed", "error", err)

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dlorenc/docstore/internal/db"
 	evtypes "github.com/dlorenc/docstore/internal/events/types"
 	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/secrets"
 	"github.com/dlorenc/docstore/internal/service"
 	"github.com/dlorenc/docstore/internal/store"
 )
@@ -64,6 +65,12 @@ type repoSettingsPage struct {
 	Repo  model.Repo
 	Roles []model.Role
 	Err   string
+}
+
+type repoSecretsPage struct {
+	Repo    model.Repo
+	Secrets []secrets.Metadata
+	Err     string
 }
 
 type branchRow struct {
@@ -1755,6 +1762,52 @@ func (h *Handler) renderRepoSettingsPage(w http.ResponseWriter, r *http.Request,
 			{Label: "settings", Href: ""},
 		},
 		Body: repoSettingsPage{Repo: *repo, Roles: roles, Err: errMsg},
+	})
+}
+
+// handleRepoSecrets renders the read-only secrets metadata page for a repo.
+// The page only shows names, sizes, and audit timestamps — plaintext is never
+// fetched. Writing and deleting secrets is intentionally CLI-only (`ds secrets
+// set / unset`); the browser surface for plaintext input has a wider threat
+// model (extensions, clipboard, screen recorders) and we don't want to invite
+// it.
+func (h *Handler) handleRepoSecrets(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	repoName := owner + "/" + name
+	ctx := r.Context()
+
+	repo, err := h.write.GetRepo(ctx, repoName)
+	if err != nil {
+		if errors.Is(err, db.ErrRepoNotFound) {
+			h.renderError(w, r, http.StatusNotFound, "repo not found: "+repoName)
+			return
+		}
+		slog.Error("ui get repo", "repo", repoName, "error", err)
+		h.renderError(w, r, http.StatusInternalServerError, "could not load repo")
+		return
+	}
+
+	if h.secrets == nil {
+		h.renderError(w, r, http.StatusServiceUnavailable, "secrets service is not configured")
+		return
+	}
+
+	list, err := h.secrets.List(ctx, repoName)
+	if err != nil {
+		slog.Error("ui list secrets", "repo", repoName, "error", err)
+		h.renderError(w, r, http.StatusInternalServerError, "could not load secrets")
+		return
+	}
+
+	h.render(w, r, h.tmpl.repoSecrets, "layout.html", pageData{
+		Title: repoName + " / secrets",
+		Breadcrumbs: []crumb{
+			{Label: "repos", Href: "/"},
+			{Label: repoName, Href: "/r/" + repoName},
+			{Label: "secrets", Href: ""},
+		},
+		Body: repoSecretsPage{Repo: *repo, Secrets: list},
 	})
 }
 

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -45,6 +45,7 @@ type templateSet struct {
 	createRepo      *template.Template
 	newCommit       *template.Template
 	repoSettings    *template.Template
+	repoSecrets     *template.Template
 	userProfile     *template.Template
 	commitFileDiff  *template.Template
 }
@@ -200,6 +201,10 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse settings: %w", err)
 	}
+	repoSecrets, err := load("secrets.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse secrets: %w", err)
+	}
 	userProfile, err := load("user.html")
 	if err != nil {
 		return nil, fmt.Errorf("parse user: %w", err)
@@ -237,6 +242,7 @@ func parseTemplates(root fs.FS) (*templateSet, error) {
 		createRepo:      createRepo,
 		newCommit:       newCommit,
 		repoSettings:    repoSettings,
+		repoSecrets:     repoSecrets,
 		userProfile:     userProfile,
 		commitFileDiff:  commitFileDiff,
 	}, nil

--- a/internal/ui/templatecheck_test.go
+++ b/internal/ui/templatecheck_test.go
@@ -146,6 +146,9 @@ func TestTemplateTypes(t *testing.T) {
 	t.Run("repo_settings", func(t *testing.T) {
 		check(t, tmpl.repoSettings.Lookup("content"), repoSettingsPage{})
 	})
+	t.Run("repo_secrets", func(t *testing.T) {
+		check(t, tmpl.repoSecrets.Lookup("content"), repoSecretsPage{})
+	})
 	t.Run("user_profile", func(t *testing.T) {
 		check(t, tmpl.userProfile.Lookup("content"), userProfilePage{
 			Memberships: []model.OrgMember{{Role: model.OrgRoleMember}},

--- a/internal/ui/templates/branches.html
+++ b/internal/ui/templates/branches.html
@@ -8,6 +8,7 @@
   <a href="/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/r/{{.Repo.Name}}/log">log</a>
+  <a href="/r/{{.Repo.Name}}/secrets">secrets</a>
   <a href="/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/ci_job_detail.html
+++ b/internal/ui/templates/ci_job_detail.html
@@ -6,6 +6,7 @@
   <a href="/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/r/{{.Repo.Name}}/ci-jobs" class="active">ci-jobs</a>
   <a href="/r/{{.Repo.Name}}/log">log</a>
+  <a href="/r/{{.Repo.Name}}/secrets">secrets</a>
   <a href="/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/ci_jobs.html
+++ b/internal/ui/templates/ci_jobs.html
@@ -11,6 +11,7 @@
   <a href="/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/r/{{.Repo.Name}}/ci-jobs" class="active">ci-jobs</a>
   <a href="/r/{{.Repo.Name}}/log">log</a>
+  <a href="/r/{{.Repo.Name}}/secrets">secrets</a>
   <a href="/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/commit.html
+++ b/internal/ui/templates/commit.html
@@ -12,6 +12,7 @@
   <a href="/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/r/{{.Repo.Name}}/log" class="active">log</a>
+  <a href="/r/{{.Repo.Name}}/secrets">secrets</a>
   <a href="/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/issue_detail.html
+++ b/internal/ui/templates/issue_detail.html
@@ -7,6 +7,7 @@
   <a href="/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/r/{{.Repo.Name}}/log">log</a>
+  <a href="/r/{{.Repo.Name}}/secrets">secrets</a>
   <a href="/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/issues.html
+++ b/internal/ui/templates/issues.html
@@ -11,6 +11,7 @@
   <a href="/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/r/{{.Repo.Name}}/log">log</a>
+  <a href="/r/{{.Repo.Name}}/secrets">secrets</a>
   <a href="/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/log.html
+++ b/internal/ui/templates/log.html
@@ -10,6 +10,7 @@
   <a href="/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/r/{{.Repo.Name}}/log" class="active">log</a>
+  <a href="/r/{{.Repo.Name}}/secrets">secrets</a>
   <a href="/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/new_issue.html
+++ b/internal/ui/templates/new_issue.html
@@ -6,6 +6,7 @@
   <a href="/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/r/{{.Repo.Name}}/log">log</a>
+  <a href="/r/{{.Repo.Name}}/secrets">secrets</a>
   <a href="/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/proposal_detail.html
+++ b/internal/ui/templates/proposal_detail.html
@@ -6,6 +6,7 @@
   <a href="/r/{{.Repo.Name}}/proposals" class="active">proposals</a>
   <a href="/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/r/{{.Repo.Name}}/log">log</a>
+  <a href="/r/{{.Repo.Name}}/secrets">secrets</a>
   <a href="/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/proposals.html
+++ b/internal/ui/templates/proposals.html
@@ -11,6 +11,7 @@
   <a href="/r/{{.Repo.Name}}/proposals" class="active">proposals</a>
   <a href="/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/r/{{.Repo.Name}}/log">log</a>
+  <a href="/r/{{.Repo.Name}}/secrets">secrets</a>
   <a href="/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/release_detail.html
+++ b/internal/ui/templates/release_detail.html
@@ -6,6 +6,7 @@
   <a href="/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/r/{{.Repo.Name}}/log">log</a>
+  <a href="/r/{{.Repo.Name}}/secrets">secrets</a>
   <a href="/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/releases.html
+++ b/internal/ui/templates/releases.html
@@ -11,6 +11,7 @@
   <a href="/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/r/{{.Repo.Name}}/log">log</a>
+  <a href="/r/{{.Repo.Name}}/secrets">secrets</a>
   <a href="/r/{{.Repo.Name}}/settings">settings</a>
 </nav>
 

--- a/internal/ui/templates/secrets.html
+++ b/internal/ui/templates/secrets.html
@@ -1,0 +1,53 @@
+{{define "content"}}
+<div class="headline"><h1>{{.Repo.Name}}</h1><span class="meta">owner {{.Repo.Owner}} · {{relTime .Repo.CreatedAt}}</span></div>
+
+<nav class="repo-tabs">
+  <a href="/r/{{.Repo.Name}}">branches</a>
+  <a href="/r/{{.Repo.Name}}/issues">issues</a>
+  <a href="/r/{{.Repo.Name}}/releases">releases</a>
+  <a href="/r/{{.Repo.Name}}/proposals">proposals</a>
+  <a href="/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
+  <a href="/r/{{.Repo.Name}}/log">log</a>
+  <a href="/r/{{.Repo.Name}}/secrets" class="active">secrets</a>
+  <a href="/r/{{.Repo.Name}}/settings">settings</a>
+</nav>
+
+<div class="card" style="border-left: 3px solid var(--accent); margin-bottom: 14px">
+  <div class="row-body">
+    Repo secrets are surfaced to CI jobs as BuildKit secret mounts at
+    <code>/run/secrets/&lt;NAME&gt;</code>. This page shows metadata only —
+    plaintext values are never returned through the API or the UI. Use
+    <code>ds secrets set</code> / <code>ds secrets unset</code> to write or
+    delete. See the <a href="https://docs.docstore.dev/secrets/">secrets guide</a>
+    for the full model.
+  </div>
+</div>
+
+<h2>Secrets ({{len .Secrets}})</h2>
+<div class="card">
+  {{if not .Secrets}}<div class="empty">no secrets configured · use <code>ds secrets set &lt;NAME&gt; -</code></div>{{else}}
+  <table class="grid">
+    <thead><tr>
+      <th>name</th>
+      <th>size</th>
+      <th>created</th>
+      <th>updated</th>
+      <th>last used</th>
+      <th>by</th>
+    </tr></thead>
+    <tbody>
+    {{range .Secrets}}
+    <tr>
+      <td><code>{{.Name}}</code>{{with .Description}}<div class="meta">{{.}}</div>{{end}}</td>
+      <td class="meta">{{.SizeBytes}} B</td>
+      <td class="meta">{{relTime .CreatedAt}}</td>
+      <td class="meta">{{if .UpdatedAt}}{{relTimep .UpdatedAt}}{{else}}—{{end}}</td>
+      <td class="meta">{{if .LastUsedAt}}{{relTimep .LastUsedAt}}{{else}}never{{end}}</td>
+      <td class="meta">{{$by := .CreatedBy}}{{with .UpdatedBy}}{{$by = .}}{{end}}{{$by}}</td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{end}}
+</div>
+{{end}}

--- a/internal/ui/templates/settings.html
+++ b/internal/ui/templates/settings.html
@@ -8,6 +8,7 @@
   <a href="/r/{{.Repo.Name}}/proposals">proposals</a>
   <a href="/r/{{.Repo.Name}}/ci-jobs">ci-jobs</a>
   <a href="/r/{{.Repo.Name}}/log">log</a>
+  <a href="/r/{{.Repo.Name}}/secrets">secrets</a>
   <a href="/r/{{.Repo.Name}}/settings" class="active">settings</a>
 </nav>
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/dlorenc/docstore/internal/events"
 	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/secrets"
 	"github.com/dlorenc/docstore/internal/service"
 	"github.com/dlorenc/docstore/internal/store"
 )
@@ -119,11 +120,21 @@ var templatesFS embed.FS
 //go:embed static
 var staticFS embed.FS
 
+// SecretsLister is the minimal subset of secrets.Service the UI needs. The
+// metadata page calls List only — Set, Delete, and Reveal are never exposed
+// over the browser surface. Defining the type here keeps the UI from
+// depending on the full secrets.Service interface and makes the privilege
+// boundary explicit.
+type SecretsLister interface {
+	List(ctx context.Context, repo string) ([]secrets.Metadata, error)
+}
+
 // Handler renders the web UI.
 type Handler struct {
 	read      ReadStore
 	write     WriteStoreLite
 	svc       *service.Service
+	secrets   SecretsLister
 	assemble  AssembleFn
 	identity  IdentityFn
 	tmpl      *templateSet
@@ -144,7 +155,8 @@ func (h *Handler) emit(ctx context.Context, e events.Event) {
 
 // NewHandler constructs a UI handler wired to the given data sources.
 // svc is the service layer that enforces business logic for write operations.
-func NewHandler(read ReadStore, write WriteStoreLite, svc *service.Service, assemble AssembleFn, identity IdentityFn) (*Handler, error) {
+// secretsLister is optional — when nil, the secrets metadata page returns 503.
+func NewHandler(read ReadStore, write WriteStoreLite, svc *service.Service, secretsLister SecretsLister, assemble AssembleFn, identity IdentityFn) (*Handler, error) {
 	t, err := parseTemplates(templatesFS)
 	if err != nil {
 		return nil, err
@@ -157,6 +169,7 @@ func NewHandler(read ReadStore, write WriteStoreLite, svc *service.Service, asse
 		read:      read,
 		write:     write,
 		svc:       svc,
+		secrets:   secretsLister,
 		assemble:  assemble,
 		identity:  identity,
 		tmpl:      t,
@@ -169,7 +182,7 @@ func NewHandler(read ReadStore, write WriteStoreLite, svc *service.Service, asse
 // during development so template edits take effect on the next request without
 // recompiling. The server must be run from the repository root so that the
 // path "internal/ui" resolves correctly.
-func NewHandlerDev(read ReadStore, write WriteStoreLite, svc *service.Service, assemble AssembleFn, identity IdentityFn) (*Handler, error) {
+func NewHandlerDev(read ReadStore, write WriteStoreLite, svc *service.Service, secretsLister SecretsLister, assemble AssembleFn, identity IdentityFn) (*Handler, error) {
 	root := os.DirFS("internal/ui")
 	t, err := parseTemplates(root)
 	if err != nil {
@@ -183,6 +196,7 @@ func NewHandlerDev(read ReadStore, write WriteStoreLite, svc *service.Service, a
 		read:      read,
 		write:     write,
 		svc:       svc,
+		secrets:   secretsLister,
 		assemble:  assemble,
 		identity:  identity,
 		tmpl:      t,
@@ -210,6 +224,7 @@ func (h *Handler) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /o/{org}", h.handleOrg)
 	mux.HandleFunc("GET /r/{owner}/{name}", h.handleBranches)
 	mux.HandleFunc("GET /r/{owner}/{name}/settings", h.handleRepoSettings)
+	mux.HandleFunc("GET /r/{owner}/{name}/secrets", h.handleRepoSecrets)
 	mux.HandleFunc("GET /r/{owner}/{name}/log", h.handleRepoLog)
 	// Branch routes use {branch...} to support multi-segment branch names like
 	// "feature/auth". The dispatch handlers parse the trailing suffix to route

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/dlorenc/docstore/internal/db"
 	"github.com/dlorenc/docstore/internal/model"
+	"github.com/dlorenc/docstore/internal/secrets"
 	"github.com/dlorenc/docstore/internal/service"
 	"github.com/dlorenc/docstore/internal/store"
 )
@@ -302,7 +303,7 @@ func strPtr(s string) *string { return &s }
 func newTestHandler(t *testing.T, r ReadStore, w *fakeWrite, a AssembleFn) http.Handler {
 	t.Helper()
 	svc := service.New(w, nil, nil)
-	h, err := NewHandler(r, w, svc, a, nil)
+	h, err := NewHandler(r, w, svc, nil, a, nil)
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}
@@ -315,7 +316,7 @@ func newTestHandlerWithIdentity(t *testing.T, r ReadStore, w *fakeWrite, identit
 	t.Helper()
 	svc := service.New(w, nil, nil)
 	identFn := func(_ context.Context) string { return identity }
-	h, err := NewHandler(r, w, svc, nil, identFn)
+	h, err := NewHandler(r, w, svc, nil, nil, identFn)
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}
@@ -1331,5 +1332,107 @@ func TestCSRFMiddleware_FormContainsCsrfField(t *testing.T) {
 	}
 	if !strings.Contains(body, `name="csrf_token"`) {
 		t.Errorf("rendered form does not contain csrf_token hidden field; body snippet: %.200s", body)
+	}
+}
+
+// fakeSecretsLister implements ui.SecretsLister for tests.
+type fakeSecretsLister struct {
+	rows []secrets.Metadata
+	err  error
+}
+
+func (f *fakeSecretsLister) List(_ context.Context, _ string) ([]secrets.Metadata, error) {
+	return f.rows, f.err
+}
+
+// newTestHandlerWithSecrets is like newTestHandler but injects a SecretsLister.
+func newTestHandlerWithSecrets(t *testing.T, w *fakeWrite, sl SecretsLister) http.Handler {
+	t.Helper()
+	svc := service.New(w, nil, nil)
+	h, err := NewHandler(&fakeRead{}, w, svc, sl, nil, nil)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	mux := http.NewServeMux()
+	h.Register(mux)
+	return mux
+}
+
+func TestHandleRepoSecrets_Empty(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedBy: "me", CreatedAt: time.Now()}}
+	h := newTestHandlerWithSecrets(t, &fakeWrite{repos: repos}, &fakeSecretsLister{})
+	code, body := getStatusAndBody(t, h, "/r/acme/a/secrets")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", code, body)
+	}
+	for _, want := range []string{
+		"acme/a",
+		"no secrets configured",
+		`href="/r/acme/a/secrets" class="active"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleRepoSecrets_RendersRows(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedBy: "me", CreatedAt: time.Now()}}
+	updatedAt := time.Now().Add(-1 * time.Hour)
+	updatedBy := "bob@example.com"
+	rows := []secrets.Metadata{
+		{
+			ID: "s1", Repo: "acme/a", Name: "DOCKERHUB_TOKEN",
+			Description: "deploy token", SizeBytes: 36,
+			CreatedBy: "alice@example.com", CreatedAt: time.Now().Add(-24 * time.Hour),
+		},
+		{
+			ID: "s2", Repo: "acme/a", Name: "SLACK_INCOMING",
+			SizeBytes: 80,
+			CreatedBy: "alice@example.com", CreatedAt: time.Now().Add(-48 * time.Hour),
+			UpdatedBy: &updatedBy, UpdatedAt: &updatedAt,
+		},
+	}
+	h := newTestHandlerWithSecrets(t, &fakeWrite{repos: repos}, &fakeSecretsLister{rows: rows})
+	code, body := getStatusAndBody(t, h, "/r/acme/a/secrets")
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", code, body)
+	}
+	for _, want := range []string{
+		"DOCKERHUB_TOKEN",
+		"deploy token",
+		"SLACK_INCOMING",
+		"alice@example.com",
+		"bob@example.com",
+		"36 B",
+		"80 B",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q; body snippet: %.500s", want, body)
+		}
+	}
+	// Defense-in-depth: nothing in the page should hint at sealed bytes.
+	for _, banned := range []string{"ciphertext", "encrypted_dek", "kms_key_name"} {
+		if strings.Contains(body, banned) {
+			t.Errorf("page leaks internal field %q", banned)
+		}
+	}
+}
+
+func TestHandleRepoSecrets_NotConfigured_503(t *testing.T) {
+	repos := []model.Repo{{Name: "acme/a", Owner: "acme", CreatedBy: "me", CreatedAt: time.Now()}}
+	// No SecretsLister injected.
+	h := newTestHandlerWithSecrets(t, &fakeWrite{repos: repos}, nil)
+	code, _ := getStatusAndBody(t, h, "/r/acme/a/secrets")
+	if code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", code)
+	}
+}
+
+func TestHandleRepoSecrets_UnknownRepo_404(t *testing.T) {
+	h := newTestHandlerWithSecrets(t, &fakeWrite{miss: true}, &fakeSecretsLister{})
+	code, _ := getStatusAndBody(t, h, "/r/no/such/secrets")
+	if code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", code)
 	}
 }


### PR DESCRIPTION
## Summary

Adds a read-only `secrets` tab to every repo at `/r/{owner}/{name}/secrets`. Lists names, descriptions, sizes, timestamps, and authoring identity for the repo's secrets. **Plaintext is never fetched.** Write and delete stay CLI-only (`ds secrets set` / `ds secrets unset`) — the browser threat model for plaintext input is wider than `stdin` (extensions, clipboard managers, screen recorders, autofill all see the value as it's typed) and we don't want to invite it.

Why a separate `SecretsLister` interface instead of using the full `secrets.Service`:

```go
type SecretsLister interface {
    List(ctx context.Context, repo string) ([]secrets.Metadata, error)
}
```

The UI surface literally cannot call `Set`, `Delete`, or `Reveal` even by accident. The existing `s.secrets *secrets.Service` on `*server` satisfies the smaller interface implicitly, so production wiring is a one-line change in `internal/server/server.go`.

## Changes

- New template `internal/ui/templates/secrets.html` — repo-tabs nav, an info card explaining why writes are CLI-only, and a metadata table.
- New handler `handleRepoSecrets` registered at `GET /r/{owner}/{name}/secrets` — same pattern as `handleRepoSettings`.
- `ui.NewHandler` / `ui.NewHandlerDev` gain a `SecretsLister` parameter (nil-safe — passing nil makes the page return 503). Updated callers: `internal/server/server.go`, `cmd/ui-preview/main.go`, and test helpers.
- The new tab is added to all 13 repo-tabs templates so navigation is consistent.

## Threat-model checks

- ✅ No write surface exposed by the UI. The page is GET-only; no form, no fetch, no inline JS.
- ✅ Sealed bytes never leave the database row. The handler calls `Service.List`, which already projects them away.
- ✅ Defense-in-depth test asserts the rendered HTML contains no internal field name (`ciphertext`, `encrypted_dek`, `kms_key_name`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./internal/ui/...` — 4 new handler tests + the existing `TestTemplateTypes/repo_secrets` case validates every field referenced by the template against `repoSecretsPage`.
- [ ] Live preview — Docker is wedged on the dev box, so this PR relies on CI's Linux runner for the integration suite. The unit-level rendering tests cover the page's correctness independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)